### PR TITLE
Add support for reviving a JSON-serialized double-precision floating-point number

### DIFF
--- a/lib/node_modules/@stdlib/number/float64/reviver/README.md
+++ b/lib/node_modules/@stdlib/number/float64/reviver/README.md
@@ -1,0 +1,129 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2022 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# reviveNumber
+
+> Revive a JSON-serialized number.
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var reviveNumber = require( '@stdlib/number/float64/reviver' );
+```
+
+#### reviveNumber( key, value )
+
+Revives a JSON-serialized number.
+
+```javascript
+var parseJSON = require( '@stdlib/utils/parse-json' );
+
+var str = '{"type":"float64","value":"NaN"}';
+
+var buf = parseJSON( str, reviveNumber );
+// returns NaN
+```
+
+For details on the JSON serialization format, see [`@stdlib/number/float64/to-json`][@stdlib/number/float64/to-json].
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var parseJSON = require( '@stdlib/utils/parse-json' );
+var number2json = require( '@stdlib/number/float64/to-json' );
+var reviveNumber = require( '@stdlib/number/float64/reviver' );
+
+var str = JSON.stringify( number2json( NaN ) );
+console.log( str );
+// => '{"type":"float64","value":"NaN"}'
+
+var out = parseJSON( str, reviveNumber );
+if ( out instanceof Error ) {
+    throw out;
+}
+console.log( out );
+// => NaN
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/number/float64/to-json`][@stdlib/number/float64/to-json]</span><span class="delimiter">: </span><span class="description">return a JSON representation of a number.</span>
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[@stdlib/number/float64/to-json]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/number/float64/to-json
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/number/float64/reviver/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/number/float64/reviver/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var parseJSON = require( '@stdlib/utils/parse-json' );
+var number2json = require( '@stdlib/number/float64/to-json' );
 var pkg = require( './../package.json' ).name;
 var reviver = require( './../lib' );
 
@@ -36,6 +37,27 @@ bench( pkg, function benchmark( b ) {
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
 		o = parseJSON( values[ i%values.length ], reviver );
+		if ( o instanceof Error ) {
+			b.fail( 'should not return an error' );
+		}
+	}
+	b.toc();
+
+	if ( o instanceof Error ) {
+		b.fail( 'should not return an error' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::number', function benchmark( b ) {
+	var str;
+	var o;
+	var i;
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		str = JSON.stringify( number2json( 3.14 ) );
+		o = parseJSON( str, reviver );
 		if ( o instanceof Error ) {
 			b.fail( 'should not return an error' );
 		}

--- a/lib/node_modules/@stdlib/number/float64/reviver/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/number/float64/reviver/benchmark/benchmark.js
@@ -1,0 +1,50 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var parseJSON = require( '@stdlib/utils/parse-json' );
+var pkg = require( './../package.json' ).name;
+var reviver = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var values = [ '{"type":"float64","value":"NaN"}', '{"type":"float64","value":"Infinity"}', '{"type":"float64","value":"-Infinity"}'];
+	var o;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		o = parseJSON( values[ i%values.length ], reviver );
+		if ( o instanceof Error ) {
+			b.fail( 'should not return an error' );
+		}
+	}
+	b.toc();
+
+	if ( o instanceof Error ) {
+		b.fail( 'should not return an error' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/number/float64/reviver/docs/repl.txt
+++ b/lib/node_modules/@stdlib/number/float64/reviver/docs/repl.txt
@@ -34,6 +34,5 @@
     > out = {{alias:@stdlib/utils/parse-json}}( str, {{alias}} )
     -Infinity
 
-
     See Also
     --------

--- a/lib/node_modules/@stdlib/number/float64/reviver/docs/repl.txt
+++ b/lib/node_modules/@stdlib/number/float64/reviver/docs/repl.txt
@@ -1,0 +1,39 @@
+
+{{alias}}( key, value )
+    Revives a JSON-serialized number.
+
+    The serialization format for a numberis a number itself
+    Or can have a object having the following
+    fields:
+
+    - type: value type (float64)
+    - value: 'NaN' or '+Infinity' or '-Infinity'
+
+    Parameters
+    ----------
+    key: string
+        Key.
+
+    value: any
+        Value.
+
+    Returns
+    -------
+    out: any
+        Value.
+
+    Examples
+    --------
+    > var str = '{"type":"float64","value":"NaN"}';
+    > var out = {{alias:@stdlib/utils/parse-json}}( str, {{alias}} )
+    NaN
+    > str = '{"type":"float64","value":"+Infinity"}';
+    > out = {{alias:@stdlib/utils/parse-json}}( str, {{alias}} )
+    Infinity
+    > str = '{"type":"float64","value":"-Infinity"}';
+    > out = {{alias:@stdlib/utils/parse-json}}( str, {{alias}} )
+    -Infinity
+
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/number/float64/reviver/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/number/float64/reviver/docs/types/index.d.ts
@@ -19,7 +19,7 @@
 // TypeScript Version: 2.0
 
 /**
-* Revive a JSON-serialized number.
+* Revives a JSON-serialized number.
 *
 * @param key - key
 * @param value - value

--- a/lib/node_modules/@stdlib/number/float64/reviver/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/number/float64/reviver/docs/types/index.d.ts
@@ -1,0 +1,41 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 2.0
+
+/**
+* Revive a JSON-serialized number.
+*
+* @param key - key
+* @param value - value
+* @returns value
+*
+* @example
+* var parseJSON = require( `@stdlib/utils/parse-json` );
+*
+* var str = '{"type":"float64","value":"NaN"}';
+*
+* var out = parseJSON( str, reviveNumber );
+* // returns NaN
+*/
+declare function reviveNumber( key: string, value: any ): any;
+
+
+// EXPORTS //
+
+export = reviveNumber;

--- a/lib/node_modules/@stdlib/number/float64/reviver/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/number/float64/reviver/docs/types/test.ts
@@ -23,25 +23,25 @@ import reviveNumber = require( '../../lib/main' );
 
 // The function revives a JSON-serialized number...
 {
-	const o = {
-		'type': 'float64',
-		'value': 'NaN'
-	};
-	reviveNumber( 'key', o ); // $ExpectType any
+    const o = {
+        'type': 'float64',
+        'value': 'NaN'
+    };
+    reviveNumber( 'key', o ); // $ExpectType any
 }
 
 // The compiler throws an error if the function is provided a first argument that is not a string or number...
 {
-	reviveNumber( true, 1 ); // $ExpectError
-	reviveNumber( false, 1 ); // $ExpectError
-	reviveNumber( null, 1 ); // $ExpectError
-	reviveNumber( undefined, 1 ); // $ExpectError
-	reviveNumber( [], 1 ); // $ExpectError
-	reviveNumber( {}, 1 ); // $ExpectError
+    reviveNumber( true, 1 ); // $ExpectError
+    reviveNumber( false, 1 ); // $ExpectError
+    reviveNumber( null, 1 ); // $ExpectError
+    reviveNumber( undefined, 1 ); // $ExpectError
+    reviveNumber( [], 1 ); // $ExpectError
+    reviveNumber( {}, 1 ); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided insufficient arguments...
 {
-	reviveNumber(); // $ExpectError
-	reviveNumber( 'foo' ); // $ExpectError
+    reviveNumber(); // $ExpectError
+    reviveNumber( 'foo' ); // $ExpectError
 }

--- a/lib/node_modules/@stdlib/number/float64/reviver/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/number/float64/reviver/docs/types/test.ts
@@ -43,5 +43,5 @@ import reviveNumber = require( '../../lib/main' );
 // The compiler throws an error if the function is provided insufficient arguments...
 {
 	reviveNumber(); // $ExpectError
-	reviveNumber( '{"type":"float64","value":"NaN"}' ); // $ExpectError
+	reviveNumber( 'foo' ); // $ExpectError
 }

--- a/lib/node_modules/@stdlib/number/float64/reviver/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/number/float64/reviver/docs/types/test.ts
@@ -1,0 +1,47 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import reviveNumber = require( '../../lib/main' );
+
+
+// TESTS //
+
+// The function revives a JSON-serialized number...
+{
+	const o = {
+		'type': 'float64',
+		'value': 'NaN'
+	};
+	reviveNumber( 'key', o ); // $ExpectType any
+}
+
+// The compiler throws an error if the function is provided a first argument that is not a string or number...
+{
+	reviveNumber( true, 1 ); // $ExpectError
+	reviveNumber( false, 1 ); // $ExpectError
+	reviveNumber( null, 1 ); // $ExpectError
+	reviveNumber( undefined, 1 ); // $ExpectError
+	reviveNumber( [], 1 ); // $ExpectError
+	reviveNumber( {}, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided insufficient arguments...
+{
+	reviveNumber(); // $ExpectError
+	reviveNumber( '{"type":"float64","value":"NaN"}' ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/number/float64/reviver/examples/index.js
+++ b/lib/node_modules/@stdlib/number/float64/reviver/examples/index.js
@@ -1,0 +1,58 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var parseJSON = require( '@stdlib/utils/parse-json' );
+var number2json = require( '@stdlib/number/float64/to-json' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+var reviver = require( './../lib' );
+
+var str = JSON.stringify( number2json( PINF ) );
+console.log( str );
+// => '{"type":"float64","value":"+Infinity"}'
+
+var out = parseJSON( str, reviver );
+if ( out instanceof Error ) {
+	throw out;
+}
+console.log( out );
+// => Infinity
+
+str = JSON.stringify( number2json( NINF ) );
+console.log( str );
+// => '{"type":"float64","value":"-Infinity"}'
+
+out = parseJSON( str, reviver );
+if ( out instanceof Error ) {
+	throw out;
+}
+console.log( out );
+// => -Infinity
+
+str = JSON.stringify( number2json( NaN ) );
+console.log( str );
+// => '{"type":"float64","value":"NaN"}'
+
+out = parseJSON( str, reviver );
+if ( out instanceof Error ) {
+	throw out;
+}
+console.log( out );
+// => NaN

--- a/lib/node_modules/@stdlib/number/float64/reviver/lib/index.js
+++ b/lib/node_modules/@stdlib/number/float64/reviver/lib/index.js
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Revive a JSON-serialized number.
+*
+* @module @stdlib/number/float64/reviver
+*
+* @example
+* var parseJSON = require( '@stdlib/utils/parse-json' );
+* var reviveNumber = require( '@stdlib/number/float64/reviver' );
+*
+* var str = '{"type":"float64","value":"NaN"}';
+*
+* var buf = parseJSON( str, reviveNumber );
+* // returns NaN
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/number/float64/reviver/lib/index.js
+++ b/lib/node_modules/@stdlib/number/float64/reviver/lib/index.js
@@ -29,7 +29,7 @@
 *
 * var str = '{"type":"float64","value":"NaN"}';
 *
-* var buf = parseJSON( str, reviveNumber );
+* var x = parseJSON( str, reviveNumber );
 * // returns NaN
 */
 

--- a/lib/node_modules/@stdlib/number/float64/reviver/lib/index.js
+++ b/lib/node_modules/@stdlib/number/float64/reviver/lib/index.js
@@ -29,7 +29,7 @@
 *
 * var str = '{"type":"float64","value":"NaN"}';
 *
-* var x = parseJSON( str, reviveNumber );
+* var out = parseJSON( str, reviveNumber );
 * // returns NaN
 */
 

--- a/lib/node_modules/@stdlib/number/float64/reviver/lib/main.js
+++ b/lib/node_modules/@stdlib/number/float64/reviver/lib/main.js
@@ -27,7 +27,7 @@ var NINF = require( '@stdlib/constants/float64/ninf' );
 // MAIN //
 
 /**
-* Revive a JSON-serialized number.
+* Revives a JSON-serialized number.
 *
 * @param {string} key - key
 * @param {*} value - value

--- a/lib/node_modules/@stdlib/number/float64/reviver/lib/main.js
+++ b/lib/node_modules/@stdlib/number/float64/reviver/lib/main.js
@@ -1,0 +1,66 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+
+
+// MAIN //
+
+/**
+* Revive a JSON-serialized number.
+*
+* @param {string} key - key
+* @param {*} value - value
+* @returns {*} revived value
+*
+* @example
+* var parseJSON = require( '@stdlib/utils/parse-json' );
+*
+* var str = '{"type":"float64","value":"NaN"}';
+*
+* var v = parseJSON( str, reviver );
+* // returns NaN
+*/
+function reviver( key, value ) {
+	if (
+		value !== null &&
+		typeof value === 'object' &&
+		value.type === 'float64'
+	) {
+		if ( value.value === 'NaN' ) {
+			return NaN;
+		}
+		if ( value.value === '+Infinity' ) {
+			return PINF;
+		}
+		if ( value.value === '-Infinity' ) {
+			return NINF;
+		}
+	}
+	return value;
+}
+
+
+// EXPORTS //
+
+module.exports = reviver;

--- a/lib/node_modules/@stdlib/number/float64/reviver/package.json
+++ b/lib/node_modules/@stdlib/number/float64/reviver/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@stdlib/number/float64/reviver",
+  "version": "0.0.0",
+  "description": "Revive a JSON-serialized number.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdtypes",
+    "utils",
+    "util",
+    "utilities",
+    "utility",
+    "number",
+    "json",
+    "reviver",
+    "revive",
+    "unmarshal",
+    "deserialize",
+    "convert",
+    "parse",
+    "object",
+    "obj"
+  ]
+}

--- a/lib/node_modules/@stdlib/number/float64/reviver/test/test.js
+++ b/lib/node_modules/@stdlib/number/float64/reviver/test/test.js
@@ -1,0 +1,127 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var copy = require( '@stdlib/utils/copy' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+var parseJSON = require( '@stdlib/utils/parse-json' );
+var toJSON = require( '@stdlib/number/float64/to-json' );
+var reviver = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof reviver, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'values which are not recognized as numbers are unaffected', function test( t ) {
+	var expected;
+	var actual;
+
+	expected = {
+		'beep': 'boop'
+	};
+	actual = parseJSON( '{"beep":"boop"}', reviver );
+
+	t.deepEqual( actual, expected, 'deep equal' );
+
+	// Null edge case:
+	actual = parseJSON( 'null', reviver );
+	t.strictEqual( actual, null, 'equals null' );
+
+	t.end();
+});
+
+tape( 'an object must have a recognized "type" field in order to be revived', function test( t ) {
+	var expected;
+	var actual;
+	var json;
+
+	json = {
+		'type': 'Boop',
+		'value': 'NaN'
+	};
+
+	expected = copy( json );
+	actual = parseJSON( JSON.stringify( json ), reviver );
+
+	t.deepEqual( actual, expected, 'deep equal' );
+	t.end();
+});
+
+tape( 'an object must have a recognized "value" field in order to be revived', function test( t ) {
+	var expected;
+	var actual;
+	var json;
+
+	json = {
+		'type': 'float64'
+	};
+
+	expected = copy( json );
+	actual = parseJSON( JSON.stringify( json ), reviver );
+
+	t.deepEqual( actual, expected, 'deep equal' );
+
+	json = {
+		'type': 'float64',
+		'value': null
+	};
+
+	expected = copy( json );
+	actual = parseJSON( JSON.stringify( json ), reviver );
+
+	t.deepEqual( actual, expected, 'deep equal' );
+
+	t.end();
+});
+
+tape( 'the function will revive a JSON-serialized number', function test( t ) {
+	var json;
+	var out;
+
+	json = toJSON( PINF );
+	out = parseJSON( JSON.stringify( json ), reviver );
+
+	t.strictEqual( out, PINF, 'has expected value' );
+
+	json = toJSON( NINF );
+	out = parseJSON( JSON.stringify( json ), reviver );
+
+	t.strictEqual( out, NINF, 'has expected value' );
+
+	json = toJSON( NaN );
+	out = parseJSON( JSON.stringify( json ), reviver );
+
+	t.strictEqual( typeof out, 'number', 'has expected value' );
+
+	json = toJSON( 5 );
+	out = parseJSON( JSON.stringify( json ), reviver );
+
+	t.strictEqual( out, 5, 'has expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/number/float64/reviver/test/test.js
+++ b/lib/node_modules/@stdlib/number/float64/reviver/test/test.js
@@ -116,7 +116,7 @@ tape( 'the function will revive a JSON-serialized number', function test( t ) {
 	json = toJSON( NaN );
 	out = parseJSON( JSON.stringify( json ), reviver );
 
-	t.strictEqual( typeof out, 'number', 'has expected value' );
+	t.strictEqual( out !== out, true, 'has expected value' );
 
 	json = toJSON( 5 );
 	out = parseJSON( JSON.stringify( json ), reviver );


### PR DESCRIPTION

## Description
This PR creates a reviver for ```float64```.

## Checklist

- [x] Add lib
- [x] Add package.json
- [x] Add readme.md 
- [x] Add index.d.ts in docs/types
- [x] Add test.ts in docs/types
- [x] Add repl.txt in docs
- [x] Add benchmark
- [x] Add test
- [x] Add examples

* * *

@kgryte 

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
