### PR TITLE
Fix some relative links that don't work from npm

### DIFF
--- a/lib/node_modules/@stdlib/bench/README.md
+++ b/lib/node_modules/@stdlib/bench/README.md
@@ -42,7 +42,7 @@ var bench = require( '@stdlib/bench' );
 
 #### bench( name\[, options]\[, benchmark] )
 
-This function is an alias for [@stdlib/bench/harness][@stdlib/bench/harness].
+This function is an alias for [@stdlib/bench/harness][https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/@stdlib/bench/harness].
 
 </section>
 
@@ -80,7 +80,7 @@ This function is an alias for [@stdlib/bench/harness][@stdlib/bench/harness].
 
 ## See Also
 
--   <span class="package-name">[`@stdlib/utils/timeit`][@stdlib/utils/timeit]</span><span class="delimiter">: </span><span class="description">time a snippet.</span>
+-   <span class="package-name">[`@stdlib/utils/timeit`][https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/@stdlib/utils/timeit]</span><span class="delimiter">: </span><span class="description">time a snippet.</span>
 
 </section>
 


### PR DESCRIPTION
From this package's [npm readme](https://www.npmjs.com/package/@stdlib/bench) these relative links are 404s e.g. https://www.npmjs.com/package/@stdlib/bench/tree/main/harness