### PR TITLE
Modify insert-eqations repository regex to accept colon

### DIFF
--- a/tools/remark/plugins/remark-img-equations-src-urls/lib/git.js
+++ b/tools/remark/plugins/remark-img-equations-src-urls/lib/git.js
@@ -9,7 +9,7 @@ var exec = require( 'child_process' ).execSync;
 // VARIABLES //
 
 // Regular expression to extract a repository slug:
-var RE = /(?:.+github\.com\/)(.+)\.(?:.+)/;
+var RE = /(?:.+github\.com)(?:\/|:)(.+)\.(?:.+)/;
 
 
 // MAIN //


### PR DESCRIPTION
Resolves #138.

<!--lint disable first-heading-level-->

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing], including the relevant style guides.
-   [x] Read and understand the [Code of Conduct][code-of-conduct].
-   [x] Read and understood the [licensing terms][license].
-   [x] Searched for existing issues and pull requests **before** submitting this pull request.
-   [x] Filed an issue (or an issue already existed) **prior to** submitting this pull request.
-   [x] Rebased onto latest `develop`.
-   [x] Submitted against `develop` branch.

## Description

> What is the purpose of this pull request?

This pull request modifies the insert-equations git repo regex to accept `git@github.com:rreusser/stdlib.git` instead of requiring `https://github.com/stdlib-js/stdlib.git`. In other words, it allows a `:` between github.com and stdlib instead of requiring a `/`.

It seems technically correct, but there's a chance this is undesirable since the wrong person running this script would get the rawgit urls incorrect anyway.

It's also possible this may (or may not be) applicable in other places.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

* * *

@stdlib-js/reviewers

<!-- <links> -->

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[code-of-conduct]: https://github.com/stdlib-js/stdlib/blob/develop/CODE_OF_CONDUCT.md

[license]: https://github.com/stdlib-js/stdlib/blob/develop/LICENSE

<!-- </links> -->
