### PR TITLE
Replace internal constants with package constants

### DIFF
--- a/lib/node_modules/@stdlib/math/base/dist/cauchy/quantile/test/test.quantile.js
+++ b/lib/node_modules/@stdlib/math/base/dist/cauchy/quantile/test/test.quantile.js
@@ -118,7 +118,7 @@ tape( 'the function evaluates the quantile function at `p` given parameters `x0`
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 50.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. x0: '+x0[i]+'. gamma: '+gamma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. x0: '+x0[i]+'. gamma: '+gamma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();
@@ -145,7 +145,7 @@ tape( 'the function evaluates the quantile function at `p` given parameters `x0`
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 125.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. x0: '+x0[i]+'. gamma: '+gamma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. x0: '+x0[i]+'. gamma: '+gamma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();
@@ -173,7 +173,7 @@ tape( 'the function evaluates the quantile function at `p` given parameters `x0`
 		} else {
 			delta = abs( y - expected[ i ] );
 			tol = 50.0 * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[ i ]+'. x0: '+x0[i]+'. gamma: '+gamma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			t.ok( delta <= tol, 'within tolerance. p: '+p[ i ]+'. x0: '+x0[i]+'. gamma: '+gamma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/math/base/special/acos/lib/acos.js
+++ b/lib/node_modules/@stdlib/math/base/special/acos/lib/acos.js
@@ -27,11 +27,11 @@
 var isnan = require( '@stdlib/math/base/utils/is-nan' );
 var asin = require( '@stdlib/math/base/special/asin' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
+var PIO4 = require( '@stdlib/math/constants/float64-fourth-pi' );
 
 
 // VARIABLES //
 
-var PIO4 = 7.85398163397448309616e-1; // pi/4
 var MOREBITS = 6.123233995736765886130e-17; // pi/2 = PIO2 + MOREBITS.
 
 

--- a/lib/node_modules/@stdlib/math/base/special/asin/lib/asin.js
+++ b/lib/node_modules/@stdlib/math/base/special/asin/lib/asin.js
@@ -27,11 +27,11 @@
 var evalrational = require( '@stdlib/math/base/tools/evalrational' ).factory;
 var isnan = require( '@stdlib/math/base/utils/is-nan' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
+var PIO4 = require( '@stdlib/math/constants/float64-fourth-pi' );
 
 
 // VARIABLES //
 
-var PIO4 = 7.85398163397448309616e-1; // pi/4
 var MOREBITS = 6.123233995736765886130e-17; // pi/2 = PIO2 + MOREBITS.
 
 /*

--- a/lib/node_modules/@stdlib/math/base/special/atan/lib/atan.js
+++ b/lib/node_modules/@stdlib/math/base/special/atan/lib/atan.js
@@ -27,6 +27,8 @@
 var evalpoly = require( '@stdlib/math/base/tools/evalpoly' ).factory;
 var isnan = require( '@stdlib/math/base/utils/is-nan' );
 var PINF = require( '@stdlib/math/constants/float64-pinf' );
+var PIO2 = require( '@stdlib/math/constants/float64-half-pi' );
+var PIO4 = require( '@stdlib/math/constants/float64-fourth-pi' );
 var NINF = require( '@stdlib/math/constants/float64-ninf' );
 
 
@@ -47,8 +49,6 @@ var Q = [
 	2.485846490142306297962e1,
 	1.0
 ];
-var PIO2 = 1.57079632679489661923; // pi/2
-var PIO4 = 7.85398163397448309616e-1; // pi/4
 var MOREBITS = 6.123233995736765886130e-17; // pi/2 = PIO2 + MOREBITS.
 var T3P8 = 2.41421356237309504880; // tan( 3*pi/8 )
 


### PR DESCRIPTION
Resolves #74.

<!--lint disable first-heading-level-->

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

* [x] Read, understood, and followed the [contributing guidelines][contributing], including the relevant style guides.
* [x] Read and understand the [Code of Conduct][code-of-conduct].
* [x] Read and understood the [licensing terms][license].
* [x] Searched for existing issues and pull requests __before__ submitting this pull request.
* [x] Filed an issue (or an issue already existed) __prior to__ submitting this pull request.
* [x] Rebased onto latest `develop`.
* [x] Submitted against `develop` branch.


## Description

> What is the purpose of this pull request?

This pull request:

* updates base math implementations for pi/2 and pi/4 to use package constants


## Related Issues

> Does this pull request have any related issues?

This pull request:

* resolves #74


## Questions

> Any questions for reviewers of this pull request?

Yes. I've noticed variable naming in the examples (e.g for pi/4 variables are declared as `FOUTRH_PI`) is different from the names in the function implementation (e.g `PIO4`), is this ok?


## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.


---

@stdlib-js/reviewers


<!-- <links> -->

[contributing]: https://github.com/stdlib-js/stdlib/blob/master/CONTRIBUTING.md
[code-of-conduct]: https://github.com/stdlib-js/stdlib/blob/master/CODE_OF_CONDUCT.md
[license]: https://github.com/stdlib-js/stdlib/blob/master/LICENSE

<!-- </links> -->
