### PR TITLE
Change '/' to path.sep in postinstall script

### DIFF
--- a/tools/scripts/postinstall
+++ b/tools/scripts/postinstall
@@ -306,7 +306,7 @@ function main() {
 	debug( 'Modifying package meta data...' );
 	for ( i = 0; i < pkgs.length; i++ ) {
 		pdir = pkgs[ i ].slice( PKG_DIR.length+1 ); // +1 to account for trailing `/`
-		if ( pdir[ 0 ] !== '_' && pdir.split( '/' ).length === 1 ) {
+		if ( pdir[ 0 ] !== '_' && pdir.split( path.sep ).length === 1 ) {
 			meta.dependencies[ '@stdlib/'+pdir ] = 'file:./lib/node_modules/@stdlib/'+pdir;
 		}
 	}


### PR DESCRIPTION
On Windows, the postinstall script causes the package.json of any project depending on @stdlib/stdlib to end up with a bunch of "\\\\" in the dependency names, which breaks npm install after the first installation. 

Resolves #351  .

<!--lint disable first-heading-level-->

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [X] Read, understood, and followed the [contributing guidelines][contributing], including the relevant style guides.
-   [X] Read and understand the [Code of Conduct][code-of-conduct].
-   [X] Read and understood the [licensing terms][license].
-   [X] Searched for existing issues and pull requests **before** submitting this pull request.
-   [X] Filed an issue (or an issue already existed) **prior to** submitting this pull request.
-   [x] Rebased onto latest `develop`.
-   [X] Submitted against `develop` branch.

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes running `npm install` on Windows when @stdlib/stdlib is a package dependency

## Related Issues

> Does this pull request have any related issues?

No.

This pull request:

-   fixes #351 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

* * *

@stdlib-js/reviewers

<!-- <links> -->

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

[code-of-conduct]: https://github.com/stdlib-js/stdlib/blob/develop/CODE_OF_CONDUCT.md

[license]: https://github.com/stdlib-js/stdlib/blob/develop/LICENSE

<!-- </links> -->
