### PR TITLE
📝 Banner now links to website, instead of img asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ limitations under the License.
     <div class="image" align="center">
         <br>
         <br>
-        <img src="https://cdn.rawgit.com/stdlib-js/stdlib/9f7d30f089ecc458a8b836a75afab75caf5c0b36/docs/assets/logo_banner.svg" alt="stdlib logo">
+        <a href="https://stdlib.io/" />
+            <img src="https://cdn.rawgit.com/stdlib-js/stdlib/9f7d30f089ecc458a8b836a75afab75caf5c0b36/docs/assets/logo_banner.svg" alt="stdlib logo">
+        </a>
         <br>
         <br>
         <br>

--- a/README.md
+++ b/README.md
@@ -328,13 +328,13 @@ Test and build infrastructure is generously provided by the following services:
 
 [coverage-url-develop]: https://codecov.io/github/stdlib-js/stdlib/branch/develop
 
-[dependencies-image]: https://img.shields.io/david/stdlib-js/stdlib/develop.svg
+[dependencies-image]: https://david-dm.org/stdlib-js/stdlib/develop/status.svg
 
 [dependencies-url]: https://david-dm.org/stdlib-js/stdlib/develop
 
-[dev-dependencies-image]: https://img.shields.io/david/dev/stdlib-js/stdlib/develop.svg
+[dev-dependencies-image]: https://david-dm.org/stdlib-js/stdlib/develop/dev-status.svg
 
-[dev-dependencies-url]: https://david-dm.org/stdlib-js/stdlib/develop#info=devDependencies
+[dev-dependencies-url]: https://david-dm.org/stdlib-js/stdlib/develop?type=dev
 
 [chat-image]: https://img.shields.io/gitter/room/stdlib-js/stdlib.svg
 


### PR DESCRIPTION
Resolves #272 .

<!--lint disable first-heading-level-->

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing], including the relevant style guides.
-   [x] Read and understand the [Code of Conduct][code-of-conduct].
-   [x] Read and understood the [licensing terms][license].
-   [x] Searched for existing issues and pull requests **before** submitting this pull request.
-   [x] Filed an issue (or an issue already existed) **prior to** submitting this pull request.
-   [x] Rebased onto latest `develop`.
-   [x] Submitted against `develop` branch.

## Description

> What is the purpose of this pull request?

This pull request:

- Made the banner link to the official website instead of to the banner image asset.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #272 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

* * *

@stdlib-js/reviewers

<!-- <links> -->

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[code-of-conduct]: https://github.com/stdlib-js/stdlib/blob/develop/CODE_OF_CONDUCT.md

[license]: https://github.com/stdlib-js/stdlib/blob/develop/LICENSE

<!-- </links> -->
