### PR TITLE
Add support for reviving a JSON serialized regular expression

### DIFF
--- a/lib/node_modules/@stdlib/regexp/reviver/README.md
+++ b/lib/node_modules/@stdlib/regexp/reviver/README.md
@@ -1,0 +1,109 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2022 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# reviveRegExp
+
+> Revive a JSON-serialized [regular expression][regexp] object.
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var reviveRegExp = require( '@stdlib/regexp/reviver' );
+```
+
+#### reviveRegExp( key, value )
+
+Revives a JSON-serialized [regular expression][regexp] object.
+
+```javascript
+var str = '{"type":"RegExp","pattern":"ab+c","flags":""}';
+
+var regex = JSON.parse( str, reviveRegExp );
+// returns <RegExp>
+```
+
+<!-- For details on the JSON serialization format, see [regexp-to-json][@stdlib/regexp/to-json]. -->
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="examples">
+
+## Examples
+
+```javascript
+// add example
+
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+* * *
+
+## See Also
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+<!-- <related-links> -->
+
+[regexp]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+
+<!-- [@stdlib/regexp/to-json]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/regexp/to-json -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/regexp/reviver/README.md
+++ b/lib/node_modules/@stdlib/regexp/reviver/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # reviveRegExp
 
-> Revive a JSON-serialized [regular expression][regexp] object.
+> Revive a JSON-serialized [regular expression][regexp].
 
 <!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
 
@@ -42,7 +42,7 @@ var reviveRegExp = require( '@stdlib/regexp/reviver' );
 
 #### reviveRegExp( key, value )
 
-Revives a JSON-serialized [regular expression][regexp] object.
+Revives a JSON-serialized [regular expression][regexp].
 
 ```javascript
 var str = '{"type":"RegExp","pattern":"ab+c","flags":""}';
@@ -51,7 +51,7 @@ var regex = JSON.parse( str, reviveRegExp );
 // returns <RegExp>
 ```
 
-<!-- For details on the JSON serialization format, see [regexp-to-json][@stdlib/regexp/to-json]. -->
+For details on the JSON serialization format, see [regexp-to-json][@stdlib/regexp/to-json].
 
 </section>
 
@@ -64,8 +64,27 @@ var regex = JSON.parse( str, reviveRegExp );
 ## Examples
 
 ```javascript
-// add example
+var regex2json = require( '@stdlib/regexp/to-json' );
+var reviveRegExp = require( '@stdlib/regexp/reviver' );
 
+var regex = /ab+c/;
+var json = regex2json( regex );
+/* returns
+    {
+        'type': 'RegExp',
+        'pattern': 'ab+c',
+        'flags': ''
+    }
+*/
+
+var str = JSON.stringify( json );
+// returns '{"type":"RegExp","pattern":"ab+c","flags":""}'
+
+var regex2 = JSON.parse( str, reviveRegExp );
+// returns <RegExp>
+
+var bool = ( String( regex ) === String( regex2 ) );
+// returns true
 ```
 
 </section>
@@ -84,10 +103,6 @@ var regex = JSON.parse( str, reviveRegExp );
 
 <section class="related">
 
-* * *
-
-## See Also
-
 </section>
 
 <!-- /.related -->
@@ -100,7 +115,7 @@ var regex = JSON.parse( str, reviveRegExp );
 
 [regexp]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
 
-<!-- [@stdlib/regexp/to-json]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/regexp/to-json -->
+[@stdlib/regexp/to-json]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/regexp/to-json
 
 <!-- </related-links> -->
 

--- a/lib/node_modules/@stdlib/regexp/reviver/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/regexp/reviver/benchmark/benchmark.js
@@ -1,0 +1,21 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// to do: add benchmark

--- a/lib/node_modules/@stdlib/regexp/reviver/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/regexp/reviver/benchmark/benchmark.js
@@ -18,4 +18,100 @@
 
 'use strict';
 
-// to do: add benchmark
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var parseJSON = require( '@stdlib/utils/parse-json' );
+var regex2json = require( '@stdlib/regexp/to-json' );
+var pkg = require( './../package.json' ).name;
+var reviver = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var values;
+	var json;
+	var o;
+	var i;
+
+	values = [
+		/beep/,
+		/boop/,
+		/.*/,
+		/ab+c/
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		json = JSON.stringify( regex2json( values[ i%values.length ] ) );
+		o = parseJSON( json, reviver );
+		if ( typeof o !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+	if ( typeof o !== 'object' ) {
+		b.fail( 'should return an object' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::no_reviver', function benchmark( b ) {
+	var values;
+	var json;
+	var o;
+	var i;
+
+	values = [
+		/beep/,
+		/boop/,
+		/.*/,
+		/ab+c/
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		json = JSON.stringify( regex2json( values[ i%values.length ] ) );
+		o = parseJSON( json );
+		if ( typeof o !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+	if ( typeof o !== 'object' ) {
+		b.fail( 'should return an object' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::no_reviver,built-in', function benchmark( b ) {
+	var values;
+	var json;
+	var o;
+	var i;
+
+	values = [
+		/beep/,
+		/boop/,
+		/.*/,
+		/ab+c/
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		json = JSON.stringify( regex2json( values[ i%values.length ] ) );
+		o = JSON.parse( json );
+		if ( typeof o !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+	if ( typeof o !== 'object' ) {
+		b.fail( 'should return an object' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/regexp/reviver/docs/repl.txt
+++ b/lib/node_modules/@stdlib/regexp/reviver/docs/repl.txt
@@ -1,0 +1,24 @@
+{{alias}}( key, value )
+    Revives a JSON-serialized regular expression object.
+
+    Parameters
+    ----------
+    key: string
+        Key.
+
+    value: any
+        Value.
+
+    Returns
+    -------
+    out: any
+        Value or RegExp object.
+
+    Examples
+    --------
+    > var str = '{"type":"RegExp","pattern":"ab+c","flags":""}';
+    > var err = JSON.parse( str, {{alias}} )
+    <RegExp>
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/regexp/reviver/docs/repl.txt
+++ b/lib/node_modules/@stdlib/regexp/reviver/docs/repl.txt
@@ -1,5 +1,5 @@
 {{alias}}( key, value )
-    Revives a JSON-serialized regular expression object.
+    Revives a JSON-serialized regular expression.
 
     Parameters
     ----------
@@ -12,7 +12,7 @@
     Returns
     -------
     out: any
-        Value or RegExp object.
+        Value or regular expression.
 
     Examples
     --------

--- a/lib/node_modules/@stdlib/regexp/reviver/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/regexp/reviver/docs/types/index.d.ts
@@ -1,0 +1,38 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 2.0
+
+/**
+* Revives a JSON-serialized regular expression object.
+*
+* @param key - key
+* @param value - value
+* @returns value or RegExp object
+*
+* @example
+* var str = '{"type":"RegExp","pattern":"ab+c","flags":""}';
+* var regex = JSON.parse( str, reviver );
+* // returns <RegExp>
+*/
+declare function reviver( key: string, value: any ): any;
+
+
+// EXPORTS //
+
+export = reviver;

--- a/lib/node_modules/@stdlib/regexp/reviver/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/regexp/reviver/docs/types/index.d.ts
@@ -19,11 +19,11 @@
 // TypeScript Version: 2.0
 
 /**
-* Revives a JSON-serialized regular expression object.
+* Revives a JSON-serialized regular expression.
 *
 * @param key - key
 * @param value - value
-* @returns value or RegExp object
+* @returns value or regular expression
 *
 * @example
 * var str = '{"type":"RegExp","pattern":"ab+c","flags":""}';

--- a/lib/node_modules/@stdlib/regexp/reviver/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/regexp/reviver/docs/types/test.ts
@@ -1,0 +1,45 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import reviver = require( './index' );
+
+
+// TESTS //
+
+// The function can be used to revive a serialized object...
+{
+	JSON.parse( '{"type":"RegExp","pattern":"ab+c","flags":""}', reviver ); // $ExpectType any
+}
+
+// The function does not compile if provided a first argument that is not a string...
+{
+	reviver( true, 1 ); // $ExpectError
+	reviver( false, 1 ); // $ExpectError
+	reviver( null, 1 ); // $ExpectError
+	reviver( undefined, 1 ); // $ExpectError
+	reviver( 5, 1 ); // $ExpectError
+	reviver( [], 1 ); // $ExpectError
+	reviver( {}, 1 ); // $ExpectError
+	reviver( ( x: number ): number => x, 1 ); // $ExpectError
+}
+
+// The function does not compile if provided insufficient arguments...
+{
+	reviver(); // $ExpectError
+	reviver( 'beep' ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/regexp/reviver/examples/index.js
+++ b/lib/node_modules/@stdlib/regexp/reviver/examples/index.js
@@ -18,4 +18,24 @@
 
 'use strict';
 
-// to do: add example
+var regex2json = require( '@stdlib/regexp/to-json' );
+var reviveRegExp = require( './../lib' );
+
+var regex = /ab+c/;
+var json = regex2json( regex );
+/* returns
+    {
+        'type': 'RegExp',
+        'pattern': 'ab+c',
+        'flags': ''
+    }
+*/
+
+var str = JSON.stringify( json );
+// returns '{"type":"RegExp","pattern":"ab+c","flags":""}'
+
+var regex2 = JSON.parse( str, reviveRegExp );
+// returns <RegExp>
+
+console.log( String( regex ) === String( regex2 ) );
+// => true

--- a/lib/node_modules/@stdlib/regexp/reviver/examples/index.js
+++ b/lib/node_modules/@stdlib/regexp/reviver/examples/index.js
@@ -1,0 +1,21 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// to do: add example

--- a/lib/node_modules/@stdlib/regexp/reviver/lib/index.js
+++ b/lib/node_modules/@stdlib/regexp/reviver/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Revive a JSON-serialized regular expression object.
+* Revive a JSON-serialized regular expression.
 *
 * @module @stdlib/regexp/reviver
 *

--- a/lib/node_modules/@stdlib/regexp/reviver/lib/index.js
+++ b/lib/node_modules/@stdlib/regexp/reviver/lib/index.js
@@ -1,0 +1,41 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Revive a JSON-serialized regular expression object.
+*
+* @module @stdlib/regexp/reviver
+*
+* @example
+* var reviver = require( '@stdlib/regexp/reviver' );
+*
+* var str = '{"type":"RegExp","pattern":"ab+c","flags":""}';
+* var err = JSON.parse( str, reviver );
+* // returns <RegExp>
+*/
+
+// MODULES //
+
+var reviver = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = reviver;

--- a/lib/node_modules/@stdlib/regexp/reviver/lib/main.js
+++ b/lib/node_modules/@stdlib/regexp/reviver/lib/main.js
@@ -1,0 +1,45 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MAIN //
+
+/**
+* Revives a JSON-serialized regular expression object.
+*
+* @param {string} key - key
+* @param {*} value - value
+* @returns {RegExp} RegExp object
+*
+* @example
+* var str = '{"type":"RegExp","pattern":"ab+c","flags":""}';
+* var err = JSON.parse( str, reviver );
+* // returns <RegExp>
+*/
+function reviver( key, value ) {
+	if ( value && value.pattern && value.flags && value.type === 'RegExp' ) {
+		return new RegExp( value.pattern, value.flags );
+	}
+	return value;
+}
+
+
+// EXPORTS //
+
+module.exports = reviver;

--- a/lib/node_modules/@stdlib/regexp/reviver/lib/main.js
+++ b/lib/node_modules/@stdlib/regexp/reviver/lib/main.js
@@ -21,11 +21,11 @@
 // MAIN //
 
 /**
-* Revives a JSON-serialized regular expression object.
+* Revives a JSON-serialized regular expression.
 *
 * @param {string} key - key
 * @param {*} value - value
-* @returns {RegExp} RegExp object
+* @returns {RegExp} regular expression
 *
 * @example
 * var str = '{"type":"RegExp","pattern":"ab+c","flags":""}';
@@ -33,7 +33,7 @@
 * // returns <RegExp>
 */
 function reviver( key, value ) {
-	if ( value && value.pattern && value.flags && value.type === 'RegExp' ) {
+	if ( value && value.pattern && value.type === 'RegExp' ) {
 		return new RegExp( value.pattern, value.flags );
 	}
 	return value;

--- a/lib/node_modules/@stdlib/regexp/reviver/package.json
+++ b/lib/node_modules/@stdlib/regexp/reviver/package.json
@@ -1,0 +1,67 @@
+{
+    "name": "@stdlib/regexp/reviver",
+    "version": "0.0.0",
+    "description": "Revive a JSON-serialized regular expression object.",
+    "license": "Apache-2.0",
+    "author": {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    },
+    "contributors": [
+      {
+        "name": "The Stdlib Authors",
+        "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+      }
+    ],
+    "main": "./lib",
+    "directories": {
+      "benchmark": "./benchmark",
+      "doc": "./docs",
+      "example": "./examples",
+      "lib": "./lib",
+      "test": "./test"
+    },
+    "types": "./docs/types",
+    "scripts": {},
+    "homepage": "https://github.com/stdlib-js/stdlib",
+    "repository": {
+      "type": "git",
+      "url": "git://github.com/stdlib-js/stdlib.git"
+    },
+    "bugs": {
+      "url": "https://github.com/stdlib-js/stdlib/issues"
+    },
+    "dependencies": {},
+    "devDependencies": {},
+    "engines": {
+      "node": ">=0.10.0",
+      "npm": ">2.7.0"
+    },
+    "os": [
+      "aix",
+      "darwin",
+      "freebsd",
+      "linux",
+      "macos",
+      "openbsd",
+      "sunos",
+      "win32",
+      "windows"
+    ],
+    "keywords": [
+      "stdlib",
+      "stdutils",
+      "stdutil",
+      "utils",
+      "object",
+      "regexp",
+      "re",
+      "regular",
+      "expression",
+      "obj",
+      "reviver",
+      "json",
+      "revive",
+      "deserialize"
+    ]
+  }

--- a/lib/node_modules/@stdlib/regexp/reviver/test/test.js
+++ b/lib/node_modules/@stdlib/regexp/reviver/test/test.js
@@ -62,7 +62,7 @@ tape( 'values which are not recognized as serialized RegExp objects are unaffect
 	t.end();
 });
 
-tape( 'an object must have a recognized "type" field in order to be revived', function test( t ) {
+tape( 'an object must have a recognized `type` field in order to be revived', function test( t ) {
 	var expected;
 	var actual;
 	var json;
@@ -78,7 +78,7 @@ tape( 'an object must have a recognized "type" field in order to be revived', fu
 	t.end();
 });
 
-tape( 'an object must have a "pattern" field in order to be revived', function test( t ) {
+tape( 'an object must have a `pattern` field in order to be revived', function test( t ) {
 	var expected;
 	var actual;
 	var json;
@@ -95,7 +95,7 @@ tape( 'an object must have a "pattern" field in order to be revived', function t
 	t.end();
 });
 
-tape( 'an object must have a "flags" field in order to be revived', function test( t ) {
+tape( 'an object must have a `flags` field in order to be revived', function test( t ) {
 	var expected;
 	var actual;
 	var json;
@@ -112,7 +112,7 @@ tape( 'an object must have a "flags" field in order to be revived', function tes
 	t.end();
 });
 
-tape( 'the function will revive a JSON-serialized RegExp object', function test( t ) {
+tape( 'the function will revive a JSON-serialized regular expression', function test( t ) {
 	var expected;
 	var patterns;
 	var actual;

--- a/lib/node_modules/@stdlib/regexp/reviver/test/test.js
+++ b/lib/node_modules/@stdlib/regexp/reviver/test/test.js
@@ -1,0 +1,148 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var copy = require( '@stdlib/utils/copy' );
+var reviveRegExp = require( './../lib' );
+
+
+// FUNCTIONS //
+
+function setup( pattern, flags ) {
+	var json = {};
+	json.type = 'RegExp';
+	json.pattern = pattern;
+	json.flags = flags || '';
+	return json;
+}
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.equal( typeof reviveRegExp, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'values which are not recognized as serialized RegExp objects are unaffected', function test( t ) {
+	var expected;
+	var actual;
+
+	expected = {
+		'beep': 'boop'
+	};
+	actual = JSON.parse( '{"beep":"boop"}', reviveRegExp );
+
+	t.deepEqual( actual, expected, 'deep equal' );
+
+	// Null edge case:
+	actual = JSON.parse( 'null', reviveRegExp );
+	t.equal( actual, null, 'equals null' );
+
+	t.end();
+});
+
+tape( 'an object must have a recognized "type" field in order to be revived', function test( t ) {
+	var expected;
+	var actual;
+	var json;
+
+	json = setup( 'ab+c' );
+	json.type = 'Boop';
+
+	expected = copy( json );
+
+	actual = JSON.parse( JSON.stringify( json ), reviveRegExp );
+
+	t.deepEqual( actual, expected, 'deep equal' );
+	t.end();
+});
+
+tape( 'an object must have a "pattern" field in order to be revived', function test( t ) {
+	var expected;
+	var actual;
+	var json;
+
+	json = setup( 'ab+c' );
+	delete json.pattern;
+
+	expected = copy( json );
+
+	actual = JSON.parse( JSON.stringify( json ), reviveRegExp );
+
+	t.deepEqual( actual, expected, 'deep equal' );
+
+	t.end();
+});
+
+tape( 'an object must have a "flags" field in order to be revived', function test( t ) {
+	var expected;
+	var actual;
+	var json;
+
+	json = setup( 'ab+c' );
+	delete json.flags;
+
+	expected = copy( json );
+
+	actual = JSON.parse( JSON.stringify( json ), reviveRegExp );
+
+	t.deepEqual( actual, expected, 'deep equal' );
+
+	t.end();
+});
+
+tape( 'the function will revive a JSON-serialized RegExp object', function test( t ) {
+	var expected;
+	var patterns;
+	var actual;
+	var flags;
+	var json;
+	var i;
+
+	patterns = [
+		'.*',
+		'ab+c',
+		'/.*^1',
+		'a+.b*'
+	];
+
+	flags = [
+		'd',
+		'dy',
+		's',
+		'd'
+	];
+
+	for ( i = 0; i < patterns.length; i++ ) {
+		json = setup( patterns[ i ], flags[ i ] );
+
+		expected = new RegExp( patterns[i], flags[i] );
+
+		actual = JSON.parse( JSON.stringify( json ), reviveRegExp );
+
+		t.ok( actual instanceof RegExp, 'instance of type RegExp' );
+		t.equal( String(actual), String(expected), 'equal pattern and flags' );
+	}
+	t.end();
+});

--- a/lib/node_modules/@stdlib/regexp/reviver/test/test.js
+++ b/lib/node_modules/@stdlib/regexp/reviver/test/test.js
@@ -95,23 +95,6 @@ tape( 'an object must have a `pattern` field in order to be revived', function t
 	t.end();
 });
 
-tape( 'an object must have a `flags` field in order to be revived', function test( t ) {
-	var expected;
-	var actual;
-	var json;
-
-	json = setup( 'ab+c' );
-	delete json.flags;
-
-	expected = copy( json );
-
-	actual = JSON.parse( JSON.stringify( json ), reviveRegExp );
-
-	t.deepEqual( actual, expected, 'deep equal' );
-
-	t.end();
-});
-
 tape( 'the function will revive a JSON-serialized regular expression', function test( t ) {
 	var expected;
 	var patterns;
@@ -131,7 +114,7 @@ tape( 'the function will revive a JSON-serialized regular expression', function 
 		'd',
 		'dy',
 		's',
-		'd'
+		''
 	];
 
 	for ( i = 0; i < patterns.length; i++ ) {


### PR DESCRIPTION
Resolves https://github.com/stdlib-js/todo/issues/412.

## Description

> What is the purpose of this pull request?

This pull request:

-   adds support for deserializing a JSON to RegExp

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves https://github.com/stdlib-js/todo/issues/412

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Please note that this PR is dependent on with https://github.com/stdlib-js/stdlib/pull/521, once that one is merged I will update this branch and add the examples and benchmark that depend on that package.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
