### PR TITLE
Add support for serializing a RegExp to JSON

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -286,7 +286,7 @@ setReadOnly( stdlib, 'random', require( '@stdlib/random' ) );
 * @type {Namespace}
 * @see {@link module:@stdlib/regexp}
 */
-setReadOnly( stdlib, 'RegExp', require( '@stdlib/regexp' ) );
+setReadOnly( stdlib, 'regexp', require( '@stdlib/regexp' ) );
 
 /**
 * @name repl

--- a/lib/main.js
+++ b/lib/main.js
@@ -286,7 +286,7 @@ setReadOnly( stdlib, 'random', require( '@stdlib/random' ) );
 * @type {Namespace}
 * @see {@link module:@stdlib/regexp}
 */
-setReadOnly( stdlib, 'regexp', require( '@stdlib/regexp' ) );
+setReadOnly( stdlib, 'RegExp', require( '@stdlib/regexp' ) );
 
 /**
 * @name repl

--- a/lib/node_modules/@stdlib/regexp/to-json/README.md
+++ b/lib/node_modules/@stdlib/regexp/to-json/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # toJSON
 
-> Return a [JSON][json] representation of a [regular expression][regexp] object.
+> Return a [JSON][json] representation of a [regular expression][mdn-regexp].
 
 <!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
 
@@ -42,13 +42,10 @@ var toJSON = require( '@stdlib/regexp/to-json' );
 
 #### toJSON( regexp )
 
-Returns a [JSON][json] representation of a [regular expression][regexp] object.
+Returns a [JSON][json] representation of a [regular expression][mdn-regexp].
 
 ```javascript
-var pattern = 'ab+c';
-var regex = new RegExp(pattern);
-
-var json = toJSON( regex );
+var json = toJSON( /ab+c/ );
 /* returns
     {
         'type': 'RegExp',
@@ -58,23 +55,14 @@ var json = toJSON( regex );
 */
 ```
 
-The [JSON][json] `object` is **guaranteed** to have the following properties:
+The returned object has the following properties:
 
--   **type**: regular expression type.
--   **pattern**: regular expression string pattern.
--   **flags**: aditional options for matching.
-
-The function also serializes **all** `enumerable` properties.
-
-<!-- eslint-disable object-curly-newline -->
+-   **type**: value type. The assigned value is always `'RegExp'`.
+-   **pattern**: regular expression pattern.
+-   **flags**: regular expression flags.
 
 ```javascript
-var pattern = 'ab+c';
-var regex = new RegExp(pattern);
-regex.a = 'b';
-regex.c = { 'd': 'e' };
-
-var json = toJSON( regex );
+var json = toJSON( /ab+c/ );
 /* returns
     {
         'type': 'RegExp',
@@ -98,10 +86,7 @@ var json = toJSON( regex );
 
 ```javascript
 var toJSON = require( '@stdlib/regexp/to-json' );
-var pattern = 'ab+c';
-
-var regex = new RegExp(pattern);
-var out = toJSON( regex );
+var out = toJSON( /ab+c/ );
 /* returns
     {
         'type': 'RegExp',
@@ -110,13 +95,12 @@ var out = toJSON( regex );
     }
 */
 
-regex = new RegExp(pattern, 'd');
-out = toJSON( regex );
+out = toJSON( /ab+c/g );
 /* returns
     {
         'type': 'RegExp',
         'pattern': 'ab+c',
-        'flags': 'd'
+        'flags': 'g'
     }
 */
 ```
@@ -137,10 +121,6 @@ out = toJSON( regex );
 
 <section class="related">
 
-* * *
-
-## See Also
-
 </section>
 
 <!-- /.related -->
@@ -151,7 +131,7 @@ out = toJSON( regex );
 
 [json]: http://www.json.org/
 
-[regexp]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+[mdn-regexp]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
 
 <!-- <related-links> -->
 

--- a/lib/node_modules/@stdlib/regexp/to-json/README.md
+++ b/lib/node_modules/@stdlib/regexp/to-json/README.md
@@ -61,17 +61,6 @@ The returned object has the following properties:
 -   **pattern**: regular expression pattern.
 -   **flags**: regular expression flags.
 
-```javascript
-var json = toJSON( /ab+c/ );
-/* returns
-    {
-        'type': 'RegExp',
-        'pattern': 'ab+c',
-        'flags': ''
-    }
-*/
-```
-
 </section>
 
 <!-- /.usage -->
@@ -86,6 +75,7 @@ var json = toJSON( /ab+c/ );
 
 ```javascript
 var toJSON = require( '@stdlib/regexp/to-json' );
+
 var out = toJSON( /ab+c/ );
 /* returns
     {

--- a/lib/node_modules/@stdlib/regexp/to-json/README.md
+++ b/lib/node_modules/@stdlib/regexp/to-json/README.md
@@ -45,14 +45,15 @@ var toJSON = require( '@stdlib/regexp/to-json' );
 Returns a [JSON][json] representation of a [regular expression][regexp] object.
 
 ```javascript
-var regex = new RegExp('ab+c');
+var pattern = 'ab+c';
+var regex = new RegExp(pattern);
 
 var json = toJSON( regex );
 /* returns
     {
-        'type': 'regexp',
+        'type': 'RegExp',
         'pattern': 'ab+c',
-        'flags': '...' // if present
+        'flags': ''
     }
 */
 ```
@@ -61,9 +62,6 @@ The [JSON][json] `object` is **guaranteed** to have the following properties:
 
 -   **type**: regular expression type.
 -   **pattern**: regular expression string pattern.
-
-Depending on the object, the following property **may** be present:
-
 -   **flags**: aditional options for matching.
 
 The function also serializes **all** `enumerable` properties.
@@ -71,20 +69,17 @@ The function also serializes **all** `enumerable` properties.
 <!-- eslint-disable object-curly-newline -->
 
 ```javascript
-var regex = new RegExp('ab+c');
+var pattern = 'ab+c';
+var regex = new RegExp(pattern);
 regex.a = 'b';
 regex.c = { 'd': 'e' };
 
 var json = toJSON( regex );
 /* returns
     {
-        'type': 'regexp',
+        'type': 'RegExp',
         'pattern': 'ab+c',
-        'flags': '...', // if present
-        'a': 'b',
-        'c': {
-            'd': 'e'
-        }
+        'flags': ''
     }
 */
 ```
@@ -99,26 +94,27 @@ var json = toJSON( regex );
 
 ## Examples
 
-<!-- eslint no-undef: "regexp" -->
+<!-- eslint no-undef: "error" -->
 
 ```javascript
 var toJSON = require( '@stdlib/regexp/to-json' );
+var pattern = 'ab+c';
 
-var regex = new RegExp('ab+c');
+var regex = new RegExp(pattern);
 var out = toJSON( regex );
 /* returns
     {
-        'type': 'regexp',
+        'type': 'RegExp',
         'pattern': 'ab+c',
         'flags': ''
     }
 */
 
-var regexf = new RegExp('ab+c', 'd');
-var out = toJSON( regexf );
+regex = new RegExp(pattern, 'd');
+out = toJSON( regex );
 /* returns
     {
-        'type': 'regexp',
+        'type': 'RegExp',
         'pattern': 'ab+c',
         'flags': 'd'
     }
@@ -145,8 +141,6 @@ var out = toJSON( regexf );
 
 ## See Also
 
--   <span class="package-name">[`@stdlib/regexp/regexp`][@stdlib/regexp/regexp]</span><span class="delimiter">: </span><span class="description">regular expression to parse a string.</span>
-
 </section>
 
 <!-- /.related -->
@@ -160,8 +154,6 @@ var out = toJSON( regexf );
 [regexp]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
 
 <!-- <related-links> -->
-
-[@stdlib/error/reviver]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/error/reviver
 
 <!-- </related-links> -->
 

--- a/lib/node_modules/@stdlib/regexp/to-json/README.md
+++ b/lib/node_modules/@stdlib/regexp/to-json/README.md
@@ -1,0 +1,170 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2022 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# toJSON
+
+> Return a [JSON][json] representation of a [regular expression][regexp] object.
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var toJSON = require( '@stdlib/regexp/to-json' );
+```
+
+#### toJSON( regexp )
+
+Returns a [JSON][json] representation of a [regular expression][regexp] object.
+
+```javascript
+var regex = new RegExp('ab+c');
+
+var json = toJSON( regex );
+/* returns
+    {
+        'type': 'regexp',
+        'pattern': 'ab+c',
+        'flags': '...' // if present
+    }
+*/
+```
+
+The [JSON][json] `object` is **guaranteed** to have the following properties:
+
+-   **type**: regular expression type.
+-   **pattern**: regular expression string pattern.
+
+Depending on the object, the following property **may** be present:
+
+-   **flags**: aditional options for matching.
+
+The function also serializes **all** `enumerable` properties.
+
+<!-- eslint-disable object-curly-newline -->
+
+```javascript
+var regex = new RegExp('ab+c');
+regex.a = 'b';
+regex.c = { 'd': 'e' };
+
+var json = toJSON( regex );
+/* returns
+    {
+        'type': 'regexp',
+        'pattern': 'ab+c',
+        'flags': '...', // if present
+        'a': 'b',
+        'c': {
+            'd': 'e'
+        }
+    }
+*/
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package usage examples. -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "regexp" -->
+
+```javascript
+var toJSON = require( '@stdlib/regexp/to-json' );
+
+var regex = new RegExp('ab+c');
+var out = toJSON( regex );
+/* returns
+    {
+        'type': 'regexp',
+        'pattern': 'ab+c',
+        'flags': ''
+    }
+*/
+
+var regexf = new RegExp('ab+c', 'd');
+var out = toJSON( regexf );
+/* returns
+    {
+        'type': 'regexp',
+        'pattern': 'ab+c',
+        'flags': 'd'
+    }
+*/
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/regexp/regexp`][@stdlib/regexp/regexp]</span><span class="delimiter">: </span><span class="description">regular expression to parse a string.</span>
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[json]: http://www.json.org/
+
+[regexp]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+
+<!-- <related-links> -->
+
+[@stdlib/error/reviver]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/error/reviver
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/regexp/to-json/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/regexp/to-json/benchmark/benchmark.js
@@ -33,8 +33,8 @@ bench( pkg, function benchmark( b ) {
 	var i;
 
 	b.tic();
+	regexp = /beep/;
 	for ( i = 0; i < b.iterations; i++ ) {
-		regexp = new RegExp( i + '*' );
 		o = toJSON( regexp );
 		if ( typeof o !== 'object' ) {
 			b.fail( 'should return an object' );

--- a/lib/node_modules/@stdlib/regexp/to-json/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/regexp/to-json/benchmark/benchmark.js
@@ -1,0 +1,50 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var fromCodePoint = require( '@stdlib/string/from-code-point' );
+var pkg = require( './../package.json' ).name;
+var toJSON = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var regexp;
+	var o;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+        regexp = new RegExp( i + '*' )
+		o = toJSON( regexp );
+		if ( typeof o !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+	if ( typeof o !== 'object' ) {
+		b.fail( 'should return an object' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/regexp/to-json/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/regexp/to-json/benchmark/benchmark.js
@@ -21,7 +21,6 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var fromCodePoint = require( '@stdlib/string/from-code-point' );
 var pkg = require( './../package.json' ).name;
 var toJSON = require( './../lib' );
 
@@ -35,7 +34,7 @@ bench( pkg, function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-        regexp = new RegExp( i + '*' )
+		regexp = new RegExp( i + '*' );
 		o = toJSON( regexp );
 		if ( typeof o !== 'object' ) {
 			b.fail( 'should return an object' );

--- a/lib/node_modules/@stdlib/regexp/to-json/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/regexp/to-json/benchmark/benchmark.js
@@ -28,14 +28,20 @@ var toJSON = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
-	var regexp;
+	var values;
 	var o;
 	var i;
+	
+	values = [
+		/beep/,
+		/boop/,
+		/.*/,
+		/ab+c/
+	];
 
 	b.tic();
-	regexp = /beep/;
 	for ( i = 0; i < b.iterations; i++ ) {
-		o = toJSON( regexp );
+		o = toJSON( values[ i%values.length ] );
 		if ( typeof o !== 'object' ) {
 			b.fail( 'should return an object' );
 		}

--- a/lib/node_modules/@stdlib/regexp/to-json/docs/repl.txt
+++ b/lib/node_modules/@stdlib/regexp/to-json/docs/repl.txt
@@ -1,17 +1,12 @@
 
-{{alias}}( error )
-    Returns a JSON representation of a regexp object.
+{{alias}}( regexp )
+    Returns a JSON representation of a RegExp object.
 
     The JSON object is guaranteed to have the following properties:
 
-    - type: regexp type.
+    - type: RegExp type.
     - pattern: regular expression pattern string.
-
-   Depending on the object, the following properties *may* be present:
-
     - flags: aditional options for matching.
-
-    The function also serializes all enumerable properties.
 
     Parameters
     ----------
@@ -25,8 +20,9 @@
 
     Examples
     --------
-    > var regex = new RegExp('ab+c');
-    > var json = {{alias}}( regex )
+    > var pattern = 'ab+c';
+    > var regexp = new RegExp( pattern );
+    > var json = {{alias}}( regexp )
     <Object>
 
     See Also

--- a/lib/node_modules/@stdlib/regexp/to-json/docs/repl.txt
+++ b/lib/node_modules/@stdlib/regexp/to-json/docs/repl.txt
@@ -1,0 +1,33 @@
+
+{{alias}}( error )
+    Returns a JSON representation of a regexp object.
+
+    The JSON object is guaranteed to have the following properties:
+
+    - type: regexp type.
+    - pattern: regular expression pattern string.
+
+   Depending on the object, the following properties *may* be present:
+
+    - flags: aditional options for matching.
+
+    The function also serializes all enumerable properties.
+
+    Parameters
+    ----------
+    regexp: RegExp
+        Regular expression to serialize.
+
+    Returns
+    -------
+    out: Object
+        JSON representation.
+
+    Examples
+    --------
+    > var regex = new RegExp('ab+c');
+    > var json = {{alias}}( regex )
+    <Object>
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/regexp/to-json/docs/repl.txt
+++ b/lib/node_modules/@stdlib/regexp/to-json/docs/repl.txt
@@ -1,12 +1,12 @@
 
 {{alias}}( regexp )
-    Returns a JSON representation of a RegExp object.
+    Returns a JSON representation of a regular expression.
 
-    The JSON object is guaranteed to have the following properties:
+    The returned object has the following properties:
 
-    - type: RegExp type.
-    - pattern: regular expression pattern string.
-    - flags: aditional options for matching.
+    - type: value type. The assigned value is always 'RegExp'.
+    - pattern: regular expression pattern.
+    - flags: regular expression flags.
 
     Parameters
     ----------
@@ -20,9 +20,7 @@
 
     Examples
     --------
-    > var pattern = 'ab+c';
-    > var regexp = new RegExp( pattern );
-    > var json = {{alias}}( regexp )
+    > var json = {{alias}}( /ab+c/ )
     <Object>
 
     See Also

--- a/lib/node_modules/@stdlib/regexp/to-json/docs/repl.txt
+++ b/lib/node_modules/@stdlib/regexp/to-json/docs/repl.txt
@@ -17,11 +17,21 @@
     -------
     out: Object
         JSON representation.
+        
+    out.type: string
+        Value type.
+        
+    out.pattern: string
+        Regular expression pattern.
+        
+    out.flags: string
+        Regular expression flags.
 
     Examples
     --------
     > var json = {{alias}}( /ab+c/ )
-    <Object>
+    {...}
 
     See Also
     --------
+    

--- a/lib/node_modules/@stdlib/regexp/to-json/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/regexp/to-json/docs/types/index.d.ts
@@ -48,7 +48,7 @@ interface JSONRepresentation {
 * var json = toJSON( /ab+c/ );
 * // returns {...}
 */
-declare function toJSON( regex: RegExp ): JSONRepresentation;
+declare function toJSON( regexp: RegExp ): JSONRepresentation;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/regexp/to-json/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/regexp/to-json/docs/types/index.d.ts
@@ -1,0 +1,37 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 2.0
+
+/**
+* Returns a JSON representation of a regexp object.
+*
+* @param regexp - regular expression to serialize
+* @returns JSON representation
+*
+* @example
+* var regex = new reRegExp('ab+c');
+* var json = toJSON( regex );
+* // returns {...}
+*/
+declare function toJSON( regex: RegExp ): any; // tslint-disable-line max-line-length
+
+
+// EXPORTS //
+
+export = toJSON;

--- a/lib/node_modules/@stdlib/regexp/to-json/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/regexp/to-json/docs/types/index.d.ts
@@ -19,35 +19,33 @@
 // TypeScript Version: 2.0
 
 /**
-* JSON representation of typed array.
+* JSON representation of a regular expression.
 */
 interface JSONRepresentation {
 	/**
-	* Typed RegExp type.
+	* Value type.
 	*/
 	type: 'RegExp';
 
 	/**
-	* Typed pattern.
+	* Regular expression pattern.
 	*/
-	pattern: String;
+	pattern: string;
 
 	/**
-	* Typed flags.
+	* Regular expression flags.
 	*/
-	flags: String;
+	flags: string;
 }
 
 /**
-* Returns a JSON representation of a regexp object.
+* Returns a JSON representation of a regular expression.
 *
 * @param regexp - regular expression to serialize
 * @returns JSON representation
 *
 * @example
-* var pattern = 'ab+c';
-* var regex = new reRegExp( pattern );
-* var json = toJSON( regex );
+* var json = toJSON( /ab+c/ );
 * // returns {...}
 */
 declare function toJSON( regex: RegExp ): JSONRepresentation;

--- a/lib/node_modules/@stdlib/regexp/to-json/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/regexp/to-json/docs/types/index.d.ts
@@ -19,17 +19,38 @@
 // TypeScript Version: 2.0
 
 /**
+* JSON representation of typed array.
+*/
+interface JSONRepresentation {
+	/**
+	* Typed RegExp type.
+	*/
+	type: 'RegExp';
+
+	/**
+	* Typed pattern.
+	*/
+	pattern: String;
+
+	/**
+	* Typed flags.
+	*/
+	flags: String;
+}
+
+/**
 * Returns a JSON representation of a regexp object.
 *
 * @param regexp - regular expression to serialize
 * @returns JSON representation
 *
 * @example
-* var regex = new reRegExp('ab+c');
+* var pattern = 'ab+c';
+* var regex = new reRegExp( pattern );
 * var json = toJSON( regex );
 * // returns {...}
 */
-declare function toJSON( regex: RegExp ): any; // tslint-disable-line max-line-length
+declare function toJSON( regex: RegExp ): JSONRepresentation;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/regexp/to-json/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/regexp/to-json/docs/types/test.ts
@@ -23,7 +23,8 @@ import toJSON = require( './index' );
 
 // The function returns an object...
 {
-	toJSON( new RegExp('ab+c') ); // $ExpectType any
+	const pattern = 'ab+c';
+	toJSON( new RegExp( pattern ) ); // $ExpectType JSONRepresentation
 }
 
 // The function does not compile if provided a value other than an error object...

--- a/lib/node_modules/@stdlib/regexp/to-json/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/regexp/to-json/docs/types/test.ts
@@ -23,11 +23,10 @@ import toJSON = require( './index' );
 
 // The function returns an object...
 {
-	const pattern = 'ab+c';
-	toJSON( new RegExp( pattern ) ); // $ExpectType JSONRepresentation
+	toJSON( new RegExp( /ab+c/ ) ); // $ExpectType JSONRepresentation
 }
 
-// The function does not compile if provided a value other than an error object...
+// // The compiler throws an error if the function is provided a value other than a regular expression...
 {
 	toJSON( 'abc' ); // $ExpectError
 	toJSON( true ); // $ExpectError
@@ -40,7 +39,7 @@ import toJSON = require( './index' );
 	toJSON( ( x: number ): number => x ); // $ExpectError
 }
 
-// The function does not compile if provided insufficient arguments...
+// The compiler throws an error if the function is provided insufficient arguments...
 {
 	toJSON(); // $ExpectError
 }

--- a/lib/node_modules/@stdlib/regexp/to-json/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/regexp/to-json/docs/types/test.ts
@@ -23,7 +23,7 @@ import toJSON = require( './index' );
 
 // The function returns an object...
 {
-	toJSON( new RegExp( /ab+c/ ) ); // $ExpectType JSONRepresentation
+	toJSON( /ab+c/ ); // $ExpectType JSONRepresentation
 }
 
 // // The compiler throws an error if the function is provided a value other than a regular expression...

--- a/lib/node_modules/@stdlib/regexp/to-json/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/regexp/to-json/docs/types/test.ts
@@ -1,0 +1,45 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import toJSON = require( './index' );
+
+
+// TESTS //
+
+// The function returns an object...
+{
+	toJSON( new RegExp('ab+c') ); // $ExpectType any
+}
+
+// The function does not compile if provided a value other than an error object...
+{
+	toJSON( 'abc' ); // $ExpectError
+	toJSON( true ); // $ExpectError
+	toJSON( false ); // $ExpectError
+	toJSON( null ); // $ExpectError
+	toJSON( undefined ); // $ExpectError
+	toJSON( 5 ); // $ExpectError
+	toJSON( [] ); // $ExpectError
+	toJSON( {} ); // $ExpectError
+	toJSON( ( x: number ): number => x ); // $ExpectError
+}
+
+// The function does not compile if provided insufficient arguments...
+{
+	toJSON(); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/regexp/to-json/examples/index.js
+++ b/lib/node_modules/@stdlib/regexp/to-json/examples/index.js
@@ -1,0 +1,41 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var toJSON = require( './../lib' );
+
+var regexp = new RegExp( 'ab+c' );
+console.log( toJSON( regexp ) );
+/* =>
+	{
+		'type': 'regexp',
+        'pattern': 'ab+c',
+        'flags': ''
+	}
+*/
+
+regexp = new RegExp( 'ab+c', 'd' );
+console.log( toJSON( regexp ) );
+/* =>
+	{
+		'type': 'regexp',
+        'pattern': 'ab+c',
+        'flags': 'd'
+	}
+*/

--- a/lib/node_modules/@stdlib/regexp/to-json/examples/index.js
+++ b/lib/node_modules/@stdlib/regexp/to-json/examples/index.js
@@ -20,21 +20,22 @@
 
 var toJSON = require( './../lib' );
 
-var regexp = new RegExp( 'ab+c' );
+var pattern = 'ab+c';
+var regexp = new RegExp( pattern );
 console.log( toJSON( regexp ) );
 /* =>
 	{
-		'type': 'regexp',
+		'type': 'RegExp',
         'pattern': 'ab+c',
         'flags': ''
 	}
 */
 
-regexp = new RegExp( 'ab+c', 'd' );
+regexp = new RegExp( pattern, 'd' );
 console.log( toJSON( regexp ) );
 /* =>
 	{
-		'type': 'regexp',
+		'type': 'RegExp',
         'pattern': 'ab+c',
         'flags': 'd'
 	}

--- a/lib/node_modules/@stdlib/regexp/to-json/examples/index.js
+++ b/lib/node_modules/@stdlib/regexp/to-json/examples/index.js
@@ -20,9 +20,7 @@
 
 var toJSON = require( './../lib' );
 
-var pattern = 'ab+c';
-var regexp = new RegExp( pattern );
-console.log( toJSON( regexp ) );
+console.log( toJSON( /ab+c/ ) );
 /* =>
 	{
 		'type': 'RegExp',
@@ -31,12 +29,11 @@ console.log( toJSON( regexp ) );
 	}
 */
 
-regexp = new RegExp( pattern, 'd' );
-console.log( toJSON( regexp ) );
+console.log( toJSON( /ab+c/g ) );
 /* =>
 	{
 		'type': 'RegExp',
         'pattern': 'ab+c',
-        'flags': 'd'
+        'flags': 'g'
 	}
 */

--- a/lib/node_modules/@stdlib/regexp/to-json/lib/index.js
+++ b/lib/node_modules/@stdlib/regexp/to-json/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Return a JSON representation of a regexp object.
+* Return a JSON representation of a regular expression.
 *
 * @module @stdlib/regexp/to-json
 *

--- a/lib/node_modules/@stdlib/regexp/to-json/lib/index.js
+++ b/lib/node_modules/@stdlib/regexp/to-json/lib/index.js
@@ -26,9 +26,7 @@
 * @example
 * var toJSON = require( '@stdlib/regexp/to-json' );
 *
-* var pattern = 'ab+c'
-* var regexp = new RegExp( pattern );
-* var json = toJSON( regexp );
+* var json = toJSON( /ab+c/ );
 * // returns <Object>
 */
 

--- a/lib/node_modules/@stdlib/regexp/to-json/lib/index.js
+++ b/lib/node_modules/@stdlib/regexp/to-json/lib/index.js
@@ -19,14 +19,15 @@
 'use strict';
 
 /**
-* Returns a JSON representation of a regexp object.
+* Return a JSON representation of a regexp object.
 *
 * @module @stdlib/regexp/to-json
 *
 * @example
 * var toJSON = require( '@stdlib/regexp/to-json' );
 *
-* var regexp = new RegExp( 'ab+c' );
+* var pattern = 'ab+c'
+* var regexp = new RegExp( pattern );
 * var json = toJSON( regexp );
 * // returns <Object>
 */

--- a/lib/node_modules/@stdlib/regexp/to-json/lib/index.js
+++ b/lib/node_modules/@stdlib/regexp/to-json/lib/index.js
@@ -1,0 +1,41 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Returns a JSON representation of a regexp object.
+*
+* @module @stdlib/regexp/to-json
+*
+* @example
+* var toJSON = require( '@stdlib/regexp/to-json' );
+*
+* var regexp = new RegExp( 'ab+c' );
+* var json = toJSON( regexp );
+* // returns <Object>
+*/
+
+// MODULES //
+
+var toJSON = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = toJSON;

--- a/lib/node_modules/@stdlib/regexp/to-json/lib/main.js
+++ b/lib/node_modules/@stdlib/regexp/to-json/lib/main.js
@@ -21,50 +21,36 @@
 // MODULES //
 
 var isRegExp = require( '@stdlib/assert/is-regexp' );
+var reRegExp = require( '@stdlib/regexp/regexp' );
 var format = require( '@stdlib/string/format' );
 
 
 // MAIN //
 
 /**
-* Return a JSON representation of a regexp object.
+* Returns a JSON representation of a regular expression.
 *
 * @param {RegExp} regex - regular expression to serialize
-* @throws {TypeError} first argument must be an RegExp object
+* @throws {TypeError} first argument must be a regular expression
 * @returns {Object} JSON representation
 *
 * @example
-* var pattern = 'ab+c';
-* var regex = new RegExp( pattern );
-* var json = toJSON( regex );
+* var json = toJSON( /ab+c/ );
 * // returns {...}
 */
 function toJSON( regex ) {
-	var pattern;
-	var out;
-
+	var parts;
+	var re;
 	if ( !isRegExp( regex ) ) {
 		throw new TypeError( format( 'invalid argument. Must provide a regular expression. Value: `%s`.', regex ) );
 	}
-	out = {};
-
-	// Guaranteed properties:
-	regex = String(regex).split('/');
-	pattern = regex.slice(1, -1);
-
-	// Insert the missing '/' inside of the pattern
-	if ( pattern.length > 1 ) {
-		pattern = pattern.join( '/' );
-	}
-	else {
-		pattern = pattern[0];
-	}
-
-	out.type = 'RegExp';
-	out.flags = regex[ regex.length - 1 ];
-	out.pattern = pattern;
-
-	return out;
+	re = reRegExp();
+	parts = re.exec( regex.toString() );
+	return {
+		'type': 'RegExp',
+		'pattern': parts[ 1 ],
+		'flags': parts[ 2 ]
+	};
 }
 
 

--- a/lib/node_modules/@stdlib/regexp/to-json/lib/main.js
+++ b/lib/node_modules/@stdlib/regexp/to-json/lib/main.js
@@ -1,0 +1,72 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var objectKeys = require( '@stdlib/utils/keys' );
+var copy = require( '@stdlib/utils/copy' );
+var isRegExp = require( '@stdlib/assert/is-regexp' );
+var format = require( '@stdlib/string/format' );
+var typeName = require( './type.js' );
+
+
+// MAIN //
+
+/**
+* Returns a JSON representation of a regexp object.
+*
+* @param {RegExp} regex - regular expression to serialize
+* @throws {TypeError} first argument must be an error object
+* @returns {Object} JSON representation
+*
+* @example
+* var regex = new RegExp( 'ab+c' );
+* var json = toJSON( regex );
+* // returns {...}
+*/
+function toJSON( regex ) {
+	var keys;
+	var out;
+	var i;
+	if ( !isRegExp( regex ) ) {
+		throw new TypeError( format( 'invalid argument. Must provide a RegExp object. Value: `%s`.', err ) );
+	}
+	out = {};
+
+	// Guaranteed properties:
+    out.type = 'regexp';
+	out.pattern = regex.source;
+
+	// Possible general error properties...
+	if ( regex.flags ) {
+		out.flags = regex.flags;
+	}
+	// Any enumerable properties...
+	keys = objectKeys( err );
+	for ( i = 0; i < keys.length; i++ ) {
+		out[ keys[i] ] = copy( err[ keys[i] ] );
+	}
+	return out;
+}
+
+
+// EXPORTS //
+
+module.exports = toJSON;

--- a/lib/node_modules/@stdlib/regexp/to-json/lib/main.js
+++ b/lib/node_modules/@stdlib/regexp/to-json/lib/main.js
@@ -20,49 +20,50 @@
 
 // MODULES //
 
-var objectKeys = require( '@stdlib/utils/keys' );
-var copy = require( '@stdlib/utils/copy' );
 var isRegExp = require( '@stdlib/assert/is-regexp' );
 var format = require( '@stdlib/string/format' );
-var typeName = require( './type.js' );
 
 
 // MAIN //
 
 /**
-* Returns a JSON representation of a regexp object.
+* Return a JSON representation of a regexp object.
 *
 * @param {RegExp} regex - regular expression to serialize
-* @throws {TypeError} first argument must be an error object
+* @throws {TypeError} first argument must be an RegExp object
 * @returns {Object} JSON representation
 *
 * @example
-* var regex = new RegExp( 'ab+c' );
+* var pattern = 'ab+c';
+* var regex = new RegExp( pattern );
 * var json = toJSON( regex );
 * // returns {...}
 */
 function toJSON( regex ) {
-	var keys;
+	var pattern;
 	var out;
-	var i;
+
 	if ( !isRegExp( regex ) ) {
-		throw new TypeError( format( 'invalid argument. Must provide a RegExp object. Value: `%s`.', err ) );
+		throw new TypeError( format( 'invalid argument. Must provide a regular expression. Value: `%s`.', regex ) );
 	}
 	out = {};
 
 	// Guaranteed properties:
-    out.type = 'regexp';
-	out.pattern = regex.source;
+	regex = String(regex).split('/');
+	pattern = regex.slice(1, -1);
 
-	// Possible general error properties...
-	if ( regex.flags ) {
-		out.flags = regex.flags;
+	// Insert the missing '/' inside of the pattern
+	if ( pattern.length > 1 ) {
+		pattern = pattern.join( '/' );
 	}
-	// Any enumerable properties...
-	keys = objectKeys( err );
-	for ( i = 0; i < keys.length; i++ ) {
-		out[ keys[i] ] = copy( err[ keys[i] ] );
+	else {
+		pattern = pattern[0];
 	}
+
+	out.type = 'RegExp';
+	out.flags = regex[ regex.length - 1 ];
+	out.pattern = pattern;
+
 	return out;
 }
 

--- a/lib/node_modules/@stdlib/regexp/to-json/package.json
+++ b/lib/node_modules/@stdlib/regexp/to-json/package.json
@@ -1,0 +1,68 @@
+{
+    "name": "@stdlib/regexp/to-json",
+    "version": "0.0.0",
+    "description": "Return a JSON representation of a regexp object.",
+    "license": "Apache-2.0",
+    "author": {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    },
+    "contributors": [
+      {
+        "name": "The Stdlib Authors",
+        "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+      }
+    ],
+    "main": "./lib",
+    "directories": {
+      "benchmark": "./benchmark",
+      "doc": "./docs",
+      "example": "./examples",
+      "lib": "./lib",
+      "test": "./test"
+    },
+    "types": "./docs/types",
+    "scripts": {},
+    "homepage": "https://github.com/stdlib-js/stdlib",
+    "repository": {
+      "type": "git",
+      "url": "git://github.com/stdlib-js/stdlib.git"
+    },
+    "bugs": {
+      "url": "https://github.com/stdlib-js/stdlib/issues"
+    },
+    "dependencies": {},
+    "devDependencies": {},
+    "engines": {
+      "node": ">=0.10.0",
+      "npm": ">2.7.0"
+    },
+    "os": [
+      "aix",
+      "darwin",
+      "freebsd",
+      "linux",
+      "macos",
+      "openbsd",
+      "sunos",
+      "win32",
+      "windows"
+    ],
+    "keywords": [
+      "stdlib",
+      "stdutils",
+      "stdutil",
+      "utils",
+      "object",
+      "regexp",
+      "re",
+      "regular",
+      "expression",
+      "obj",
+      "serialize",
+      "tojson",
+      "json",
+      "to",
+      "convert"
+    ]
+  }

--- a/lib/node_modules/@stdlib/regexp/to-json/package.json
+++ b/lib/node_modules/@stdlib/regexp/to-json/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@stdlib/regexp/to-json",
     "version": "0.0.0",
-    "description": "Return a JSON representation of a regexp object.",
+    "description": "Return a JSON representation of a regular expression.",
     "license": "Apache-2.0",
     "author": {
       "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/regexp/to-json/test/test.js
+++ b/lib/node_modules/@stdlib/regexp/to-json/test/test.js
@@ -1,0 +1,224 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var vm = require( 'vm' );
+var tape = require( 'tape' );
+var IS_BROWSER = require( '@stdlib/assert/is-browser' );
+var isPlainObject = require( '@stdlib/assert/is-plain-object' );
+var defineProperty = require( '@stdlib/utils/define-property' );
+var toJSON = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof toJSON, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'if provided anything other than an regexp instance, the function will throw an error', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		NaN,
+		null,
+		void 0,
+		true,
+		[],
+		{},
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), Error, 'throws when provided a ' + (typeof values[i]) );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			toJSON( value );
+		};
+	}
+});
+
+tape( 'the function returns a JSON object', function test( t ) {
+	var json;
+	var regex;
+
+	regex = new RegExp( 'beep' );
+	json = toJSON( regex );
+	t.strictEqual( isPlainObject( json ), true, 'returns an object' );
+	t.end();
+});
+
+tape( 'the JSON object includes a regexp type', function test( t ) {
+	var expected;
+	var value;
+	var json;
+
+	value = new RegExp();
+	expected = 'regexp';
+    json = toJSON( value );
+    t.strictEqual( json.type, expected, 'type equal to ' + expected );
+	t.end();
+});
+
+tape( 'the JSON object includes a pattern', function test( t ) {
+	var expected;
+	var values;
+	var json;
+	var i;
+
+	values = [
+		new RegExp( '.*' ),
+		new RegExp( 'ab+c' ),
+        new RegExp( '//.*^1' )
+	];
+
+	expected = [
+		'.*',
+		'ab+c',
+		'//.*^1'
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		json = toJSON( values[ i ] );
+		t.strictEqual( json.pattern, expected[ i ], 'pattern equal to \'' + expected[ i ] + '\'' );
+	}
+	t.end();
+});
+
+tape( 'if a `flags` property is present, the JSON object includes that field', function test( t ) {
+	var expected;
+	var values;
+	var json;
+	var i;
+
+	values = [
+		new RegExp( '.*', 'd' ),
+		new RegExp( 'ab+c', 'dy' ),
+        new RegExp( '//.*^1', 's' )
+	];
+
+	expected = [
+		'd',
+		'dy',
+		's'
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		values[ i ].stack = expected[ i ];
+		json = toJSON( values[ i ] );
+		t.strictEqual( json.flags, expected[ i ], 'flags equal to \'' + expected[ i ] + '\'' );
+	}
+	t.end();
+});
+
+tape( 'if a `flags` property is not present, the JSON object will not include a `flags` property', function test( t ) {
+	var json;
+	var regex;
+
+	regex = new RegExp('*.');
+
+	// Fake not having a `flags` by intercepting access and returning `undefined`, similar to non-existent property behavior...
+	defineProperty( regex, 'flags', {
+		'value': void 0,
+		'enumerable': false,
+		'configuable': true,
+		'writable': true
+	});
+
+	json = toJSON( regex );
+	t.strictEqual( json.flags, void 0, 'no flags property' );
+	t.end();
+});
+
+tape( 'if a provided regex has additional enumerable properties, the function will include these properties and their values in the output JSON', function test( t ) {
+	var json;
+	var regex;
+
+	// Data descriptor...
+	regex = new RegExp( 'ab+c' );
+	regex.beep = 'boop';
+	regex.boop = 'beep';
+
+	json = toJSON( regex );
+	t.strictEqual( json.beep, regex.beep, 'data descriptor' );
+	t.strictEqual( json.boop, regex.boop, 'data descriptor' );
+
+	// Accessor descriptor...
+	regex = new RegExp( 'ab+c' );
+	defineProperty( regex, 'beep', {
+		'enumerable': true,
+		'configurable': true,
+		'get': function get() {
+			return 'boop';
+		}
+	});
+	defineProperty( regex, 'boop', {
+		'enumerable': true,
+		'configurable': false,
+		'get': function get() {
+			return 'beep';
+		}
+	});
+
+	json = toJSON( regex );
+	t.strictEqual( json.beep, regex.regex, 'accessor descriptor' );
+	t.strictEqual( json.boop, regex.regex, 'accessor descriptor' );
+
+	t.end();
+});
+
+tape( 'the function deep copies enumerable properties', function test( t ) {
+	var json;
+	var regex;
+
+	// Deep equal...
+	regex = new RegExp( 'ab+c' );
+	regex.arr = [ 1, 2, [ 3, 4, 5 ] ];
+
+	json = toJSON( regex );
+	t.notEqual( json.arr, regex.arr, 'new instances' );
+	t.deepEqual( json.arr, regex.arr, 'deep equal' );
+
+	t.end();
+});
+
+opts.skip = IS_BROWSER;
+tape( 'the function supports serializing a regular expression from a different realm', opts, function test( t ) {
+	var json;
+	var regex;
+
+	regex = vm.runInNewContext( 'new RegExp( "ab+c", "g" )' );
+	json = toJSON( regex );
+
+	t.strictEqual( json.type, 'regexp', 'type equal to regexp' );
+	t.strictEqual( json.pattern, regex.pattern, 'equal pattern' );
+	t.strictEqual( json.flags, regex.flags, 'equal flags' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/regexp/to-json/test/test.js
+++ b/lib/node_modules/@stdlib/regexp/to-json/test/test.js
@@ -59,7 +59,7 @@ tape( 'if provided anything other than a regular expression, the function throws
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		t.throws( badValue( values[i] ), Error, 'throws when provided a ' + (typeof values[i]) );
+		t.throws( badValue( values[i] ), Error, 'throws when provided ' + values[i] );
 	}
 	t.end();
 
@@ -82,7 +82,7 @@ tape( 'the JSON object includes a `type` field', function test( t ) {
 	var json;
 
 	json = toJSON( /beep/ );
-	t.strictEqual( json.type, 'RegExp', 'type equal to RegExp' );
+	t.strictEqual( json.type, 'RegExp', 'returns expected value' );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/regexp/to-json/test/test.js
+++ b/lib/node_modules/@stdlib/regexp/to-json/test/test.js
@@ -24,8 +24,14 @@ var vm = require( 'vm' );
 var tape = require( 'tape' );
 var IS_BROWSER = require( '@stdlib/assert/is-browser' );
 var isPlainObject = require( '@stdlib/assert/is-plain-object' );
-var defineProperty = require( '@stdlib/utils/define-property' );
 var toJSON = require( './../lib' );
+
+
+// VARIABLES //
+
+var opts = {
+	'skip': false
+};
 
 
 // TESTS //
@@ -36,7 +42,7 @@ tape( 'main export is a function', function test( t ) {
 	t.end();
 });
 
-tape( 'if provided anything other than an regexp instance, the function will throw an error', function test( t ) {
+tape( 'if provided anything other than a regular expression, the function will throw an error', function test( t ) {
 	var values;
 	var i;
 
@@ -65,62 +71,69 @@ tape( 'if provided anything other than an regexp instance, the function will thr
 });
 
 tape( 'the function returns a JSON object', function test( t ) {
-	var json;
+	var pattern;
 	var regex;
+	var json;
 
-	regex = new RegExp( 'beep' );
+	pattern = 'beep';
+	regex = new RegExp( pattern );
 	json = toJSON( regex );
 	t.strictEqual( isPlainObject( json ), true, 'returns an object' );
 	t.end();
 });
 
-tape( 'the JSON object includes a regexp type', function test( t ) {
+tape( 'the JSON object includes a type field', function test( t ) {
 	var expected;
+	var pattern;
 	var value;
 	var json;
 
-	value = new RegExp();
-	expected = 'regexp';
-    json = toJSON( value );
-    t.strictEqual( json.type, expected, 'type equal to ' + expected );
+	pattern = 'beep';
+	value = new RegExp( pattern );
+	expected = 'RegExp';
+	json = toJSON( value );
+	t.strictEqual( json.type, expected, 'type equal to ' + expected );
 	t.end();
 });
 
-tape( 'the JSON object includes a pattern', function test( t ) {
+tape( 'the JSON object includes a pattern field', function test( t ) {
 	var expected;
 	var values;
+	var regex;
 	var json;
 	var i;
 
 	values = [
-		new RegExp( '.*' ),
-		new RegExp( 'ab+c' ),
-        new RegExp( '//.*^1' )
+		'.*',
+		'ab+c',
+		'/.*^1'
 	];
 
 	expected = [
 		'.*',
 		'ab+c',
-		'//.*^1'
+		'\\/.*^1'
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		json = toJSON( values[ i ] );
+		regex = new RegExp( values[ i ] );
+		json = toJSON( regex );
 		t.strictEqual( json.pattern, expected[ i ], 'pattern equal to \'' + expected[ i ] + '\'' );
 	}
 	t.end();
 });
 
-tape( 'if a `flags` property is present, the JSON object includes that field', function test( t ) {
+tape( 'the JSON object includes a flags field', function test( t ) {
 	var expected;
 	var values;
+	var regex;
 	var json;
 	var i;
 
 	values = [
-		new RegExp( '.*', 'd' ),
-		new RegExp( 'ab+c', 'dy' ),
-        new RegExp( '//.*^1', 's' )
+		'.*',
+		'ab+c',
+		'/.*^1'
 	];
 
 	expected = [
@@ -130,95 +143,24 @@ tape( 'if a `flags` property is present, the JSON object includes that field', f
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		values[ i ].stack = expected[ i ];
-		json = toJSON( values[ i ] );
+		regex = new RegExp( values[ i ], expected[ i ] );
+		json = toJSON( regex );
 		t.strictEqual( json.flags, expected[ i ], 'flags equal to \'' + expected[ i ] + '\'' );
 	}
 	t.end();
 });
 
-tape( 'if a `flags` property is not present, the JSON object will not include a `flags` property', function test( t ) {
-	var json;
-	var regex;
-
-	regex = new RegExp('*.');
-
-	// Fake not having a `flags` by intercepting access and returning `undefined`, similar to non-existent property behavior...
-	defineProperty( regex, 'flags', {
-		'value': void 0,
-		'enumerable': false,
-		'configuable': true,
-		'writable': true
-	});
-
-	json = toJSON( regex );
-	t.strictEqual( json.flags, void 0, 'no flags property' );
-	t.end();
-});
-
-tape( 'if a provided regex has additional enumerable properties, the function will include these properties and their values in the output JSON', function test( t ) {
-	var json;
-	var regex;
-
-	// Data descriptor...
-	regex = new RegExp( 'ab+c' );
-	regex.beep = 'boop';
-	regex.boop = 'beep';
-
-	json = toJSON( regex );
-	t.strictEqual( json.beep, regex.beep, 'data descriptor' );
-	t.strictEqual( json.boop, regex.boop, 'data descriptor' );
-
-	// Accessor descriptor...
-	regex = new RegExp( 'ab+c' );
-	defineProperty( regex, 'beep', {
-		'enumerable': true,
-		'configurable': true,
-		'get': function get() {
-			return 'boop';
-		}
-	});
-	defineProperty( regex, 'boop', {
-		'enumerable': true,
-		'configurable': false,
-		'get': function get() {
-			return 'beep';
-		}
-	});
-
-	json = toJSON( regex );
-	t.strictEqual( json.beep, regex.regex, 'accessor descriptor' );
-	t.strictEqual( json.boop, regex.regex, 'accessor descriptor' );
-
-	t.end();
-});
-
-tape( 'the function deep copies enumerable properties', function test( t ) {
-	var json;
-	var regex;
-
-	// Deep equal...
-	regex = new RegExp( 'ab+c' );
-	regex.arr = [ 1, 2, [ 3, 4, 5 ] ];
-
-	json = toJSON( regex );
-	t.notEqual( json.arr, regex.arr, 'new instances' );
-	t.deepEqual( json.arr, regex.arr, 'deep equal' );
-
-	t.end();
-});
-
 opts.skip = IS_BROWSER;
 tape( 'the function supports serializing a regular expression from a different realm', opts, function test( t ) {
-	var json;
 	var regex;
+	var json;
 
 	regex = vm.runInNewContext( 'new RegExp( "ab+c", "g" )' );
 	json = toJSON( regex );
 
-	t.strictEqual( json.type, 'regexp', 'type equal to regexp' );
-	t.strictEqual( json.pattern, regex.pattern, 'equal pattern' );
-	t.strictEqual( json.flags, regex.flags, 'equal flags' );
+	t.strictEqual( json.type, 'RegExp', 'type equal to regexp' );
+	t.strictEqual( json.pattern, 'ab+c', 'equal pattern' );
+	t.strictEqual( json.flags, 'g', 'equal flags' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/regexp/to-json/test/test.js
+++ b/lib/node_modules/@stdlib/regexp/to-json/test/test.js
@@ -42,7 +42,7 @@ tape( 'main export is a function', function test( t ) {
 	t.end();
 });
 
-tape( 'if provided anything other than a regular expression, the function will throw an error', function test( t ) {
+tape( 'if provided anything other than a regular expression, the function throws an error', function test( t ) {
 	var values;
 	var i;
 
@@ -71,42 +71,31 @@ tape( 'if provided anything other than a regular expression, the function will t
 });
 
 tape( 'the function returns a JSON object', function test( t ) {
-	var pattern;
-	var regex;
 	var json;
 
-	pattern = 'beep';
-	regex = new RegExp( pattern );
-	json = toJSON( regex );
+	json = toJSON( /beep/ );
 	t.strictEqual( isPlainObject( json ), true, 'returns an object' );
 	t.end();
 });
 
-tape( 'the JSON object includes a type field', function test( t ) {
-	var expected;
-	var pattern;
-	var value;
+tape( 'the JSON object includes a `type` field', function test( t ) {
 	var json;
 
-	pattern = 'beep';
-	value = new RegExp( pattern );
-	expected = 'RegExp';
-	json = toJSON( value );
-	t.strictEqual( json.type, expected, 'type equal to ' + expected );
+	json = toJSON( /beep/ );
+	t.strictEqual( json.type, 'RegExp', 'type equal to RegExp' );
 	t.end();
 });
 
-tape( 'the JSON object includes a pattern field', function test( t ) {
+tape( 'the JSON object includes a `pattern` field', function test( t ) {
 	var expected;
 	var values;
-	var regex;
 	var json;
 	var i;
 
 	values = [
-		'.*',
-		'ab+c',
-		'/.*^1'
+		/.*/,
+		/ab+c/,
+		/\/.*^1/
 	];
 
 	expected = [
@@ -116,36 +105,33 @@ tape( 'the JSON object includes a pattern field', function test( t ) {
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		regex = new RegExp( values[ i ] );
-		json = toJSON( regex );
-		t.strictEqual( json.pattern, expected[ i ], 'pattern equal to \'' + expected[ i ] + '\'' );
+		json = toJSON( values[ i ] );
+		t.strictEqual( json.pattern, expected[ i ], 'returns expected value when provided '+values[ i ].toString() );
 	}
 	t.end();
 });
 
-tape( 'the JSON object includes a flags field', function test( t ) {
+tape( 'the JSON object includes a `flags` field', function test( t ) {
 	var expected;
 	var values;
-	var regex;
 	var json;
 	var i;
 
 	values = [
-		'.*',
-		'ab+c',
-		'/.*^1'
+		/.*/g,
+		/ab+c/i,
+		/\/.*^1/gi
 	];
 
 	expected = [
-		'd',
-		'dy',
-		's'
+		'g',
+		'i',
+		'gi'
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		regex = new RegExp( values[ i ], expected[ i ] );
-		json = toJSON( regex );
-		t.strictEqual( json.flags, expected[ i ], 'flags equal to \'' + expected[ i ] + '\'' );
+		json = toJSON( values[i] );
+		t.strictEqual( json.flags, expected[ i ], 'returns expected value when provided '+values[ i ].toString() );
 	}
 	t.end();
 });
@@ -155,12 +141,12 @@ tape( 'the function supports serializing a regular expression from a different r
 	var regex;
 	var json;
 
-	regex = vm.runInNewContext( 'new RegExp( "ab+c", "g" )' );
+	regex = vm.runInNewContext( '/ab+c/g' );
 	json = toJSON( regex );
 
-	t.strictEqual( json.type, 'RegExp', 'type equal to regexp' );
-	t.strictEqual( json.pattern, 'ab+c', 'equal pattern' );
-	t.strictEqual( json.flags, 'g', 'equal flags' );
+	t.strictEqual( json.type, 'RegExp', 'returns expected value' );
+	t.strictEqual( json.pattern, 'ab+c', 'returns expected value' );
+	t.strictEqual( json.flags, 'g', 'returns expected value' );
 
 	t.end();
 });


### PR DESCRIPTION
Resolves https://github.com/stdlib-js/todo/issues/411.

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds to-json package for RegExp objects

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves https://github.com/stdlib-js/todo/issues/411

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
