### PR TITLE
Return `NaN` rather than throw if provided invalid numeric values

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/acos/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/acos/README.md
@@ -1,5 +1,4 @@
-acos
-===
+# acos
 
 > Compute the [arccosine][arccosine] of a number.
 
@@ -30,11 +29,11 @@ v = acos( NaN );
 // returns NaN
 ```
 
-The domain of `x` is restricted to `[-1,1]`. If `|x| > 1`, the function will throw a `RangeError`.
+The domain of `x` is restricted to `[-1,1]`. If `|x| > 1`, the function returns `NaN`.
 
 ``` javascript
 var v = acos( -3.14 );
-// throws <RangeError>
+// returns NaN
 ```
 
 <!-- </usage> -->

--- a/lib/node_modules/@stdlib/math/base/special/acos/lib/acos.js
+++ b/lib/node_modules/@stdlib/math/base/special/acos/lib/acos.js
@@ -41,7 +41,6 @@ var MOREBITS = 6.123233995736765886130e-17; // pi/2 = PIO2 + MOREBITS.
 * Computes the arccosine of a number.
 *
 * @param {number} x - input value
-* @throws {RangeError} must provide a value on the interval `[-1,1]`
 * @returns {number} arccosine (in radians)
 *
 * @example
@@ -60,7 +59,7 @@ function acos( x ) {
 		return NaN;
 	}
 	if ( x < -1.0 || x > 1.0 ) {
-		throw new RangeError( 'invalid input argument. Must provide a value on the interval `[-1,1]`. Value: `' + x + '`.' );
+		return NaN;
 	}
 	if ( x > 0.5 ) {
 		return 2.0 * asin( sqrt( 0.5 - 0.5*x ) );

--- a/lib/node_modules/@stdlib/math/base/special/acos/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/acos/test/test.js
@@ -103,7 +103,7 @@ tape( 'the function returns `NaN` if provided a `NaN`', function test( t ) {
 	t.end();
 });
 
-tape( 'the function throws an error if provided a value less than `-1`', function test( t ) {
+tape( 'the function returns `NaN` if provided a value less than `-1`', function test( t ) {
 	var v;
 	var i;
 	for ( i = 0; i < 1e4; i++ ) {
@@ -113,7 +113,7 @@ tape( 'the function throws an error if provided a value less than `-1`', functio
 	t.end();
 });
 
-tape( 'the function throws an error if provided a value greater than `+1`', function test( t ) {
+tape( 'the function returns `NaN` if provided a value greater than `+1`', function test( t ) {
 	var v;
 	var i;
 	for ( i = 0; i < 1e4; i++ ) {

--- a/lib/node_modules/@stdlib/math/base/special/acos/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/acos/test/test.js
@@ -108,15 +108,9 @@ tape( 'the function throws an error if provided a value less than `-1`', functio
 	var i;
 	for ( i = 0; i < 1e4; i++ ) {
 		v = -randu()*1e6 - (1+EPS);
-		t.throws( badValue( v ), RangeError, 'throws a range error when provided '+v );
+		t.equal( isnan( acos( v ) ), true, 'returns NaN when provided '+v );
 	}
 	t.end();
-
-	function badValue( value ) {
-		return function badValue() {
-			acos( value );
-		};
-	}
 });
 
 tape( 'the function throws an error if provided a value greater than `+1`', function test( t ) {
@@ -124,13 +118,7 @@ tape( 'the function throws an error if provided a value greater than `+1`', func
 	var i;
 	for ( i = 0; i < 1e4; i++ ) {
 		v = randu()*1e6 + 1 + EPS;
-		t.throws( badValue( v ), RangeError, 'throws a range error when provided '+v );
+		t.equal( isnan( acos( v ) ), true, 'returns NaN when provided '+v );
 	}
 	t.end();
-
-	function badValue( value ) {
-		return function badValue() {
-			acos( value );
-		};
-	}
 });

--- a/lib/node_modules/@stdlib/math/base/special/acosh/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/acosh/README.md
@@ -1,5 +1,4 @@
-acosh
-===
+# acosh
 
 > Compute the [hyperbolic arccosine][hyperbolic-arccosine] of a number.
 
@@ -27,11 +26,11 @@ v = acosh( 0.5 );
 // returns NaN
 ```
 
-The domain of `x` is restricted to `[1,+infinity)`. If `x < 1`, the function will throw a `RangeError`.
+The domain of `x` is restricted to `[1,+infinity)`. If `x < 1`, the function will return `NaN`.
 
 ``` javascript
 var v = acos( 0.0 );
-// throws <RangeError>
+// returns NaN
 ```
 
 <!-- </usage> -->

--- a/lib/node_modules/@stdlib/math/base/special/acosh/lib/acosh.js
+++ b/lib/node_modules/@stdlib/math/base/special/acosh/lib/acosh.js
@@ -63,7 +63,6 @@ var HUGE = 1 << 28; // 2**28
 * ```
 *
 * @param {number} x - input value
-* @throws {RangeError} must provide a value on the interval `[1,+infinity)`
 * @returns {number} hyperbolic arccosine (in radians)
 *
 * @example
@@ -82,7 +81,7 @@ function acosh( x ) {
 		return NaN;
 	}
 	if ( x < 1.0 ) {
-		throw new RangeError( 'invalid input argument. Must provide a value on the interval `[1,+infinity)`. Value: `' + x + '`.' );
+		return NaN;
 	}
 	if ( x === 1.0 ) {
 		return 0.0;

--- a/lib/node_modules/@stdlib/math/base/special/acosh/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/acosh/test/test.js
@@ -128,19 +128,13 @@ tape( 'the function returns `NaN` if provided a `NaN`', function test( t ) {
 	t.end();
 });
 
-tape( 'the function throws a range error if provided value less than `1`', function test( t ) {
+tape( 'the function returns `NaN` if provided value less than `1`', function test( t ) {
 	var v;
 	var i;
 
 	for ( i = 0; i < 1e3; i++ ) {
 		v = -randu()*1e6 + (1-EPS);
-		t.throws( badValue( v ), RangeError, 'throws a range error when provided '+v );
+		t.equal( isnan( acosh( v ) ), true, 'returns NaN when provided '+v );
 	}
 	t.end();
-
-	function badValue( value ) {
-		return function badValue() {
-			acosh( value );
-		};
-	}
 });

--- a/lib/node_modules/@stdlib/math/base/special/asin/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/asin/README.md
@@ -1,5 +1,4 @@
-asin
-===
+# asin
 
 > Compute the [arcsine][arcsine] of a number.
 
@@ -27,11 +26,11 @@ v = asin( -Math.PI/6.0 );
 // returns ~-0.5
 ```
 
-The domain of `x` is restricted to `[-1,1]`. If `|x| > 1`, the function will throw a `RangeError`.
+The domain of `x` is restricted to `[-1,1]`. If `|x| > 1`, the function returns `NaN`.
 
 ``` javascript
 var v = asin( -3.14 );
-// throws <RangeError>
+// returns NaN
 ```
 
 <!-- </usage> -->

--- a/lib/node_modules/@stdlib/math/base/special/asin/lib/asin.js
+++ b/lib/node_modules/@stdlib/math/base/special/asin/lib/asin.js
@@ -90,7 +90,6 @@ var ratevalRS = evalrational( R, S );
 * Computes the arcsine of a number.
 *
 * @param {number} x - input value
-* @throws {RangeError} must provide a value on the interval `[-1,1]`
 * @returns {number} arcsine (in radians)
 *
 * @example
@@ -123,7 +122,7 @@ function asin( x ) {
 		a = -x;
 	}
 	if ( a > 1.0 ) {
-		throw new RangeError( 'invalid input argument. Must provide a value on the interval `[-1,1]`. Value: `' + x + '`.' );
+		return NaN;
 	}
 	if ( a > 0.625 ) {
 		// arcsin(1-x) = pi/2 - sqrt(2x)(1+R(x))

--- a/lib/node_modules/@stdlib/math/base/special/asin/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/asin/test/test.js
@@ -114,7 +114,7 @@ tape( 'the function returns `NaN` if provided a value less than `-1`', function 
 	t.end();
 });
 
-tape( 'the function throws a range error if provided a value greater than `+1`', function test( t ) {
+tape( 'the function returns `NaN` if provided a value greater than `+1`', function test( t ) {
 	var v;
 	var i;
 

--- a/lib/node_modules/@stdlib/math/base/special/asin/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/asin/test/test.js
@@ -103,21 +103,15 @@ tape( 'the function returns `NaN` if provided a `NaN`', function test( t ) {
 	t.end();
 });
 
-tape( 'the function throws a range error if provided a value less than `-1`', function test( t ) {
+tape( 'the function returns `NaN` if provided a value less than `-1`', function test( t ) {
 	var v;
 	var i;
 
 	for ( i = 0; i < 1e3; i++ ) {
 		v = -randu()*1e6 - (1.0-EPS);
-		t.throws( badValue( v ), RangeError, 'throws a range error when provided '+v );
+		t.equal( isnan( asin( v ) ), true, 'returns NaN when provided '+v );
 	}
 	t.end();
-
-	function badValue( value ) {
-		return function badValue() {
-			asin( value );
-		};
-	}
 });
 
 tape( 'the function throws a range error if provided a value greater than `+1`', function test( t ) {
@@ -126,13 +120,7 @@ tape( 'the function throws a range error if provided a value greater than `+1`',
 
 	for ( i = 0; i < 1e3; i++ ) {
 		v = randu()*1e6 + 1.0 + EPS;
-		t.throws( badValue( v ), RangeError, 'throws a range error when provided '+v );
+		t.equal( isnan( asin( v ) ), true, 'returns NaN when provided '+v );
 	}
 	t.end();
-
-	function badValue( value ) {
-		return function badValue() {
-			asin( value );
-		};
-	}
 });

--- a/lib/node_modules/@stdlib/math/base/special/atanh/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/atanh/README.md
@@ -1,5 +1,4 @@
-atanh
-===
+# atanh
 
 > Compute the [hyperbolic arctangent][hyperbolic-arctangent] of a number.
 
@@ -36,11 +35,11 @@ v = atanh( -1.0 );
 // returns Number.NEGATIVE_INFINITY
 ```
 
-The domain of `x` is restricted to `[-1,1]`. If `|x| > 1`, the function will throw a `RangeError`.
+The domain of `x` is restricted to `[-1,1]`. If `|x| > 1`, the function returns `NaN`.
 
 ``` javascript
 var v = atanh( -3.14 );
-// throws <RangeError>
+// returns NaN
 ```
 
 <!-- </usage> -->

--- a/lib/node_modules/@stdlib/math/base/special/atanh/lib/atanh.js
+++ b/lib/node_modules/@stdlib/math/base/special/atanh/lib/atanh.js
@@ -62,7 +62,6 @@ var NEAR_ZERO = 1.0 / (1 << 28); // 2**-28
 * ```
 *
 * @param {number} x - input value
-* @throws {RangeError} must provide a value on the interval `[-1,1]`
 * @returns {number} hyperbolic arctangent (in radians)
 *
 * @example
@@ -88,7 +87,7 @@ function atanh( x ) {
 		return NaN;
 	}
 	if ( x < -1.0 || x > 1.0 ) {
-		throw new RangeError( 'invalid input argument. Must provide a value on the interval `[-1,1]`. Value: `' + x + '`.' );
+		return NaN;
 	}
 	if ( x === 1.0 ) {
 		return PINF;

--- a/lib/node_modules/@stdlib/math/base/special/atanh/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/atanh/test/test.js
@@ -119,32 +119,20 @@ tape( 'the function throws a range error if provided a value less than `-1`', fu
 
 	for ( i = 0; i < 1e3; i++ ) {
 		v = -randu()*1e6 - (1.0+EPS);
-		t.throws( badValue( v ), RangeError, 'throws a range error when provided '+v );
+		t.equal( isnan( atanh( v ) ), true, 'returns NaN when provided '+v );
 	}
 	t.end();
-
-	function badValue( v ) {
-		return function badValue() {
-			atanh( v );
-		};
-	}
 });
 
-tape( 'the function throws a range error if provided a value greater than `1`', function test( t ) {
+tape( 'the function returns `NaN` if provided a value greater than `1`', function test( t ) {
 	var v;
 	var i;
 
 	for ( i = 0; i < 1e3; i++ ) {
 		v = randu()*1e6 + 1.0 + EPS;
-		t.throws( badValue( v ), RangeError, 'throws a range error when provided '+v );
+		t.equal( isnan( atanh( v ) ), true, 'returns NaN when provided '+v );
 	}
 	t.end();
-
-	function badValue( v ) {
-		return function badValue() {
-			atanh( v );
-		};
-	}
 });
 
 tape( 'the function returns `-0` if provided `-0`', function test( t ) {

--- a/lib/node_modules/@stdlib/math/base/special/atanh/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/atanh/test/test.js
@@ -113,7 +113,7 @@ tape( 'the function returns `-Infinity` if provided `-1.0`', function test( t ) 
 	t.end();
 });
 
-tape( 'the function throws a range error if provided a value less than `-1`', function test( t ) {
+tape( 'the function returns `NaN` if provided a value less than `-1`', function test( t ) {
 	var v;
 	var i;
 

--- a/lib/node_modules/@stdlib/math/base/special/binomcoef/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoef/README.md
@@ -1,5 +1,4 @@
-Binomial Coefficient
-===
+# Binomial Coefficient
 
 > Compute the [binomial coefficient][binomial-coefficient].
 
@@ -76,6 +75,16 @@ var v = binomcoef( 2, -1 );
 
 v = binomcoef( -3, -1 );
 // returns 0
+```
+
+The function returns `NaN` for non-integer `n` or `k`.
+
+``` javascript
+var v = binomcoef( 2, 1.5 );
+// returns NaN
+
+v = binomcoef( 5.5, 2 );
+// returns NaN
 ```
 
 <!-- </usage> -->

--- a/lib/node_modules/@stdlib/math/base/special/binomcoef/lib/binomcoef.js
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoef/lib/binomcoef.js
@@ -32,7 +32,7 @@ function binomcoef( n, k ) {
 		return NaN;
 	}
 	if ( !isInteger( n ) || !isInteger( k ) ) {
-		throw new TypeError( 'invalid input argument(s). Both arguments must be integers. n: `' + n + '`.' + 'k: `' + k + '`' );
+		return NaN;
 	}
 	if ( k < 0 ) {
 		return 0;

--- a/lib/node_modules/@stdlib/math/base/special/binomcoef/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoef/test/test.js
@@ -57,7 +57,7 @@ tape( 'the function evaluates the binomial coefficient for integers `m` and `k`'
 	t.end();
 });
 
-tape( 'the function throws an error if the `n` value is not an integer or `NaN`', function test( t ) {
+tape( 'the function returns `NaN` if the `n` value is not an integer', function test( t ) {
 	var values;
 	var i;
 
@@ -73,18 +73,12 @@ tape( 'the function throws an error if the `n` value is not an integer or `NaN`'
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+		t.equal( isnan( binomcoef( values[i], 2 ) ), true, 'returns NaN when provided '+values[i] );
 	}
 	t.end();
-
-	function badValue( value ) {
-		return function() {
-			binomcoef( value, 2 );
-		};
-	}
 });
 
-tape( 'the function throws an error if the `k` value is not an integer or `NaN`', function test( t ) {
+tape( 'the function returns `NaN` if the `k` value is not an integer', function test( t ) {
 	var values;
 	var i;
 
@@ -100,15 +94,9 @@ tape( 'the function throws an error if the `k` value is not an integer or `NaN`'
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+		t.equal( isnan( binomcoef( 2, values[i] ) ), true, 'returns NaN when provided '+values[i] );
 	}
 	t.end();
-
-	function badValue( value ) {
-		return function() {
-			binomcoef( 2, value );
-		};
-	}
 });
 
 tape( 'the function returns `0` for a negative integer `k`', function test( t ) {

--- a/lib/node_modules/@stdlib/math/base/special/binomcoefln/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoefln/README.md
@@ -1,5 +1,4 @@
-Logarithm of Binomial Coefficient
-===
+# Logarithm of Binomial Coefficient
 
 > Compute the natural logarithm of the [binomial coefficient][binomial-coefficient].
 
@@ -88,6 +87,16 @@ var v = binomcoefln( 2, -1 );
 
 v = binomcoefln( -3, -1 );
 // returns Number.NEGATIVE_INFINITY
+```
+
+The function returns `NaN` for non-integer `n` or `k`.
+
+``` javascript
+var v = binomcoefln( 2, 1.5 );
+// returns NaN
+
+v = binomcoefln( 5.5, 2 );
+// returns NaN
 ```
 
 <!-- </usage> -->

--- a/lib/node_modules/@stdlib/math/base/special/binomcoefln/lib/binomcoefln.js
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoefln/lib/binomcoefln.js
@@ -46,7 +46,7 @@ function binomcoefln( n, k  ) {
 		return NaN;
 	}
 	if ( !isInteger( n ) || !isInteger( k ) ) {
-		throw new TypeError( 'invalid input argument(s). Both arguments must be integers. n: `' + n + '`.' + 'k: `' + k + '`' );
+		return NaN;
 	}
 	if ( n < 0.0 ) {
 		return binomcoefln( -n + k - 1.0, k );

--- a/lib/node_modules/@stdlib/math/base/special/binomcoefln/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoefln/test/test.js
@@ -64,7 +64,7 @@ tape( 'the function evaluates the binomial coefficient for integers `m` and `k`'
 	t.end();
 });
 
-tape( 'the function throws an error if the `n` value is not an integer or `NaN`', function test( t ) {
+tape( 'the function returns `NaN` if the `n` value is not an integer', function test( t ) {
 	var values;
 	var i;
 
@@ -80,18 +80,12 @@ tape( 'the function throws an error if the `n` value is not an integer or `NaN`'
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+		t.equal( isnan( binomcoefln( values[i], 2 ) ), true, 'returns NaN when provided '+values[i] );
 	}
 	t.end();
-
-	function badValue( value ) {
-		return function() {
-			binomcoefln( value, 2 );
-		};
-	}
 });
 
-tape( 'the function throws an error if the `k` value is not an integer or `NaN`', function test( t ) {
+tape( 'the function returns `NaN` if the `k` value is not an integer', function test( t ) {
 	var values;
 	var i;
 
@@ -107,15 +101,9 @@ tape( 'the function throws an error if the `k` value is not an integer or `NaN`'
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+		t.equal( isnan( binomcoefln( 2, values[i] ) ), true, 'returns NaN when provided '+values[i] );
 	}
 	t.end();
-
-	function badValue( value ) {
-		return function() {
-			binomcoefln( 2, value );
-		};
-	}
 });
 
 tape( 'the function returns `-Infinity` for a negative integer `k`', function test( t ) {

--- a/lib/node_modules/@stdlib/math/base/special/erfcinv/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/erfcinv/README.md
@@ -1,5 +1,4 @@
-erfcinv
-===
+# erfcinv
 
 > [Inverse complementary error function][erfcinv].
 
@@ -47,11 +46,11 @@ y = erfcinv( 2.0 );
 // returns Number.NEGATIVE_INFINITY
 ```
 
-The domain of `x` is restricted to `[0,2]`. If `x` is outside this interval, the function will throw a `RangeError`.
+The domain of `x` is restricted to `[0,2]`. If `x` is outside this interval, the function returns `NaN`.
 
 ``` javascript
 var y = erfcinv( -3.14 );
-// throws <RangeError>
+// returns NaN
 ```
 
 If provided `NaN`, the function returns `NaN`.

--- a/lib/node_modules/@stdlib/math/base/special/erfcinv/lib/erfcinv.js
+++ b/lib/node_modules/@stdlib/math/base/special/erfcinv/lib/erfcinv.js
@@ -231,7 +231,6 @@ var rationalFcnR5 = evalrational( P5, Q5 );
 *
 *
 * @param {number} x - input value
-* @throws {RangeError} must provide a number on the interval `[0,2]`
 * @returns {number} function value
 *
 * @example
@@ -274,7 +273,7 @@ function erfcinv( x ) {
 		return 0.0;
 	}
 	if ( x > 2.0 || x < 0.0 ) {
-		throw new RangeError( 'invalid input argument. Input argument must be on the interval `[0,2]`. Value: `' + x + '`.' );
+		return NaN;
 	}
 	// Argument reduction (reduce to interval [0,1]). If `x` is outside [0,1], we can take advantage of the complementary error function reflection formula: `erfc(-z) = 2 - erfc(z)`, by negating the result once finished.
 	if ( x > 1.0 ) {

--- a/lib/node_modules/@stdlib/math/base/special/erfcinv/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/erfcinv/test/test.js
@@ -64,8 +64,9 @@ tape( 'if provided `1`, the function returns `0`', function test( t ) {
 	t.end();
 });
 
-tape( 'if provided a value which is either less than `0` or greater than `2`, the function throws a range error', function test( t ) {
+tape( 'if provided a value which is either less than `0` or greater than `2`, the function returns `NaN`', function test( t ) {
 	var values;
+	var v;
 	var i;
 
 	values = [
@@ -78,15 +79,10 @@ tape( 'if provided a value which is either less than `0` or greater than `2`, th
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		t.throws( badValue( values[i] ), RangeError, 'throws range error when provided '+values[i] );
+		v = erfcinv( values[i] );
+		t.equal( isnan( v ), true, 'returns NaN when provided '+values[i] );
 	}
 	t.end();
-
-	function badValue( value ) {
-		return function badValue() {
-			erfcinv( value );
-		};
-	}
 });
 
 tape( 'the function evaluates the inverse complementary error function for `x` on the interval `[0.5,1.5]', function test( t ) {

--- a/lib/node_modules/@stdlib/math/base/special/erfinv/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/erfinv/README.md
@@ -1,5 +1,4 @@
-erfinv
-===
+# erfinv
 
 > [Inverse error function][inverse-error-function].
 
@@ -56,11 +55,11 @@ y = erfinv( 1.0 );
 // returns Number.POSITIVE_INFINITY
 ```
 
-The domain of `x` is restricted to `[-1,1]`. If `|x| > 1`, the function will throw a `RangeError`.
+The domain of `x` is restricted to `[-1,1]`. If `|x| > 1`, the function returns `NaN`.
 
 ``` javascript
 var y = erfinv( -3.14 );
-// throws <RangeError>
+// returns NaN
 ```
 
 If provided `NaN`, the function returns `NaN`.

--- a/lib/node_modules/@stdlib/math/base/special/erfinv/lib/erfinv.js
+++ b/lib/node_modules/@stdlib/math/base/special/erfinv/lib/erfinv.js
@@ -225,7 +225,6 @@ var rationalFcnR5 = evalrational( P5, Q5 );
 *
 *
 * @param {number} x - input value
-* @throws {RangeError} must provide a number on the interval `[-1,1]`
 * @returns {number} function value
 *
 * @example
@@ -276,7 +275,7 @@ function erfinv( x ) {
 	}
 	// Special case: |x| > 1 (range error)
 	if ( x > 1.0 || x < -1.0 ) {
-		throw new RangeError( 'invalid input argument. Input argument must be on the interval `[-1,1]`. Value: `' + x + '`.' );
+		return NaN;
 	}
 	// Argument reduction (reduce to interval [0,1]). If `x` is negative, we can safely negate the value, taking advantage of the error function being an odd function; i.e., `erf(-x) = -erf(x)`.
 	if ( x < 0.0 ) {

--- a/lib/node_modules/@stdlib/math/base/special/erfinv/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/erfinv/test/test.js
@@ -70,7 +70,7 @@ tape( 'if provided `0`, the function returns `0`', function test( t ) {
 	t.end();
 });
 
-tape( 'if provided a value which is either less than `-1` or greater than `1`, the function throws a range error', function test( t ) {
+tape( 'if provided a value which is either less than `-1` or greater than `1`, the function returns `NaN`', function test( t ) {
 	var values;
 	var i;
 	var v;

--- a/lib/node_modules/@stdlib/math/base/special/erfinv/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/erfinv/test/test.js
@@ -73,6 +73,7 @@ tape( 'if provided `0`, the function returns `0`', function test( t ) {
 tape( 'if provided a value which is either less than `-1` or greater than `1`, the function throws a range error', function test( t ) {
 	var values;
 	var i;
+	var v;
 
 	values = [
 		3.14,
@@ -84,15 +85,10 @@ tape( 'if provided a value which is either less than `-1` or greater than `1`, t
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		t.throws( badValue( values[i] ), RangeError, 'throws range error when provided '+values[i] );
+		v = erfinv( values[i] );
+		t.equal( isnan( v ), true, 'returns NaN when provided '+values[i] );
 	}
 	t.end();
-
-	function badValue( value ) {
-		return function badValue() {
-			erfinv( value );
-		};
-	}
 });
 
 tape( 'the function evaluates the inverse error function for `x` on the interval `[-0.5,0.5]', function test( t ) {

--- a/lib/node_modules/@stdlib/math/base/special/sinpi/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/sinpi/README.md
@@ -1,5 +1,4 @@
-sinpi
-===
+# sinpi
 
 > Compute the [sine][sin] of a number times [π][pi].
 

--- a/lib/node_modules/@stdlib/math/base/special/sinpi/lib/sinpi.js
+++ b/lib/node_modules/@stdlib/math/base/special/sinpi/lib/sinpi.js
@@ -26,7 +26,6 @@ var PI = require( '@stdlib/math/constants/float64-pi' );
 * Computes the value of `sin(πx)`.
 *
 * @param {number} x - input value
-* @throws {RangeError} must provide a finite number
 * @returns {number} function value
 *
 * @example
@@ -49,8 +48,7 @@ function sinpi( x ) {
 		return NaN;
 	}
 	if ( isInfinite( x ) ) {
-		// TODO: should we throw or return NaN?
-		throw new RangeError( 'invalid input argument. Must provide a finite number. Value: `' + x + '`.' );
+		return NaN;
 	}
 	// Argument reduction (reduce to [0,2))...
 	r = x % 2.0; // sign preserving

--- a/lib/node_modules/@stdlib/math/base/special/sinpi/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/sinpi/test/test.js
@@ -25,17 +25,12 @@ tape( 'main export is a function', function test( t ) {
 	t.end();
 });
 
-tape( 'the function throws a range error if provided either positive or negative infinity', function test( t ) {
-	t.throws( foo, RangeError, 'throws range error' );
-	t.throws( bar, RangeError, 'throws range error' );
+tape( 'the function returns `NaN` if provided either positive or negative infinity', function test( t ) {
+	var v = sinpi( PINF );
+	t.equal( isnan( v ), true, 'returns NaN if provided +Infinity' );
+	v = sinpi( NINF );
+	t.equal( isnan( v ), true, 'returns NaN if provided -Infinity' );
 	t.end();
-
-	function foo() {
-		sinpi( PINF );
-	}
-	function bar() {
-		sinpi( NINF );
-	}
 });
 
 tape( 'if provided `NaN`, the function returns `NaN`', function test( t ) {


### PR DESCRIPTION
This pull request changes base special functions from throwing errors to consistently returning `NaN`. 
