### PR TITLE
Update licensing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,24 +1,180 @@
-The MIT License (MIT)
 
-Copyright (c) 2016 The stdlib Authors.
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+   1. Definitions.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
 
 
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,1 @@
+Copyright (c) 2016 The Stdlib Authors.

--- a/lib/node_modules/@stdlib/crypto/arc4/package.json
+++ b/lib/node_modules/@stdlib/crypto/arc4/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/crypto/package.json
+++ b/lib/node_modules/@stdlib/crypto/package.json
@@ -14,5 +14,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/datasets/afinn-111/LICENSE
+++ b/lib/node_modules/@stdlib/datasets/afinn-111/LICENSE
@@ -1,7 +1,7 @@
 The use of the database is licensed under a Open Data Commons Attribution 1.0
 License (ODC BY 1.0), while the database contents are licensed under a Creative
 Commons Attribution 4.0 International License (CC BY 4.0). The software is
-licensed under a MIT License.
+licensed under an Apache-2.0 license.
 
 If you use the database or its contents, please cite the following
 paper:
@@ -13,27 +13,182 @@ Proceedings: 93-98. http://arxiv.org/abs/1103.2903
 
 
 
-The MIT License (MIT)
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2016 The Stdlib Authors.
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
 
 
 

--- a/lib/node_modules/@stdlib/datasets/afinn-111/README.md
+++ b/lib/node_modules/@stdlib/datasets/afinn-111/README.md
@@ -144,7 +144,7 @@ Network, and Services.* SocialComNet.
 
 ## License
 
-The data files (databases) are licensed under an [Open Data Commons Attribution 1.0 License][odc-by-1.0] and their contents are licensed under a [Creative Commons Attribution 4.0 International Public License][cc-by-4.0]. The original dataset is attributed to Finn Årup Nielsen and can be found [here][afinn]. The software is licensed under an [MIT License][mit-license].
+The data files (databases) are licensed under an [Open Data Commons Attribution 1.0 License][odc-by-1.0] and their contents are licensed under a [Creative Commons Attribution 4.0 International Public License][cc-by-4.0]. The original dataset is attributed to Finn Årup Nielsen and can be found [here][afinn]. The software is licensed under [Apache License, Version 2.0][apache-license].
 
 <!-- </license> -->
 
@@ -157,6 +157,6 @@ The data files (databases) are licensed under an [Open Data Commons Attribution 
 [ndjson]: http://specs.frictionlessdata.io/ndjson/
 [odc-by-1.0]: http://opendatacommons.org/licenses/by/1.0/
 [cc-by-4.0]: http://creativecommons.org/licenses/by/4.0/
-[mit-license]: http://opensource.org/licenses/MIT
+[apache-license]: https://www.apache.org/licenses/LICENSE-2.0
 
 <!-- </links> -->

--- a/lib/node_modules/@stdlib/datasets/afinn-111/package.json
+++ b/lib/node_modules/@stdlib/datasets/afinn-111/package.json
@@ -37,5 +37,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/datasets/afinn-96/LICENSE
+++ b/lib/node_modules/@stdlib/datasets/afinn-96/LICENSE
@@ -1,7 +1,7 @@
 The use of the database is licensed under a Open Data Commons Attribution 1.0
 License (ODC BY 1.0), while the database contents are licensed under a Creative
 Commons Attribution 4.0 International License (CC BY 4.0). The software is
-licensed under a MIT License.
+licensed under an Apache-2.0 license.
 
 If you use the database or its contents, please cite the following
 paper:
@@ -13,27 +13,182 @@ Proceedings: 93-98. http://arxiv.org/abs/1103.2903
 
 
 
-The MIT License (MIT)
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2016 The Stdlib Authors.
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
 
 
 

--- a/lib/node_modules/@stdlib/datasets/afinn-96/README.md
+++ b/lib/node_modules/@stdlib/datasets/afinn-96/README.md
@@ -146,7 +146,7 @@ Network, and Services.* SocialComNet.
 
 ## License
 
-The data files (databases) are licensed under an [Open Data Commons Attribution 1.0 License][odc-by-1.0] and their contents are licensed under a [Creative Commons Attribution 4.0 International Public License][cc-by-4.0]. The original dataset is attributed to Finn Årup Nielsen and can be found [here][afinn]. The software is licensed under an [MIT License][mit-license].
+The data files (databases) are licensed under an [Open Data Commons Attribution 1.0 License][odc-by-1.0] and their contents are licensed under a [Creative Commons Attribution 4.0 International Public License][cc-by-4.0]. The original dataset is attributed to Finn Årup Nielsen and can be found [here][afinn]. The software is licensed under [Apache License, Version 2.0][apache-license].
 
 <!-- </license> -->
 
@@ -159,6 +159,6 @@ The data files (databases) are licensed under an [Open Data Commons Attribution 
 [ndjson]: http://specs.frictionlessdata.io/ndjson/
 [odc-by-1.0]: http://opendatacommons.org/licenses/by/1.0/
 [cc-by-4.0]: http://creativecommons.org/licenses/by/4.0/
-[mit-license]: http://opensource.org/licenses/MIT
+[apache-license]: https://www.apache.org/licenses/LICENSE-2.0
 
 <!-- </links> -->

--- a/lib/node_modules/@stdlib/datasets/afinn-96/package.json
+++ b/lib/node_modules/@stdlib/datasets/afinn-96/package.json
@@ -37,5 +37,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/datasets/female-first-names-en/LICENSE
+++ b/lib/node_modules/@stdlib/datasets/female-first-names-en/LICENSE
@@ -1,31 +1,186 @@
 The use of the database is licensed under an Open Data Commons Public Domain
 Dedication & License 1.0 (PDDL 1.0), while the database contents are licensed
 under a Creative Commons Zero v1.0 Universal (CC0 1.0). The software is licensed
-under a MIT License.
+under an Apache-2.0 license.
 
 
 
-The MIT License (MIT)
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2016 The Stdlib Authors.
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
 
 
 

--- a/lib/node_modules/@stdlib/datasets/female-first-names-en/README.md
+++ b/lib/node_modules/@stdlib/datasets/female-first-names-en/README.md
@@ -116,7 +116,7 @@ $ female-first-names-en
 
 ## License
 
-The data files (databases) are licensed under an [Open Data Commons Public Domain Dedication & License 1.0][pddl-1.0] and their contents are licensed under a [Creative Commons Zero v1.0 Universal][cc0]. The software is licensed under an [MIT License][mit-license].
+The data files (databases) are licensed under an [Open Data Commons Public Domain Dedication & License 1.0][pddl-1.0] and their contents are licensed under a [Creative Commons Zero v1.0 Universal][cc0]. The software is licensed under [Apache License, Version 2.0][apache-license].
 
 <!-- </license> -->
 
@@ -125,7 +125,7 @@ The data files (databases) are licensed under an [Open Data Commons Public Domai
 
 [pddl-1.0]: http://opendatacommons.org/licenses/pddl/1.0/
 [cc0]: https://creativecommons.org/publicdomain/zero/1.0
-[mit-license]: http://opensource.org/licenses/MIT
+[apache-license]: https://www.apache.org/licenses/LICENSE-2.0
 
 [given-name]: https://en.wikipedia.org/wiki/Given_name
 [moby-word]: http://www.gutenberg.org/files/3201/3201.txt

--- a/lib/node_modules/@stdlib/datasets/female-first-names-en/package.json
+++ b/lib/node_modules/@stdlib/datasets/female-first-names-en/package.json
@@ -33,5 +33,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/datasets/liu-negative-opinion-words-en/LICENSE
+++ b/lib/node_modules/@stdlib/datasets/liu-negative-opinion-words-en/LICENSE
@@ -1,6 +1,6 @@
 The use of the database is licensed under a Open Data Commons Attribution 1.0
 License (ODC BY 1.0), while the database contents are licensed under a Creative
-Commons Attribution 4.0 International License (CC BY 4.0). The software is licensed under a MIT License.
+Commons Attribution 4.0 International License (CC BY 4.0). The software is licensed under an Apache-2.0 license.
 
 If you use the database or its contents, please cite one of the following two
 papers:
@@ -15,27 +15,182 @@ International World Wide Web Conference (WWW-2005), May 10-14, Chiba, Japan.
 
 
 
-The MIT License (MIT)
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2016 The Stdlib Authors.
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
 
 
 

--- a/lib/node_modules/@stdlib/datasets/liu-negative-opinion-words-en/README.md
+++ b/lib/node_modules/@stdlib/datasets/liu-negative-opinion-words-en/README.md
@@ -131,7 +131,7 @@ $ liu-negative-opinion-words-en
 
 ## License
 
-The data files (databases) are licensed under an [Open Data Commons Attribution 1.0 License][odc-by-1.0] and their contents are licensed under a [Creative Commons Attribution 4.0 International Public License][cc-by-4.0]. The original dataset is attributed to Bing Liu and Minqing Hu and can be found [here][sentiment-lexicon]. The software is licensed under an [MIT License][mit-license].
+The data files (databases) are licensed under an [Open Data Commons Attribution 1.0 License][odc-by-1.0] and their contents are licensed under a [Creative Commons Attribution 4.0 International Public License][cc-by-4.0]. The original dataset is attributed to Bing Liu and Minqing Hu and can be found [here][sentiment-lexicon]. The software is licensed under [Apache License, Version 2.0][apache-license].
 
 <!-- </license> -->
 
@@ -141,6 +141,6 @@ The data files (databases) are licensed under an [Open Data Commons Attribution 
 [sentiment-lexicon]: http://www.cs.uic.edu/~liub/FBS/sentiment-analysis.html#lexicon
 [odc-by-1.0]: http://opendatacommons.org/licenses/by/1.0/
 [cc-by-4.0]: http://creativecommons.org/licenses/by/4.0/
-[mit-license]: http://opensource.org/licenses/MIT
+[apache-license]: https://www.apache.org/licenses/LICENSE-2.0
 
 <!-- </links> -->

--- a/lib/node_modules/@stdlib/datasets/liu-negative-opinion-words-en/package.json
+++ b/lib/node_modules/@stdlib/datasets/liu-negative-opinion-words-en/package.json
@@ -33,5 +33,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/datasets/liu-positive-opinion-words-en/LICENSE
+++ b/lib/node_modules/@stdlib/datasets/liu-positive-opinion-words-en/LICENSE
@@ -1,6 +1,6 @@
 The use of the database is licensed under a Open Data Commons Attribution 1.0
 License (ODC BY 1.0), while the database contents are licensed under a Creative
-Commons Attribution 4.0 International License (CC BY 4.0). The software is licensed under a MIT License.
+Commons Attribution 4.0 International License (CC BY 4.0). The software is licensed under an Apache-2.0 license.
 
 If you use the database or its contents, please cite one of the following two
 papers:
@@ -15,27 +15,182 @@ International World Wide Web Conference (WWW-2005), May 10-14, Chiba, Japan.
 
 
 
-The MIT License (MIT)
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2016 The Stdlib Authors.
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
 
 
 

--- a/lib/node_modules/@stdlib/datasets/liu-positive-opinion-words-en/README.md
+++ b/lib/node_modules/@stdlib/datasets/liu-positive-opinion-words-en/README.md
@@ -130,7 +130,7 @@ $ liu-positive-opinion-words-en
 
 ## License
 
-The data files (databases) are licensed under an [Open Data Commons Attribution 1.0 License][odc-by-1.0] and their contents are licensed under a [Creative Commons Attribution 4.0 International Public License][cc-by-4.0]. The original dataset is attributed to Bing Liu and Minqing Hu and can be found [here][sentiment-lexicon]. The software is licensed under an [MIT License][mit-license].
+The data files (databases) are licensed under an [Open Data Commons Attribution 1.0 License][odc-by-1.0] and their contents are licensed under a [Creative Commons Attribution 4.0 International Public License][cc-by-4.0]. The original dataset is attributed to Bing Liu and Minqing Hu and can be found [here][sentiment-lexicon]. The software is licensed under [Apache License, Version 2.0][apache-license].
 
 <!-- </license> -->
 
@@ -140,6 +140,6 @@ The data files (databases) are licensed under an [Open Data Commons Attribution 
 [sentiment-lexicon]: http://www.cs.uic.edu/~liub/FBS/sentiment-analysis.html#lexicon
 [odc-by-1.0]: http://opendatacommons.org/licenses/by/1.0/
 [cc-by-4.0]: http://creativecommons.org/licenses/by/4.0/
-[mit-license]: http://opensource.org/licenses/MIT
+[apache-license]: https://www.apache.org/licenses/LICENSE-2.0
 
 <!-- </links> -->

--- a/lib/node_modules/@stdlib/datasets/liu-positive-opinion-words-en/package.json
+++ b/lib/node_modules/@stdlib/datasets/liu-positive-opinion-words-en/package.json
@@ -33,5 +33,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/datasets/male-first-names-en/LICENSE
+++ b/lib/node_modules/@stdlib/datasets/male-first-names-en/LICENSE
@@ -1,32 +1,186 @@
 The use of the database is licensed under an Open Data Commons Public Domain
 Dedication & License 1.0 (PDDL 1.0), while the database contents are licensed
 under a Creative Commons Zero v1.0 Universal (CC0 1.0). The software is licensed
-under a MIT License.
+under an Apache-2.0 license.
 
 
 
-The MIT License (MIT)
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2016 The Stdlib Authors.
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
 
 
 

--- a/lib/node_modules/@stdlib/datasets/male-first-names-en/README.md
+++ b/lib/node_modules/@stdlib/datasets/male-first-names-en/README.md
@@ -115,7 +115,7 @@ $ male-first-names-en
 
 ## License
 
-The data files (databases) are licensed under an [Open Data Commons Public Domain Dedication & License 1.0][pddl-1.0] and their contents are licensed under a [Creative Commons Zero v1.0 Universal][cc0]. The software is licensed under an [MIT License][mit-license].
+The data files (databases) are licensed under an [Open Data Commons Public Domain Dedication & License 1.0][pddl-1.0] and their contents are licensed under a [Creative Commons Zero v1.0 Universal][cc0]. The software is licensed under [Apache License, Version 2.0][apache-license].
 
 <!-- </license> -->
 
@@ -124,7 +124,7 @@ The data files (databases) are licensed under an [Open Data Commons Public Domai
 
 [pddl-1.0]: http://opendatacommons.org/licenses/pddl/1.0/
 [cc0]: https://creativecommons.org/publicdomain/zero/1.0
-[mit-license]: http://opensource.org/licenses/MIT
+[apache-license]: https://www.apache.org/licenses/LICENSE-2.0
 
 [given-name]: https://en.wikipedia.org/wiki/Given_name
 [moby-word]: http://www.gutenberg.org/files/3201/3201.txt

--- a/lib/node_modules/@stdlib/datasets/male-first-names-en/package.json
+++ b/lib/node_modules/@stdlib/datasets/male-first-names-en/package.json
@@ -33,5 +33,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/datasets/nightingales-rose/LICENSE
+++ b/lib/node_modules/@stdlib/datasets/nightingales-rose/LICENSE
@@ -1,32 +1,186 @@
 The use of the database is licensed under an Open Data Commons Public Domain
 Dedication & License 1.0 (PDDL 1.0), while the database contents are licensed
 under a Creative Commons Zero v1.0 Universal (CC0 1.0). The software is licensed
-under a MIT License.
+under an Apache-2.0 license.
 
 
 
-The MIT License (MIT)
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2016 The Stdlib Authors.
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
 
 
 

--- a/lib/node_modules/@stdlib/datasets/nightingales-rose/README.md
+++ b/lib/node_modules/@stdlib/datasets/nightingales-rose/README.md
@@ -134,7 +134,7 @@ $ nightingales-rose
 
 ## License
 
-The data files (databases) are licensed under an [Open Data Commons Public Domain Dedication & License 1.0][pddl-1.0] and their contents are licensed under a [Creative Commons Zero v1.0 Universal][cc0]. The software is licensed under an [MIT License][mit-license].
+The data files (databases) are licensed under an [Open Data Commons Public Domain Dedication & License 1.0][pddl-1.0] and their contents are licensed under a [Creative Commons Zero v1.0 Universal][cc0]. The software is licensed under [Apache License, Version 2.0][apache-license].
 
 <!-- </license> -->
 
@@ -150,6 +150,6 @@ The data files (databases) are licensed under an [Open Data Commons Public Domai
 
 [pddl-1.0]: http://opendatacommons.org/licenses/pddl/1.0/
 [cc0]: https://creativecommons.org/publicdomain/zero/1.0
-[mit-license]: http://opensource.org/licenses/MIT
+[apache-license]: https://www.apache.org/licenses/LICENSE-2.0
 
 <!-- </links> -->

--- a/lib/node_modules/@stdlib/datasets/nightingales-rose/package.json
+++ b/lib/node_modules/@stdlib/datasets/nightingales-rose/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/datasets/package.json
+++ b/lib/node_modules/@stdlib/datasets/package.json
@@ -20,5 +20,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/datasets/sotu-addresses/LICENSE
+++ b/lib/node_modules/@stdlib/datasets/sotu-addresses/LICENSE
@@ -1,32 +1,186 @@
 The use of the database is licensed under an Open Data Commons Public Domain
 Dedication & License 1.0 (PDDL 1.0), while the database contents are licensed
 under a Creative Commons Zero v1.0 Universal (CC0 1.0). The software is licensed
-under a MIT License.
+under an Apache-2.0 license.
 
 
 
-The MIT License (MIT)
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2016 The Stdlib Authors.
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
 
 
 

--- a/lib/node_modules/@stdlib/datasets/sotu-addresses/README.md
+++ b/lib/node_modules/@stdlib/datasets/sotu-addresses/README.md
@@ -203,7 +203,7 @@ $ sotu --name 'Barack Obama' --year 2009
 
 ## License
 
-The data files (databases) are licensed under an [Open Data Commons Public Domain Dedication & License 1.0][pddl-1.0] and their contents are licensed under a [Creative Commons Zero v1.0 Universal][cc0]. [State of the Union][sotu] addresses are works of the United States Government and thus have no copyright protection under [United States copyright law][us-copyright]. The software is licensed under an [MIT License][mit-license].
+The data files (databases) are licensed under an [Open Data Commons Public Domain Dedication & License 1.0][pddl-1.0] and their contents are licensed under a [Creative Commons Zero v1.0 Universal][cc0]. [State of the Union][sotu] addresses are works of the United States Government and thus have no copyright protection under [United States copyright law][us-copyright]. The software is licensed under [Apache License, Version 2.0][apache-license].
 
 <!-- </license> -->
 
@@ -216,6 +216,6 @@ The data files (databases) are licensed under an [Open Data Commons Public Domai
 [pddl-1.0]: http://opendatacommons.org/licenses/pddl/1.0/
 [cc0]: https://creativecommons.org/publicdomain/zero/1.0
 [us-copyright]: https://en.wikisource.org/wiki/United_States_Code/Title_17/Chapter_1/Sections_105_and_106
-[mit-license]: http://opensource.org/licenses/MIT
+[apache-license]: https://www.apache.org/licenses/LICENSE-2.0
 
 <!-- </links> -->

--- a/lib/node_modules/@stdlib/datasets/sotu-addresses/package.json
+++ b/lib/node_modules/@stdlib/datasets/sotu-addresses/package.json
@@ -33,5 +33,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/datasets/stopwords-english/LICENSE
+++ b/lib/node_modules/@stdlib/datasets/stopwords-english/LICENSE
@@ -1,5 +1,185 @@
 The data contents and the use of the database are licensed under a BSD
-License (BSD-2-Clause). The software is licensed under a MIT License.
+License (BSD-2-Clause). The software is licensed under an Apache-2.0 license.
+
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
 
 Copyright (c) 2005, Jacques Savoy.
 All rights reserved.
@@ -24,27 +204,3 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-
-The MIT License (MIT)
-
-Copyright (c) 2016 The Stdlib Authors.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.

--- a/lib/node_modules/@stdlib/datasets/stopwords-english/package.json
+++ b/lib/node_modules/@stdlib/datasets/stopwords-english/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/fs/exists/package.json
+++ b/lib/node_modules/@stdlib/fs/exists/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/fs/package.json
+++ b/lib/node_modules/@stdlib/fs/package.json
@@ -19,5 +19,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/fs/read-dir/package.json
+++ b/lib/node_modules/@stdlib/fs/read-dir/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/fs/read-file/package.json
+++ b/lib/node_modules/@stdlib/fs/read-file/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/blas/dasum/package.json
+++ b/lib/node_modules/@stdlib/math/base/blas/dasum/package.json
@@ -32,5 +32,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/blas/daxpy/package.json
+++ b/lib/node_modules/@stdlib/math/base/blas/daxpy/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/blas/dcopy/package.json
+++ b/lib/node_modules/@stdlib/math/base/blas/dcopy/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/blas/package.json
+++ b/lib/node_modules/@stdlib/math/base/blas/package.json
@@ -32,5 +32,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/beta/cdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/beta/cdf/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/beta/logpdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/beta/logpdf/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/beta/pdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/beta/pdf/package.json
@@ -20,5 +20,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/beta/quantile/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/beta/quantile/package.json
@@ -21,5 +21,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/binomial/cdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/binomial/cdf/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/binomial/pmf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/binomial/pmf/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/binomial/quantile/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/binomial/quantile/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/cauchy/cdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/cauchy/cdf/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/cauchy/logcdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/cauchy/logcdf/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/cauchy/logpdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/cauchy/logpdf/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/cauchy/pdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/cauchy/pdf/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/cauchy/quantile/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/cauchy/quantile/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/chisquare/cdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/chisquare/cdf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "",
-  "version": "0.0.0",
+  "version": "",
   "description": "Chi-squared distribution cumulative distribution function (CDF).",
   "author": {},
   "contributors": [],
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/chisquare/pdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/chisquare/pdf/package.json
@@ -20,5 +20,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/chisquare/quantile/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/chisquare/quantile/package.json
@@ -21,5 +21,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/degenerate/cdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/degenerate/cdf/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/degenerate/logcdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/degenerate/logcdf/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/degenerate/logpdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/degenerate/logpdf/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/degenerate/pdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/degenerate/pdf/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/degenerate/pmf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/degenerate/pmf/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/degenerate/quantile/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/degenerate/quantile/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/erlang/cdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/erlang/cdf/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/erlang/pdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/erlang/pdf/package.json
@@ -20,5 +20,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/erlang/quantile/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/erlang/quantile/package.json
@@ -21,5 +21,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/exponential/cdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/exponential/cdf/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/exponential/pdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/exponential/pdf/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/exponential/quantile/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/exponential/quantile/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/f/cdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/f/cdf/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/f/pdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/f/pdf/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/f/quantile/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/f/quantile/package.json
@@ -21,5 +21,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/gamma/cdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/gamma/cdf/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/gamma/pdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/gamma/pdf/package.json
@@ -20,5 +20,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/gamma/quantile/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/gamma/quantile/package.json
@@ -21,5 +21,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/geometric/cdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/geometric/cdf/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/geometric/logcdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/geometric/logcdf/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/geometric/logpmf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/geometric/logpmf/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/geometric/pmf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/geometric/pmf/package.json
@@ -21,5 +21,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/geometric/quantile/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/geometric/quantile/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/gumbel/cdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/gumbel/cdf/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/gumbel/logcdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/gumbel/logcdf/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/gumbel/logpdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/gumbel/logpdf/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/gumbel/pdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/gumbel/pdf/package.json
@@ -20,5 +20,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/gumbel/quantile/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/gumbel/quantile/package.json
@@ -21,5 +21,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/hypergeometric/cdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/hypergeometric/cdf/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/hypergeometric/pmf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/hypergeometric/pmf/package.json
@@ -20,5 +20,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/hypergeometric/quantile/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/hypergeometric/quantile/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/invgamma/cdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/invgamma/cdf/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/invgamma/pdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/invgamma/pdf/package.json
@@ -20,5 +20,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/invgamma/quantile/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/invgamma/quantile/package.json
@@ -21,5 +21,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/laplace/cdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/laplace/cdf/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/laplace/logcdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/laplace/logcdf/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/laplace/logpdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/laplace/logpdf/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/laplace/pdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/laplace/pdf/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/laplace/quantile/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/laplace/quantile/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/logistic/cdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/logistic/cdf/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/logistic/logcdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/logistic/logcdf/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/logistic/logpdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/logistic/logpdf/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/logistic/pdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/logistic/pdf/package.json
@@ -20,5 +20,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/logistic/quantile/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/logistic/quantile/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/lognormal/cdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/lognormal/cdf/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/lognormal/pdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/lognormal/pdf/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/lognormal/quantile/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/lognormal/quantile/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/negative-binomial/cdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/negative-binomial/cdf/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/negative-binomial/pmf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/negative-binomial/pmf/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/negative-binomial/quantile/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/negative-binomial/quantile/package.json
@@ -21,5 +21,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/normal/cdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/normal/cdf/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/normal/pdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/normal/pdf/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/normal/quantile/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/normal/quantile/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/pareto-type1/cdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/pareto-type1/cdf/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/pareto-type1/pdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/pareto-type1/pdf/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/pareto-type1/quantile/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/pareto-type1/quantile/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/poisson/cdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/poisson/cdf/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/poisson/pmf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/poisson/pmf/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/poisson/quantile/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/poisson/quantile/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/rayleigh/cdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/rayleigh/cdf/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/rayleigh/logcdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/rayleigh/logcdf/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/rayleigh/logpdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/rayleigh/logpdf/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/rayleigh/pdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/rayleigh/pdf/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/rayleigh/quantile/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/rayleigh/quantile/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/t/cdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/t/cdf/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/t/pdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/t/pdf/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/t/quantile/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/t/quantile/package.json
@@ -21,5 +21,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/triangular/cdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/triangular/cdf/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/triangular/pdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/triangular/pdf/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/triangular/quantile/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/triangular/quantile/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/truncated-normal/pdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/truncated-normal/pdf/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/uniform/cdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/uniform/cdf/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/uniform/logcdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/uniform/logcdf/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/uniform/logpdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/uniform/logpdf/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/uniform/pdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/uniform/pdf/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/uniform/quantile/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/uniform/quantile/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/weibull/cdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/weibull/cdf/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/weibull/logcdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/weibull/logcdf/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/weibull/logpdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/weibull/logpdf/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/weibull/pdf/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/weibull/pdf/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/dist/weibull/quantile/package.json
+++ b/lib/node_modules/@stdlib/math/base/dist/weibull/quantile/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/beta/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/beta/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/binomial/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/binomial/package.json
@@ -30,5 +30,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/box-muller/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/box-muller/package.json
@@ -34,5 +34,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/cauchy/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/cauchy/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/chisquare/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/chisquare/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/erlang/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/erlang/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/exponential/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/exponential/package.json
@@ -30,5 +30,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/f/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/f/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/gamma/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/gamma/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/geometric/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/geometric/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/gumbel/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/gumbel/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/hypergeometric/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/hypergeometric/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/improved-ziggurat/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/improved-ziggurat/package.json
@@ -32,5 +32,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/invgamma/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/invgamma/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/laplace/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/laplace/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/logistic/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/logistic/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/lognormal/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/lognormal/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/minstd-shuffle/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/minstd-shuffle/package.json
@@ -36,5 +36,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/minstd/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/minstd/package.json
@@ -33,5 +33,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/negative-binomial/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/negative-binomial/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/normal/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/normal/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/pareto-type1/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/pareto-type1/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/poisson/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/poisson/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/randn/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/randn/package.json
@@ -30,5 +30,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/randu/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/randu/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/rayleigh/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/rayleigh/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/t/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/t/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/triangular/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/triangular/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/uniform/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/uniform/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/random/weibull/package.json
+++ b/lib/node_modules/@stdlib/math/base/random/weibull/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/abs/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/abs/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/acos/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/acos/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/acosh/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/acosh/package.json
@@ -30,5 +30,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/asin/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/asin/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/asinh/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/asinh/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/atan/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/atan/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/atan2/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/atan2/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/atanh/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/atanh/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/beta/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/beta/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT AND BSL-1.0"
+  "license": "Apache-2.0 AND BSL-1.0"
 }

--- a/lib/node_modules/@stdlib/math/base/special/betainc/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/betainc/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT AND BSL-1.0"
+  "license": "Apache-2.0 AND BSL-1.0"
 }

--- a/lib/node_modules/@stdlib/math/base/special/betaincinv/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/betaincinv/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT AND BSL-1.0"
+  "license": "Apache-2.0 AND BSL-1.0"
 }

--- a/lib/node_modules/@stdlib/math/base/special/betaln/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/betaln/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/binomcoef/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoef/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/binomcoefln/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoefln/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/cbrt/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/cbrt/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/ceil/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/ceil/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/copysign/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/copysign/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/cos/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/cos/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/cosh/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/cosh/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/cosm1/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/cosm1/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/cospi/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/cospi/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/deg2rad/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/deg2rad/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/digamma/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/digamma/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT AND BSL-1.0"
+  "license": "Apache-2.0 AND BSL-1.0"
 }

--- a/lib/node_modules/@stdlib/math/base/special/dirchlet-eta/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/dirchlet-eta/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/erf/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/erf/package.json
@@ -21,5 +21,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/erfc/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/erfc/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/erfcinv/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/erfcinv/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT AND BSL-1.0"
+  "license": "Apache-2.0 AND BSL-1.0"
 }

--- a/lib/node_modules/@stdlib/math/base/special/erfinv/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/erfinv/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT AND BSL-1.0"
+  "license": "Apache-2.0 AND BSL-1.0"
 }

--- a/lib/node_modules/@stdlib/math/base/special/exp/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/exp/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/exp10/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/exp10/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/exp2/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/exp2/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/expm1/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/expm1/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/factorial/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/factorial/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/factorialln/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/factorialln/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/flipsign/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/flipsign/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/floor/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/floor/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/frexp/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/frexp/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/gamma/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/gamma/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/gammainc/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/gammainc/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT AND BSL-1.0"
+  "license": "Apache-2.0 AND BSL-1.0"
 }

--- a/lib/node_modules/@stdlib/math/base/special/gammaincinv/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/gammaincinv/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/gammaln/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/gammaln/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/ldexp/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/ldexp/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/ln/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/ln/package.json
@@ -21,5 +21,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/log10/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/log10/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/log1p/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/log1p/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/log2/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/log2/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/pow/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/pow/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/powm1/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/powm1/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT AND BSL-1.0"
+  "license": "Apache-2.0 AND BSL-1.0"
 }

--- a/lib/node_modules/@stdlib/math/base/special/rad2deg/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/rad2deg/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/riemann-zeta/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/riemann-zeta/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT AND BSL-1.0"
+  "license": "Apache-2.0 AND BSL-1.0"
 }

--- a/lib/node_modules/@stdlib/math/base/special/round/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/round/package.json
@@ -21,5 +21,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/roundn/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/roundn/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/signum/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/signum/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/sin/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/sin/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/sinh/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/sinh/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/sinpi/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/sinpi/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/sqrt/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/sqrt/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/tan/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/tan/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/tanh/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/tanh/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/special/truncate/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/truncate/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/tools/continued-fraction/package.json
+++ b/lib/node_modules/@stdlib/math/base/tools/continued-fraction/package.json
@@ -19,5 +19,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/tools/evalpoly/package.json
+++ b/lib/node_modules/@stdlib/math/base/tools/evalpoly/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/tools/evalrational/package.json
+++ b/lib/node_modules/@stdlib/math/base/tools/evalrational/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT AND BSL-1.0"
+  "license": "Apache-2.0 AND BSL-1.0"
 }

--- a/lib/node_modules/@stdlib/math/base/tools/sum-series/package.json
+++ b/lib/node_modules/@stdlib/math/base/tools/sum-series/package.json
@@ -19,5 +19,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/absolute-difference/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/absolute-difference/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/float32-exponent/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/float32-exponent/package.json
@@ -31,5 +31,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/float32-from-binary-string/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/float32-from-binary-string/package.json
@@ -32,5 +32,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/float32-from-word/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/float32-from-word/package.json
@@ -36,5 +36,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/float32-normalize/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/float32-normalize/package.json
@@ -30,5 +30,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/float32-signbit/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/float32-signbit/package.json
@@ -31,5 +31,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/float32-significand/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/float32-significand/package.json
@@ -34,5 +34,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/float32-to-binary-string/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/float32-to-binary-string/package.json
@@ -30,5 +30,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/float32-to-word/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/float32-to-word/package.json
@@ -36,5 +36,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/float64-epsilon-difference/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/float64-epsilon-difference/package.json
@@ -30,5 +30,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/float64-exponent/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/float64-exponent/package.json
@@ -31,5 +31,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/float64-from-binary-string/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/float64-from-binary-string/package.json
@@ -32,5 +32,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/float64-from-words/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/float64-from-words/package.json
@@ -34,5 +34,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/float64-get-high-word/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/float64-get-high-word/package.json
@@ -35,5 +35,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/float64-get-low-word/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/float64-get-low-word/package.json
@@ -33,5 +33,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/float64-normalize/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/float64-normalize/package.json
@@ -31,5 +31,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/float64-set-high-word/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/float64-set-high-word/package.json
@@ -36,5 +36,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/float64-set-low-word/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/float64-set-low-word/package.json
@@ -33,5 +33,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/float64-signbit/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/float64-signbit/package.json
@@ -31,5 +31,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/float64-to-binary-string/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/float64-to-binary-string/package.json
@@ -31,5 +31,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/float64-to-float32/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/float64-to-float32/package.json
@@ -31,5 +31,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/float64-to-int32/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/float64-to-int32/package.json
@@ -33,5 +33,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/float64-to-uint32/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/float64-to-uint32/package.json
@@ -33,5 +33,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/float64-to-words/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/float64-to-words/package.json
@@ -35,5 +35,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/is-even/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/is-even/package.json
@@ -30,5 +30,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/is-finite/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/is-finite/package.json
@@ -32,5 +32,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/is-infinite/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/is-infinite/package.json
@@ -37,5 +37,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/is-integer/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/is-integer/package.json
@@ -30,5 +30,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/is-nan/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/is-nan/package.json
@@ -31,5 +31,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/is-negative-integer/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/is-negative-integer/package.json
@@ -31,5 +31,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/is-negative-zero/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/is-negative-zero/package.json
@@ -31,5 +31,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/is-nonnegative-integer/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/is-nonnegative-integer/package.json
@@ -32,5 +32,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/is-nonpositive-integer/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/is-nonpositive-integer/package.json
@@ -32,5 +32,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/is-odd/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/is-odd/package.json
@@ -30,5 +30,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/is-positive-integer/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/is-positive-integer/package.json
@@ -34,5 +34,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/is-positive-zero/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/is-positive-zero/package.json
@@ -32,5 +32,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/relative-difference/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/relative-difference/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/uint16-to-binary-string/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/uint16-to-binary-string/package.json
@@ -32,5 +32,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/uint32-to-binary-string/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/uint32-to-binary-string/package.json
@@ -32,5 +32,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/uint32-to-int32/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/uint32-to-int32/package.json
@@ -32,5 +32,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/base/utils/uint8-to-binary-string/package.json
+++ b/lib/node_modules/@stdlib/math/base/utils/uint8-to-binary-string/package.json
@@ -32,5 +32,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float16-precision/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float16-precision/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float32-exponent-bias/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float32-exponent-bias/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float32-max/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float32-max/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float32-ninf/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float32-ninf/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float32-pinf/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float32-pinf/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float32-precision/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float32-precision/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float32-smallest-normal/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float32-smallest-normal/package.json
@@ -30,5 +30,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float32-smallest-subnormal/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float32-smallest-subnormal/package.json
@@ -30,5 +30,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-catalan/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-catalan/package.json
@@ -31,5 +31,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-e/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-e/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-eps/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-eps/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-eulergamma/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-eulergamma/package.json
@@ -31,5 +31,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-exponent-bias/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-exponent-bias/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-glaisher-kinkelin/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-glaisher-kinkelin/package.json
@@ -33,5 +33,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-half-ln-two/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-half-ln-two/package.json
@@ -30,5 +30,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-half-pi/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-half-pi/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-high-word-exponent-mask/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-high-word-exponent-mask/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-ln-half/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-ln-half/package.json
@@ -30,5 +30,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-ln-pi/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-ln-pi/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-ln-sqrt-two-pi/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-ln-sqrt-two-pi/package.json
@@ -34,5 +34,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-ln-two/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-ln-two/package.json
@@ -30,5 +30,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-max-base10-exponent-subnormal/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-max-base10-exponent-subnormal/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-max-base10-exponent/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-max-base10-exponent/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-max-base2-exponent-subnormal/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-max-base2-exponent-subnormal/package.json
@@ -31,5 +31,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-max-base2-exponent/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-max-base2-exponent/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-max-ln/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-max-ln/package.json
@@ -34,5 +34,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-max-safe-integer/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-max-safe-integer/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-max/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-max/package.json
@@ -30,5 +30,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-min-base10-exponent-subnormal/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-min-base10-exponent-subnormal/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-min-base10-exponent/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-min-base10-exponent/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-min-base2-exponent-subnormal/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-min-base2-exponent-subnormal/package.json
@@ -31,5 +31,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-min-base2-exponent/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-min-base2-exponent/package.json
@@ -30,5 +30,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-min-ln/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-min-ln/package.json
@@ -32,5 +32,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-min-safe-integer/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-min-safe-integer/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-ninf/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-ninf/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-phi/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-phi/package.json
@@ -36,5 +36,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-pi-squared/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-pi-squared/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-pi/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-pi/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-pinf/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-pinf/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-precision/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-precision/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-smallest-normal/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-smallest-normal/package.json
@@ -31,5 +31,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-smallest-subnormal/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-smallest-subnormal/package.json
@@ -32,5 +32,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-sqrt-eps/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-sqrt-eps/package.json
@@ -32,5 +32,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-sqrt-half/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-sqrt-half/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-sqrt-phi/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-sqrt-phi/package.json
@@ -39,5 +39,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-sqrt-two-pi/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-sqrt-two-pi/package.json
@@ -30,5 +30,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-sqrt-two/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-sqrt-two/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/float64-two-pi/package.json
+++ b/lib/node_modules/@stdlib/math/constants/float64-two-pi/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/int16-max/package.json
+++ b/lib/node_modules/@stdlib/math/constants/int16-max/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/int16-min/package.json
+++ b/lib/node_modules/@stdlib/math/constants/int16-min/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/int32-max/package.json
+++ b/lib/node_modules/@stdlib/math/constants/int32-max/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/int32-min/package.json
+++ b/lib/node_modules/@stdlib/math/constants/int32-min/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/int8-max/package.json
+++ b/lib/node_modules/@stdlib/math/constants/int8-max/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/int8-min/package.json
+++ b/lib/node_modules/@stdlib/math/constants/int8-min/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/package.json
+++ b/lib/node_modules/@stdlib/math/constants/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/uint16-max/package.json
+++ b/lib/node_modules/@stdlib/math/constants/uint16-max/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/uint32-max/package.json
+++ b/lib/node_modules/@stdlib/math/constants/uint32-max/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/constants/uint8-max/package.json
+++ b/lib/node_modules/@stdlib/math/constants/uint8-max/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/generics/statistics/incrcount/package.json
+++ b/lib/node_modules/@stdlib/math/generics/statistics/incrcount/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/generics/statistics/incrkurtosis/package.json
+++ b/lib/node_modules/@stdlib/math/generics/statistics/incrkurtosis/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/generics/statistics/incrmax/package.json
+++ b/lib/node_modules/@stdlib/math/generics/statistics/incrmax/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/generics/statistics/incrmean/package.json
+++ b/lib/node_modules/@stdlib/math/generics/statistics/incrmean/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/generics/statistics/incrmidrange/package.json
+++ b/lib/node_modules/@stdlib/math/generics/statistics/incrmidrange/package.json
@@ -30,5 +30,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/generics/statistics/incrmin/package.json
+++ b/lib/node_modules/@stdlib/math/generics/statistics/incrmin/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/generics/statistics/incrmmean/package.json
+++ b/lib/node_modules/@stdlib/math/generics/statistics/incrmmean/package.json
@@ -31,5 +31,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/generics/statistics/incrmstdev/package.json
+++ b/lib/node_modules/@stdlib/math/generics/statistics/incrmstdev/package.json
@@ -33,5 +33,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/generics/statistics/incrmsum/package.json
+++ b/lib/node_modules/@stdlib/math/generics/statistics/incrmsum/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/generics/statistics/incrmsummary/package.json
+++ b/lib/node_modules/@stdlib/math/generics/statistics/incrmsummary/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/generics/statistics/incrmvariance/package.json
+++ b/lib/node_modules/@stdlib/math/generics/statistics/incrmvariance/package.json
@@ -33,5 +33,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/generics/statistics/incrrange/package.json
+++ b/lib/node_modules/@stdlib/math/generics/statistics/incrrange/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/generics/statistics/incrskewness/package.json
+++ b/lib/node_modules/@stdlib/math/generics/statistics/incrskewness/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/generics/statistics/incrstdev/package.json
+++ b/lib/node_modules/@stdlib/math/generics/statistics/incrstdev/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/generics/statistics/incrsum/package.json
+++ b/lib/node_modules/@stdlib/math/generics/statistics/incrsum/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/generics/statistics/incrsummary/package.json
+++ b/lib/node_modules/@stdlib/math/generics/statistics/incrsummary/package.json
@@ -21,5 +21,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/generics/statistics/incrvariance/package.json
+++ b/lib/node_modules/@stdlib/math/generics/statistics/incrvariance/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/generics/statistics/kstest/package.json
+++ b/lib/node_modules/@stdlib/math/generics/statistics/kstest/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/generics/statistics/ttest/package.json
+++ b/lib/node_modules/@stdlib/math/generics/statistics/ttest/package.json
@@ -21,5 +21,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/generics/statistics/ttest2/package.json
+++ b/lib/node_modules/@stdlib/math/generics/statistics/ttest2/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/generics/utils/incrspace/package.json
+++ b/lib/node_modules/@stdlib/math/generics/utils/incrspace/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/generics/utils/linspace/package.json
+++ b/lib/node_modules/@stdlib/math/generics/utils/linspace/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/generics/utils/logspace/package.json
+++ b/lib/node_modules/@stdlib/math/generics/utils/logspace/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/ml/online-sgd-regression/package.json
+++ b/lib/node_modules/@stdlib/math/ml/online-sgd-regression/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/math/package.json
+++ b/lib/node_modules/@stdlib/math/package.json
@@ -16,5 +16,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/namespace/package.json
+++ b/lib/node_modules/@stdlib/namespace/package.json
@@ -18,5 +18,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/net/http-server/package.json
+++ b/lib/node_modules/@stdlib/net/http-server/package.json
@@ -19,5 +19,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/net/package.json
+++ b/lib/node_modules/@stdlib/net/package.json
@@ -20,5 +20,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/nlp/lda/package.json
+++ b/lib/node_modules/@stdlib/nlp/lda/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/nlp/tokenize/package.json
+++ b/lib/node_modules/@stdlib/nlp/tokenize/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/package.json
+++ b/lib/node_modules/@stdlib/package.json
@@ -16,5 +16,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/plot/components/svg/annotations/package.json
+++ b/lib/node_modules/@stdlib/plot/components/svg/annotations/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/plot/components/svg/axis/package.json
+++ b/lib/node_modules/@stdlib/plot/components/svg/axis/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/plot/components/svg/background/package.json
+++ b/lib/node_modules/@stdlib/plot/components/svg/background/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/plot/components/svg/canvas/package.json
+++ b/lib/node_modules/@stdlib/plot/components/svg/canvas/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/plot/components/svg/clip-path/package.json
+++ b/lib/node_modules/@stdlib/plot/components/svg/clip-path/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/plot/components/svg/defs/package.json
+++ b/lib/node_modules/@stdlib/plot/components/svg/defs/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/plot/components/svg/graph/package.json
+++ b/lib/node_modules/@stdlib/plot/components/svg/graph/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/plot/components/svg/marks/package.json
+++ b/lib/node_modules/@stdlib/plot/components/svg/marks/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/plot/components/svg/path/package.json
+++ b/lib/node_modules/@stdlib/plot/components/svg/path/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/plot/components/svg/rug/package.json
+++ b/lib/node_modules/@stdlib/plot/components/svg/rug/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/plot/components/svg/symbols/package.json
+++ b/lib/node_modules/@stdlib/plot/components/svg/symbols/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/plot/components/svg/title/package.json
+++ b/lib/node_modules/@stdlib/plot/components/svg/title/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/plot/package.json
+++ b/lib/node_modules/@stdlib/plot/package.json
@@ -13,5 +13,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/plot/plot/package.json
+++ b/lib/node_modules/@stdlib/plot/plot/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/plot/sparklines/unicode/base/package.json
+++ b/lib/node_modules/@stdlib/plot/sparklines/unicode/base/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/plot/sparklines/unicode/column/package.json
+++ b/lib/node_modules/@stdlib/plot/sparklines/unicode/column/package.json
@@ -30,5 +30,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/plot/sparklines/unicode/line/package.json
+++ b/lib/node_modules/@stdlib/plot/sparklines/unicode/line/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/plot/sparklines/unicode/tristate/package.json
+++ b/lib/node_modules/@stdlib/plot/sparklines/unicode/tristate/package.json
@@ -30,5 +30,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/plot/sparklines/unicode/win-loss/package.json
+++ b/lib/node_modules/@stdlib/plot/sparklines/unicode/win-loss/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/plot/unicode/stemleaf/package.json
+++ b/lib/node_modules/@stdlib/plot/unicode/stemleaf/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/regexp/dirname-posix/package.json
+++ b/lib/node_modules/@stdlib/regexp/dirname-posix/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/regexp/dirname-windows/package.json
+++ b/lib/node_modules/@stdlib/regexp/dirname-windows/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/regexp/dirname/package.json
+++ b/lib/node_modules/@stdlib/regexp/dirname/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/regexp/eol/package.json
+++ b/lib/node_modules/@stdlib/regexp/eol/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/regexp/extname-posix/package.json
+++ b/lib/node_modules/@stdlib/regexp/extname-posix/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/regexp/extname-windows/package.json
+++ b/lib/node_modules/@stdlib/regexp/extname-windows/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/regexp/extname/package.json
+++ b/lib/node_modules/@stdlib/regexp/extname/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/regexp/function-name/package.json
+++ b/lib/node_modules/@stdlib/regexp/function-name/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/regexp/package.json
+++ b/lib/node_modules/@stdlib/regexp/package.json
@@ -21,5 +21,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/regexp/regexp/package.json
+++ b/lib/node_modules/@stdlib/regexp/regexp/package.json
@@ -21,5 +21,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/repl/package.json
+++ b/lib/node_modules/@stdlib/repl/package.json
@@ -18,5 +18,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/streams/base/package.json
+++ b/lib/node_modules/@stdlib/streams/base/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/streams/base/stderr/package.json
+++ b/lib/node_modules/@stdlib/streams/base/stderr/package.json
@@ -18,5 +18,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/streams/base/stdin/package.json
+++ b/lib/node_modules/@stdlib/streams/base/stdin/package.json
@@ -18,5 +18,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/streams/base/stdout/package.json
+++ b/lib/node_modules/@stdlib/streams/base/stdout/package.json
@@ -18,5 +18,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/streams/math/package.json
+++ b/lib/node_modules/@stdlib/streams/math/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/streams/package.json
+++ b/lib/node_modules/@stdlib/streams/package.json
@@ -21,5 +21,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/streams/utils/debug/package.json
+++ b/lib/node_modules/@stdlib/streams/utils/debug/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/streams/utils/inspect/package.json
+++ b/lib/node_modules/@stdlib/streams/utils/inspect/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/streams/utils/join/package.json
+++ b/lib/node_modules/@stdlib/streams/utils/join/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/streams/utils/package.json
+++ b/lib/node_modules/@stdlib/streams/utils/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/streams/utils/split/package.json
+++ b/lib/node_modules/@stdlib/streams/utils/split/package.json
@@ -33,5 +33,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/streams/utils/transform/package.json
+++ b/lib/node_modules/@stdlib/streams/utils/transform/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/string/capitalize/package.json
+++ b/lib/node_modules/@stdlib/string/capitalize/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/string/ends-with/package.json
+++ b/lib/node_modules/@stdlib/string/ends-with/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/string/left-pad/package.json
+++ b/lib/node_modules/@stdlib/string/left-pad/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/string/left-trim/package.json
+++ b/lib/node_modules/@stdlib/string/left-trim/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/string/lowercase/package.json
+++ b/lib/node_modules/@stdlib/string/lowercase/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/string/package.json
+++ b/lib/node_modules/@stdlib/string/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/string/pad/package.json
+++ b/lib/node_modules/@stdlib/string/pad/package.json
@@ -33,5 +33,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/string/remove-punctuation/package.json
+++ b/lib/node_modules/@stdlib/string/remove-punctuation/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/string/repeat/package.json
+++ b/lib/node_modules/@stdlib/string/repeat/package.json
@@ -32,5 +32,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/string/replace/package.json
+++ b/lib/node_modules/@stdlib/string/replace/package.json
@@ -30,5 +30,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/string/right-pad/package.json
+++ b/lib/node_modules/@stdlib/string/right-pad/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/string/right-trim/package.json
+++ b/lib/node_modules/@stdlib/string/right-trim/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/string/starts-with/package.json
+++ b/lib/node_modules/@stdlib/string/starts-with/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/string/trim/package.json
+++ b/lib/node_modules/@stdlib/string/trim/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/string/uncapitalize/package.json
+++ b/lib/node_modules/@stdlib/string/uncapitalize/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/string/uppercase/package.json
+++ b/lib/node_modules/@stdlib/string/uppercase/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/tools/disposable-http-server/package.json
+++ b/lib/node_modules/@stdlib/tools/disposable-http-server/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/tools/package.json
+++ b/lib/node_modules/@stdlib/tools/package.json
@@ -18,5 +18,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/tools/simple-http-server/package.json
+++ b/lib/node_modules/@stdlib/tools/simple-http-server/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/constructor-name/package.json
+++ b/lib/node_modules/@stdlib/utils/constructor-name/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/contains/package.json
+++ b/lib/node_modules/@stdlib/utils/contains/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/copy/package.json
+++ b/lib/node_modules/@stdlib/utils/copy/package.json
@@ -47,5 +47,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/cwd/package.json
+++ b/lib/node_modules/@stdlib/utils/cwd/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/define-read-only-property/package.json
+++ b/lib/node_modules/@stdlib/utils/define-read-only-property/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/detect-class-support/package.json
+++ b/lib/node_modules/@stdlib/utils/detect-class-support/package.json
@@ -34,5 +34,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/detect-function-name-support/package.json
+++ b/lib/node_modules/@stdlib/utils/detect-function-name-support/package.json
@@ -32,5 +32,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/detect-generator-support/package.json
+++ b/lib/node_modules/@stdlib/utils/detect-generator-support/package.json
@@ -35,5 +35,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/detect-map-support/package.json
+++ b/lib/node_modules/@stdlib/utils/detect-map-support/package.json
@@ -31,5 +31,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/detect-set-support/package.json
+++ b/lib/node_modules/@stdlib/utils/detect-set-support/package.json
@@ -31,5 +31,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/detect-symbol-support/package.json
+++ b/lib/node_modules/@stdlib/utils/detect-symbol-support/package.json
@@ -31,5 +31,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/detect-tostringtag-support/package.json
+++ b/lib/node_modules/@stdlib/utils/detect-tostringtag-support/package.json
@@ -35,5 +35,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/detect-weakmap-support/package.json
+++ b/lib/node_modules/@stdlib/utils/detect-weakmap-support/package.json
@@ -33,5 +33,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/detect-weakset-support/package.json
+++ b/lib/node_modules/@stdlib/utils/detect-weakset-support/package.json
@@ -33,5 +33,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/dirname/package.json
+++ b/lib/node_modules/@stdlib/utils/dirname/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/eval/package.json
+++ b/lib/node_modules/@stdlib/utils/eval/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/extname/package.json
+++ b/lib/node_modules/@stdlib/utils/extname/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/find/package.json
+++ b/lib/node_modules/@stdlib/utils/find/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/function-name/package.json
+++ b/lib/node_modules/@stdlib/utils/function-name/package.json
@@ -21,5 +21,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/identity-function/package.json
+++ b/lib/node_modules/@stdlib/utils/identity-function/package.json
@@ -21,5 +21,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/index-of/package.json
+++ b/lib/node_modules/@stdlib/utils/index-of/package.json
@@ -32,5 +32,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-array-like/package.json
+++ b/lib/node_modules/@stdlib/utils/is-array-like/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-array/package.json
+++ b/lib/node_modules/@stdlib/utils/is-array/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-binary-string/package.json
+++ b/lib/node_modules/@stdlib/utils/is-binary-string/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-boolean/package.json
+++ b/lib/node_modules/@stdlib/utils/is-boolean/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-browser/package.json
+++ b/lib/node_modules/@stdlib/utils/is-browser/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-buffer/package.json
+++ b/lib/node_modules/@stdlib/utils/is-buffer/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-darwin/package.json
+++ b/lib/node_modules/@stdlib/utils/is-darwin/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-electron-main/package.json
+++ b/lib/node_modules/@stdlib/utils/is-electron-main/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-electron-renderer/package.json
+++ b/lib/node_modules/@stdlib/utils/is-electron-renderer/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-electron/package.json
+++ b/lib/node_modules/@stdlib/utils/is-electron/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-email-address/package.json
+++ b/lib/node_modules/@stdlib/utils/is-email-address/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-empty-array/package.json
+++ b/lib/node_modules/@stdlib/utils/is-empty-array/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-even/package.json
+++ b/lib/node_modules/@stdlib/utils/is-even/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-function/package.json
+++ b/lib/node_modules/@stdlib/utils/is-function/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-integer/package.json
+++ b/lib/node_modules/@stdlib/utils/is-integer/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-json/package.json
+++ b/lib/node_modules/@stdlib/utils/is-json/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-little-endian/package.json
+++ b/lib/node_modules/@stdlib/utils/is-little-endian/package.json
@@ -30,5 +30,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-matrix-like/package.json
+++ b/lib/node_modules/@stdlib/utils/is-matrix-like/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-matrix/package.json
+++ b/lib/node_modules/@stdlib/utils/is-matrix/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-nan/package.json
+++ b/lib/node_modules/@stdlib/utils/is-nan/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-negative-integer/package.json
+++ b/lib/node_modules/@stdlib/utils/is-negative-integer/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-node/package.json
+++ b/lib/node_modules/@stdlib/utils/is-node/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-nonnegative-integer/package.json
+++ b/lib/node_modules/@stdlib/utils/is-nonnegative-integer/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-nonnegative-number/package.json
+++ b/lib/node_modules/@stdlib/utils/is-nonnegative-number/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-nonpositive-integer/package.json
+++ b/lib/node_modules/@stdlib/utils/is-nonpositive-integer/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-null/package.json
+++ b/lib/node_modules/@stdlib/utils/is-null/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-number/package.json
+++ b/lib/node_modules/@stdlib/utils/is-number/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-object-like/package.json
+++ b/lib/node_modules/@stdlib/utils/is-object-like/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-object/package.json
+++ b/lib/node_modules/@stdlib/utils/is-object/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-odd/package.json
+++ b/lib/node_modules/@stdlib/utils/is-odd/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-positive-integer/package.json
+++ b/lib/node_modules/@stdlib/utils/is-positive-integer/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-positive-number/package.json
+++ b/lib/node_modules/@stdlib/utils/is-positive-number/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-primitive/package.json
+++ b/lib/node_modules/@stdlib/utils/is-primitive/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-regexp-string/package.json
+++ b/lib/node_modules/@stdlib/utils/is-regexp-string/package.json
@@ -34,5 +34,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-regexp/package.json
+++ b/lib/node_modules/@stdlib/utils/is-regexp/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-string/package.json
+++ b/lib/node_modules/@stdlib/utils/is-string/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-typed-array-like/package.json
+++ b/lib/node_modules/@stdlib/utils/is-typed-array-like/package.json
@@ -33,5 +33,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-typed-array/package.json
+++ b/lib/node_modules/@stdlib/utils/is-typed-array/package.json
@@ -30,5 +30,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-uri/package.json
+++ b/lib/node_modules/@stdlib/utils/is-uri/package.json
@@ -30,5 +30,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-web-worker/package.json
+++ b/lib/node_modules/@stdlib/utils/is-web-worker/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/is-windows/package.json
+++ b/lib/node_modules/@stdlib/utils/is-windows/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/merge/package.json
+++ b/lib/node_modules/@stdlib/utils/merge/package.json
@@ -33,5 +33,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/move-property/package.json
+++ b/lib/node_modules/@stdlib/utils/move-property/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/native-class/package.json
+++ b/lib/node_modules/@stdlib/utils/native-class/package.json
@@ -34,5 +34,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/node-version/package.json
+++ b/lib/node_modules/@stdlib/utils/node-version/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/noop/package.json
+++ b/lib/node_modules/@stdlib/utils/noop/package.json
@@ -25,5 +25,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/num-cpus/package.json
+++ b/lib/node_modules/@stdlib/utils/num-cpus/package.json
@@ -36,5 +36,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/open-url/package.json
+++ b/lib/node_modules/@stdlib/utils/open-url/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/package.json
+++ b/lib/node_modules/@stdlib/utils/package.json
@@ -18,5 +18,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/parallel/package.json
+++ b/lib/node_modules/@stdlib/utils/parallel/package.json
@@ -39,5 +39,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/platform/package.json
+++ b/lib/node_modules/@stdlib/utils/platform/package.json
@@ -32,5 +32,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/read-stdin/package.json
+++ b/lib/node_modules/@stdlib/utils/read-stdin/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/regexp-from-string/package.json
+++ b/lib/node_modules/@stdlib/utils/regexp-from-string/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/tools/array-function/package.json
+++ b/lib/node_modules/@stdlib/utils/tools/array-function/package.json
@@ -20,5 +20,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/tools/array-like-function/package.json
+++ b/lib/node_modules/@stdlib/utils/tools/array-like-function/package.json
@@ -20,5 +20,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/tools/typed-array-function/package.json
+++ b/lib/node_modules/@stdlib/utils/tools/typed-array-function/package.json
@@ -20,5 +20,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/try-function/package.json
+++ b/lib/node_modules/@stdlib/utils/try-function/package.json
@@ -26,5 +26,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/type-of/package.json
+++ b/lib/node_modules/@stdlib/utils/type-of/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/unzip/package.json
+++ b/lib/node_modules/@stdlib/utils/unzip/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/lib/node_modules/@stdlib/utils/zip/package.json
+++ b/lib/node_modules/@stdlib/utils/zip/package.json
@@ -21,5 +21,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/package.json
+++ b/package.json
@@ -94,5 +94,5 @@
   "engines": {
     "node": ">=0.10"
   },
-  "license": "MIT AND BSL-1.0"
+  "license": "Apache-2.0 AND BSL-1.0"
 }

--- a/tools/licenses/infer/package.json
+++ b/tools/licenses/infer/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/licenses/licenses/package.json
+++ b/tools/licenses/licenses/package.json
@@ -28,5 +28,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/licenses/reporters/ambiguous/package.json
+++ b/tools/licenses/reporters/ambiguous/package.json
@@ -31,5 +31,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/licenses/reporters/basic/package.json
+++ b/tools/licenses/reporters/basic/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/licenses/reporters/group/package.json
+++ b/tools/licenses/reporters/group/package.json
@@ -30,5 +30,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/licenses/reporters/no-license/package.json
+++ b/tools/licenses/reporters/no-license/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/licenses/reporters/root-deps/package.json
+++ b/tools/licenses/reporters/root-deps/package.json
@@ -29,5 +29,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/licenses/reporters/summary/package.json
+++ b/tools/licenses/reporters/summary/package.json
@@ -31,5 +31,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/licenses/reporters/whitelist/package.json
+++ b/tools/licenses/reporters/whitelist/package.json
@@ -33,5 +33,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/lint/filenames/package.json
+++ b/tools/lint/filenames/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/ls/module-names/package.json
+++ b/tools/ls/module-names/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/ls/pkgs/package.json
+++ b/tools/ls/pkgs/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/makie/makie/package.json
+++ b/tools/makie/makie/package.json
@@ -20,5 +20,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/makie/plugins/makie-benchmark/package.json
+++ b/tools/makie/plugins/makie-benchmark/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/makie/plugins/makie-complexity/package.json
+++ b/tools/makie/plugins/makie-complexity/package.json
@@ -20,5 +20,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/makie/plugins/makie-examples/package.json
+++ b/tools/makie/plugins/makie-examples/package.json
@@ -18,5 +18,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/makie/plugins/makie-lint-javascript/package.json
+++ b/tools/makie/plugins/makie-lint-javascript/package.json
@@ -20,5 +20,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/makie/plugins/makie-lint-markdown/package.json
+++ b/tools/makie/plugins/makie-lint-markdown/package.json
@@ -21,5 +21,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/makie/plugins/makie-list-module-names/package.json
+++ b/tools/makie/plugins/makie-list-module-names/package.json
@@ -24,5 +24,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/makie/plugins/makie-list-modules/package.json
+++ b/tools/makie/plugins/makie-list-modules/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/makie/plugins/makie-notes/package.json
+++ b/tools/makie/plugins/makie-notes/package.json
@@ -19,5 +19,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/makie/plugins/makie-repl/package.json
+++ b/tools/makie/plugins/makie-repl/package.json
@@ -18,5 +18,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/makie/plugins/makie-test-cov/package.json
+++ b/tools/makie/plugins/makie-test-cov/package.json
@@ -22,5 +22,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/makie/plugins/makie-test-summary/package.json
+++ b/tools/makie/plugins/makie-test-summary/package.json
@@ -20,5 +20,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/makie/plugins/makie-test/package.json
+++ b/tools/makie/plugins/makie-test/package.json
@@ -19,5 +19,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/makie/plugins/makie-view-complexity/package.json
+++ b/tools/makie/plugins/makie-view-complexity/package.json
@@ -21,5 +21,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/makie/plugins/makie-view-cov/package.json
+++ b/tools/makie/plugins/makie-view-cov/package.json
@@ -23,5 +23,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/remark/plugins/remark-html-equation-src-urls/package.json
+++ b/tools/remark/plugins/remark-html-equation-src-urls/package.json
@@ -26,7 +26,6 @@
   ],
   "bugs": {},
   "dependencies": {},
-  "devDependencies": {
-  },
-  "license": "MIT"
+  "devDependencies": {},
+  "license": ""
 }

--- a/tools/remark/plugins/remark-html-equations/package.json
+++ b/tools/remark/plugins/remark-html-equations/package.json
@@ -27,5 +27,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/remark/plugins/remark-svg-equations/package.json
+++ b/tools/remark/plugins/remark-svg-equations/package.json
@@ -27,7 +27,6 @@
   ],
   "bugs": {},
   "dependencies": {},
-  "devDependencies": {
-  },
-  "license": "MIT"
+  "devDependencies": {},
+  "license": ""
 }

--- a/tools/snippets/package.json
+++ b/tools/snippets/package.json
@@ -14,5 +14,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }

--- a/tools/test-cov/tape-istanbul/package.json
+++ b/tools/test-cov/tape-istanbul/package.json
@@ -21,5 +21,5 @@
   "bugs": {},
   "dependencies": {},
   "devDependencies": {},
-  "license": "MIT"
+  "license": ""
 }


### PR DESCRIPTION
Updates the license from MIT to Apache-2.0, where the Apache-2.0 includes additional provisions related to patent termination and indemnification.
