### PR TITLE
fix raw buffer access

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/dispatch/benchmark/benchmark.dispatch_size.js
+++ b/lib/node_modules/@stdlib/ndarray/dispatch/benchmark/benchmark.dispatch_size.js
@@ -113,7 +113,7 @@ function createBenchmark( size ) {
 
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
-			x[ 0 ] = i;
+			x.data[ 0 ] = i;
 			z = fcn( x, y );
 			if ( isnan( z.data[ 0 ] ) ) {
 				b.fail( 'should not return NaN' );


### PR DESCRIPTION

## Description

Fix a small bug when directly setting a value in the raw buffer - x is an object and `x[0]` is equivalent `x.0` which is different from `x.data[0]`

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
