### PR TITLE
Fix pi link address in sincospi readme

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/sincospi/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/sincospi/README.md
@@ -1,6 +1,6 @@
 # sincospi
 
-> Simultaneously compute the [sine][@stdlib/math/base/special/sin] and [cosine][@stdlib/math/base/special/cos] of a number times [π][@stdlib/math/constants/pi].
+> Simultaneously compute the [sine][@stdlib/math/base/special/sin] and [cosine][@stdlib/math/base/special/cos] of a number times [π][@stdlib/math/constants/float64-pi].
 
 <section class="usage">
 
@@ -12,7 +12,7 @@ var sincospi = require( '@stdlib/math/base/special/sincospi' );
 
 #### sincospi( \[out,] x )
 
-Simultaneously computes the [sine][@stdlib/math/base/special/sin] and [cosine][@stdlib/math/base/special/cos] of a `number` times [π][@stdlib/math/constants/pi] more accurately than `sincos(pi*x)`, especially for large `x`.
+Simultaneously computes the [sine][@stdlib/math/base/special/sin] and [cosine][@stdlib/math/base/special/cos] of a `number` times [π][@stdlib/math/constants/float64-pi] more accurately than `sincos(pi*x)`, especially for large `x`.
 
 ```javascript
 var v = sincospi( 0.0 );
@@ -70,7 +70,7 @@ for ( i = 0; i < x.length; i++ ) {
 
 [@stdlib/math/base/special/cos]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/cos
 
-[@stdlib/math/constants/pi]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/constants/float64-pi
+[@stdlib/math/constants/float64-pi]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/constants/float64-pi
 
 </section>
 

--- a/lib/node_modules/@stdlib/math/base/special/sincospi/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/sincospi/README.md
@@ -70,7 +70,7 @@ for ( i = 0; i < x.length; i++ ) {
 
 [@stdlib/math/base/special/cos]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/cos
 
-[@stdlib/math/constants/pi]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/constants/pi
+[@stdlib/math/constants/pi]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/constants/float64-pi
 
 </section>
 


### PR DESCRIPTION
<!--lint disable first-heading-level-->

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing], including the relevant style guides.
-   [x] Read and understand the [Code of Conduct][code-of-conduct].
-   [x] Read and understood the [licensing terms][license].
-   [x] Searched for existing issues and pull requests **before** submitting this pull request.
-   [x] Filed an issue (or an issue already existed) **prior to** submitting this pull request.
-   [x] Rebased onto latest `develop`.
-   [x] Submitted against `develop` branch.

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes the `pi` link in sincospi, which really should have been `float64-pi`, not just `pi`.

* * *

@stdlib-js/reviewers

<!-- <links> -->

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[code-of-conduct]: https://github.com/stdlib-js/stdlib/blob/develop/CODE_OF_CONDUCT.md

[license]: https://github.com/stdlib-js/stdlib/blob/develop/LICENSE

<!-- </links> -->
