### PR TITLE
Feature/incrwmean

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/wmean/README.md
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/README.md
@@ -62,8 +62,7 @@ If provided an input value `x` and a weight `w`, the accumulator function return
 ```javascript
 var accumulator = incrwmean();
 
-// Default weight is 1.0
-var mu = accumulator( 2.0 );
+var mu = accumulator( 2.0, 1.0 );
 // returns 2.0
 
 mu = accumulator( 2.0, 0.5 );

--- a/lib/node_modules/@stdlib/stats/incr/wmean/README.md
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/README.md
@@ -62,7 +62,8 @@ If provided an input value `x` and a weight `w`, the accumulator function return
 ```javascript
 var accumulator = incrwmean();
 
-var mu = accumulator( 2.0, 1.0 );
+// Default weight is 1.0
+var mu = accumulator( 2.0 );
 // returns 2.0
 
 mu = accumulator( 2.0, 0.5 );

--- a/lib/node_modules/@stdlib/stats/incr/wmean/README.md
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/README.md
@@ -1,0 +1,129 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2019 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# incrwmean
+
+> Compute a [weighted arithmetic mean][weighted-arithmetic-mean] incrementally.
+
+<section class="intro">
+
+The [weighted arithmetic mean][weighted-arithmetic-mean] is defined as
+
+<!-- <equation class="equation" label="eq:arithmetic_mean" align="center" raw="{\bar {x}}={\frac {\sum \limits _{i=1}^{n}w_{i}x_{i}}{\sum \limits _{i=1}^{n}w_{i}}}" alt="Equation for the arithmetic mean."> -->
+
+<div class="equation" align="center" data-raw-text="{\bar {x}}={\frac {\sum \limits _{i=1}^{n}w_{i}x_{i}}{\sum \limits _{i=1}^{n}w_{i}}}" data-equation="eq:arithmetic_mean">
+    <img src="" alt="Equation for the weighted arithmetic mean.">
+    <br>
+</div>
+
+<!-- </equation> -->
+
+</section>
+
+<!-- /.intro -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var incrwmean = require( '@stdlib/stats/incr/wmean' );
+```
+
+#### incrwmean()
+
+Returns an accumulator `function` which incrementally computes an [weighted arithmetic mean][weighted-arithmetic-mean].
+
+```javascript
+var accumulator = incrwmean();
+```
+
+#### accumulator( \[x, w] )
+
+If provided an input value `x` and a weight `w`, the accumulator function returns an updated weighted mean. If not provided any input values, the accumulator function returns the current mean.
+
+```javascript
+var accumulator = incrwmean();
+
+var mu = accumulator( 2.0, 1.0 );
+// returns 2.0
+
+mu = accumulator( 2.0, 0.5 );
+// returns 2.0
+
+mu = accumulator( 3.0, 1.5 );
+// returns 2.5
+
+mu = accumulator();
+// returns 2.5
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   Input values are **not** type checked. If provided `NaN` or a value which, when used in computations, results in `NaN`, the accumulated value is `NaN` for **all** future invocations. If non-numeric inputs are possible, you are advised to type check and handle accordingly **before** passing the value to the accumulator function.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var randu = require( '@stdlib/random/base/randu' );
+var incrwmean = require( '@stdlib/stats/incr/wmean' );
+
+var accumulator;
+var v;
+var w;
+var i;
+
+// Initialize an accumulator:
+accumulator = incrwmean();
+
+// For each simulated datum, update the weighted mean...
+for ( i = 0; i < 100; i++ ) {
+    v = randu() * 100.0;
+    w = randu() * 100.0;
+    accumulator( v, w );
+}
+console.log( accumulator() );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<section class="links">
+
+[weighted-arithmetic-mean]: https://en.wikipedia.org/wiki/Weighted_arithmetic_mean
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/stats/incr/wmean/README.md
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/README.md
@@ -26,9 +26,9 @@ limitations under the License.
 
 The [weighted arithmetic mean][weighted-arithmetic-mean] is defined as
 
-<!-- <equation class="equation" label="eq:arithmetic_mean" align="center" raw="{\bar {x}}={\frac {\sum \limits _{i=1}^{n}w_{i}x_{i}}{\sum \limits _{i=1}^{n}w_{i}}}" alt="Equation for the arithmetic mean."> -->
+<!-- <equation class="equation" label="eq:weighted_arithmetic_mean" align="center" raw="\bar {x}= \frac{\sum_{i=1}^{n} w_{i}x_{i}}{\sum_{i=1}^{n}w_{i}}" alt="Equation for the weighted arithmetic mean."> -->
 
-<div class="equation" align="center" data-raw-text="{\bar {x}}={\frac {\sum \limits _{i=1}^{n}w_{i}x_{i}}{\sum \limits _{i=1}^{n}w_{i}}}" data-equation="eq:arithmetic_mean">
+<div class="equation" align="center" data-raw-text="\bar {x}= \frac{\sum_{i=1}^{n} w_{i}x_{i}}{\sum_{i=1}^{n}w_{i}}" data-equation="eq:weighted_arithmetic_mean">
     <img src="" alt="Equation for the weighted arithmetic mean.">
     <br>
 </div>
@@ -49,7 +49,7 @@ var incrwmean = require( '@stdlib/stats/incr/wmean' );
 
 #### incrwmean()
 
-Returns an accumulator `function` which incrementally computes an [weighted arithmetic mean][weighted-arithmetic-mean].
+Returns an accumulator `function` which incrementally computes a [weighted arithmetic mean][weighted-arithmetic-mean].
 
 ```javascript
 var accumulator = incrwmean();

--- a/lib/node_modules/@stdlib/stats/incr/wmean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/benchmark/benchmark.js
@@ -1,0 +1,69 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2019 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var pkg = require( './../package.json' ).name;
+var incrwmean = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var f;
+	var i;
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		f = incrwmean();
+		if ( typeof f !== 'function' ) {
+			b.fail( 'should return a function' );
+		}
+	}
+	b.toc();
+	if ( typeof f !== 'function' ) {
+		b.fail( 'should return a function' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::accumulator', function benchmark( b ) {
+	var acc;
+	var v;
+	var i;
+
+	acc = incrwmean();
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		v = acc( randu(), randu() );
+		if ( v !== v ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( v !== v ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/stats/incr/wmean/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/docs/repl.txt
@@ -1,0 +1,37 @@
+
+{{alias}}()
+    Returns an accumulator function which incrementally computes a weighted
+    arithmetic mean.
+
+    If provided parameter(s), the accumulator function returns an updated
+    weighted mean. If not provided a value, the accumulator function returns
+    the current weighted mean.
+
+    If provided `NaN` or a value which, when used in computations, results in
+    `NaN`, the accumulated value is `NaN` for all future invocations.
+
+    The accumulator accepts two parameters, the first is the value and the
+    second is the weight.  If the weight is not provided, it defaults to 1.0.
+
+    Returns
+    -------
+    acc: Function
+        Accumulator function.
+
+    Examples
+    --------
+    > var accumulator = {{alias}}();
+    > var mu = accumulator()
+    null
+    > mu = accumulator( 2.0 )
+    2.0
+    > mu = accumulator( 2.0, 0.5 )
+    2.0
+    > mu = accumulator( 3.0, 1.5 )
+    2.5
+    > mu = accumulator()
+    2.5
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/stats/incr/wmean/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/docs/repl.txt
@@ -3,14 +3,14 @@
     Returns an accumulator function which incrementally computes a weighted
     arithmetic mean.
 
-    If provided parameter(s), the accumulator function returns an updated
-    weighted mean. If not provided a value, the accumulator function returns
+    If provided arguments, the accumulator function returns an updated
+    weighted mean. If not provided arguments, the accumulator function returns
     the current weighted mean.
 
     If provided `NaN` or a value which, when used in computations, results in
     `NaN`, the accumulated value is `NaN` for all future invocations.
 
-    The accumulator accepts two parameters, the first is the value and the
+    The accumulator accepts two arguments: the first is the value and the
     second is the weight.
 
     Returns

--- a/lib/node_modules/@stdlib/stats/incr/wmean/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/docs/repl.txt
@@ -11,7 +11,7 @@
     `NaN`, the accumulated value is `NaN` for all future invocations.
 
     The accumulator accepts two parameters, the first is the value and the
-    second is the weight.  If the weight is not provided, it defaults to 1.0.
+    second is the weight.
 
     Returns
     -------
@@ -23,7 +23,7 @@
     > var accumulator = {{alias}}();
     > var mu = accumulator()
     null
-    > mu = accumulator( 2.0 )
+    > mu = accumulator( 2.0, 1.0 )
     2.0
     > mu = accumulator( 2.0, 0.5 )
     2.0

--- a/lib/node_modules/@stdlib/stats/incr/wmean/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/docs/types/index.d.ts
@@ -21,6 +21,17 @@
 /// <reference types="@stdlib/types"/>
 
 /**
+ * Accumulator function
+ *
+ * @param x value
+ * @param w weight
+ *
+ * @returns the incrementally computed weighted arithmetic mean.
+ *
+ */
+type incrwmean_acc = ( x: number, w: number ) => number | null;
+
+/**
 * Returns an accumulator function which incrementally computes a weighted arithmetic mean.
 *
 * @returns accumulator function
@@ -45,7 +56,7 @@
 * mu = accumulator();
 * // returns 2.5
 */
-declare function incrwmean(): ( x: number, w: number ) => number | null;
+declare function incrwmean(): incrwmean_acc;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/stats/incr/wmean/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/docs/types/index.d.ts
@@ -1,0 +1,53 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2019 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 2.0
+
+/// <reference types="@stdlib/types"/>
+
+/**
+* Returns an accumulator function which incrementally computes a weighted arithmetic mean.
+*
+* @returns accumulator function
+*
+* @example* var incrwmean = require( '@stdlib/stats/incr/wmean' );
+*
+* var accumulator = incrwmean();
+*
+* var mu = accumulator();
+* // returns null
+*
+* // Default weight is 1.0
+* var mu = accumulator( 2.0 );
+* // returns 2.0
+*
+* mu = accumulator( 2.0, 0.5 );
+* // returns 2.0
+*
+* mu = accumulator( 3.0, 1.5 );
+* // returns 2.5
+*
+* mu = accumulator();
+* // returns 2.5
+*/
+declare function incrwmean(): ( x: number, w?: number ) => number | null;
+
+
+// EXPORTS //
+
+export = incrwmean;

--- a/lib/node_modules/@stdlib/stats/incr/wmean/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/docs/types/index.d.ts
@@ -25,7 +25,8 @@
 *
 * @returns accumulator function
 *
-* @example* var incrwmean = require( '@stdlib/stats/incr/wmean' );
+* @example
+* var incrwmean = require( '@stdlib/stats/incr/wmean' );
 *
 * var accumulator = incrwmean();
 *

--- a/lib/node_modules/@stdlib/stats/incr/wmean/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/docs/types/index.d.ts
@@ -32,8 +32,7 @@
 * var mu = accumulator();
 * // returns null
 *
-* // Default weight is 1.0
-* var mu = accumulator( 2.0 );
+* var mu = accumulator( 2.0, 1.0 );
 * // returns 2.0
 *
 * mu = accumulator( 2.0, 0.5 );
@@ -45,7 +44,7 @@
 * mu = accumulator();
 * // returns 2.5
 */
-declare function incrwmean(): ( x: number, w?: number ) => number | null;
+declare function incrwmean(): ( x: number, w: number ) => number | null;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/stats/incr/wmean/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/docs/types/index.d.ts
@@ -21,7 +21,7 @@
 /// <reference types="@stdlib/types"/>
 
 /**
- * Accumulator function
+ * Weighted arithmetic mean accumulator function
  *
  * @param x value
  * @param w weight

--- a/lib/node_modules/@stdlib/stats/incr/wmean/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/docs/types/test.ts
@@ -37,3 +37,18 @@ import incrwmean = require( './index' );
 	incrwmean( {} ); // $ExpectError
 	incrwmean( ( x: number ): number => x ); // $ExpectError
 }
+
+// The compiler throws an error if the function is provided arguments...
+{
+	let acc = incrwmean();
+
+	acc( '5' ); // $ExpectError
+	acc( 5 ); // $ExpectError
+	acc( true ); // $ExpectError
+	acc( false ); // $ExpectError
+	acc( null ); // $ExpectError
+	acc( undefined ); // $ExpectError
+	acc( [] ); // $ExpectError
+	acc( {} ); // $ExpectError
+	acc( ( x: number ): number => x ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/stats/incr/wmean/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/docs/types/test.ts
@@ -22,7 +22,7 @@ import incrwmean = require( './index' );
 
 // The function returns either a number or null...
 {
-	incrwmean(); // $ExpectType (x: number, w?: number | undefined) => number | null
+	incrwmean(); // $ExpectType (x: number, w: number) => number | null
 }
 
 // The compiler throws an error if the function is any arguments

--- a/lib/node_modules/@stdlib/stats/incr/wmean/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/docs/types/test.ts
@@ -1,0 +1,39 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2019 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import incrwmean = require( './index' );
+
+// TESTS //
+
+// The function returns either a number or null...
+{
+	incrwmean(); // $ExpectType (x: number, w?: number | undefined) => number | null
+}
+
+// The compiler throws an error if the function is any arguments
+{
+	incrwmean( '5' ); // $ExpectError
+	incrwmean( 5 ); // $ExpectError
+	incrwmean( true ); // $ExpectError
+	incrwmean( false ); // $ExpectError
+	incrwmean( null ); // $ExpectError
+	incrwmean( undefined ); // $ExpectError
+	incrwmean( [] ); // $ExpectError
+	incrwmean( {} ); // $ExpectError
+	incrwmean( ( x: number ): number => x ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/stats/incr/wmean/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/docs/types/test.ts
@@ -25,7 +25,7 @@ import incrwmean = require( './index' );
 	incrwmean(); // $ExpectType (x: number, w: number) => number | null
 }
 
-// The compiler throws an error if the function is any arguments
+// The compiler throws an error if the function is provided arguments...
 {
 	incrwmean( '5' ); // $ExpectError
 	incrwmean( 5 ); // $ExpectError

--- a/lib/node_modules/@stdlib/stats/incr/wmean/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/docs/types/test.ts
@@ -22,7 +22,7 @@ import incrwmean = require( './index' );
 
 // The function returns either a number or null...
 {
-	incrwmean(); // $ExpectType (x: number, w: number) => number | null
+	incrwmean(); // $ExpectType incrwmean_acc
 }
 
 // The compiler throws an error if the function is provided arguments...

--- a/lib/node_modules/@stdlib/stats/incr/wmean/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/examples/index.js
@@ -1,0 +1,41 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2019 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var randu = require( '@stdlib/random/base/randu' );
+var incrwmean = require( './../lib' );
+
+var accumulator;
+var mu;
+var x;
+var w;
+var i;
+
+// Initialize an accumulator:
+accumulator = incrwmean();
+
+// For each simulated datum, update the weighted mean...
+console.log( '\nValue\tWeight\tWeighted Mean\n' );
+for ( i = 0; i < 100; i++ ) {
+	x = randu() * 100.0;
+	w = randu() * 100.0;
+	mu = accumulator( x );
+	console.log( '%d\t%d\t%d', x.toFixed( 4 ), w.toFixed( 4 ), mu.toFixed( 4 ) );
+}
+console.log( '\nFinal weighted mean: %d\n', accumulator() );

--- a/lib/node_modules/@stdlib/stats/incr/wmean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/lib/index.js
@@ -31,7 +31,8 @@
 * var mu = accumulator();
 * // returns null
 *
-* var mu = accumulator( 2.0, 1.0 );
+* // Default weight is 1.0
+* var mu = accumulator( 2.0 );
 * // returns 2.0
 *
 * mu = accumulator( 2.0, 0.5 );

--- a/lib/node_modules/@stdlib/stats/incr/wmean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/lib/index.js
@@ -1,0 +1,54 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2019 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Compute a weighted arithmetic mean incrementally.
+*
+* @module @stdlib/stats/incr/wmean
+*
+* @example
+* var incrwmean = require( '@stdlib/stats/incr/wmean' );
+*
+* var accumulator = incrwmean();
+*
+* var mu = accumulator();
+* // returns null
+*
+* var mu = accumulator( 2.0, 1.0 );
+* // returns 2.0
+*
+* mu = accumulator( 2.0, 0.5 );
+* // returns 2.0
+*
+* mu = accumulator( 3.0, 1.5 );
+* // returns 2.5
+*
+* mu = accumulator();
+* // returns 2.5
+*/
+
+// MODULES //
+
+var incrwmean = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = incrwmean;

--- a/lib/node_modules/@stdlib/stats/incr/wmean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/lib/index.js
@@ -31,8 +31,7 @@
 * var mu = accumulator();
 * // returns null
 *
-* // Default weight is 1.0
-* var mu = accumulator( 2.0 );
+* var mu = accumulator( 2.0, 1.0 );
 * // returns 2.0
 *
 * mu = accumulator( 2.0, 0.5 );

--- a/lib/node_modules/@stdlib/stats/incr/wmean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/lib/index.js
@@ -31,7 +31,7 @@
 * var mu = accumulator();
 * // returns null
 *
-* var mu = accumulator( 2.0, 1.0 );
+* mu = accumulator( 2.0, 1.0 );
 * // returns 2.0
 *
 * mu = accumulator( 2.0, 0.5 );

--- a/lib/node_modules/@stdlib/stats/incr/wmean/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/lib/main.js
@@ -42,8 +42,8 @@
 * // returns 2.5
 */
 function incrwmean() {
-	var wSum;
 	var xwSum;
+	var wSum;
 	var mu;
 
 	wSum = 0.0;
@@ -57,12 +57,15 @@ function incrwmean() {
 	*
 	* @private
 	* @param {number} [x] - new value
-	* @param {number} [w] - new value's weight
+	* @param {number} [w] - new value's weight (or 1.0 if not provided)
 	* @returns {(number|null)} weighted mean value or null
 	*/
 	function accumulator( x, w ) {
 		if ( arguments.length === 0 ) {
 			return mu;
+		}
+		if ( w === undefined ) {
+			w = 1.0
 		}
 		wSum += w;
 		xwSum += x * w;

--- a/lib/node_modules/@stdlib/stats/incr/wmean/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/lib/main.js
@@ -29,7 +29,8 @@
 * var mu = accumulator();
 * // returns null
 *
-* var mu = accumulator( 2.0, 1.0 );
+* // Default weight is 1.0
+* var mu = accumulator( 2.0 );
 * // returns 2.0
 *
 * mu = accumulator( 2.0, 0.5 );
@@ -60,12 +61,9 @@ function incrwmean() {
 	* @param {number} [w] - new value's weight (or 1.0 if not provided)
 	* @returns {(number|null)} weighted mean value or null
 	*/
-	function accumulator( x, w ) {
+	function accumulator( x, w = 1.0 ) {
 		if ( arguments.length === 0 ) {
 			return mu;
-		}
-		if ( w === undefined ) {
-			w = 1.0
 		}
 		wSum += w;
 		xwSum += x * w;

--- a/lib/node_modules/@stdlib/stats/incr/wmean/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/lib/main.js
@@ -29,8 +29,7 @@
 * var mu = accumulator();
 * // returns null
 *
-* // Default weight is 1.0
-* var mu = accumulator( 2.0 );
+* var mu = accumulator( 2.0, 1.0 );
 * // returns 2.0
 *
 * mu = accumulator( 2.0, 0.5 );
@@ -58,10 +57,10 @@ function incrwmean() {
 	*
 	* @private
 	* @param {number} [x] - new value
-	* @param {number} [w] - new value's weight (or 1.0 if not provided)
+	* @param {number} [w] - new value's weight
 	* @returns {(number|null)} weighted mean value or null
 	*/
-	function accumulator( x, w = 1.0 ) {
+	function accumulator( x, w ) {
 		if ( arguments.length === 0 ) {
 			return mu;
 		}

--- a/lib/node_modules/@stdlib/stats/incr/wmean/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/lib/main.js
@@ -1,0 +1,77 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2019 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Returns an accumulator function which incrementally computes a weighted arithmetic mean.
+*
+* @returns {Function} accumulator function
+*
+* @example
+* var accumulator = incrwmean();
+*
+* var mu = accumulator();
+* // returns null
+*
+* var mu = accumulator( 2.0, 1.0 );
+* // returns 2.0
+*
+* mu = accumulator( 2.0, 0.5 );
+* // returns 2.0
+*
+* mu = accumulator( 3.0, 1.5 );
+* // returns 2.5
+*
+* mu = accumulator();
+* // returns 2.5
+*/
+function incrwmean() {
+	var wSum;
+	var xwSum;
+	var mu;
+
+	wSum = 0.0;
+	xwSum = 0.0;
+	mu = null;
+
+	return accumulator;
+
+	/**
+	* If provided a value, the accumulator function returns an updated weighted mean. If not provided a value, the accumulator function returns the current weighted mean.
+	*
+	* @private
+	* @param {number} [x] - new value
+	* @param {number} [w] - new value's weight
+	* @returns {(number|null)} weighted mean value or null
+	*/
+	function accumulator( x, w ) {
+		if ( arguments.length === 0 ) {
+			return mu;
+		}
+		wSum += w;
+		xwSum += x * w;
+		mu = xwSum / wSum;
+		return mu;
+	}
+}
+
+
+// EXPORTS //
+
+module.exports = incrwmean;

--- a/lib/node_modules/@stdlib/stats/incr/wmean/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/lib/main.js
@@ -29,7 +29,7 @@
 * var mu = accumulator();
 * // returns null
 *
-* var mu = accumulator( 2.0, 1.0 );
+* mu = accumulator( 2.0, 1.0 );
 * // returns 2.0
 *
 * mu = accumulator( 2.0, 0.5 );
@@ -51,19 +51,19 @@ function incrwmean() {
 	return accumulator;
 
 	/**
-	* If provided a value, the accumulator function returns an updated weighted mean. If not provided a value, the accumulator function returns the current weighted mean.
+	* If provided arguments, the accumulator function returns an updated weighted mean. If not provided arguments, the accumulator function returns the current weighted mean.
 	*
 	* @private
 	* @param {number} [x] - new value
 	* @param {number} [w] - new value's weight
-	* @returns {(number|null)} weighted mean value or null
+	* @returns {(number|null)} weighted mean or null
 	*/
 	function accumulator( x, w ) {
 		if ( arguments.length === 0 ) {
 			return mu;
 		}
 		wSum += w;
-		mu += ( (w / wSum) * (x - mu) );
+		mu += (w / wSum) * (x - mu);
 		return mu;
 	}
 }

--- a/lib/node_modules/@stdlib/stats/incr/wmean/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/lib/main.js
@@ -42,12 +42,10 @@
 * // returns 2.5
 */
 function incrwmean() {
-	var xwSum;
 	var wSum;
 	var mu;
 
 	wSum = 0.0;
-	xwSum = 0.0;
 	mu = null;
 
 	return accumulator;
@@ -65,8 +63,7 @@ function incrwmean() {
 			return mu;
 		}
 		wSum += w;
-		xwSum += x * w;
-		mu = xwSum / wSum;
+		mu += ( (w / wSum) * (x - mu) );
 		return mu;
 	}
 }

--- a/lib/node_modules/@stdlib/stats/incr/wmean/package.json
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@stdlib/stats/incr/wmean",
+  "version": "0.0.0",
+  "description": "Compute a weighted arithmetic mean incrementally.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "statistics",
+    "stats",
+    "mathematics",
+    "math",
+    "average",
+    "avg",
+    "mean",
+    "arithmetic mean",
+    "central tendency",
+    "incremental",
+    "accumulator",
+    "weighted"
+  ]
+}

--- a/lib/node_modules/@stdlib/stats/incr/wmean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/test/test.js
@@ -46,10 +46,10 @@ tape( 'the initial accumulated value is `null`', function test( t ) {
 tape( 'the accumulator function incrementally computes a weighted arithmetic mean', function test( t ) {
 	var expected;
 	var actual;
-	var xwSum;
-	var wSum;
 	var dataX;
 	var dataW;
+	var xwSum;
+	var wSum;
 	var acc;
 	var N;
 	var x;

--- a/lib/node_modules/@stdlib/stats/incr/wmean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/test/test.js
@@ -95,25 +95,20 @@ tape( 'if not provided an input value, the accumulator function returns the curr
 	t.end();
 });
 
-tape( 'if weight is not provided, the accumulator function uses 1.0 as the weight', function test( t ) {
-	var dataX;
-	var acc;
-	var i;
-
-	dataX = [ 2.0, 3.0, 1.0 ];
-	acc = incrwmean();
-	for ( i = 0; i < dataX.length; i++ ) {
-		acc( dataX[ i ] );
-	}
-	t.equal( acc(), 2.0, 'returns the current accumulated mean' );
-	t.end();
-});
-
 tape( 'if null is passed as a weight, the accumulator function returns NaN', function test( t ) {
 	var acc;
 
 	acc = incrwmean();
 	acc();
 	t.ok( isNaN( acc(2.0, null) ), 'returns NaN' );
+	t.end();
+});
+
+tape( 'if no weight is passed, the accumulator function returns NaN', function test( t ) {
+	var acc;
+
+	acc = incrwmean();
+	acc();
+	t.ok( isNaN( acc(2.0) ), 'returns NaN' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/incr/wmean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/test/test.js
@@ -21,6 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
+var EPS = require( '@stdlib/constants/math/float64-eps' );
+var abs = require( '@stdlib/math/base/special/abs' );
 var incrwmean = require( './../lib' );
 
 
@@ -46,11 +48,13 @@ tape( 'the initial accumulated value is `null`', function test( t ) {
 tape( 'the accumulator function incrementally computes a weighted arithmetic mean', function test( t ) {
 	var expected;
 	var actual;
+	var delta;
 	var dataX;
 	var dataW;
 	var xwSum;
 	var wSum;
 	var acc;
+	var tol;
 	var N;
 	var x;
 	var w;
@@ -74,8 +78,10 @@ tape( 'the accumulator function incrementally computes a weighted arithmetic mea
 		wSum += w;
 		expected[ i ] = xwSum / wSum;
 		actual[ i ] = acc( x, w );
+		delta = abs( actual[ i ] - expected[ i ] );
+		tol = EPS * abs( expected[ i ] );
+		t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. Value: ' + actual[ i ] + '. Expected: ' + expected[ i ] + '. Tolerance: ' + tol + '.' );
 	}
-	t.deepEqual( actual, expected, 'returns expected incremental results' );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/stats/incr/wmean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/test/test.js
@@ -1,0 +1,119 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2019 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var incrwmean = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.equal( typeof incrwmean, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns an accumulator function', function test( t ) {
+	t.equal( typeof incrwmean(), 'function', 'returns a function' );
+	t.end();
+});
+
+tape( 'the initial accumulated value is `null`', function test( t ) {
+	var acc = incrwmean();
+	t.equal( acc(), null, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the accumulator function incrementally computes a weighted arithmetic mean', function test( t ) {
+	var expected;
+	var actual;
+	var xwSum;
+	var wSum;
+	var dataX;
+	var dataW;
+	var acc;
+	var N;
+	var x;
+	var w;
+	var i;
+
+	dataX = [ 2.0, 3.0, 2.0, 4.0, 3.0, 4.0 ];
+	dataW = [ 1.0, 2.0, 0.1, 1.8, 9.9, 3.6 ];
+	N = dataX.length;
+
+	expected = new Array( N );
+	actual = new Array( N );
+
+	acc = incrwmean();
+
+	xwSum = 0;
+	wSum = 0;
+	for ( i = 0; i < N; i++ ) {
+		x = dataX[ i ];
+		w = dataW[ i ];
+		xwSum += x * w;
+		wSum += w;
+		expected[ i ] = xwSum / wSum;
+		actual[ i ] = acc( x, w );
+	}
+	t.deepEqual( actual, expected, 'returns expected incremental results' );
+	t.end();
+});
+
+tape( 'if not provided an input value, the accumulator function returns the current weighted mean', function test( t ) {
+	var dataX;
+	var dataW;
+	var acc;
+	var i;
+
+	dataX = [ 2.0, 3.0, 1.0 ];
+	dataW = [ 2.0, 2.0, 1.0 ];
+	acc = incrwmean();
+	for ( i = 0; i < dataX.length; i++ ) {
+		acc( dataX[ i ], dataW[ i ] );
+	}
+	t.equal( acc(), 2.2, 'returns the current accumulated mean' );
+	t.end();
+});
+
+tape( 'if weight is not provided, the accumulator function uses 1.0 as the weight', function test( t ) {
+	var dataX;
+	var acc;
+	var i;
+
+	dataX = [ 2.0, 3.0, 1.0 ];
+	acc = incrwmean();
+	for ( i = 0; i < dataX.length; i++ ) {
+		acc( dataX[ i ] );
+	}
+	t.equal( acc(), 2.0, 'returns the current accumulated mean' );
+	t.end();
+});
+
+tape( 'if null is passed as a weight, the accumulator function returns NaN', function test( t ) {
+	var acc;
+
+	acc = incrwmean();
+	acc();
+	t.ok( isNaN( acc(2.0, null) ), 'returns NaN' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/stats/incr/wmean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/test/test.js
@@ -23,6 +23,7 @@
 var tape = require( 'tape' );
 var EPS = require( '@stdlib/constants/math/float64-eps' );
 var abs = require( '@stdlib/math/base/special/abs' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var incrwmean = require( './../lib' );
 
 
@@ -101,20 +102,11 @@ tape( 'if not provided an input value, the accumulator function returns the curr
 	t.end();
 });
 
-tape( 'if null is passed as a weight, the accumulator function returns NaN', function test( t ) {
-	var acc;
-
-	acc = incrwmean();
-	acc();
-	t.ok( isNaN( acc(2.0, null) ), 'returns NaN' );
-	t.end();
-});
-
 tape( 'if no weight is passed, the accumulator function returns NaN', function test( t ) {
 	var acc;
 
 	acc = incrwmean();
 	acc();
-	t.ok( isNaN( acc(2.0) ), 'returns NaN' );
+	t.ok( isnan( acc(2.0) ), 'returns NaN' );
 	t.end();
 });


### PR DESCRIPTION
Resolves #45  .

<!--lint disable first-heading-level-->

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing], including the relevant style guides.
-   [x] Read and understand the [Code of Conduct][code-of-conduct].
-   [x] Read and understood the [licensing terms][license].
-   [x] Searched for existing issues and pull requests **before** submitting this pull request.
-   [x] Filed an issue (or an issue already existed) **prior to** submitting this pull request.
-   [x] Rebased onto latest `develop`.
-   [x] Submitted against `develop` branch.

## Description

> What is the purpose of this pull request?

This pull request:

-   Implements an incremental weighted mean

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #45 

## Questions

> Any questions for reviewers of this pull request?

Do you agree that the weight should default to 1.0?  then `incrwmean` with one parameter is equivalient to `incrmean` (though slower).

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

I'm not sure that other incremental stat functions have typescript definitions.  Didn't see why I shouldn't add one for this though.  Let me know if there's some reason I shouldn't.

I wasn't aware of a more efficient way to implement this algorithm, I don't believe there's a shortcut like for `incrmean`.

* * *

@stdlib-js/reviewers

<!-- <links> -->

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[code-of-conduct]: https://github.com/stdlib-js/stdlib/blob/develop/CODE_OF_CONDUCT.md

[license]: https://github.com/stdlib-js/stdlib/blob/develop/LICENSE

<!-- </links> -->
