### PR TITLE
Export as 'statistics' instead of 'stats'

### DIFF
--- a/lib/node_modules/@stdlib/math/lib/index.js
+++ b/lib/node_modules/@stdlib/math/lib/index.js
@@ -46,13 +46,13 @@ setReadOnly( ns, 'constants', require( '@stdlib/math/constants' ) );
 setReadOnly( ns, 'random', require( '@stdlib/math/random' ) );
 
 /**
-* @name stats
+* @name statistics
 * @memberof ns
 * @readonly
 * @type {Namespace}
 * @see {@link module:@stdlib/math/statistics}
 */
-setReadOnly( ns, 'stats', require( '@stdlib/math/statistics' ) );
+setReadOnly( ns, 'statistics', require( '@stdlib/math/statistics' ) );
 
 /**
 * @name utils


### PR DESCRIPTION
Exporting as `stats` causes an inconsistency between usage in Node.js (stdlib.math.stats) and browser bundles (stdlib.math.statistics). See https://github.com/stencila/mini-core/pull/1/files#r141970198

<!--lint disable first-heading-level-->

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing], including the relevant style guides.
-   [x] Read and understand the [Code of Conduct][code-of-conduct].
-   [x] Read and understood the [licensing terms][license].
-   [x] Searched for existing issues and pull requests **before** submitting this pull request.
-   [ ] Filed an issue (or an issue already existed) **prior to** submitting this pull request.
-   [x] Rebased onto latest `develop`.
-   [x] Submitted against `develop` branch.

## Description

> What is the purpose of this pull request?

Fixes a possible bug with export of `stdlib.math.statistics`.

Exporting as `stats` causes and inconsistency between usage in Node.js (stdlib.math.stats) and browser bundles (stdlib.math.statistics).

## Related Issues

> Does this pull request have any related issues?

Couldn't find any.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

See https://github.com/stencila/mini-core/pull/1/files#r141970198

* * *

@stdlib-js/reviewers

<!-- <links> -->

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[code-of-conduct]: https://github.com/stdlib-js/stdlib/blob/develop/CODE_OF_CONDUCT.md

[license]: https://github.com/stdlib-js/stdlib/blob/develop/LICENSE

<!-- </links> -->
