### PR TITLE
Add C implementation for `@stdlib/number/float64/base/exponent`

### DIFF
--- a/lib/node_modules/@stdlib/number/float64/base/exponent/README.md
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/README.md
@@ -113,24 +113,24 @@ for ( i = 0; i < 100; i++ ) {
 #include "stdlib/number/float64/base/exponent.h"
 ```
 
-#### stdlib_base_float64_eponent( x, \*out )
+#### stdlib_base_float64_exponent( x, \*out )
 
-Extracts an integer corresponding to the unbiased exponent of a double-precision floating-point number.
+Extracts the integer corresponding to the unbiased exponent of a double-precision floating-point number.
 
 ```c
 #include <stdint.h>
 
 int32_t out;
-stdlib_base_float64_eponent( 3.14, &out );
+stdlib_base_float64_exponent( 3.14, &out );
 ```
 
 The function accepts the following arguments:
 
 -   **x**: `[in] double` input value.
--   **out**: `[out] int32_t*` unbiased exponent.
+-   **out**: `[out] int32_t*` destination for unbiased exponent.
 
 ```c
-void stdlib_base_float64_eponent( const double x, int32_t *out );
+void stdlib_base_float64_exponent( const double x, int32_t *out );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/README.md
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/README.md
@@ -115,7 +115,7 @@ for ( i = 0; i < 100; i++ ) {
 
 #### stdlib_base_float64_eponent( x, \*out )
 
-Return an integer corresponding to the unbiased exponent of a double-precision floating-point number.
+Extracts an integer corresponding to the unbiased exponent of a double-precision floating-point number.
 
 ```c
 #include <stdint.h>

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/README.md
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/README.md
@@ -87,6 +87,93 @@ for ( i = 0; i < 100; i++ ) {
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/number/float64/base/exponent.h"
+```
+
+#### stdlib_base_float64_eponent( x, \*out )
+
+Return an integer corresponding to the unbiased exponent of a double-precision floating-point number.
+
+```c
+#include <stdint.h>
+
+int32_t out;
+stdlib_base_float64_eponent( 3.14, &out );
+```
+
+The function accepts the following arguments:
+
+-   **x**: `[in] double` input value.
+-   **out**: `[out] int32_t*` unbiased exponent.
+
+```c
+void stdlib_base_float64_eponent( const double x, int32_t *out );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/number/float64/base/exponent.h"
+#include <stdint.h>
+#include <stdio.h>
+
+int main() {
+    double x[] = { 4.0, 0.0, -0.0, 1.0, -1.0, 3.14, -3.14, 1.0e308, -1.0e308, 1.0e-308, -1.0e-308, 1.0/0.0, -1.0/0.0, 0.0/0.0 };
+
+    int32_t out;
+    int i;
+    for ( i = 0; i < 14; i++ ) {
+        stdlib_base_float64_exponent( x[ i ], &out );
+        printf( "%lf => out: %u\n", x[ i ], out );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/README.md
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/README.md
@@ -174,6 +174,8 @@ int main() {
 
 </section>
 
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/benchmark/benchmark.native.js
@@ -1,0 +1,60 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var exponent = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( exponent instanceof Error )
+};
+
+
+// MAIN //
+
+bench( pkg, opts, function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		x = randu();
+		y = exponent( x );
+		if ( isnan( y ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnan( y ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/benchmark/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2020 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/benchmark/c/Makefile
@@ -1,7 +1,7 @@
 #/
 # @license Apache-2.0
 #
-# Copyright (c) 2020 The Stdlib Authors.
+# Copyright (c) 2022 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/benchmark/c/benchmark.c
@@ -105,14 +105,14 @@ double benchmark() {
 		x = ( rand_double()*200.0 ) - 100.0;
 		x = pow( 10.0, x );
 		stdlib_base_float64_exponent( x, &out );
-		if ( out != 1023 ) {
-			printf( "unexpected result\n" );
+		if ( out != out ) {
+			printf( "should not return NaN\n" );
 			break;
 		}
 	}
 	elapsed = tic() - t;
-	if ( out == 0 ) {
-		printf( "unexpected result\n" );
+	if ( out != out ) {
+		printf( "should not return NaN\n" );
 	}
 	return elapsed;
 }

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/benchmark/c/benchmark.c
@@ -95,9 +95,9 @@ double rand_double() {
 */
 double benchmark() {
 	double elapsed;
+	int32_t out;
 	double x;
 	double t;
-	int32_t out;
 	int i;
 
 	t = tic();

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/benchmark/c/benchmark.c
@@ -17,7 +17,7 @@
 */
 
 /**
-* Benchmark 'float64_exponent'
+* Benchmark 'float64_exponent'.
 */
 #include "stdlib/number/float64/base/exponent.h"
 #include <stdlib.h>

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/benchmark/c/benchmark.c
@@ -1,0 +1,138 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/**
+* Benchmark 'float64_exponent'
+*/
+#include "stdlib/number/float64/base/exponent.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "float64_exponent"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+void print_version() {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+double tic() {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1].
+*
+* @return random number
+*/
+double rand_double() {
+	int r = rand();
+	return (double)r / ( (double)RAND_MAX + 1.0 );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+double benchmark() {
+	double elapsed;
+	double x;
+	double t;
+	int32_t out;
+	int i;
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		x = ( rand_double()*200.0 ) - 100.0;
+		x = pow( 10.0, x );
+		stdlib_base_float64_exponent( x, &out );
+		if ( out != 1023 ) {
+			printf( "unexpected result\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( out == 0 ) {
+		printf( "unexpected result\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main ( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::native::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/benchmark/c/benchmark.c
@@ -105,13 +105,13 @@ double benchmark() {
 		x = ( rand_double()*200.0 ) - 100.0;
 		x = pow( 10.0, x );
 		stdlib_base_float64_exponent( x, &out );
-		if ( out == 0 ) {
+		if ( out == 1024 ) {
 			printf( "unexpected result\n" );
 			break;
 		}
 	}
 	elapsed = tic() - t;
-	if ( out == 0 ) {
+	if ( out == 1024 ) {
 		printf( "unexpected result\n" );
 	}
 	return elapsed;

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/benchmark/c/benchmark.c
@@ -105,14 +105,14 @@ double benchmark() {
 		x = ( rand_double()*200.0 ) - 100.0;
 		x = pow( 10.0, x );
 		stdlib_base_float64_exponent( x, &out );
-		if ( out != out ) {
-			printf( "should not return NaN\n" );
+		if ( out == 0 ) {
+			printf( "unexpected result\n" );
 			break;
 		}
 	}
 	elapsed = tic() - t;
-	if ( out != out ) {
-		printf( "should not return NaN\n" );
+	if ( out == 0 ) {
+		printf( "unexpected result\n" );
 	}
 	return elapsed;
 }

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/binding.gyp
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2022 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2022 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/examples/c/example.c
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/examples/c/example.c
@@ -1,0 +1,32 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/number/float64/base/exponent.h"
+#include <stdint.h>
+#include <stdio.h>
+
+int main() {
+	double x[] = { 4.0, 0.0, -0.0, 1.0, -1.0, 3.14, -3.14, 1.0e308, -1.0e308, 1.0e-308, -1.0e-308, 1.0/0.0, -1.0/0.0, 0.0/0.0 };
+
+	int32_t out;
+	int i;
+	for ( i = 0; i < 14; i++ ) {
+		stdlib_base_float64_exponent( x[ i ], &out );
+		printf( "%lf => high: %u\n", x[ i ], out );
+	}
+}

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/examples/c/example.c
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/examples/c/example.c
@@ -27,6 +27,6 @@ int main() {
 	int i;
 	for ( i = 0; i < 14; i++ ) {
 		stdlib_base_float64_exponent( x[ i ], &out );
-		printf( "%lf => high: %u\n", x[ i ], out );
+		printf( "%lf => out: %u\n", x[ i ], out );
 	}
 }

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/include.gypi
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2022 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/include/stdlib/number/float64/base/exponent.h
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/include/stdlib/number/float64/base/exponent.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2020 The Stdlib Authors.
+* Copyright (c) 2022 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/include/stdlib/number/float64/base/exponent.h
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/include/stdlib/number/float64/base/exponent.h
@@ -1,0 +1,41 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2020 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_NUMBER_FLOAT64_BASE_EXPONENT_H
+#define STDLIB_NUMBER_FLOAT64_BASE_EXPONENT_H
+
+#include <stdint.h>
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/**
+* Extracts the exponent from a double-precision floating-point number.
+*/
+void stdlib_base_float64_exponent( const int64_t X, int64_t *out );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_NUMBER_FLOAT64_BASE_EXPONENT_H

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/include/stdlib/number/float64/base/exponent.h
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/include/stdlib/number/float64/base/exponent.h
@@ -30,7 +30,7 @@ extern "C" {
 
 
 /**
-* Returns the unbiased exponent of a double-precision floating-point number.
+* Extracts an integer corresponding to the unbiased exponent of a double-precision floating-point number.
 */
 void stdlib_base_float64_exponent( const double x, int32_t *out );
 

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/include/stdlib/number/float64/base/exponent.h
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/include/stdlib/number/float64/base/exponent.h
@@ -30,7 +30,7 @@ extern "C" {
 
 
 /**
-* Extracts the exponent from a double-precision floating-point number.
+* Returns the unbiased exponent of a double-precision floating-point number.
 */
 void stdlib_base_float64_exponent( const double x, int32_t *out );
 

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/include/stdlib/number/float64/base/exponent.h
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/include/stdlib/number/float64/base/exponent.h
@@ -32,7 +32,7 @@ extern "C" {
 /**
 * Extracts the exponent from a double-precision floating-point number.
 */
-void stdlib_base_float64_exponent( const int64_t X, int32_t *out );
+void stdlib_base_float64_exponent( const double x, int32_t *out );
 
 #ifdef __cplusplus
 }

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/include/stdlib/number/float64/base/exponent.h
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/include/stdlib/number/float64/base/exponent.h
@@ -30,7 +30,7 @@ extern "C" {
 
 
 /**
-* Extracts an integer corresponding to the unbiased exponent of a double-precision floating-point number.
+* Extracts the integer corresponding to the unbiased exponent of a double-precision floating-point number.
 */
 void stdlib_base_float64_exponent( const double x, int32_t *out );
 

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/include/stdlib/number/float64/base/exponent.h
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/include/stdlib/number/float64/base/exponent.h
@@ -32,7 +32,7 @@ extern "C" {
 /**
 * Extracts the exponent from a double-precision floating-point number.
 */
-void stdlib_base_float64_exponent( const int64_t X, int64_t *out );
+void stdlib_base_float64_exponent( const int64_t X, int32_t *out );
 
 #ifdef __cplusplus
 }

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/lib/native.js
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/lib/native.js
@@ -1,0 +1,46 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../lib/addon.node' );
+
+
+// MAIN //
+
+/**
+* Returns the unbiased exponent of a double-precision floating-point number.
+*
+* @private
+* @param {number} x - input value
+* @returns {integer32} unbiased exponent
+*
+* @example
+* var v = exponent( 4.0 ); // => 100
+* // returns 2
+*/
+function exponent( x ) {
+	return addon( x );
+}
+
+
+// EXPORTS //
+
+module.exports = exponent;

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/lib/native.js
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/lib/native.js
@@ -26,7 +26,7 @@ var addon = require( './../lib/addon.node' );
 // MAIN //
 
 /**
-* Returns the unbiased exponent of a double-precision floating-point number.
+* Returns an integer corresponding to the unbiased exponent of a double-precision floating-point number.
 *
 * @private
 * @param {number} x - input value

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/lib/native.js
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/lib/native.js
@@ -33,8 +33,20 @@ var addon = require( './../lib/addon.node' );
 * @returns {integer32} unbiased exponent
 *
 * @example
-* var v = exponent( 4.0 ); // => 100
-* // returns 2
+* var exp = exponent( 3.14e-307 ); // => 2**-1019 ~ 1e-307
+* // returns -1019
+*
+* @example
+* var exp = exponent( -3.14 );
+* // returns 1
+*
+* @example
+* var exp = exponent( 0.0 );
+* // returns -1023
+*
+* @example
+* var exp = exponent( NaN );
+* // returns 1024
 */
 function exponent( x ) {
 	return addon( x );

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/manifest.json
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/manifest.json
@@ -1,0 +1,40 @@
+{
+	"options": {},
+	"fields": [
+		{
+			"field": "src",
+			"resolve": true,
+			"relative": true
+		},
+		{
+			"field": "include",
+			"resolve": true,
+			"relative": true
+		},
+		{
+			"field": "libraries",
+			"resolve": false,
+			"relative": false
+		},
+		{
+			"field": "libpath",
+			"resolve": true,
+			"relative": false
+		}
+	],
+	"confs": [
+		{
+			"src": [
+				"./src/exponent.c"
+			],
+			"include": [
+				"./include"
+			],
+			"libraries": [],
+			"libpath": [],
+			"dependencies": [
+				"@stdlib/number/float64/base/get-high-word"
+			]
+		}
+	]
+}

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/src/Makefile
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2022 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/src/addon.c
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/src/addon.c
@@ -1,0 +1,92 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/number/float64/base/exponent.h"
+#include <node_api.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <assert.h>
+
+/**
+* Receives JavaScript callback invocation data.
+*
+* @private
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @return       Node-API value
+*/
+static napi_value addon( napi_env env, napi_callback_info info ) {
+	napi_status status;
+
+	// Get callback arguments:
+	size_t argc = 1;
+	napi_value argv[ 1 ];
+	status = napi_get_cb_info( env, info, &argc, argv, NULL, NULL );
+	assert( status == napi_ok );
+
+	// Check whether we were provided the correct number of arguments:
+	if ( argc < 1 ) {
+		status = napi_throw_error( env, NULL, "invalid invocation. Insufficient arguments." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+	if ( argc > 1 ) {
+		status = napi_throw_error( env, NULL, "invalid invocation. Too many arguments." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	napi_valuetype vtype0;
+	status = napi_typeof( env, argv[ 0 ], &vtype0 );
+	assert( status == napi_ok );
+	if ( vtype0 != napi_number ) {
+		status = napi_throw_type_error( env, NULL, "invalid argument. First argument must be a number." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	double value;
+	status = napi_get_value_double( env, argv[ 0 ], &value );
+	assert( status == napi_ok );
+
+	uint32_t out;
+	stdlib_base_float64_exponent( value, &out );
+
+	napi_value v;
+	status = napi_create_uint32( env, out, &v );
+	assert( status == napi_ok );
+
+	return v;
+}
+
+/**
+* Initializes a Node-API module.
+*
+* @private
+* @param env      environment under which the function is invoked
+* @param exports  exports object
+* @return         main export
+*/
+static napi_value init( napi_env env, napi_value exports ) {
+	napi_value fcn;
+	napi_status status = napi_create_function( env, "exports", NAPI_AUTO_LENGTH, addon, NULL, &fcn );
+	assert( status == napi_ok );
+	return fcn;
+}
+
+NAPI_MODULE( NODE_GYP_MODULE_NAME, init )

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/src/addon.c
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/src/addon.c
@@ -64,11 +64,11 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	status = napi_get_value_double( env, argv[ 0 ], &value );
 	assert( status == napi_ok );
 
-	uint32_t out;
+	int32_t out;
 	stdlib_base_float64_exponent( value, &out );
 
 	napi_value v;
-	status = napi_create_uint32( env, out, &v );
+	status = napi_create_int32( env, out, &v );
 	assert( status == napi_ok );
 
 	return v;

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/src/exponent.c
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/src/exponent.c
@@ -32,10 +32,10 @@
 * int64_t out;
 * stdlib_base_float64_exponent( 4.0, &out );
 */
-void stdlib_base_float64_exponent( const double x, int64_t *out ) {
+void stdlib_base_float64_exponent( const double x, int32_t *out ) {
 	// Extract from the input value a higher order word (unsigned 32-bit integer) which contains the exponent:
 	uint32_t high = stdlib_base_float64_get_high_word( x );
 
 	// Shift the higher order word to the right by `20` bits (i.e., divide by `2^20`) and mask the lower `11` bits (i.e., `0x7FF`) to extract the exponent:
-	*out = (int64_t)( ( high >> 20 ) & 0x7FF );
+	*out = (int32_t)( ( high >> 20 ) & 0x7FF );
 }

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/src/exponent.c
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/src/exponent.c
@@ -24,7 +24,7 @@
 * Returns the unbiased exponent of a double-precision floating-point number.
 *
 * @param x       input value
-* @param out     output exponent
+* @param out     destination for unbiased exponent
 *
 * @example
 * #include <stdint.h>

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/src/exponent.c
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/src/exponent.c
@@ -21,7 +21,7 @@
 #include <stdint.h>
 
 /**
-* Extracts the unbiased exponent of a double-precision floating-point number.
+* Extracts an integer corresponding to the unbiased exponent of a double-precision floating-point number.
 *
 * @param x       input value
 * @param out     destination for unbiased exponent

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/src/exponent.c
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/src/exponent.c
@@ -1,0 +1,41 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/number/float64/base/exponent.h"
+#include "stdlib/number/float64/base/get_high_word.h"
+#include <stdint.h>
+
+/**
+* Extracts the exponent from a double-precision floating-point number.
+*
+* @param x       input value
+* @param out     output exponent
+*
+* @example
+* #include <stdint.h>
+*
+* int64_t out;
+* stdlib_base_float64_exponent( 4.0, &out );
+*/
+void stdlib_base_float64_exponent( const double x, int64_t *out ) {
+	// Extract from the input value a higher order word (unsigned 32-bit integer) which contains the exponent:
+	uint32_t high = stdlib_base_float64_get_high_word( x );
+
+	// Shift the higher order word to the right by `20` bits (i.e., divide by `2^20`) and mask the lower `11` bits (i.e., `0x7FF`) to extract the exponent:
+	*out = (int64_t)( ( high >> 20 ) & 0x7FF );
+}

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/src/exponent.c
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/src/exponent.c
@@ -21,7 +21,7 @@
 #include <stdint.h>
 
 /**
-* Extracts the exponent from a double-precision floating-point number.
+* Returns the unbiased exponent of a double-precision floating-point number.
 *
 * @param x       input value
 * @param out     output exponent

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/src/exponent.c
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/src/exponent.c
@@ -21,7 +21,7 @@
 #include <stdint.h>
 
 /**
-* Extracts an integer corresponding to the unbiased exponent of a double-precision floating-point number.
+* Extracts the integer corresponding to the unbiased exponent of a double-precision floating-point number.
 *
 * @param x       input value
 * @param out     destination for unbiased exponent

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/src/exponent.c
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/src/exponent.c
@@ -34,7 +34,8 @@
 */
 void stdlib_base_float64_exponent( const double x, int32_t *out ) {
 	// Extract from the input value a higher order word (unsigned 32-bit integer) which contains the exponent:
-	uint32_t high = stdlib_base_float64_get_high_word( x );
+	uint32_t high;
+	stdlib_base_float64_get_high_word( x, &high );
 
 	// Shift the higher order word to the right by `20` bits (i.e., divide by `2^20`) and mask the lower `11` bits (i.e., `0x7FF`) to extract the exponent:
 	*out = (int32_t)( ( high >> 20 ) & 0x7FF );

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/src/exponent.c
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/src/exponent.c
@@ -21,7 +21,7 @@
 #include <stdint.h>
 
 /**
-* Returns the unbiased exponent of a double-precision floating-point number.
+* Extracts the unbiased exponent of a double-precision floating-point number.
 *
 * @param x       input value
 * @param out     destination for unbiased exponent

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/src/exponent.c
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/src/exponent.c
@@ -29,7 +29,7 @@
 * @example
 * #include <stdint.h>
 *
-* int64_t out;
+* int32_t out;
 * stdlib_base_float64_exponent( 4.0, &out );
 */
 void stdlib_base_float64_exponent( const double x, int32_t *out ) {

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/test/test.native.js
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/test/test.native.js
@@ -50,18 +50,7 @@ tape( 'main export is a function', opts, function test( t ) {
 });
 
 tape( 'the function returns a number', opts, function test( t ) {
-	t.equal( typeof exponent(3.14e240), 'number', 'returns a number' );
-	t.end();
-});
-
-tape( 'the function returns an integer', opts, function test( t ) {
-	var x;
-	var i;
-
-	for ( i = 0; i < 1e4; i++ ) {
-		x = randu() * 1.0e308;
-		t.equal( isInteger( exponent(x) ), true, 'returns an integer' );
-	}
+	t.equal( typeof exponent( 3.14e240 ), 'number', 'returns a number' );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/test/test.native.js
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/test/test.native.js
@@ -26,6 +26,7 @@ var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var BIAS = require( '@stdlib/constants/float64/exponent-bias' );
 var randu = require( '@stdlib/random/base/randu' );
+var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var round = require( '@stdlib/math/base/special/round' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var bits = require( '@stdlib/number/float64/base/to-binary-string' );
@@ -50,6 +51,17 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function returns a number', opts, function test( t ) {
 	t.equal( typeof exponent(3.14e240), 'number', 'returns a number' );
+	t.end();
+});
+
+tape( 'the function returns an integer', opts, function test( t ) {
+	var x;
+	var i;
+
+	for ( i = 0; i < 1e4; i++ ) {
+		x = randu() * 1e308;
+		t.equal( isInteger( exponent(x) ), true, 'returns an integer' );
+	}
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/test/test.native.js
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/test/test.native.js
@@ -1,0 +1,113 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+var BIAS = require( '@stdlib/constants/float64/exponent-bias' );
+var randu = require( '@stdlib/random/base/randu' );
+var round = require( '@stdlib/math/base/special/round' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var bits = require( '@stdlib/number/float64/base/to-binary-string' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var exponent = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( exponent instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.equal( typeof exponent, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns an integer', opts, function test( t ) {
+	var w = exponent( 3.14 );
+
+	t.equal( typeof w, 'number', 'returns a number' );
+	t.equal( w % 1, 0, 'returns an integer' );
+
+	t.end();
+});
+
+tape( 'the function returns an integer corresponding to the unbiased exponent of a double-precision floating-point number', opts, function test( t ) {
+	var expected;
+	var actual;
+	var sign;
+	var frac;
+	var exp;
+	var x;
+	var b;
+	var i;
+
+	for ( i = 0; i < 1e4; i++ ) {
+		if ( randu() < 0.5 ) {
+			sign = -1.0;
+		} else {
+			sign = 1.0;
+		}
+		frac = randu() * 10.0;
+		exp = round( randu()*646.0 ) - 323;
+		x = sign * frac * pow( 10.0, exp );
+
+		b = bits( x );
+		expected = parseInt( b.substring( 1, 12 ), 2 ) - BIAS;
+
+		actual = exponent( x );
+		t.equal( actual, expected, 'returns the unbiased exponent for ' + x );
+	}
+	t.end();
+});
+
+tape( 'the function returns the unbiased exponent for `+-0`', opts, function test( t ) {
+	t.equal( exponent( 0.0 ), -BIAS, 'returns -1023' );
+	t.equal( exponent( -0.0 ), -BIAS, 'returns -1023' );
+	t.end();
+});
+
+tape( 'the function returns the unbiased exponent for `+infinity`', opts, function test( t ) {
+	t.equal( exponent( PINF ), BIAS+1, 'returns 1024' );
+	t.end();
+});
+
+tape( 'the function returns the unbiased exponent for `-infinity`', opts, function test( t ) {
+	t.equal( exponent( NINF ), BIAS+1, 'returns 1024' );
+	t.end();
+});
+
+tape( 'the function returns the unbiased exponent for `NaN`', opts, function test( t ) {
+	t.equal( exponent( NaN ), BIAS+1, 'returns 1024' );
+	t.end();
+});
+
+tape( 'the function returns the unbiased exponent for subnormals', opts, function test( t ) {
+	t.equal( exponent( 3.14e-320 ), -BIAS, 'returns -1023' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/test/test.native.js
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/test/test.native.js
@@ -48,12 +48,8 @@ tape( 'main export is a function', opts, function test( t ) {
 	t.end();
 });
 
-tape( 'the function returns an integer', opts, function test( t ) {
-	var w = exponent( 3.14 );
-
-	t.equal( typeof w, 'number', 'returns a number' );
-	t.equal( w % 1, 0, 'returns an integer' );
-
+tape( 'the function returns a number', opts, function test( t ) {
+	t.equal( typeof exponent(3.14e240), 'number', 'returns a number' );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/test/test.native.js
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/test/test.native.js
@@ -59,7 +59,7 @@ tape( 'the function returns an integer', opts, function test( t ) {
 	var i;
 
 	for ( i = 0; i < 1e4; i++ ) {
-		x = randu() * 1e308;
+		x = randu() * 1.0e308;
 		t.equal( isInteger( exponent(x) ), true, 'returns an integer' );
 	}
 	t.end();


### PR DESCRIPTION
## Checklist

- [x] include/stdlib/number/float64/base
- [x] src
- [x] include.gypi
- [x] manifest.json
- [x] binding.gyp
- [x] examples
- [x] benchmark
- [x] update readme.md
- [x] test
* * *

@kgryte

Do tell me if I missed something in the checklist :)