### PR TITLE
Add support for testing whether a value is a string in Pascal case

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-pascalcase/README.md
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/README.md
@@ -1,0 +1,190 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2022 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# isPascalCase
+
+> Test if a value is a string in Pascal case.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var isPascalCase = require( '@stdlib/assert/is-pascalcase' );
+```
+
+#### isPascalCase( value )
+
+Tests if a `value` is a `string` in Pascal case.
+
+```javascript
+var bool = isPascalCase( 'HelloWorld' );
+// returns true
+
+bool = isPascalCase( 'Hello World' );
+// returns false
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   The function validates that a `value` is a `string`. For all other types, the function returns `false`.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var isPascalCase = require( '@stdlib/assert/is-pascalcase' );
+
+var bool = isPascalCase( 'FooBarBaz' );
+// returns true
+
+bool = isPascalCase( 'fooBarBaz' );
+// returns false
+
+bool = isPascalCase( 'Foo Bar Baz' );
+// returns false
+
+bool = isPascalCase( 'Beep-Boop' );
+// returns false
+
+bool = isPascalCase( '' );
+// returns false
+
+bool = isPascalCase( null );
+// returns false
+```
+
+</section>
+
+<!-- /.examples -->
+
+* * *
+
+<section class="cli">
+
+## CLI
+
+<section class="usage">
+
+### Usage
+
+```text
+Usage: is-pascalcase [options] [<string>]
+
+Options:
+
+  -h,    --help                Print this message.
+  -V,    --version             Print the package version.
+         --split sep           Delimiter for stdin data. Default: '/\\r?\\n/'.
+```
+
+</section>
+
+<!-- CLI usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+### Notes
+
+-   If the split separator is a [regular expression][mdn-regexp], ensure that the `split` option is either properly escaped or enclosed in quotes.
+
+    ```bash
+    # Not escaped...
+    $ echo -n $'beEp booP\nFooBar' | is-pascalcase --split /\r?\n/
+    # Escaped...
+    $ echo -n $'beEp booP\nFooBar' | is-pascalcase --split /\\r?\\n/
+    ```
+
+-   The implementation ignores trailing delimiters.
+
+</section>
+
+<!-- /.notes -->
+
+<!-- /.usage -->
+
+<section class="examples">
+
+### Examples
+
+```bash
+$ is-pascalcase Beep
+true
+```
+
+</section>
+
+To use as a [standard stream][standard-streams],
+
+```bash
+$ echo -n 'boop' | is-pascalcase
+false
+```
+
+By default, when used as a [standard stream][standard-streams], the implementation assumes newline-delimited data. To specify an alternative delimiter, set the `split` option.
+
+```bash
+$ echo -n 'beep\tFooBar' | is-pascalcase --split '\t'
+false
+true
+```
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.cli -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[standard-streams]: https://en.wikipedia.org/wiki/Standard_streams
+
+[mdn-regexp]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/README.md
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/README.md
@@ -18,7 +18,7 @@ limitations under the License.
 
 -->
 
-# isPascalCase
+# isPascalcase
 
 > Test if a value is a string in Pascal case.
 
@@ -27,18 +27,18 @@ limitations under the License.
 ## Usage
 
 ```javascript
-var isPascalCase = require( '@stdlib/assert/is-pascalcase' );
+var isPascalcase = require( '@stdlib/assert/is-pascalcase' );
 ```
 
-#### isPascalCase( value )
+#### isPascalcase( value )
 
 Tests if a `value` is a `string` in Pascal case.
 
 ```javascript
-var bool = isPascalCase( 'HelloWorld' );
+var bool = isPascalcase( 'HelloWorld' );
 // returns true
 
-bool = isPascalCase( 'Hello World' );
+bool = isPascalcase( 'Hello World' );
 // returns false
 ```
 
@@ -63,24 +63,21 @@ bool = isPascalCase( 'Hello World' );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var isPascalCase = require( '@stdlib/assert/is-pascalcase' );
+var isPascalcase = require( '@stdlib/assert/is-pascalcase' );
 
-var bool = isPascalCase( 'FooBarBaz' );
+var bool = isPascalcase( 'FooBarBaz' );
 // returns true
 
-bool = isPascalCase( 'fooBarBaz' );
+bool = isPascalcase( 'fooBarBaz' );
 // returns false
 
-bool = isPascalCase( 'Foo Bar Baz' );
+bool = isPascalcase( 'Foo Bar Baz' );
 // returns false
 
-bool = isPascalCase( 'Beep-Boop' );
+bool = isPascalcase( 'Beep-Boop' );
 // returns false
 
-bool = isPascalCase( '' );
-// returns false
-
-bool = isPascalCase( null );
+bool = isPascalcase( null );
 // returns false
 ```
 

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/benchmark/benchmark.js
@@ -23,7 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var pkg = require( './../package.json' ).name;
-var isPascalCase = require( './../lib' );
+var isPascalcase = require( './../lib' );
 
 
 // MAIN //
@@ -36,17 +36,24 @@ bench( pkg, function benchmark( b ) {
 	values = [
 		'',
 		'HelloWorld',
-		'HelloWorld!',
-		'Hello World!',
-		'Hello_World',
-		'Hello_World!',
-		'Hello_World!',
-		5
+		'helloWorld',
+		'HELLO_WORLD',
+		'123',
+		'beepBoop123',
+		'beep',
+		'foo-bar',
+		void 0,
+		null,
+		true,
+		NaN,
+		[],
+		{},
+		123
 	];
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		bool = isPascalCase( values[ i % values.length ] );
+		bool = isPascalcase( values[ i % values.length ] );
 		if ( typeof bool !== 'boolean' ) {
 			b.fail( 'should return a boolean' );
 		}
@@ -58,4 +65,3 @@ bench( pkg, function benchmark( b ) {
 	b.pass( 'benchmark finished' );
 	b.end();
 });
-

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/benchmark/benchmark.js
@@ -1,0 +1,61 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var pkg = require( './../package.json' ).name;
+var isPascalCase = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var values;
+	var bool;
+	var i;
+
+	values = [
+		'',
+		'HelloWorld',
+		'HelloWorld!',
+		'Hello World!',
+		'Hello_World',
+		'Hello_World!',
+		'Hello_World!',
+		5
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		bool = isPascalCase( values[ i % values.length ] );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/bin/cli
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/bin/cli
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-/*
+/**
 * @license Apache-2.0
 *
 * Copyright (c) 2022 The Stdlib Authors.
@@ -20,7 +20,6 @@
 
 'use strict';
 
-
 // MODULES //
 
 var resolve = require( 'path' ).resolve;
@@ -29,7 +28,9 @@ var CLI = require( '@stdlib/cli/ctor' );
 var stdin = require( '@stdlib/process/read-stdin' );
 var stdinStream = require( '@stdlib/streams/node/stdin' );
 var RE_EOL = require( '@stdlib/regexp/eol' ).REGEXP;
-var isPascalCase = require( './../lib' );
+var isRegExpString = require( '@stdlib/assert/is-regexp-string' );
+var reFromString = require( '@stdlib/utils/regexp-from-string' );
+var isPascalcase = require( './../lib' );
 
 
 // MAIN //
@@ -41,8 +42,9 @@ var isPascalCase = require( './../lib' );
 * @returns {void}
 */
 function main() {
+	var split;
 	var flags;
-	var opts;
+	var args;
 	var cli;
 
 	// Create a command-line interface:
@@ -60,43 +62,47 @@ function main() {
 		return;
 	}
 
-	// Specify the command-line options:
-	opts = {
-		'split': flags.split
-	};
+	// Get any provided command-line arguments:
+	args = cli.args();
 
 	// Check if we are receiving data from `stdin`...
 	if ( !stdinStream.isTTY ) {
+		if ( flags.split ) {
+			if ( !isRegExpString( flags.split ) ) {
+				flags.split = '/'+flags.split+'/';
+			}
+			split = reFromString( flags.split );
+		} else {
+			split = RE_EOL;
+		}
 		return stdin( onRead );
 	}
-	stdin( onRead );
+	console.log( isPascalcase( args[ 0 ] ) ); // eslint-disable-line no-console
 
 	/**
 	* Callback invoked upon reading from `stdin`.
 	*
 	* @private
 	* @param {(Error|null)} error - error object
-	* @param {Buffer} data - data
+	* @param {(string|Buffer)} data - data
 	* @returns {void}
 	*/
 	function onRead( error, data ) {
 		var lines;
-		var len;
-		var d;
 		var i;
 		if ( error ) {
 			return cli.error( error );
 		}
-		if ( data.length ) {
-			lines = data.toString().split( opts.split );
-			len = lines.length;
-			for ( i = 0; i < len; i++ ) {
-				d = lines[ i ].split( RE_EOL )[ 0 ];
-				console.log( isPascalCase( d ) ); // eslint-disable-line no-console
-			}
+		lines = data.toString().split( split );
+
+		// Remove any trailing separators (e.g., trailing newline)...
+		if ( lines[ lines.length-1 ] === '' ) {
+			lines.pop();
+		}
+		for ( i = 0; i < lines.length; i++ ) {
+			console.log( isPascalcase( lines[ i ] ) ); // eslint-disable-line no-console
 		}
 	}
 }
 
 main();
-

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/bin/cli
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/bin/cli
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var readFileSync = require( '@stdlib/fs/read-file' ).sync;
+var CLI = require( '@stdlib/cli/ctor' );
+var stdin = require( '@stdlib/process/read-stdin' );
+var stdinStream = require( '@stdlib/streams/node/stdin' );
+var RE_EOL = require( '@stdlib/regexp/eol' ).REGEXP;
+var isPascalCase = require( './../lib' );
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+* @returns {void}
+*/
+function main() {
+	var flags;
+	var opts;
+	var cli;
+
+	// Create a command-line interface:
+	cli = new CLI({
+		'pkg': require( './../package.json' ),
+		'options': require( './../etc/cli_opts.json' ),
+		'help': readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+			'encoding': 'utf8'
+		})
+	});
+
+	// Get any provided command-line options:
+	flags = cli.flags();
+	if ( flags.help || flags.version ) {
+		return;
+	}
+
+	// Specify the command-line options:
+	opts = {
+		'split': flags.split
+	};
+
+	// Check if we are receiving data from `stdin`...
+	if ( !stdinStream.isTTY ) {
+		return stdin( onRead );
+	}
+	stdin( onRead );
+
+	/**
+	* Callback invoked upon reading from `stdin`.
+	*
+	* @private
+	* @param {(Error|null)} error - error object
+	* @param {Buffer} data - data
+	* @returns {void}
+	*/
+	function onRead( error, data ) {
+		var lines;
+		var len;
+		var d;
+		var i;
+		if ( error ) {
+			return cli.error( error );
+		}
+		if ( data.length ) {
+			lines = data.toString().split( opts.split );
+			len = lines.length;
+			for ( i = 0; i < len; i++ ) {
+				d = lines[ i ].split( RE_EOL )[ 0 ];
+				console.log( isPascalCase( d ) ); // eslint-disable-line no-console
+			}
+		}
+	}
+}
+
+main();
+

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/docs/repl.txt
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/docs/repl.txt
@@ -10,7 +10,7 @@
     Returns
     -------
     bool: boolean
-        Boolean indicating whether value is a string in Pascal case.
+        Boolean indicating whether a value is a string in Pascal case.
 
     Examples
     --------

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/docs/repl.txt
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/docs/repl.txt
@@ -1,0 +1,23 @@
+
+{{alias}}( value )
+    Tests if a value is a string in Pascal case.
+
+    Parameters
+    ----------
+    value: any
+        Value to test.
+
+    Returns
+    -------
+    bool: boolean
+        Boolean indicating whether value is a string in Pascal case.
+
+    Examples
+    --------
+    > var bool = {{alias}}( 'HelloWorld' )
+    true
+    > bool = {{alias}}( 'Hello World' )
+    false
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/docs/repl.txt
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/docs/repl.txt
@@ -16,7 +16,7 @@
     --------
     > var bool = {{alias}}( 'HelloWorld' )
     true
-    > bool = {{alias}}( 'Hello World' )
+    > bool = {{alias}}( 'hello-world' )
     false
 
     See Also

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/docs/types/index.d.ts
@@ -1,0 +1,49 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 2.0
+
+/**
+* Tests if a `value` is a `string` in Pascal case.
+*
+* @param value - value to test
+* @returns boolean indicating if a value is a `string` in Pascal case
+*
+* @example
+* var bool = isPascalCase( 'HelloWorld' );
+* // returns true
+*
+* @example
+* var bool = isPascalCase( 'Hello world' );
+* // returns false
+*
+* @example
+* var bool = isPascalCase( 'Hello_World' );
+* // returns false
+*
+* @example
+* var bool = isPascalCase( 'hello' );
+* // returns false
+*/
+declare function isPascalCase( value: any ): boolean;
+
+
+// EXPORTS //
+
+export = isPascalCase;
+

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/docs/types/index.d.ts
@@ -25,25 +25,24 @@
 * @returns boolean indicating if a value is a `string` in Pascal case
 *
 * @example
-* var bool = isPascalCase( 'HelloWorld' );
+* var bool = isPascalcase( 'HelloWorld' );
 * // returns true
 *
 * @example
-* var bool = isPascalCase( 'Hello world' );
+* var bool = isPascalcase( 'helloWorld' );
 * // returns false
 *
 * @example
-* var bool = isPascalCase( 'Hello_World' );
+* var bool = isPascalcase( 'HELLO_WORLD' );
 * // returns false
 *
 * @example
-* var bool = isPascalCase( 'hello' );
+* var bool = isPascalcase( null );
 * // returns false
 */
-declare function isPascalCase( value: any ): boolean;
+declare function isPascalcase( value: any ): boolean;
 
 
 // EXPORTS //
 
-export = isPascalCase;
-
+export = isPascalcase;

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/docs/types/index.d.ts
@@ -22,7 +22,7 @@
 * Tests if a value is a string in Pascal case.
 *
 * @param value - value to test
-* @returns boolean indicating if a value is a `string` in Pascal case
+* @returns boolean indicating if a value is a string in Pascal case
 *
 * @example
 * var bool = isPascalcase( 'HelloWorld' );

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/docs/types/index.d.ts
@@ -22,7 +22,7 @@
 * Tests if a value is a string in Pascal case.
 *
 * @param value - value to test
-* @returns boolean indicating if a value is a string in Pascal case
+* @returns boolean indicating whether a value is a string in Pascal case
 *
 * @example
 * var bool = isPascalcase( 'HelloWorld' );

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/docs/types/index.d.ts
@@ -19,7 +19,7 @@
 // TypeScript Version: 2.0
 
 /**
-* Tests if a `value` is a `string` in Pascal case.
+* Tests if a value is a string in Pascal case.
 *
 * @param value - value to test
 * @returns boolean indicating if a value is a `string` in Pascal case

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/docs/types/test.ts
@@ -1,0 +1,35 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import isPascalCase = require( './index' );
+
+
+// TESTS //
+
+// The function returns a boolean...
+{
+	isPascalCase( 'Hello' ); // $ExpectType boolean
+	isPascalCase( 5 ); // $ExpectType boolean
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	isPascalCase(); // $ExpectError
+	isPascalCase( 'Hello', 123 ); // $ExpectError
+}
+

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/docs/types/test.ts
@@ -16,20 +16,19 @@
 * limitations under the License.
 */
 
-import isPascalCase = require( './index' );
+import isPascalcase = require( './index' );
 
 
 // TESTS //
 
 // The function returns a boolean...
 {
-	isPascalCase( 'Hello' ); // $ExpectType boolean
-	isPascalCase( 5 ); // $ExpectType boolean
+	isPascalcase( 'Hello' ); // $ExpectType boolean
+	isPascalcase( 5 ); // $ExpectType boolean
 }
 
 // The compiler throws an error if the function is provided an unsupported number of arguments...
 {
-	isPascalCase(); // $ExpectError
-	isPascalCase( 'Hello', 123 ); // $ExpectError
+	isPascalcase(); // $ExpectError
+	isPascalcase( 'Hello', 123 ); // $ExpectError
 }
-

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/docs/usage.txt
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/docs/usage.txt
@@ -1,0 +1,9 @@
+
+Usage: is-pascalcase [options] [<string>]
+
+Options:
+
+  -h,    --help                Print this message.
+  -V,    --version             Print the package version.
+         --split sep           Delimiter for stdin data. Default: '/\\r?\\n/'.
+

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/docs/usage.txt
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/docs/usage.txt
@@ -6,4 +6,3 @@ Options:
   -h,    --help                Print this message.
   -V,    --version             Print the package version.
          --split sep           Delimiter for stdin data. Default: '/\\r?\\n/'.
-

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/etc/cli_opts.json
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/etc/cli_opts.json
@@ -1,0 +1,17 @@
+{
+	"string": [
+		"split"
+	],
+	"boolean": [
+		"help",
+		"version"
+	],
+	"alias": {
+		"help": [
+			"h"
+		],
+		"version": [
+			"V"
+		]
+	}
+}

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/examples/index.js
@@ -1,0 +1,39 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var isPascalCase = require( './../lib' );
+
+console.log( isPascalCase( 'FooBarBaz' ) );
+// => true
+
+console.log( isPascalCase( 'fooBarBaz' ) );
+// => false
+
+console.log( isPascalCase( 'Foo Bar Baz' ) );
+// => false
+
+console.log( isPascalCase( 'Beep-Boop' ) );
+// => false
+
+console.log( isPascalCase( '' ) );
+// => false
+
+console.log( isPascalCase( null ) );
+// => false

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/examples/index.js
@@ -18,22 +18,19 @@
 
 'use strict';
 
-var isPascalCase = require( './../lib' );
+var isPascalcase = require( './../lib' );
 
-console.log( isPascalCase( 'FooBarBaz' ) );
+console.log( isPascalcase( 'FooBarBaz' ) );
 // => true
 
-console.log( isPascalCase( 'fooBarBaz' ) );
+console.log( isPascalcase( 'fooBarBaz' ) );
 // => false
 
-console.log( isPascalCase( 'Foo Bar Baz' ) );
+console.log( isPascalcase( 'Foo Bar Baz' ) );
 // => false
 
-console.log( isPascalCase( 'Beep-Boop' ) );
+console.log( isPascalcase( 'Beep-Boop' ) );
 // => false
 
-console.log( isPascalCase( '' ) );
-// => false
-
-console.log( isPascalCase( null ) );
+console.log( isPascalcase( null ) );
 // => false

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/lib/index.js
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/lib/index.js
@@ -1,0 +1,43 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Test if a value is a string in Pascal case.
+*
+* @module @stdlib/assert/is-pascalcase
+*
+* @example
+* var isPascalCase = require( '@stdlib/assert/is-pascalcase' );
+*
+* var bool = isPascalCase( 'HelloWorld' );
+* // returns true
+*
+* bool = isPascalCase( 'Hello World' );
+* // returns false
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/lib/index.js
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/lib/index.js
@@ -24,12 +24,12 @@
 * @module @stdlib/assert/is-pascalcase
 *
 * @example
-* var isPascalCase = require( '@stdlib/assert/is-pascalcase' );
+* var isPascalcase = require( '@stdlib/assert/is-pascalcase' );
 *
-* var bool = isPascalCase( 'HelloWorld' );
+* var bool = isPascalcase( 'HelloWorld' );
 * // returns true
 *
-* bool = isPascalCase( 'Hello World' );
+* bool = isPascalcase( 'Hello World' );
 * // returns false
 */
 

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/lib/main.js
@@ -30,7 +30,7 @@ var pascalcase = require( '@stdlib/string/base/pascalcase' );
 * Tests if a value is a string in Pascal case.
 *
 * @param {*} value - value to test
-* @returns {boolean} boolean indicating if a value is a string in Pascal case
+* @returns {boolean} boolean indicating whether a value is a string in Pascal case
 *
 * @example
 * var bool = isPascalcase( 'HelloWorld' );

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/lib/main.js
@@ -1,0 +1,57 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+// TODO: Load required modules...
+
+
+// MAIN //
+
+/**
+* Tests if a `value` is a `string` in Pascal case.
+*
+* @param {*} value - value to test
+* @returns {boolean} boolean indicating if a value is a `string` in Pascal case
+*
+* @example
+* var bool = isPascalCase( 'HelloWorld' );
+* // returns true
+*
+* @example
+* var bool = isPascalCase( 'Hello world' );
+* // returns false
+*
+* @example
+* var bool = isPascalCase( 'Hello_World' );
+* // returns false
+*
+* @example
+* var bool = isPascalCase( 'hello' );
+* // returns false
+*/
+function isPascalCase( value ) {
+	// TODO: Add implementation...
+}
+
+
+// EXPORTS //
+
+module.exports = isPascalCase;

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/lib/main.js
@@ -27,10 +27,10 @@ var pascalcase = require( '@stdlib/string/base/pascalcase' );
 // MAIN //
 
 /**
-* Tests if a `value` is a `string` in Pascal case.
+* Tests if a value is a string in Pascal case.
 *
 * @param {*} value - value to test
-* @returns {boolean} boolean indicating if a value is a `string` in Pascal case
+* @returns {boolean} boolean indicating if a value is a string in Pascal case
 *
 * @example
 * var bool = isPascalcase( 'HelloWorld' );

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/lib/main.js
@@ -20,7 +20,8 @@
 
 // MODULES //
 
-// TODO: Load required modules...
+var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
+var pascalcase = require( '@stdlib/string/base/pascalcase' );
 
 
 // MAIN //
@@ -32,26 +33,26 @@
 * @returns {boolean} boolean indicating if a value is a `string` in Pascal case
 *
 * @example
-* var bool = isPascalCase( 'HelloWorld' );
+* var bool = isPascalcase( 'HelloWorld' );
 * // returns true
 *
 * @example
-* var bool = isPascalCase( 'Hello world' );
+* var bool = isPascalcase( 'helloWorld' );
 * // returns false
 *
 * @example
-* var bool = isPascalCase( 'Hello_World' );
+* var bool = isPascalcase( 'HELLO_WORLD' );
 * // returns false
 *
 * @example
-* var bool = isPascalCase( 'hello' );
+* var bool = isPascalcase( null );
 * // returns false
 */
-function isPascalCase( value ) {
-	// TODO: Add implementation...
+function isPascalcase( value ) {
+	return ( isString( value ) && pascalcase( value ) === value );
 }
 
 
 // EXPORTS //
 
-module.exports = isPascalCase;
+module.exports = isPascalcase;

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/package.json
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/assert/is-pascalcase",
   "version": "0.0.0",
-  "description": "",
+  "description": "Test if a value is a string in Pascal case.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",
@@ -51,5 +51,21 @@
     "win32",
     "windows"
   ],
-  "keywords": []
+  "keywords": [
+    "stdlib",
+    "stdassert",
+    "assertion",
+    "assert",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "is",
+    "ispascalcase",
+    "pascalcase",
+    "string",
+    "valid",
+    "validate",
+    "test"
+  ]
 }

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/package.json
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@stdlib/assert/is-pascalcase",
+  "version": "0.0.0",
+  "description": "",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "bin": {
+    "is-pascalcase": "./bin/cli"
+  },
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": []
+}

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/test/fixtures/stdin_error.js.txt
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/test/fixtures/stdin_error.js.txt
@@ -1,0 +1,33 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+var proc = require( 'process' );
+var resolve = require( 'path' ).resolve;
+var proxyquire = require( 'proxyquire' );
+
+var fpath = resolve( __dirname, '..', 'bin', 'cli' );
+
+proc.stdin.isTTY = false;
+
+proxyquire( fpath, {
+	'@stdlib/process/read-stdin': stdin
+});
+
+function stdin( clbk ) {
+	clbk( new Error( 'beep' ) );
+}

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/test/test.cli.js
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/test/test.cli.js
@@ -155,7 +155,7 @@ tape( 'the command-line interface tests if an input argument is in Pascal case',
 		if ( error ) {
 			t.fail( error.message );
 		} else {
-			t.strictEqual( stdout.toString(), 'true\n', 'expected value' );
+			t.strictEqual( stdout.toString(), 'false\n', 'expected value' );
 			t.strictEqual( stderr.toString(), '', 'does not print to `stderr`' );
 		}
 		t.end();
@@ -167,7 +167,7 @@ tape( 'the command-line interface supports use as a standard stream', opts, func
 	var cmd;
 
 	cmd = [
-		'printf "FooBar\nboopbeep\nBeepBoopBaz" |',
+		'printf "FooBar\nboop-beep\nBeepBoopBaz"',
 		'|',
 		EXEC_PATH,
 		fpath
@@ -187,16 +187,13 @@ tape( 'the command-line interface supports use as a standard stream', opts, func
 	}
 });
 
-tape( 'the command-line interface supports use as a standard stream (delimiter)', opts, function test( t ) {
-	var expected;
-	var cmd;
-
-	cmd = [
-		'printf "BeepBoop\\tboopbeep"',
+tape( 'the command-line interface supports specifying a custom delimiter when used as a standard stream (string)', opts, function test( t ) {
+	var cmd = [
+		'printf \'beep boop\tFooBar\'',
 		'|',
 		EXEC_PATH,
 		fpath,
-		'--split="\\t"'
+		'--split \'\t\''
 	];
 
 	exec( cmd.join( ' ' ), done );
@@ -205,8 +202,29 @@ tape( 'the command-line interface supports use as a standard stream (delimiter)'
 		if ( error ) {
 			t.fail( error.message );
 		} else {
-			expected = [ true, false ].join( '\n' )+'\n';
-			t.strictEqual( stdout.toString(), expected, 'expected value' );
+			t.strictEqual( stdout.toString(), 'false\ntrue\n', 'expected value' );
+			t.strictEqual( stderr.toString(), '', 'does not print to `stderr`' );
+		}
+		t.end();
+	}
+});
+
+tape( 'the command-line interface supports specifying a custom delimiter when used as a standard stream (regexp)', opts, function test( t ) {
+	var cmd = [
+		'printf \'beep boop\tFooBar\'',
+		'|',
+		EXEC_PATH,
+		fpath,
+		'--split=/\\\\t/'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), 'false\ntrue\n', 'expected value' );
 			t.strictEqual( stderr.toString(), '', 'does not print to `stderr`' );
 		}
 		t.end();

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/test/test.cli.js
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/test/test.cli.js
@@ -17,435 +17,233 @@
 */
 
 'use strict';
-#!/usr/bin/env node
-'use strict';
 
-var stdin = require( '@stdlib/streams/node/stdin' );
-var IS_PASCALCASE = require( './../lib' );
-var opts = require( './options.json' );
-var optsPkg = require( './../package.json' );
-var readme = require( './../docs/readme.md' );
-var minimist = require( 'minimist' );
-var replace = require( '@stdlib/string/replace' );
-var split = require( '@stdlib/string/split-by-regexp' );
-var print = require( './print.js' );
-var proc = require( './process.js' );
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
 var exec = require( 'child_process' ).exec;
-var tmpl = require( './template.js' );
-var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
-var findPkgs = require( '@stdlib/_tools/pkgs/find' );
+var tape = require( 'tape' );
+var IS_BROWSER = require( '@stdlib/assert/is-browser' );
 var IS_WINDOWS = require( '@stdlib/assert/is-windows' );
+var EXEC_PATH = require( '@stdlib/process/exec-path' );
+var replace = require( '@stdlib/string/replace' );
+var readFileSync = require( '@stdlib/fs/read-file' ).sync;
 
 
 // VARIABLES //
 
-// Split separator:
-var SEP = '/\\r?\\n/';
-
-// Template render context:
-var ctx = {
-	'pkg_name': '@stdlib/assert/is-pascal-case',
-	'pkg_version': optsPkg.version,
-	'usage': `Usage: ${optsPkg.name} [options] [<string>]`,
-	'options': [
-		{
-			'flags': '--help',
-			'label': 'Print this message.'
-		},
-		{
-			'flags': '--version',
-			'label': 'Print the package version.'
-		},
-		{
-			'flags': '--split sep',
-			'label': 'Delimiter for stdin data. Default: \'/\\\\r?\\\\n/\'.'
-		}
-	],
-	'notes': [
-		{
-			'html': 'If the split separator is a <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions">regular expression</a>, ensure that the `split` option is either properly escaped or enclosed in quotes.'
-		},
-		{
-			'html': 'The implementation ignores trailing delimiters.'
-		}
-	],
-	'examples': [
-		'$ is-pascalcase Beep',
-		'$ echo -n \'boop\' | is-pascalcase',
-		'$ echo -n \'beep\\tFooBar\' | is-pascalcase --split \'\\t\'',
-		'$ echo -n \'beEp booP\\nFooBar\' | is-pascalcase --split /\\r?\\n/',
-		'$ echo -n \'beEp booP\\nFooBar\' | is-pascalcase --split /\\\\r?\\\\n/'
-	],
-	'links': [
-		{
-			'html': '<a href="https://github.com/stdlib-js/stdlib/tree/master/lib/node_modules/%40stdlib/assert/is-pascal-case">@stdlib/assert/is-pascal-case</a>',
-			'label': '@stdlib/assert/is-pascal-case'
-		},
-		{
-			'html': '<a href="https://github.com/stdlib-js/stdlib/issues">@stdlib/assert/is-pascal-case</a>',
-			'label': 'Support'
-		}
-	],
-	'more': [
-		{
-			'html': '<a href="https://github.com/stdlib-js/stdlib">stdlib</a>',
-			'label': 'stdlib'
-		},
-		{
-			'html': '<a href="https://github.com/stdlib-js/stdlib/tree/master/lib/node_modules/%40stdlib/datasets">datasets</a>',
-			'label': '@stdlib/datasets'
-		},
-		{
-			'html': '<a href="http://stdlib.io/">stdlib.io</a>',
-			'label': 'stdlib.io'
-		},
-		{
-			'html': '<a href="http://stdlib.io/docs">API Documentation</a>',
-			'label': 'API Documentation'
-		}
-	]
+var fpath = resolve( __dirname, '..', 'bin', 'cli' );
+var opts = {
+	'skip': IS_BROWSER || IS_WINDOWS
 };
 
 
-// FUNCTIONS //
+// FIXTURES //
 
-/**
-* Renders a template.
-*
-* @private
-* @param {ObjectArray} arr - list of template elements
-* @returns {string} rendered template
-*/
-function render( arr ) {
-	var out;
-	var i;
-	out = '';
-	for ( i = 0; i < arr.length; i++ ) {
-		out += arr[ i ].html;
-	}
-	return out;
-}
+var PKG_VERSION = require( './../package.json' ).version;
 
-/**
-* Renders a template in context.
-*
-* @private
-* @param {ObjectArray} arr - list of template elements
-* @returns {string} rendered template
-*/
-function renderContext( arr ) {
-	var out;
-	var i;
-	out = '';
-	for ( i = 0; i < arr.length; i++ ) {
-		out += tmpl( arr[i].html, ctx );
-	}
-	return out;
-}
 
-/**
-* Returns a callback to be invoked upon calling the command-line interface.
-*
-* @private
-* @param {string} name - package name
-* @returns {Function} callback
-*/
-function cli( name ) {
-	return onExit;
+// TESTS //
 
-	/**
-	* Callback invoked upon calling the command-line interface.
-	*
-	* @private
-	* @param {(Error|null)} error - error object
-	* @param {Object} result - result
-	* @returns {void}
-	*/
-	function onExit( error, result ) {
-		var str;
+tape( 'command-line interface', function test( t ) {
+	t.ok( true, __filename );
+	t.end();
+});
+
+tape( 'when invoked with a `--help` flag, the command-line interface prints the help text to `stderr`', opts, function test( t ) {
+	var expected;
+	var cmd;
+
+	expected = readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+		'encoding': 'utf8'
+	});
+	cmd = [
+		EXEC_PATH,
+		fpath,
+		'--help'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
 		if ( error ) {
-			str = error.message;
+			t.fail( error.message );
 		} else {
-			str = name + ': ' + result.pkg.version;
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), expected+'\n', 'expected value' );
 		}
-		print.clear();
-		print.write( str+'\n' );
-		print.flush();
-		proc.exit( error, result );
+		t.end();
 	}
-} // end FUNCTION cli()
+});
 
-/**
-* Returns a callback to be invoked upon calling the command-line interface.
-*
-* @private
-* @param {string} name - package name
-* @returns {Function} callback
-*/
-function cliVersion( name ) {
-	return onExit;
+tape( 'when invoked with a `-h` flag, the command-line interface prints the help text to `stderr`', opts, function test( t ) {
+	var expected;
+	var cmd;
 
-	/**
-	* Callback invoked upon calling the command-line interface.
-	*
-	* @private
-	* @param {(Error|null)} error - error object
-	* @param {Object} result - result
-	* @returns {void}
-	*/
-	function onExit( error, result ) {
-		var str;
+	expected = readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+		'encoding': 'utf8'
+	});
+	cmd = [
+		EXEC_PATH,
+		fpath,
+		'-h'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
 		if ( error ) {
-			str = error.message;
+			t.fail( error.message );
 		} else {
-			str = name + ': ' + result.pkg.version + ' ' + result.pkg.repository.url;
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), expected+'\n', 'expected value' );
 		}
-		print.clear();
-		print.write( str+'\n' );
-		print.flush();
-		proc.exit( error, result );
+		t.end();
 	}
-} // end FUNCTION cliVersion()
+});
 
-/**
-* Returns a callback to be invoked upon calling the command-line interface.
-*
-* @private
-* @returns {Function} callback
-*/
-function cliHelp() {
-	var out;
-	var i;
-	var j;
+tape( 'when invoked with a `--version` flag, the command-line interface prints the version to `stderr`', opts, function test( t ) {
+	var cmd = [
+		EXEC_PATH,
+		fpath,
+		'--version'
+	];
 
-	// Initialize a counter for each category:
-	for ( i = 0; i < ctx.options.length; i++ ) {
-		ctx.options[ i ].count = 0;
-	}
-	for ( i = 0; i < ctx.notes.length; i++ ) {
-		ctx.notes[ i ].count = 0;
-	}
-	for ( i = 0; i < ctx.examples.length; i++ ) {
-		ctx.examples[ i ].count = 0;
-	}
-	for ( i = 0; i < ctx.links.length; i++ ) {
-		ctx.links[ i ].count = 0;
-	}
-	for ( i = 0; i < ctx.more.length; i++ ) {
-		ctx.more[ i ].count = 0;
-	}
-	return onExit;
+	exec( cmd.join( ' ' ), done );
 
-	/**
-	* Callback invoked upon calling the command-line interface.
-	*
-	* @private
-	* @param {(Error|null)} error - error object
-	* @param {Object} result - result
-	* @returns {void}
-	*/
-	function onExit( error, result ) {
-		var i;
+	function done( error, stdout, stderr ) {
 		if ( error ) {
-			print.clear();
-			print.write( error.message+'\n' );
-			print.flush();
-			proc.exit( error, result );
-			return;
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), PKG_VERSION+'\n', 'expected value' );
 		}
-		out = '';
-
-		// Render the usage section...
-		out += '\n'+renderContext( readme.usage );
-
-		// Render the options section...
-		out += '\nOptions:\n\n';
-		out += renderContext( readme.options );
-
-		// Render the notes section...
-		if ( ctx.notes.length ) {
-			out += '\nNotes:\n\n';
-			out += renderContext( readme.notes );
-		}
-		// Render the examples section...
-		if ( ctx.examples.length ) {
-			out += '\nExamples:\n\n';
-			out += renderContext( readme.examples );
-		}
-		// Render the links section...
-		if ( ctx.links.length ) {
-			out += '\nLinks:\n\n';
-			out += renderContext( readme.links );
-		}
-		// Render the more section...
-		if ( ctx.more.length ) {
-			out += '\nMore:\n\n';
-			out += renderContext( readme.more );
-		}
-		print.clear();
-		print.write( out+'\n' );
-		print.flush();
-		proc.exit( error, result );
+		t.end();
 	}
-} // end FUNCTION cliHelp()
+});
 
-/**
-* Returns a callback to be invoked upon calling the command-line interface.
-*
-* @private
-* @returns {Function} callback
-*/
-function cliPkgs() {
-	var out;
-	var i;
-	var j;
+tape( 'when invoked with a `-V` flag, the command-line interface prints the version to `stderr`', opts, function test( t ) {
+	var cmd = [
+		EXEC_PATH,
+		fpath,
+		'-V'
+	];
 
-	// Initialize a counter for each category:
-	for ( i = 0; i < ctx.options.length; i++ ) {
-		ctx.options[ i ].count = 0;
-	}
-	for ( i = 0; i < ctx.notes.length; i++ ) {
-		ctx.notes[ i ].count = 0;
-	}
-	for ( i = 0; i < ctx.examples.length; i++ ) {
-		ctx.examples[ i ].count = 0;
-	}
-	for ( i = 0; i < ctx.links.length; i++ ) {
-		ctx.links[ i ].count = 0;
-	}
-	for ( i = 0; i < ctx.more.length; i++ ) {
-		ctx.more[ i ].count = 0;
-	}
-	return onExit;
+	exec( cmd.join( ' ' ), done );
 
-	/**
-	* Callback invoked upon calling the command-line interface.
-	*
-	* @private
-	* @param {(Error|null)} error - error object
-	* @param {Object} result - result
-	* @returns {void}
-	*/
-	function onExit( error, result ) {
-		var out;
-		var pkgs;
-		var i;
+	function done( error, stdout, stderr ) {
 		if ( error ) {
-			print.clear();
-			print.write( error.message+'\n' );
-			print.flush();
-			proc.exit( error, result );
-			return;
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), PKG_VERSION+'\n', 'expected value' );
 		}
-		pkgs = result.pkgs;
-		out = '';
-
-		// Render the usage section...
-		out += '\n'+renderContext( readme.usage );
-
-		// Render the options section...
-		out += '\nOptions:\n\n';
-		out += renderContext( readme.options );
-
-		// Render the notes section...
-		if ( ctx.notes.length ) {
-			out += '\nNotes:\n\n';
-			out += renderContext( readme.notes );
-		}
-		// Render the examples section...
-		if ( ctx.examples.length ) {
-			out += '\nExamples:\n\n';
-			out += renderContext( readme.examples );
-		}
-		// Render the links section...
-		if ( ctx.links.length ) {
-			out += '\nLinks:\n\n';
-			out += renderContext( readme.links );
-		}
-		// Render the more section...
-		if ( ctx.more.length ) {
-			out += '\nMore:\n\n';
-			out += renderContext( readme.more );
-		}
-		print.clear();
-		print.write( out+'\n' );
-		print.write( 'Packages:\n' );
-		for ( i = 0; i < pkgs.length; i++ ) {
-			print.write( `\t${pkgs[ i ]}` + '\n' );
-		}
-		print.flush();
-		proc.exit( error, result );
+		t.end();
 	}
-} // end FUNCTION cliPkgs()
+});
 
-/**
-* Returns a callback to be invoked upon calling the command-line interface.
-*
-* @private
-* @returns {Function} callback
-*/
-function cliPkgsList() {
-	var out;
-	var i;
-	var j;
+tape( 'the command-line interface tests if an input argument is in Pascal case', opts, function test( t ) {
+	var cmd = [
+		EXEC_PATH,
+		'-e',
+		'"process.stdin.isTTY = true; process.argv[ 2 ] = \'beepBoO\'; require( \''+fpath+'\' );"'
+	];
 
-	// Initialize a counter for each category:
-	for ( i = 0; i < ctx.options.length; i++ ) {
-		ctx.options[ i ].count = 0;
-	}
-	for ( i = 0; i < ctx.notes.length; i++ ) {
-		ctx.notes[ i ].count = 0;
-	}
-	for ( i = 0; i < ctx.examples.length; i++ ) {
-		ctx.examples[ i ].count = 0;
-	}
-	for ( i = 0; i < ctx.links.length; i++ ) {
-		ctx.links[ i ].count = 0;
-	}
-	for ( i = 0; i < ctx.more.length; i++ ) {
-		ctx.more[ i ].count = 0;
-	}
-	return onExit;
+	exec( cmd.join( ' ' ), done );
 
-	/**
-	* Callback invoked upon calling the command-line interface.
-	*
-	* @private
-	* @param {(Error|null)} error - error object
-	* @param {Object} result - result
-	* @returns {void}
-	*/
-	function onExit( error, result ) {
-		var out;
-		var pkgs;
-		var i;
+	function done( error, stdout, stderr ) {
 		if ( error ) {
-			print.clear();
-			print.write( error.message+'\n' );
-			print.flush();
-			proc.exit( error, result );
-			return;
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), 'true\n', 'expected value' );
+			t.strictEqual( stderr.toString(), '', 'does not print to `stderr`' );
 		}
-		pkgs = result.pkgs;
-		out = '';
+		t.end();
+	}
+});
 
-		// Render the usage section...
-		out += '\n'+renderContext( readme.usage );
+tape( 'the command-line interface supports use as a standard stream', opts, function test( t ) {
+	var expected;
+	var cmd;
 
-		// Render the options section...
-		out += '\nOptions:\n\n';
-		out += renderContext( readme.options );
+	cmd = [
+		'printf "FooBar\nboopbeep\nBeepBoopBaz" |',
+		'|',
+		EXEC_PATH,
+		fpath
+	];
 
-		// Render the notes section...
-		if ( ctx.notes.length ) {
-			out += '\nNotes:\n\n';
-			out += renderContext( readme.notes );
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			expected = [ true, false, true ].join( '\n' )+'\n';
+			t.strictEqual( stdout.toString(), expected, 'expected value' );
+			t.strictEqual( stderr.toString(), '', 'does not print to `stderr`' );
 		}
-		// Render the examples section...
-		if ( ctx.examples.length ) {
-			out += '\nExamples:\n\n';
-			out += renderContext( readme.examples );
+		t.end();
+	}
+});
+
+tape( 'the command-line interface supports use as a standard stream (delimiter)', opts, function test( t ) {
+	var expected;
+	var cmd;
+
+	cmd = [
+		'printf "BeepBoop\\tboopbeep"',
+		'|',
+		EXEC_PATH,
+		fpath,
+		'--split="\\t"'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			expected = [ true, false ].join( '\n' )+'\n';
+			t.strictEqual( stdout.toString(), expected, 'expected value' );
+			t.strictEqual( stderr.toString(), '', 'does not print to `stderr`' );
 		}
-		// Render the links section...
-		if ( ctx.links.length ) {
-			
+		t.end();
+	}
+});
+
+tape( 'when used as a standard stream, if an error is encountered when reading from `stdin`, the command-line interface prints an error and sets a non-zero exit code', opts, function test( t ) {
+	var script;
+	var opts;
+	var cmd;
+
+	script = readFileSync( resolve( __dirname, 'fixtures', 'stdin_error.js.txt' ), {
+		'encoding': 'utf8'
+	});
+
+	// Replace single quotes with double quotes:
+	script = replace( script, '\'', '"' );
+
+	cmd = [
+		EXEC_PATH,
+		'-e',
+		'\''+script+'\''
+	];
+
+	opts = {
+		'cwd': __dirname
+	};
+
+	exec( cmd.join( ' ' ), opts, done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.pass( error.message );
+			t.strictEqual( error.code, 1, 'expected exit code' );
+		}
+		t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+		t.strictEqual( stderr.toString(), 'Error: beep\n', 'expected value' );
+		t.end();
+	}
+});

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/test/test.cli.js
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/test/test.cli.js
@@ -1,0 +1,451 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+#!/usr/bin/env node
+'use strict';
+
+var stdin = require( '@stdlib/streams/node/stdin' );
+var IS_PASCALCASE = require( './../lib' );
+var opts = require( './options.json' );
+var optsPkg = require( './../package.json' );
+var readme = require( './../docs/readme.md' );
+var minimist = require( 'minimist' );
+var replace = require( '@stdlib/string/replace' );
+var split = require( '@stdlib/string/split-by-regexp' );
+var print = require( './print.js' );
+var proc = require( './process.js' );
+var exec = require( 'child_process' ).exec;
+var tmpl = require( './template.js' );
+var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
+var findPkgs = require( '@stdlib/_tools/pkgs/find' );
+var IS_WINDOWS = require( '@stdlib/assert/is-windows' );
+
+
+// VARIABLES //
+
+// Split separator:
+var SEP = '/\\r?\\n/';
+
+// Template render context:
+var ctx = {
+	'pkg_name': '@stdlib/assert/is-pascal-case',
+	'pkg_version': optsPkg.version,
+	'usage': `Usage: ${optsPkg.name} [options] [<string>]`,
+	'options': [
+		{
+			'flags': '--help',
+			'label': 'Print this message.'
+		},
+		{
+			'flags': '--version',
+			'label': 'Print the package version.'
+		},
+		{
+			'flags': '--split sep',
+			'label': 'Delimiter for stdin data. Default: \'/\\\\r?\\\\n/\'.'
+		}
+	],
+	'notes': [
+		{
+			'html': 'If the split separator is a <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions">regular expression</a>, ensure that the `split` option is either properly escaped or enclosed in quotes.'
+		},
+		{
+			'html': 'The implementation ignores trailing delimiters.'
+		}
+	],
+	'examples': [
+		'$ is-pascalcase Beep',
+		'$ echo -n \'boop\' | is-pascalcase',
+		'$ echo -n \'beep\\tFooBar\' | is-pascalcase --split \'\\t\'',
+		'$ echo -n \'beEp booP\\nFooBar\' | is-pascalcase --split /\\r?\\n/',
+		'$ echo -n \'beEp booP\\nFooBar\' | is-pascalcase --split /\\\\r?\\\\n/'
+	],
+	'links': [
+		{
+			'html': '<a href="https://github.com/stdlib-js/stdlib/tree/master/lib/node_modules/%40stdlib/assert/is-pascal-case">@stdlib/assert/is-pascal-case</a>',
+			'label': '@stdlib/assert/is-pascal-case'
+		},
+		{
+			'html': '<a href="https://github.com/stdlib-js/stdlib/issues">@stdlib/assert/is-pascal-case</a>',
+			'label': 'Support'
+		}
+	],
+	'more': [
+		{
+			'html': '<a href="https://github.com/stdlib-js/stdlib">stdlib</a>',
+			'label': 'stdlib'
+		},
+		{
+			'html': '<a href="https://github.com/stdlib-js/stdlib/tree/master/lib/node_modules/%40stdlib/datasets">datasets</a>',
+			'label': '@stdlib/datasets'
+		},
+		{
+			'html': '<a href="http://stdlib.io/">stdlib.io</a>',
+			'label': 'stdlib.io'
+		},
+		{
+			'html': '<a href="http://stdlib.io/docs">API Documentation</a>',
+			'label': 'API Documentation'
+		}
+	]
+};
+
+
+// FUNCTIONS //
+
+/**
+* Renders a template.
+*
+* @private
+* @param {ObjectArray} arr - list of template elements
+* @returns {string} rendered template
+*/
+function render( arr ) {
+	var out;
+	var i;
+	out = '';
+	for ( i = 0; i < arr.length; i++ ) {
+		out += arr[ i ].html;
+	}
+	return out;
+}
+
+/**
+* Renders a template in context.
+*
+* @private
+* @param {ObjectArray} arr - list of template elements
+* @returns {string} rendered template
+*/
+function renderContext( arr ) {
+	var out;
+	var i;
+	out = '';
+	for ( i = 0; i < arr.length; i++ ) {
+		out += tmpl( arr[i].html, ctx );
+	}
+	return out;
+}
+
+/**
+* Returns a callback to be invoked upon calling the command-line interface.
+*
+* @private
+* @param {string} name - package name
+* @returns {Function} callback
+*/
+function cli( name ) {
+	return onExit;
+
+	/**
+	* Callback invoked upon calling the command-line interface.
+	*
+	* @private
+	* @param {(Error|null)} error - error object
+	* @param {Object} result - result
+	* @returns {void}
+	*/
+	function onExit( error, result ) {
+		var str;
+		if ( error ) {
+			str = error.message;
+		} else {
+			str = name + ': ' + result.pkg.version;
+		}
+		print.clear();
+		print.write( str+'\n' );
+		print.flush();
+		proc.exit( error, result );
+	}
+} // end FUNCTION cli()
+
+/**
+* Returns a callback to be invoked upon calling the command-line interface.
+*
+* @private
+* @param {string} name - package name
+* @returns {Function} callback
+*/
+function cliVersion( name ) {
+	return onExit;
+
+	/**
+	* Callback invoked upon calling the command-line interface.
+	*
+	* @private
+	* @param {(Error|null)} error - error object
+	* @param {Object} result - result
+	* @returns {void}
+	*/
+	function onExit( error, result ) {
+		var str;
+		if ( error ) {
+			str = error.message;
+		} else {
+			str = name + ': ' + result.pkg.version + ' ' + result.pkg.repository.url;
+		}
+		print.clear();
+		print.write( str+'\n' );
+		print.flush();
+		proc.exit( error, result );
+	}
+} // end FUNCTION cliVersion()
+
+/**
+* Returns a callback to be invoked upon calling the command-line interface.
+*
+* @private
+* @returns {Function} callback
+*/
+function cliHelp() {
+	var out;
+	var i;
+	var j;
+
+	// Initialize a counter for each category:
+	for ( i = 0; i < ctx.options.length; i++ ) {
+		ctx.options[ i ].count = 0;
+	}
+	for ( i = 0; i < ctx.notes.length; i++ ) {
+		ctx.notes[ i ].count = 0;
+	}
+	for ( i = 0; i < ctx.examples.length; i++ ) {
+		ctx.examples[ i ].count = 0;
+	}
+	for ( i = 0; i < ctx.links.length; i++ ) {
+		ctx.links[ i ].count = 0;
+	}
+	for ( i = 0; i < ctx.more.length; i++ ) {
+		ctx.more[ i ].count = 0;
+	}
+	return onExit;
+
+	/**
+	* Callback invoked upon calling the command-line interface.
+	*
+	* @private
+	* @param {(Error|null)} error - error object
+	* @param {Object} result - result
+	* @returns {void}
+	*/
+	function onExit( error, result ) {
+		var i;
+		if ( error ) {
+			print.clear();
+			print.write( error.message+'\n' );
+			print.flush();
+			proc.exit( error, result );
+			return;
+		}
+		out = '';
+
+		// Render the usage section...
+		out += '\n'+renderContext( readme.usage );
+
+		// Render the options section...
+		out += '\nOptions:\n\n';
+		out += renderContext( readme.options );
+
+		// Render the notes section...
+		if ( ctx.notes.length ) {
+			out += '\nNotes:\n\n';
+			out += renderContext( readme.notes );
+		}
+		// Render the examples section...
+		if ( ctx.examples.length ) {
+			out += '\nExamples:\n\n';
+			out += renderContext( readme.examples );
+		}
+		// Render the links section...
+		if ( ctx.links.length ) {
+			out += '\nLinks:\n\n';
+			out += renderContext( readme.links );
+		}
+		// Render the more section...
+		if ( ctx.more.length ) {
+			out += '\nMore:\n\n';
+			out += renderContext( readme.more );
+		}
+		print.clear();
+		print.write( out+'\n' );
+		print.flush();
+		proc.exit( error, result );
+	}
+} // end FUNCTION cliHelp()
+
+/**
+* Returns a callback to be invoked upon calling the command-line interface.
+*
+* @private
+* @returns {Function} callback
+*/
+function cliPkgs() {
+	var out;
+	var i;
+	var j;
+
+	// Initialize a counter for each category:
+	for ( i = 0; i < ctx.options.length; i++ ) {
+		ctx.options[ i ].count = 0;
+	}
+	for ( i = 0; i < ctx.notes.length; i++ ) {
+		ctx.notes[ i ].count = 0;
+	}
+	for ( i = 0; i < ctx.examples.length; i++ ) {
+		ctx.examples[ i ].count = 0;
+	}
+	for ( i = 0; i < ctx.links.length; i++ ) {
+		ctx.links[ i ].count = 0;
+	}
+	for ( i = 0; i < ctx.more.length; i++ ) {
+		ctx.more[ i ].count = 0;
+	}
+	return onExit;
+
+	/**
+	* Callback invoked upon calling the command-line interface.
+	*
+	* @private
+	* @param {(Error|null)} error - error object
+	* @param {Object} result - result
+	* @returns {void}
+	*/
+	function onExit( error, result ) {
+		var out;
+		var pkgs;
+		var i;
+		if ( error ) {
+			print.clear();
+			print.write( error.message+'\n' );
+			print.flush();
+			proc.exit( error, result );
+			return;
+		}
+		pkgs = result.pkgs;
+		out = '';
+
+		// Render the usage section...
+		out += '\n'+renderContext( readme.usage );
+
+		// Render the options section...
+		out += '\nOptions:\n\n';
+		out += renderContext( readme.options );
+
+		// Render the notes section...
+		if ( ctx.notes.length ) {
+			out += '\nNotes:\n\n';
+			out += renderContext( readme.notes );
+		}
+		// Render the examples section...
+		if ( ctx.examples.length ) {
+			out += '\nExamples:\n\n';
+			out += renderContext( readme.examples );
+		}
+		// Render the links section...
+		if ( ctx.links.length ) {
+			out += '\nLinks:\n\n';
+			out += renderContext( readme.links );
+		}
+		// Render the more section...
+		if ( ctx.more.length ) {
+			out += '\nMore:\n\n';
+			out += renderContext( readme.more );
+		}
+		print.clear();
+		print.write( out+'\n' );
+		print.write( 'Packages:\n' );
+		for ( i = 0; i < pkgs.length; i++ ) {
+			print.write( `\t${pkgs[ i ]}` + '\n' );
+		}
+		print.flush();
+		proc.exit( error, result );
+	}
+} // end FUNCTION cliPkgs()
+
+/**
+* Returns a callback to be invoked upon calling the command-line interface.
+*
+* @private
+* @returns {Function} callback
+*/
+function cliPkgsList() {
+	var out;
+	var i;
+	var j;
+
+	// Initialize a counter for each category:
+	for ( i = 0; i < ctx.options.length; i++ ) {
+		ctx.options[ i ].count = 0;
+	}
+	for ( i = 0; i < ctx.notes.length; i++ ) {
+		ctx.notes[ i ].count = 0;
+	}
+	for ( i = 0; i < ctx.examples.length; i++ ) {
+		ctx.examples[ i ].count = 0;
+	}
+	for ( i = 0; i < ctx.links.length; i++ ) {
+		ctx.links[ i ].count = 0;
+	}
+	for ( i = 0; i < ctx.more.length; i++ ) {
+		ctx.more[ i ].count = 0;
+	}
+	return onExit;
+
+	/**
+	* Callback invoked upon calling the command-line interface.
+	*
+	* @private
+	* @param {(Error|null)} error - error object
+	* @param {Object} result - result
+	* @returns {void}
+	*/
+	function onExit( error, result ) {
+		var out;
+		var pkgs;
+		var i;
+		if ( error ) {
+			print.clear();
+			print.write( error.message+'\n' );
+			print.flush();
+			proc.exit( error, result );
+			return;
+		}
+		pkgs = result.pkgs;
+		out = '';
+
+		// Render the usage section...
+		out += '\n'+renderContext( readme.usage );
+
+		// Render the options section...
+		out += '\nOptions:\n\n';
+		out += renderContext( readme.options );
+
+		// Render the notes section...
+		if ( ctx.notes.length ) {
+			out += '\nNotes:\n\n';
+			out += renderContext( readme.notes );
+		}
+		// Render the examples section...
+		if ( ctx.examples.length ) {
+			out += '\nExamples:\n\n';
+			out += renderContext( readme.examples );
+		}
+		// Render the links section...
+		if ( ctx.links.length ) {
+			

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/test/test.js
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/test/test.js
@@ -37,9 +37,9 @@ tape( 'the function returns `true` if provided a string in Pascal case', functio
 	var i;
 
 	values = [
-		'HelloWorld',
-		'HelloWorld123',
-		'HelloWorld1234567890'
+		'Beep',
+		'FooBar',
+		'BeepBoopBaz'
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
@@ -58,8 +58,8 @@ tape( 'the function returns `false` if not provided a string in Pascal case', fu
 		'hello world',
 		'hello_world',
 		'helloworld',
-		'helloworld123',
-		'helloworld1234567890',
+		'hello-world',
+		'HELLO_WORLD',
 		' ',
 		'',
 		5,

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/test/test.js
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/test/test.js
@@ -80,7 +80,6 @@ tape( 'the function returns `false` if not provided a string', function test( t 
 	var i;
 
 	values = [
-		new String( 'Beep' ), // eslint-disable-line no-new-wrappers
 		5,
 		null,
 		void 0,

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/test/test.js
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/test/test.js
@@ -21,14 +21,14 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var isPascalCase = require( './../lib' );
+var isPascalcase = require( './../lib' );
 
 
 // TESTS //
 
 tape( 'main export is a function', function test( t ) {
 	t.ok( true, __filename );
-	t.equal( typeof isPascalCase, 'function', 'main export is a function' );
+	t.equal( typeof isPascalcase, 'function', 'main export is a function' );
 	t.end();
 });
 
@@ -43,8 +43,13 @@ tape( 'the function returns `true` if provided a string in Pascal case', functio
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		t.equal( isPascalCase( values[i] ), true, 'returns true' );
+		t.equal( isPascalcase( values[i] ), true, 'returns true' );
 	}
+	t.end();
+});
+
+tape( 'the function returns `true` if provided an empty string', function test( t ) {
+	t.strictEqual( isPascalcase( '' ), true, 'returns true' );
 	t.end();
 });
 
@@ -61,21 +66,33 @@ tape( 'the function returns `false` if not provided a string in Pascal case', fu
 		'hello-world',
 		'HELLO_WORLD',
 		' ',
-		'',
+		'!'
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.equal( isPascalcase( values[i] ), false, 'returns false when provided '+values[i] );
+	}
+	t.end();
+});
+
+tape( 'the function returns `false` if not provided a string primitive', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		new String( 'Beep' ), // eslint-disable-line no-new-wrappers
 		5,
-		NaN,
 		null,
-		undefined,
+		void 0,
 		true,
-		false,
+		NaN,
 		[],
 		{},
 		function noop() {}
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		t.equal( isPascalCase( values[i] ), false, 'returns false when provided '+values[i] );
+		t.equal( isPascalcase( values[i] ), false, 'returns false when provided '+values[i] );
 	}
 	t.end();
 });
-

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/test/test.js
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/test/test.js
@@ -75,7 +75,7 @@ tape( 'the function returns `false` if not provided a string in Pascal case', fu
 	t.end();
 });
 
-tape( 'the function returns `false` if not provided a string primitive', function test( t ) {
+tape( 'the function returns `false` if not provided a string', function test( t ) {
 	var values;
 	var i;
 

--- a/lib/node_modules/@stdlib/assert/is-pascalcase/test/test.js
+++ b/lib/node_modules/@stdlib/assert/is-pascalcase/test/test.js
@@ -1,0 +1,81 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isPascalCase = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.equal( typeof isPascalCase, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `true` if provided a string in Pascal case', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'HelloWorld',
+		'HelloWorld123',
+		'HelloWorld1234567890'
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.equal( isPascalCase( values[i] ), true, 'returns true' );
+	}
+	t.end();
+});
+
+tape( 'the function returns `false` if not provided a string in Pascal case', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'helloWorld',
+		'HELLOWORLD',
+		'hello world',
+		'hello_world',
+		'helloworld',
+		'helloworld123',
+		'helloworld1234567890',
+		' ',
+		'',
+		5,
+		NaN,
+		null,
+		undefined,
+		true,
+		false,
+		[],
+		{},
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.equal( isPascalCase( values[i] ), false, 'returns false when provided '+values[i] );
+	}
+	t.end();
+});
+


### PR DESCRIPTION
Resolves #536 .

## Description

> What is the purpose of this pull request?

This pull request:

-   adds assertion utility `isPascalCase`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #536 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
