### PR TITLE
Add support for testing whether a value is a camel-cased string

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-camelcase/README.md
+++ b/lib/node_modules/@stdlib/assert/is-camelcase/README.md
@@ -1,0 +1,198 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2022 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# isCamelcase
+
+> Test if a value is a camelcase string.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var isCamelcase = require( '@stdlib/assert/is-camelcase' );
+```
+
+#### isCamelcase( value )
+
+Tests if a `value` is an camelcase `string`.
+
+```javascript
+var bool = isCamelcase( 'beepBoop' );
+// returns true
+
+bool = isCamelcase( 'beep and Boop' );
+// returns false
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   The function validates that a `value` is a `string`. For all other types, the function returns `false`.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var isCamelcase = require( '@stdlib/assert/is-camelcase' );
+
+console.log( isCamelcase( 'beepBoop' ) );
+// => true
+
+console.log( isCamelcase( 'beepBoop123' ) );
+// => true
+
+console.log( isCamelcase( 'beep Boop' ) );
+// => false
+
+console.log( isCamelcase( 'beep' ) );
+// => true
+
+console.log( isCamelcase( 'beep boop' ) );
+// => false
+
+console.log( isCamelcase( 'b' ) );
+// => true
+```
+
+</section>
+
+<!-- /.examples -->
+
+* * *
+
+<section class="cli">
+
+## CLI
+
+<section class="usage">
+
+### Usage
+
+```text
+Usage: is-camelcase [options] [<string>]
+
+Options:
+
+  -h,    --help                Print this message.
+  -V,    --version             Print the package version.
+         --split sep           Delimiter for stdin data. Default: '/\\r?\\n/'.
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- CLI usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+### Notes
+
+-   If the split separator is a [regular expression][mdn-regexp], ensure that the `split` option is either properly escaped or enclosed in quotes.
+
+    ```bash
+    # Not escaped...
+    $ echo -n $'beEp booP\nFOO' | is-camelcase --split /\r?\n/
+    # Escaped...
+    $ echo -n $'beEp booP\nFOO' | is-camelcase --split /\\r?\\n/
+    ```
+
+-   The implementation ignores trailing delimiters.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+### Examples
+
+```bash
+$ is-camelcase beepBoop
+true
+```
+
+To use as a [standard stream][standard-streams],
+
+```bash
+$ echo -n 'beep Boop' | is-camelcase
+false
+```
+
+By default, when used as a [standard stream][standard-streams], the implementation assumes newline-delimited data. To specify an alternative delimiter, set the `split` option.
+
+```bash
+$ echo -n 'beepBoop\tbeep_boop' | is-camelcase --split '\t'
+true
+false
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.cli -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/assert/is-string`][@stdlib/assert/is-string]</span><span class="delimiter">: </span><span class="description">test if a value is a string.</span>
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[standard-streams]: https://en.wikipedia.org/wiki/Standard_streams
+
+[mdn-regexp]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+
+<!-- <related-links> -->
+
+[@stdlib/assert/is-string]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-string
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/assert/is-camelcase/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-camelcase/benchmark/benchmark.js
@@ -1,0 +1,49 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var fromeCodePoint = require( '@stdlib/string/from-code-point' );
+var pkg = require( './../package.json' ).name;
+var isCamelcase = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var bool;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		bool = isCamelcase( fromeCodePoint( i%126 ) );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/assert/is-camelcase/bin/cli
+++ b/lib/node_modules/@stdlib/assert/is-camelcase/bin/cli
@@ -3,7 +3,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2022 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/assert/is-camelcase/bin/cli
+++ b/lib/node_modules/@stdlib/assert/is-camelcase/bin/cli
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var readFileSync = require( '@stdlib/fs/read-file' ).sync;
+var CLI = require( '@stdlib/cli/ctor' );
+var stdin = require( '@stdlib/process/read-stdin' );
+var stdinStream = require( '@stdlib/streams/node/stdin' );
+var RE_EOL = require( '@stdlib/regexp/eol' ).REGEXP;
+var isRegExpString = require( '@stdlib/assert/is-regexp-string' );
+var reFromString = require( '@stdlib/utils/regexp-from-string' );
+var isCamelcase = require( './../lib' );
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+* @returns {void}
+*/
+function main() {
+	var split;
+	var flags;
+	var args;
+	var cli;
+
+	// Create a command-line interface:
+	cli = new CLI({
+		'pkg': require( './../package.json' ),
+		'options': require( './../etc/cli_opts.json' ),
+		'help': readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+			'encoding': 'utf8'
+		})
+	});
+
+	// Get any provided command-line options:
+	flags = cli.flags();
+	if ( flags.help || flags.version ) {
+		return;
+	}
+
+	// Get any provided command-line arguments:
+	args = cli.args();
+
+	// Check if we are receiving data from `stdin`...
+	if ( !stdinStream.isTTY ) {
+		if ( flags.split ) {
+			if ( !isRegExpString( flags.split ) ) {
+				flags.split = '/'+flags.split+'/';
+			}
+			split = reFromString( flags.split );
+		} else {
+			split = RE_EOL;
+		}
+		return stdin( onRead );
+	}
+	console.log( isCamelcase( args[ 0 ] ) ); // eslint-disable-line no-console
+
+	/**
+	* Callback invoked upon reading from `stdin`.
+	*
+	* @private
+	* @param {(Error|null)} error - error object
+	* @param {(string|Buffer)} data - data
+	* @returns {void}
+	*/
+	function onRead( error, data ) {
+		var lines;
+		var i;
+		if ( error ) {
+			return cli.error( error );
+		}
+		lines = data.toString().split( split );
+
+		// Remove any trailing separators (e.g., trailing newline)...
+		if ( lines[ lines.length-1 ] === '' ) {
+			lines.pop();
+		}
+		for ( i = 0; i < lines.length; i++ ) {
+			console.log( isCamelcase( lines[ i ] ) ); // eslint-disable-line no-console
+		}
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/assert/is-camelcase/docs/repl.txt
+++ b/lib/node_modules/@stdlib/assert/is-camelcase/docs/repl.txt
@@ -1,0 +1,23 @@
+
+{{alias}}( value )
+    Tests if a value is a camelcase string.
+
+    Parameters
+    ----------
+    value: any
+        Value to test.
+
+    Returns
+    -------
+    bool: boolean
+        Boolean indicating whether value is a camelcase string.
+
+    Examples
+    --------
+    > var bool = {{alias}}( 'helloWorld' )
+    true
+    > bool = {{alias}}( 'hello world' )
+    false
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/assert/is-camelcase/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/is-camelcase/docs/types/index.d.ts
@@ -19,7 +19,7 @@
 // TypeScript Version: 4.9
 
 /**
-* Test if a value is a camelcase string.
+* Tests if a value is a camelcase string.
 *
 * @param value - value to test
 * @returns boolean indicating whether value is a camelcase string

--- a/lib/node_modules/@stdlib/assert/is-camelcase/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/is-camelcase/docs/types/index.d.ts
@@ -1,0 +1,48 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.9
+
+/**
+* Test if a value is a camelcase string.
+*
+* @param value - value to test
+* @returns boolean indicating whether value is a camelcase string
+*
+* @example
+* var bool = isCamelcase( 'beepBoop' );
+* // returns true
+*
+* @example
+* var bool = isCamelcase( 'HelloWorld' );
+* // returns true
+*
+* @example
+* var bool = isCamelcase( 'Hello World' );
+* // returns false
+*
+* @example
+* var bool = isCamelcase( 'hello world' );
+* // returns false
+*/
+declare function isCamelcase( value: any ): boolean;
+
+
+// EXPORTS //
+
+export = isCamelcase;

--- a/lib/node_modules/@stdlib/assert/is-camelcase/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/assert/is-camelcase/docs/types/test.ts
@@ -1,0 +1,36 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import isCamelcase = require( '../../lib/main' );
+
+
+// TESTS //
+
+// The function returns a boolean...
+{
+	isCamelcase( 'beepBoop' ); // $ExpectType boolean
+	isCamelcase( 'HelloWorld' ); // $ExpectType boolean
+	isCamelcase( '!' ); // $ExpectType boolean
+	isCamelcase( 'check_123' ); // $ExpectType boolean
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	isCamelcase(); // $ExpectError
+	isCamelcase( 'beepBoop', 123 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/assert/is-camelcase/docs/usage.txt
+++ b/lib/node_modules/@stdlib/assert/is-camelcase/docs/usage.txt
@@ -1,0 +1,8 @@
+
+Usage: is-camelcase [options] [<string>]
+
+Options:
+
+  -h,    --help                Print this message.
+  -V,    --version             Print the package version.
+         --split sep           Delimiter for stdin data. Default: '/\\r?\\n/'.

--- a/lib/node_modules/@stdlib/assert/is-camelcase/etc/cli_opts.json
+++ b/lib/node_modules/@stdlib/assert/is-camelcase/etc/cli_opts.json
@@ -1,0 +1,17 @@
+{
+	"string": [
+		"split"
+	],
+	"boolean": [
+		"help",
+		"version"
+	],
+	"alias": {
+		"help": [
+			"h"
+		],
+		"version": [
+			"V"
+		]
+	}
+}

--- a/lib/node_modules/@stdlib/assert/is-camelcase/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-camelcase/examples/index.js
@@ -1,0 +1,39 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var isCamelcase = require( './../lib' );
+
+console.log( isCamelcase( 'beepBoop' ) );
+// => true
+
+console.log( isCamelcase( 'beepBoop123' ) );
+// => true
+
+console.log( isCamelcase( 'beep Boop' ) );
+// => false
+
+console.log( isCamelcase( 'beep' ) );
+// => true
+
+console.log( isCamelcase( 'beep boop' ) );
+// => false
+
+console.log( isCamelcase( 'b' ) );
+// => true

--- a/lib/node_modules/@stdlib/assert/is-camelcase/lib/index.js
+++ b/lib/node_modules/@stdlib/assert/is-camelcase/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Test if a string is in camelcase.
+* Test if a value is a camelcase string.
 *
 * @module @stdlib/assert/is-camelcase
 *

--- a/lib/node_modules/@stdlib/assert/is-camelcase/lib/index.js
+++ b/lib/node_modules/@stdlib/assert/is-camelcase/lib/index.js
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Test if a string is in camelcase.
+*
+* @module @stdlib/assert/is-camelcase
+*
+* @example
+* var isCamelcase = require( '@stdlib/assert/is-camelcase' );
+*
+* var bool = isCamelcase( 'beepBoop' );
+* // returns true
+*
+* bool = isCamelcase( 'beep Boop' );
+* // returns false
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/assert/is-camelcase/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/is-camelcase/lib/main.js
@@ -1,0 +1,60 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
+var camelcase = require( '@stdlib/string/base/camelcase' );
+
+
+// MAIN //
+
+/**
+* Test if a string is in camelcase.
+* @param {*} value - value to test
+* @returns {boolean} boolean indicating whether a string is in camelcase
+*
+* @example
+* var bool = isCamelcase( 'beepBoop' );
+* // returns true
+*
+* @example
+* var bool = isCamelcase( 'beepBoop123' );
+* // returns true
+*
+* @example
+* var bool = isCamelcase( 'beep Boop' );
+* // returns false
+*
+* @example
+* var bool = isCamelcase( 'beep' );
+* // returns true
+*/
+function isCamelcase( value ) {
+	return (
+		isString( value ) &&
+		value === camelcase( value )
+	);
+}
+
+
+// EXPORTS //
+
+module.exports = isCamelcase;

--- a/lib/node_modules/@stdlib/assert/is-camelcase/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/is-camelcase/lib/main.js
@@ -28,6 +28,7 @@ var camelcase = require( '@stdlib/string/base/camelcase' );
 
 /**
 * Test if a string is in camelcase.
+*
 * @param {*} value - value to test
 * @returns {boolean} boolean indicating whether a string is in camelcase
 *

--- a/lib/node_modules/@stdlib/assert/is-camelcase/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/is-camelcase/lib/main.js
@@ -27,7 +27,7 @@ var camelcase = require( '@stdlib/string/base/camelcase' );
 // MAIN //
 
 /**
-* Test if a string is in camelcase.
+* Tests if a string is in camelcase.
 *
 * @param {*} value - value to test
 * @returns {boolean} boolean indicating whether a string is in camelcase

--- a/lib/node_modules/@stdlib/assert/is-camelcase/package.json
+++ b/lib/node_modules/@stdlib/assert/is-camelcase/package.json
@@ -14,7 +14,7 @@
     }
   ],
   "bin": {
-    "is-uppercase": "./bin/cli"
+    "is-camelcase": "./bin/cli"
   },
   "main": "./lib",
   "directories": {

--- a/lib/node_modules/@stdlib/assert/is-camelcase/package.json
+++ b/lib/node_modules/@stdlib/assert/is-camelcase/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@stdlib/assert/is-camelcase",
+  "version": "0.0.0",
+  "description": "Test if a value is a camelcase string.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "bin": {
+    "is-uppercase": "./bin/cli"
+  },
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdassert",
+    "assertion",
+    "assert",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "is",
+    "iscamelcase",
+    "camelcase",
+    "string",
+    "valid",
+    "validate",
+    "test"
+  ]
+}

--- a/lib/node_modules/@stdlib/assert/is-camelcase/test/fixtures/stdin_error.js.txt
+++ b/lib/node_modules/@stdlib/assert/is-camelcase/test/fixtures/stdin_error.js.txt
@@ -1,0 +1,33 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+var proc = require( 'process' );
+var resolve = require( 'path' ).resolve;
+var proxyquire = require( 'proxyquire' );
+
+var fpath = resolve( __dirname, '..', 'bin', 'cli' );
+
+proc.stdin.isTTY = false;
+
+proxyquire( fpath, {
+	'@stdlib/process/read-stdin': stdin
+});
+
+function stdin( clbk ) {
+	clbk( new Error( 'beep' ) );
+}

--- a/lib/node_modules/@stdlib/assert/is-camelcase/test/test.cli.js
+++ b/lib/node_modules/@stdlib/assert/is-camelcase/test/test.cli.js
@@ -1,0 +1,263 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var exec = require( 'child_process' ).exec;
+var tape = require( 'tape' );
+var IS_BROWSER = require( '@stdlib/assert/is-browser' );
+var IS_WINDOWS = require( '@stdlib/assert/is-windows' );
+var EXEC_PATH = require( '@stdlib/process/exec-path' );
+var replace = require( '@stdlib/string/replace' );
+var readFileSync = require( '@stdlib/fs/read-file' ).sync;
+
+
+// VARIABLES //
+
+var fpath = resolve( __dirname, '..', 'bin', 'cli' );
+var opts = {
+	'skip': IS_BROWSER || IS_WINDOWS
+};
+
+
+// FIXTURES //
+
+var PKG_VERSION = require( './../package.json' ).version;
+
+
+// TESTS //
+
+tape( 'command-line interface', function test( t ) {
+	t.ok( true, __filename );
+	t.end();
+});
+
+tape( 'when invoked with a `--help` flag, the command-line interface prints the help text to `stderr`', opts, function test( t ) {
+	var expected;
+	var cmd;
+
+	expected = readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+		'encoding': 'utf8'
+	});
+	cmd = [
+		EXEC_PATH,
+		fpath,
+		'--help'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), expected+'\n', 'expected value' );
+		}
+		t.end();
+	}
+});
+
+tape( 'when invoked with a `-h` flag, the command-line interface prints the help text to `stderr`', opts, function test( t ) {
+	var expected;
+	var cmd;
+
+	expected = readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+		'encoding': 'utf8'
+	});
+	cmd = [
+		EXEC_PATH,
+		fpath,
+		'-h'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), expected+'\n', 'expected value' );
+		}
+		t.end();
+	}
+});
+
+tape( 'when invoked with a `--version` flag, the command-line interface prints the version to `stderr`', opts, function test( t ) {
+	var cmd = [
+		EXEC_PATH,
+		fpath,
+		'--version'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), PKG_VERSION+'\n', 'expected value' );
+		}
+		t.end();
+	}
+});
+
+tape( 'when invoked with a `-V` flag, the command-line interface prints the version to `stderr`', opts, function test( t ) {
+	var cmd = [
+		EXEC_PATH,
+		fpath,
+		'-V'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), PKG_VERSION+'\n', 'expected value' );
+		}
+		t.end();
+	}
+});
+
+tape( 'the command-line interface tests if a string argument is in camelcase', opts, function test( t ) {
+	var cmd = [
+		EXEC_PATH,
+		'-e',
+		'"process.stdin.isTTY = true; process.argv[ 2 ] = \'Hello\'; require( \''+fpath+'\' );"'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), 'false\n', 'expected value' );
+			t.strictEqual( stderr.toString(), '', 'does not print to `stderr`' );
+		}
+		t.end();
+	}
+});
+
+tape( 'the command-line interface supports use as a standard stream', opts, function test( t ) {
+	var cmd = [
+		'printf "beepBoop\nbeep_boop"',
+		'|',
+		EXEC_PATH,
+		fpath
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), 'true\nfalse\n', 'expected value' );
+			t.strictEqual( stderr.toString(), '', 'does not print to `stderr`' );
+		}
+		t.end();
+	}
+});
+
+tape( 'the command-line interface supports specifying a custom delimiter when used as a standard stream (string)', opts, function test( t ) {
+	var cmd = [
+		'printf \'beep boop\tfooBar\'',
+		'|',
+		EXEC_PATH,
+		fpath,
+		'--split \'\t\''
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), 'false\ntrue\n', 'expected value' );
+			t.strictEqual( stderr.toString(), '', 'does not print to `stderr`' );
+		}
+		t.end();
+	}
+});
+
+tape( 'the command-line interface supports specifying a custom delimiter when used as a standard stream (regexp)', opts, function test( t ) {
+	var cmd = [
+		'printf \'beep boop\tfooBar\'',
+		'|',
+		EXEC_PATH,
+		fpath,
+		'--split=/\\\\t/'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), 'false\ntrue\n', 'expected value' );
+			t.strictEqual( stderr.toString(), '', 'does not print to `stderr`' );
+		}
+		t.end();
+	}
+});
+
+tape( 'when used as a standard stream, if an error is encountered when reading from `stdin`, the command-line interface prints an error and sets a non-zero exit code', opts, function test( t ) {
+	var script;
+	var opts;
+	var cmd;
+
+	script = readFileSync( resolve( __dirname, 'fixtures', 'stdin_error.js.txt' ), {
+		'encoding': 'utf8'
+	});
+
+	// Replace single quotes with double quotes:
+	script = replace( script, '\'', '"' );
+
+	cmd = [
+		EXEC_PATH,
+		'-e',
+		'\''+script+'\''
+	];
+
+	opts = {
+		'cwd': __dirname
+	};
+
+	exec( cmd.join( ' ' ), opts, done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.pass( error.message );
+			t.strictEqual( error.code, 1, 'expected exit code' );
+		}
+		t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+		t.strictEqual( stderr.toString(), 'Error: beep\n', 'expected value' );
+		t.end();
+	}
+});

--- a/lib/node_modules/@stdlib/assert/is-camelcase/test/test.js
+++ b/lib/node_modules/@stdlib/assert/is-camelcase/test/test.js
@@ -1,0 +1,82 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isCamelcase = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof isCamelcase, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `true` if provided a string in camelcase', function test( t ) {
+	var values;
+	var bool;
+	var i;
+
+	values = [
+		'beepBoop',
+		'123',
+		'beepBoop123',
+		'beep',
+		'b',
+		'beepBoopBeepBoop',
+		'helloWorld'
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		bool = isCamelcase( values[ i ] );
+		t.strictEqual( bool, true, 'returns true when provided '+values[ i ] );
+	}
+	t.end();
+});
+
+tape( 'the function returns `false` if not provided a string in camelcase', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'let\'sCheckIfThisPasses',
+		'HelloWorld',
+		'!',
+		'AddingSpAceAtEnd ',
+		' AddingSpAceAtStart',
+		'Done.',
+		NaN,
+		null,
+		true,
+		false,
+		[],
+		{},
+		void 0,
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.strictEqual( isCamelcase( values[ i ] ), false, 'returns false when provided '+values[ i ] );
+	}
+	t.end();
+});


### PR DESCRIPTION
Resolves #533 .

## Checklist

- [x] Add lib
- [x] Add examples
- [x] Add package.json
- [x] Add benchmark
- [x] Add etc
- [x] Add bin
- [x] Add readme.md
- [x] Add test
- [x] Add docs

* * *
@kgryte 

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
