### PR TITLE
Add utility to parse a duration string

### DIFF
--- a/lib/node_modules/@stdlib/time/base/parse-duration/README.md
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/README.md
@@ -68,7 +68,7 @@ The returned object has the following properties:
     -   `s`: seconds
     -   `ms`: milliseconds
 
-    For example, the string `1m3s10ms` is a duration string containing three time units: `1m` (1 minute), `3s` (3 seconds), and `10ms` (10 milliseconds). The string `60m` is a duration string containing a single time unit: `60m` (60 minutes). A duration string must contain at least one time unit. Time units must be supplied in descending order of magnitude (i.e., days, hours, minutes, seconds, milliseconds).
+    For example, the string `1m3s10ms` is a duration string containing three time units: `1m` (1 minute), `3s` (3 seconds), and `10ms` (10 milliseconds). The string `60m` is a duration string containing a single time unit: `60m` (60 minutes). A duration string must contain at least one time unit.
 
 -   Duration strings are case insensitive. For example, the string `1M3S10MS` is equivalent to `1m3s10ms`.
 

--- a/lib/node_modules/@stdlib/time/base/parse-duration/README.md
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/README.md
@@ -18,7 +18,7 @@ limitations under the License.
 
 -->
 
-# Parse Duration
+# parseDuration
 
 > Parse a duration string into an object.
 
@@ -32,7 +32,7 @@ var parseDuration = require( '@stdlib/time/base/parse-duration' );
 
 #### parseDuration
 
-Parses a duration string such as `1m3s10ms` into an object with `days`, `hours`, `minutes`, `seconds`, and `milliseconds`.
+Parses a duration string into an object.
 
 ```javascript
 var obj = parseDuration( '1m3s10ms' );
@@ -41,6 +41,14 @@ var obj = parseDuration( '1m3s10ms' );
 obj = parseDuration( '1m3s' );
 // returns { 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 3, 'milliseconds': 0 }
 ```
+
+The returned object has the following properties:
+
+-   **days**: number of days.
+-   **hours**: number of hours.
+-   **minutes**: number of minutes.
+-   **seconds**: number of seconds.
+-   **milliseconds**: number of milliseconds.
 
 </section>
 
@@ -75,8 +83,6 @@ obj = parseDuration( '1m3s' );
 <section class="examples">
 
 ## Examples
-
-<!-- TODO: better examples -->
 
 <!-- eslint no-undef: "error" -->
 

--- a/lib/node_modules/@stdlib/time/base/parse-duration/README.md
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/README.md
@@ -50,6 +50,8 @@ obj = parseDuration( '1m3s' );
 
 <section class="notes">
 
+## Notes
+
 -   A duration string is a string containing a sequence of time units. A time unit is a non-negative integer followed by a unit identifier. The following unit identifiers are supported:
 
     -   `m`: minutes

--- a/lib/node_modules/@stdlib/time/base/parse-duration/README.md
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/README.md
@@ -68,7 +68,7 @@ The returned object has the following properties:
     -   `s`: seconds
     -   `ms`: milliseconds
 
-    For example, the string `1m3s10ms` is a duration string containing three time units: `1m` (1 minute), `3s` (3 seconds), and `10ms` (10 milliseconds). The string `60m` is a duration string containing a single time unit: `60m` (60 minutes). A duration string must contain at least one time unit.
+    For example, the string `1m3s10ms` is a duration string containing three time units: `1m` (1 minute), `3s` (3 seconds), and `10ms` (10 milliseconds). The string `60m` is a duration string containing a single time unit: `60m` (60 minutes).
 
 -   Duration strings are case insensitive. For example, the string `1M3S10MS` is equivalent to `1m3s10ms`.
 

--- a/lib/node_modules/@stdlib/time/base/parse-duration/README.md
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Parse Duration
 
-> Parses a duration string into an object with `minutes`, `seconds`, and `milliseconds`.
+> Parse a duration string into an object with `minutes`, `seconds`, and `milliseconds`.
 
 <section class="usage">
 

--- a/lib/node_modules/@stdlib/time/base/parse-duration/README.md
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/README.md
@@ -1,0 +1,113 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2022 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# Parse Duration
+
+> Parses a duration string into an object with `minutes`, `seconds`, and `milliseconds`.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var parseDuration = require( '@stdlib/time/base/parse-duration' );
+```
+
+#### parseDuration
+
+Parses a duration string such as `1m3s10ms` into an object with `minutes`, `seconds`, and `milliseconds`.
+
+```javascript
+var obj = parseDuration( '1m3s10ms' );
+// returns { 'minutes': 1, 'seconds': 3, 'milliseconds': 10 }
+
+obj = parseDuration( '1m3s' );
+// returns { 'minutes': 1, 'seconds': 3, 'milliseconds': 0 }
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+-   A duration string is a string containing a sequence of time units. A time unit is a non-negative integer followed by a unit identifier. The following unit identifiers are supported:
+
+    -   `m`: minutes
+    -   `s`: seconds
+    -   `ms`: milliseconds
+
+    For example, the string `1m3s10ms` is a duration string containing three time units: `1m` (1 minute), `3s` (3 seconds), and `10ms` (10 milliseconds). The string `60m` is a duration string containing a single time unit: `60m` (60 minutes). A duration string must contain at least one time unit. Time units must be supplied in descending order of magnitude (i.e., minutes, seconds, milliseconds). 
+
+-   Duration strings are case insensitive. For example, the string `1M3S10MS` is equivalent to `1m3s10ms`.
+
+-   If a duration string does not contain a time unit, the respective property is set to `0`.
+
+-   An empty string is considered a valid duration string and is parsed as `0m0s0ms`.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- TODO: better examples -->
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var parseDuration = require( '@stdlib/time/base/parse-duration' );
+
+var obj = parseDuration( '1m3s10ms' );
+// returns { 'minutes': 1, 'seconds': 3, 'milliseconds': 10 }
+
+obj = parseDuration( '60m' );
+// returns { 'minutes': 60, 'seconds': 0, 'milliseconds': 0 }
+
+obj = parseDuration( '1M3S' );
+// returns { 'minutes': 1, 'seconds': 3, 'milliseconds': 0 }
+
+obj = parseDuration( '' );
+// returns { 'minutes': 0, 'seconds': 0, 'milliseconds': 0 }
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/time/base/parse-duration/README.md
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/README.md
@@ -60,7 +60,7 @@ The returned object has the following properties:
 
 ## Notes
 
--   A duration string is a string containing a sequence of time units. A time unit is a non-negative integer followed by a unit identifier. The following unit identifiers are supported:
+-   A duration string is a string containing a sequence of time units. A time unit is a nonnegative integer followed by a unit identifier. The following unit identifiers are supported:
 
     -   `d`: days
     -   `h`: hours

--- a/lib/node_modules/@stdlib/time/base/parse-duration/README.md
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Parse Duration
 
-> Parse a duration string into an object with `minutes`, `seconds`, and `milliseconds`.
+> Parse a duration string into an object.
 
 <section class="usage">
 
@@ -32,14 +32,14 @@ var parseDuration = require( '@stdlib/time/base/parse-duration' );
 
 #### parseDuration
 
-Parses a duration string such as `1m3s10ms` into an object with `minutes`, `seconds`, and `milliseconds`.
+Parses a duration string such as `1m3s10ms` into an object with `days`, `hours`, `minutes`, `seconds`, and `milliseconds`.
 
 ```javascript
 var obj = parseDuration( '1m3s10ms' );
-// returns { 'minutes': 1, 'seconds': 3, 'milliseconds': 10 }
+// returns { 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 3, 'milliseconds': 10 }
 
 obj = parseDuration( '1m3s' );
-// returns { 'minutes': 1, 'seconds': 3, 'milliseconds': 0 }
+// returns { 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 3, 'milliseconds': 0 }
 ```
 
 </section>
@@ -54,17 +54,19 @@ obj = parseDuration( '1m3s' );
 
 -   A duration string is a string containing a sequence of time units. A time unit is a non-negative integer followed by a unit identifier. The following unit identifiers are supported:
 
+    -   `d`: days
+    -   `h`: hours
     -   `m`: minutes
     -   `s`: seconds
     -   `ms`: milliseconds
 
-    For example, the string `1m3s10ms` is a duration string containing three time units: `1m` (1 minute), `3s` (3 seconds), and `10ms` (10 milliseconds). The string `60m` is a duration string containing a single time unit: `60m` (60 minutes). A duration string must contain at least one time unit. Time units must be supplied in descending order of magnitude (i.e., minutes, seconds, milliseconds). 
+    For example, the string `1m3s10ms` is a duration string containing three time units: `1m` (1 minute), `3s` (3 seconds), and `10ms` (10 milliseconds). The string `60m` is a duration string containing a single time unit: `60m` (60 minutes). A duration string must contain at least one time unit. Time units must be supplied in descending order of magnitude (i.e., days, hours, minutes, seconds, milliseconds).
 
 -   Duration strings are case insensitive. For example, the string `1M3S10MS` is equivalent to `1m3s10ms`.
 
 -   If a duration string does not contain a time unit, the respective property is set to `0`.
 
--   An empty string is considered a valid duration string and is parsed as `0m0s0ms`.
+-   An empty string is considered a valid duration string and is parsed as `0d0h0m0s0ms`.
 
 </section>
 
@@ -82,16 +84,19 @@ obj = parseDuration( '1m3s' );
 var parseDuration = require( '@stdlib/time/base/parse-duration' );
 
 var obj = parseDuration( '1m3s10ms' );
-// returns { 'minutes': 1, 'seconds': 3, 'milliseconds': 10 }
+// returns { 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 3, 'milliseconds': 10 }
 
 obj = parseDuration( '60m' );
-// returns { 'minutes': 60, 'seconds': 0, 'milliseconds': 0 }
+// returns { 'days': 0, 'hours': 0, 'minutes': 60, 'seconds': 0, 'milliseconds': 0 }
+
+obj = parseDuration( '2d3h' );
+// returns { 'days': 2, 'hours': 3, 'minutes': 0, 'seconds': 0, 'milliseconds': 0 }
 
 obj = parseDuration( '1M3S' );
-// returns { 'minutes': 1, 'seconds': 3, 'milliseconds': 0 }
+// returns { 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 3, 'milliseconds': 0 }
 
 obj = parseDuration( '' );
-// returns { 'minutes': 0, 'seconds': 0, 'milliseconds': 0 }
+// returns { 'days': 0, 'hours': 0, 'minutes': 0, 'seconds': 0, 'milliseconds': 0 }
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/time/base/parse-duration/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/benchmark/benchmark.js
@@ -1,0 +1,51 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isObject = require( '@stdlib/assert/is-object' );
+var pkg = require( './../package.json' ).name;
+var parseDuration = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var str;
+	var obj;
+	var i;
+
+	str = '1m3s10ms';
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		obj = parseDuration( str );
+		if ( typeof obj !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+	if ( !isObject( obj ) ) {
+		b.fail( 'should return an object' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+

--- a/lib/node_modules/@stdlib/time/base/parse-duration/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/benchmark/benchmark.js
@@ -29,13 +29,23 @@ var parseDuration = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var values;
 	var str;
 	var obj;
 	var i;
 
-	str = '1m3s10ms';
+	values = [
+		'1m3s10ms',
+		'3d2h1m',
+		'1d2h3m4s5ms',
+		'2m3s',
+		'1h2m3s4ms',
+		'1m3s10ms',
+		''
+	];
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
+		str = values[ i % values.length ];
 		obj = parseDuration( str );
 		if ( typeof obj !== 'object' ) {
 			b.fail( 'should return an object' );
@@ -48,4 +58,3 @@ bench( pkg, function benchmark( b ) {
 	b.pass( 'benchmark finished' );
 	b.end();
 });
-

--- a/lib/node_modules/@stdlib/time/base/parse-duration/docs/repl.txt
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/docs/repl.txt
@@ -1,0 +1,25 @@
+
+
+{{alias}}
+    Parses a duration string such as `1m3s10ms` into an object with `days`, `hours`,
+    `minutes`, `seconds`, and `milliseconds`.
+
+    Parameters
+    ----------
+    in: string
+        Duration string.
+
+    Returns
+    -------
+    out: Object
+        Duration object.
+
+    Examples
+    --------
+    > var obj = {{alias}}( '1m3s10ms' )
+    { 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 3, 'milliseconds': 10 }
+    > obj = {{alias}}( '1m3s' )
+    { 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 3, 'milliseconds': 0 }
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/time/base/parse-duration/docs/repl.txt
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/docs/repl.txt
@@ -12,6 +12,21 @@
     -------
     out: Object
         Duration object.
+        
+    out.days: integer
+        Number of days.
+        
+    out.hours: integer
+        Number of hours.
+        
+    out.minutes: integer
+        Number of minutes.
+        
+    out.seconds: integer
+        Number of seconds.
+        
+    out.milliseconds: integer
+        Number of milliseconds.
 
     Examples
     --------

--- a/lib/node_modules/@stdlib/time/base/parse-duration/docs/repl.txt
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/docs/repl.txt
@@ -1,12 +1,11 @@
 
-
-{{alias}}
-    Parses a duration string such as `1m3s10ms` into an object with `days`, `hours`,
-    `minutes`, `seconds`, and `milliseconds`.
+{{alias}}( str )
+    Parses a duration string such as `1m3s10ms` into an object with `days`,
+    `hours`, `minutes`, `seconds`, and `milliseconds`.
 
     Parameters
     ----------
-    in: string
+    str: string
         Duration string.
 
     Returns

--- a/lib/node_modules/@stdlib/time/base/parse-duration/docs/repl.txt
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/docs/repl.txt
@@ -1,20 +1,25 @@
 
 {{alias}}( str )
     Parses a duration string into an object.
-    
-    A duration string is a string containing a sequence of time units. A time unit is a nonnegative integer followed by a unit identifier. The following unit identifiers are supported:
-    
+
+    A duration string is a string containing a sequence of time units. A time
+    unit is a nonnegative integer followed by a unit identifier. The following
+    unit identifiers are supported:
+
     - d: days
     - h: hours
     - m: minutes
     - s: seconds
     - ms: milliseconds
-    
-    Duration strings are case insensitive. For example, the string `1M3S10MS` is equivalent to `1m3s10ms`.
-    
-    If a duration string does not contain a time unit, the respective property is set to 0.
-    
-    An empty string is considered a valid duration string and is parsed as `0d0h0m0s0ms`.
+
+    Duration strings are case insensitive. For example, the string `1M3S10MS` is
+    equivalent to `1m3s10ms`.
+
+    If a duration string does not contain a time unit, the respective property
+    is set to 0.
+
+    An empty string is considered a valid duration string and is parsed as
+    `0d0h0m0s0ms`.
 
     Parameters
     ----------
@@ -25,19 +30,19 @@
     -------
     out: Object
         Duration object.
-        
+
     out.days: integer
         Number of days.
-        
+
     out.hours: integer
         Number of hours.
-        
+
     out.minutes: integer
         Number of minutes.
-        
+
     out.seconds: integer
         Number of seconds.
-        
+
     out.milliseconds: integer
         Number of milliseconds.
 

--- a/lib/node_modules/@stdlib/time/base/parse-duration/docs/repl.txt
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/docs/repl.txt
@@ -1,7 +1,20 @@
 
 {{alias}}( str )
-    Parses a duration string such as `1m3s10ms` into an object with `days`,
-    `hours`, `minutes`, `seconds`, and `milliseconds`.
+    Parses a duration string into an object.
+    
+    A duration string is a string containing a sequence of time units. A time unit is a nonnegative integer followed by a unit identifier. The following unit identifiers are supported:
+    
+    - d: days
+    - h: hours
+    - m: minutes
+    - s: seconds
+    - ms: milliseconds
+    
+    Duration strings are case insensitive. For example, the string `1M3S10MS` is equivalent to `1m3s10ms`.
+    
+    If a duration string does not contain a time unit, the respective property is set to 0.
+    
+    An empty string is considered a valid duration string and is parsed as `0d0h0m0s0ms`.
 
     Parameters
     ----------

--- a/lib/node_modules/@stdlib/time/base/parse-duration/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/docs/types/index.d.ts
@@ -49,7 +49,7 @@ interface Duration {
 }
 
 /**
-* Parses a duration string such as `1m3s10ms` into an object with `days`, `hours`, `minutes`, `seconds`, and `milliseconds`.
+* Parses a duration string into an object.
 *
 * @param str - duration string
 * @returns duration object

--- a/lib/node_modules/@stdlib/time/base/parse-duration/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/docs/types/index.d.ts
@@ -18,10 +18,53 @@
 
 // TypeScript Version: 2.0
 
+/**
+* Interface describing a duration object.
+*/
+interface Duration {
+	/**
+	* Number of days.
+	*/
+	'days': number;
+
+	/**
+	* Number of hours.
+	*/
+	'hours': number;
+
+	/**
+	* Number of minutes.
+	*/
+	'minutes': number;
+
+	/**
+	* Number of seconds.
+	*/
+	'seconds': number;
+
+	/**
+	* Number of milliseconds.
+	*/
+	'milliseconds': number;
+}
+
+/**
+* Parses a duration string such as `1m3s10ms` into an object with `days`, `hours`, `minutes`, `seconds`, and `milliseconds`.
+*
+* @param str - duration string
+* @returns duration object
+*
+* @example
+* var obj = parseDuration( '1m3s10ms' );
+* // returns { 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 3, 'milliseconds': 10 }
+*
+* @example
+* var obj = parseDuration( '1m3s' );
+* // returns { 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 3, 'milliseconds': 0 }
+*/
 declare function parseDuration( str: string ): Duration;
 
 
 // EXPORTS //
 
 export = parseDuration;
-

--- a/lib/node_modules/@stdlib/time/base/parse-duration/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/docs/types/index.d.ts
@@ -1,0 +1,27 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 2.0
+
+declare function parseDuration( str: string ): Duration;
+
+
+// EXPORTS //
+
+export = parseDuration;
+

--- a/lib/node_modules/@stdlib/time/base/parse-duration/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/docs/types/index.d.ts
@@ -61,7 +61,7 @@ interface Duration {
 *     -   `s`: seconds
 *     -   `ms`: milliseconds
 *
-*     For example, the string `1m3s10ms` is a duration string containing three time units: `1m` (1 minute), `3s` (3 seconds), and `10ms` (10 milliseconds). The string `60m` is a duration string containing a single time unit: `60m` (60 minutes). A duration string must contain at least one time unit.
+*     For example, the string `1m3s10ms` is a duration string containing three time units: `1m` (1 minute), `3s` (3 seconds), and `10ms` (10 milliseconds). The string `60m` is a duration string containing a single time unit: `60m` (60 minutes).
 *
 * -   Duration strings are case insensitive. For example, the string `1M3S10MS` is equivalent to `1m3s10ms`.
 *

--- a/lib/node_modules/@stdlib/time/base/parse-duration/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/docs/types/index.d.ts
@@ -51,6 +51,24 @@ interface Duration {
 /**
 * Parses a duration string into an object.
 *
+* ## Notes
+*
+* -   A duration string is a string containing a sequence of time units. A time unit is a nonnegative integer followed by a unit identifier. The following unit identifiers are supported:
+*
+*     -   `d`: days
+*     -   `h`: hours
+*     -   `m`: minutes
+*     -   `s`: seconds
+*     -   `ms`: milliseconds
+*
+*     For example, the string `1m3s10ms` is a duration string containing three time units: `1m` (1 minute), `3s` (3 seconds), and `10ms` (10 milliseconds). The string `60m` is a duration string containing a single time unit: `60m` (60 minutes). A duration string must contain at least one time unit.
+*
+* -   Duration strings are case insensitive. For example, the string `1M3S10MS` is equivalent to `1m3s10ms`.
+*
+* -   If a duration string does not contain a time unit, the respective property is set to `0`.
+*
+* -   An empty string is considered a valid duration string and is parsed as `0d0h0m0s0ms`.
+*
 * @param str - duration string
 * @returns duration object
 *

--- a/lib/node_modules/@stdlib/time/base/parse-duration/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/docs/types/test.ts
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import parseDuration = require( './index' );
+
+
+// TESTS //
+
+{
+	parseDuration( '1h' ); // $ExpectType Duration
+	parseDuration( 'PT1H' ); // $ExpectType Duration
+	parseDuration( '1h1m1s' ); // $ExpectType Duration
+	parseDuration( '1ms' ); // $ExpectType Duration
+	parseDuration( 'PT1H1M' ); // $ExpectType Duration
+	parseDuration( 'PT1H1M1S' ); // $ExpectType Duration
+	parseDuration( '1h1m1s1ms' ); // $ExpectType Duration
+	parseDuration( 'P1M' ); // $ExpectType Duration
+}
+
+{
+	parseDuration( true ); // $ExpectError
+	parseDuration( false ); // $ExpectError
+	parseDuration( 5 ); // $ExpectError
+	parseDuration( [] ); // $ExpectError
+	parseDuration( {} ); // $ExpectError
+	parseDuration( ( x: number ): number => x ); // $ExpectError
+}
+

--- a/lib/node_modules/@stdlib/time/base/parse-duration/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/docs/types/test.ts
@@ -21,23 +21,28 @@ import parseDuration = require( './index' );
 
 // TESTS //
 
+// The function returns a duration object...
 {
 	parseDuration( '1h' ); // $ExpectType Duration
-	parseDuration( 'PT1H' ); // $ExpectType Duration
+	parseDuration( '1d3h' ); // $ExpectType Duration
 	parseDuration( '1h1m1s' ); // $ExpectType Duration
 	parseDuration( '1ms' ); // $ExpectType Duration
-	parseDuration( 'PT1H1M' ); // $ExpectType Duration
-	parseDuration( 'PT1H1M1S' ); // $ExpectType Duration
 	parseDuration( '1h1m1s1ms' ); // $ExpectType Duration
-	parseDuration( 'P1M' ); // $ExpectType Duration
 }
 
+// The compiler throws an error if the function is provided a value other than a string...
 {
 	parseDuration( true ); // $ExpectError
 	parseDuration( false ); // $ExpectError
+	parseDuration( null ); // $ExpectError
+	parseDuration( undefined ); // $ExpectError
 	parseDuration( 5 ); // $ExpectError
 	parseDuration( [] ); // $ExpectError
 	parseDuration( {} ); // $ExpectError
 	parseDuration( ( x: number ): number => x ); // $ExpectError
 }
 
+// The compiler throws an error if the function is provided insufficient arguments...
+{
+	parseDuration(); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/time/base/parse-duration/examples/index.js
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/examples/index.js
@@ -22,15 +22,20 @@ var parseDuration = require( './../lib' );
 
 var obj = parseDuration( '1m3s10ms' );
 console.dir( obj );
+// => { 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 3, 'milliseconds': 10 }
 
 obj = parseDuration( '60m' );
 console.dir( obj );
+// => { 'days': 0, 'hours': 0, 'minutes': 60, 'seconds': 0, 'milliseconds': 0 }
 
 obj = parseDuration( '2d3h' );
 console.dir( obj );
+// => { 'days': 2, 'hours': 3, 'minutes': 0, 'seconds': 0, 'milliseconds': 0 }
 
 obj = parseDuration( '1M3S' );
 console.dir( obj );
+// => { 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 3, 'milliseconds': 0 }
 
 obj = parseDuration( '' );
 console.dir( obj );
+// => { 'days': 0, 'hours': 0, 'minutes': 0, 'seconds': 0, 'milliseconds': 0 }

--- a/lib/node_modules/@stdlib/time/base/parse-duration/examples/index.js
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/examples/index.js
@@ -1,0 +1,36 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var parseDuration = require( './../lib' );
+
+var obj = parseDuration( '1m3s10ms' );
+console.dir( obj );
+
+obj = parseDuration( '60m' );
+console.dir( obj );
+
+obj = parseDuration( '2d3h' );
+console.dir( obj );
+
+obj = parseDuration( '1M3S' );
+console.dir( obj );
+
+obj = parseDuration( '' );
+console.dir( obj );

--- a/lib/node_modules/@stdlib/time/base/parse-duration/lib/index.js
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Parse a duration string into an object of `days`, `hours`, `minutes`, `seconds`, and `milliseconds`.
+* Parse a duration string into an object.
 *
 * @module @stdlib/time/base/parse-duration
 *
@@ -29,11 +29,8 @@
 * var obj = parseDuration( '1m3s10ms' );
 * // returns { 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 3, 'milliseconds': 10 }
 *
-* @example
-* var parseDuration = require( '@stdlib/time/base/parse-duration' );
-*
-* var obj = parseDuration( '1m3s' );
-* // returns { 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 3, 'milliseconds': 0 }
+* obj = parseDuration( '1d3h' );
+* // returns { 'days': 1, 'hours': 3, 'minutes': 9, 'seconds': 0, 'milliseconds': 0 }
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/time/base/parse-duration/lib/index.js
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/lib/index.js
@@ -1,0 +1,46 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Parse a duration string into an object of `days`, `hours`, `minutes`, `seconds`, and `milliseconds`.
+*
+* @module @stdlib/time/base/parse-duration
+*
+* @example
+* var parseDuration = require( '@stdlib/time/base/parse-duration' );
+*
+* var obj = parseDuration( '1m3s10ms' );
+* // returns { 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 3, 'milliseconds': 10 }
+*
+* @example
+* var parseDuration = require( '@stdlib/time/base/parse-duration' );
+*
+* var obj = parseDuration( '1m3s' );
+* // returns { 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 3, 'milliseconds': 0 }
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/time/base/parse-duration/lib/main.js
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/lib/main.js
@@ -26,7 +26,7 @@ var RE_TIME_UNIT = /(\d+)([a-z]+)/gi;
 // MAIN //
 
 /**
-* Parses a duration string such as `1m3s10ms` into an object with `days`, `hours`, `minutes`, `seconds`, and `milliseconds`.
+* Parses a duration string into an object.
 *
 * @param {string} str - duration string
 * @returns {Object} duration object

--- a/lib/node_modules/@stdlib/time/base/parse-duration/lib/main.js
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/lib/main.js
@@ -26,6 +26,13 @@ var lowercase = require( '@stdlib/string/base/lowercase' );
 // VARIABLES //
 
 var RE_TIME_UNIT = /(\d+)([a-z]+)/gi;
+var UNITS = {
+	'd': 'days',
+	'h': 'hours',
+	'm': 'minutes',
+	's': 'seconds',
+	'ms': 'milliseconds'
+};
 
 
 // MAIN //
@@ -65,7 +72,7 @@ var RE_TIME_UNIT = /(\d+)([a-z]+)/gi;
 function parseDuration( str ) {
 	var parts;
 	var out;
-	var i;
+	var u;
 
 	out = {
 		'days': 0,
@@ -80,17 +87,9 @@ function parseDuration( str ) {
 	str = lowercase( str );
 	parts = RE_TIME_UNIT.exec( str );
 	while ( parts ) {
-		i = parts[ 2 ];
-		if ( i === 'd' ) {
-			out.days = parseInt( parts[ 1 ], 10 );
-		} else if ( i === 'h' ) {
-			out.hours = parseInt( parts[ 1 ], 10 );
-		} else if ( i === 'm' ) {
-			out.minutes = parseInt( parts[ 1 ], 10 );
-		} else if ( i === 's' ) {
-			out.seconds = parseInt( parts[ 1 ], 10 );
-		} else if ( i === 'ms' ) {
-			out.milliseconds = parseInt( parts[ 1 ], 10 );
+		u = UNITS[ parts[ 2 ] ];
+		if ( u ) {
+			out[ u ] = parseInt( parts[ 1 ], 10 );
 		}
 		parts = RE_TIME_UNIT.exec( str );
 	}

--- a/lib/node_modules/@stdlib/time/base/parse-duration/lib/main.js
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/lib/main.js
@@ -18,9 +18,9 @@
 
 'use strict';
 
-// MODULES //
+// VARIABLES //
 
-// TODO: Load required modules...
+var RE_TIME_UNIT = /(\d+)([a-z]+)/gi;
 
 
 // MAIN //
@@ -29,8 +29,7 @@
 * Parses a duration string such as `1m3s10ms` into an object with `days`, `hours`, `minutes`, `seconds`, and `milliseconds`.
 *
 * @param {string} str - duration string
-* @throws {TypeError} first argument must be a string primitive
-* @returns {Object} parsed duration
+* @returns {Object} duration object
 *
 * @example
 * var obj = parseDuration( '1m3s10ms' );
@@ -41,7 +40,37 @@
 * // returns { 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 3, 'milliseconds': 0 }
 */
 function parseDuration( str ) {
-	// TODO: Add implementation...
+	var parts;
+	var out;
+	var i;
+
+	out = {
+		'days': 0,
+		'hours': 0,
+		'minutes': 0,
+		'seconds': 0,
+		'milliseconds': 0
+	};
+	if ( str.length === 0 ) {
+		return out;
+	}
+	parts = RE_TIME_UNIT.exec( str );
+	while ( parts ) {
+		i = parts[ 2 ];
+		if ( i === 'd' || i === 'D' ) {
+			out.days = parseInt( parts[ 1 ], 10 );
+		} else if ( i === 'h' || i === 'H' ) {
+			out.hours = parseInt( parts[ 1 ], 10 );
+		} else if ( i === 'm' || i === 'M' ) {
+			out.minutes = parseInt( parts[ 1 ], 10 );
+		} else if ( i === 's' || i === 'S' ) {
+			out.seconds = parseInt( parts[ 1 ], 10 );
+		} else if ( i === 'ms' || i === 'MS' ) {
+			out.milliseconds = parseInt( parts[ 1 ], 10 );
+		}
+		parts = RE_TIME_UNIT.exec( str );
+	}
+	return out;
 }
 
 

--- a/lib/node_modules/@stdlib/time/base/parse-duration/lib/main.js
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/lib/main.js
@@ -83,7 +83,7 @@ function parseDuration( str ) {
 		i = parts[ 2 ];
 		if ( i === 'd' ) {
 			out.days = parseInt( parts[ 1 ], 10 );
-		} else if ( i === 'h' || i === 'H' ) {
+		} else if ( i === 'h' ) {
 			out.hours = parseInt( parts[ 1 ], 10 );
 		} else if ( i === 'm' ) {
 			out.minutes = parseInt( parts[ 1 ], 10 );

--- a/lib/node_modules/@stdlib/time/base/parse-duration/lib/main.js
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/lib/main.js
@@ -18,6 +18,11 @@
 
 'use strict';
 
+// MODULES //
+
+var lowercase = require( '@stdlib/string/base/lowercase' );
+
+
 // VARIABLES //
 
 var RE_TIME_UNIT = /(\d+)([a-z]+)/gi;
@@ -27,6 +32,24 @@ var RE_TIME_UNIT = /(\d+)([a-z]+)/gi;
 
 /**
 * Parses a duration string into an object.
+*
+* ## Notes
+*
+* -   A duration string is a string containing a sequence of time units. A time unit is a nonnegative integer followed by a unit identifier. The following unit identifiers are supported:
+*
+*     -   `d`: days
+*     -   `h`: hours
+*     -   `m`: minutes
+*     -   `s`: seconds
+*     -   `ms`: milliseconds
+*
+*     For example, the string `1m3s10ms` is a duration string containing three time units: `1m` (1 minute), `3s` (3 seconds), and `10ms` (10 milliseconds). The string `60m` is a duration string containing a single time unit: `60m` (60 minutes). A duration string must contain at least one time unit.
+*
+* -   Duration strings are case insensitive. For example, the string `1M3S10MS` is equivalent to `1m3s10ms`.
+*
+* -   If a duration string does not contain a time unit, the respective property is set to `0`.
+*
+* -   An empty string is considered a valid duration string and is parsed as `0d0h0m0s0ms`.
 *
 * @param {string} str - duration string
 * @returns {Object} duration object
@@ -54,18 +77,19 @@ function parseDuration( str ) {
 	if ( str.length === 0 ) {
 		return out;
 	}
+	str = lowercase( str );
 	parts = RE_TIME_UNIT.exec( str );
 	while ( parts ) {
 		i = parts[ 2 ];
-		if ( i === 'd' || i === 'D' ) {
+		if ( i === 'd' ) {
 			out.days = parseInt( parts[ 1 ], 10 );
 		} else if ( i === 'h' || i === 'H' ) {
 			out.hours = parseInt( parts[ 1 ], 10 );
-		} else if ( i === 'm' || i === 'M' ) {
+		} else if ( i === 'm' ) {
 			out.minutes = parseInt( parts[ 1 ], 10 );
-		} else if ( i === 's' || i === 'S' ) {
+		} else if ( i === 's' ) {
 			out.seconds = parseInt( parts[ 1 ], 10 );
-		} else if ( i === 'ms' || i === 'MS' ) {
+		} else if ( i === 'ms' ) {
 			out.milliseconds = parseInt( parts[ 1 ], 10 );
 		}
 		parts = RE_TIME_UNIT.exec( str );

--- a/lib/node_modules/@stdlib/time/base/parse-duration/lib/main.js
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/lib/main.js
@@ -1,0 +1,50 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+// TODO: Load required modules...
+
+
+// MAIN //
+
+/**
+* Parses a duration string such as `1m3s10ms` into an object with `days`, `hours`, `minutes`, `seconds`, and `milliseconds`.
+*
+* @param {string} str - duration string
+* @throws {TypeError} first argument must be a string primitive
+* @returns {Object} parsed duration
+*
+* @example
+* var obj = parseDuration( '1m3s10ms' );
+* // returns { 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 3, 'milliseconds': 10 }
+*
+* @example
+* var obj = parseDuration( '1m3s' );
+* // returns { 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 3, 'milliseconds': 0 }
+*/
+function parseDuration( str ) {
+	// TODO: Add implementation...
+}
+
+
+// EXPORTS //
+
+module.exports = parseDuration;

--- a/lib/node_modules/@stdlib/time/base/parse-duration/lib/main.js
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/lib/main.js
@@ -43,7 +43,7 @@ var RE_TIME_UNIT = /(\d+)([a-z]+)/gi;
 *     -   `s`: seconds
 *     -   `ms`: milliseconds
 *
-*     For example, the string `1m3s10ms` is a duration string containing three time units: `1m` (1 minute), `3s` (3 seconds), and `10ms` (10 milliseconds). The string `60m` is a duration string containing a single time unit: `60m` (60 minutes). A duration string must contain at least one time unit.
+*     For example, the string `1m3s10ms` is a duration string containing three time units: `1m` (1 minute), `3s` (3 seconds), and `10ms` (10 milliseconds). The string `60m` is a duration string containing a single time unit: `60m` (60 minutes).
 *
 * -   Duration strings are case insensitive. For example, the string `1M3S10MS` is equivalent to `1m3s10ms`.
 *

--- a/lib/node_modules/@stdlib/time/base/parse-duration/package.json
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@stdlib/time/base/parse-duration",
+  "version": "0.0.0",
+  "description": "",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": []
+}

--- a/lib/node_modules/@stdlib/time/base/parse-duration/package.json
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/time/base/parse-duration",
   "version": "0.0.0",
-  "description": "",
+  "description": "Parse a duration string into an object.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",
@@ -48,5 +48,21 @@
     "win32",
     "windows"
   ],
-  "keywords": []
+  "keywords": [
+    "stdlib",
+    "stdtime",
+    "standard",
+    "library",
+    "std",
+    "lib",
+    "time",
+    "date",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "base",
+    "duration",
+    "parse"
+  ]
 }

--- a/lib/node_modules/@stdlib/time/base/parse-duration/test/test.js
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/test/test.js
@@ -120,6 +120,7 @@ tape( 'the function parses a duration string (mixed case)', function test( t ) {
 
 	values = [
 		'1M3s10ms',
+		'1m3s10Ms',
 		'3D2h1m',
 		'1d2h3m4s5ms',
 		'2m3S',
@@ -132,6 +133,7 @@ tape( 'the function parses a duration string (mixed case)', function test( t ) {
 		''
 	];
 	expected = [
+		{ 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 3, 'milliseconds': 10 },
 		{ 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 3, 'milliseconds': 10 },
 		{ 'days': 3, 'hours': 2, 'minutes': 1, 'seconds': 0, 'milliseconds': 0 },
 		{ 'days': 1, 'hours': 2, 'minutes': 3, 'seconds': 4, 'milliseconds': 5 },

--- a/lib/node_modules/@stdlib/time/base/parse-duration/test/test.js
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/test/test.js
@@ -1,0 +1,89 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var parseDuration = require( './../lib' );
+
+
+// FIXTURES //
+
+var VALUES = [
+	[ '1d', { 'days': 1, 'hours': 0, 'minutes': 0, 'seconds': 0, 'milliseconds': 0 } ],
+	[ '1h', { 'days': 0, 'hours': 1, 'minutes': 0, 'seconds': 0, 'milliseconds': 0 } ],
+	[ '1m', { 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 0, 'milliseconds': 0 } ],
+	[ '1s', { 'days': 0, 'hours': 0, 'minutes': 0, 'seconds': 1, 'milliseconds': 0 } ],
+	[ '1ms', { 'days': 0, 'hours': 0, 'minutes': 0, 'seconds': 0, 'milliseconds': 1 } ],
+	[ '1d2h3m4s5ms', { 'days': 1, 'hours': 2, 'minutes': 3, 'seconds': 4, 'milliseconds': 5 } ],
+	[ '2h3m4s5ms', { 'days': 0, 'hours': 2, 'minutes': 3, 'seconds': 4, 'milliseconds': 5 } ],
+	[ '3m4s5ms', { 'days': 0, 'hours': 0, 'minutes': 3, 'seconds': 4, 'milliseconds': 5 } ],
+	[ '4s5ms', { 'days': 0, 'hours': 0, 'minutes': 0, 'seconds': 4, 'milliseconds': 5 } ],
+	[ '5ms', { 'days': 0, 'hours': 0, 'minutes': 0, 'seconds': 0, 'milliseconds': 5 } ],
+	[ '1d2h', { 'days': 1, 'hours': 2, 'minutes': 0, 'seconds': 0, 'milliseconds': 0 } ],
+	[ '2h3m', { 'days': 0, 'hours': 2, 'minutes': 3, 'seconds': 0, 'milliseconds': 0 } ],
+	[ '3m4s', { 'days': 0, 'hours': 0, 'minutes': 3, 'seconds': 4, 'milliseconds': 0 } ],
+	[ '4s5ms', { 'days': 0, 'hours': 0, 'minutes': 0, 'seconds': 4, 'milliseconds': 5 } ],
+	[ '5ms', { 'days': 0, 'hours': 0, 'minutes': 0, 'seconds': 0, 'milliseconds': 5 } ]
+];
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.equal( typeof parseDuration, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function parses a duration string', function test( t ) {
+	var expected;
+	var actual;
+	var i;
+
+	for ( i = 0; i < VALUES.length; i++ ) {
+		expected = VALUES[ i ][ 1 ];
+		actual = parseDuration( VALUES[ i ][ 0 ] );
+		t.deepEqual( actual, expected, 'returns expected object' );
+	}
+	t.end();
+});
+
+tape( 'the function parses a duration string (lowercase)', function test( t ) {
+	var expected;
+	var actual;
+	var i;
+
+	for ( i = 0; i < VALUES.length; i++ ) {
+		expected = VALUES[ i ][ 1 ];
+		actual = parseDuration( VALUES[ i ][ 0 ].toLowerCase() );
+		t.deepEqual( actual, expected, 'returns expected object' );
+	}
+	t.end();
+});
+
+tape( 'the function parses a duration string (uppercase)', function test( t ) {
+	var expected;
+	var actual;
+	var i;
+
+	for ( i = 0; i < VALUES.length; i++ ) {
+		expected = VALUES[ i ][ 1 ];
+		actual = parseDuration( VALUES[ i ][ 0 ].toUpperCase() );
+		t.deepEqual( actual, expected,

--- a/lib/node_modules/@stdlib/time/base/parse-duration/test/test.js
+++ b/lib/node_modules/@stdlib/time/base/parse-duration/test/test.js
@@ -16,33 +16,15 @@
 * limitations under the License.
 */
 
+/* eslint-disable object-property-newline, object-curly-newline */
+
 'use strict';
 
 // MODULES //
 
 var tape = require( 'tape' );
+var uppercase = require( '@stdlib/string/uppercase' );
 var parseDuration = require( './../lib' );
-
-
-// FIXTURES //
-
-var VALUES = [
-	[ '1d', { 'days': 1, 'hours': 0, 'minutes': 0, 'seconds': 0, 'milliseconds': 0 } ],
-	[ '1h', { 'days': 0, 'hours': 1, 'minutes': 0, 'seconds': 0, 'milliseconds': 0 } ],
-	[ '1m', { 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 0, 'milliseconds': 0 } ],
-	[ '1s', { 'days': 0, 'hours': 0, 'minutes': 0, 'seconds': 1, 'milliseconds': 0 } ],
-	[ '1ms', { 'days': 0, 'hours': 0, 'minutes': 0, 'seconds': 0, 'milliseconds': 1 } ],
-	[ '1d2h3m4s5ms', { 'days': 1, 'hours': 2, 'minutes': 3, 'seconds': 4, 'milliseconds': 5 } ],
-	[ '2h3m4s5ms', { 'days': 0, 'hours': 2, 'minutes': 3, 'seconds': 4, 'milliseconds': 5 } ],
-	[ '3m4s5ms', { 'days': 0, 'hours': 0, 'minutes': 3, 'seconds': 4, 'milliseconds': 5 } ],
-	[ '4s5ms', { 'days': 0, 'hours': 0, 'minutes': 0, 'seconds': 4, 'milliseconds': 5 } ],
-	[ '5ms', { 'days': 0, 'hours': 0, 'minutes': 0, 'seconds': 0, 'milliseconds': 5 } ],
-	[ '1d2h', { 'days': 1, 'hours': 2, 'minutes': 0, 'seconds': 0, 'milliseconds': 0 } ],
-	[ '2h3m', { 'days': 0, 'hours': 2, 'minutes': 3, 'seconds': 0, 'milliseconds': 0 } ],
-	[ '3m4s', { 'days': 0, 'hours': 0, 'minutes': 3, 'seconds': 4, 'milliseconds': 0 } ],
-	[ '4s5ms', { 'days': 0, 'hours': 0, 'minutes': 0, 'seconds': 4, 'milliseconds': 5 } ],
-	[ '5ms', { 'days': 0, 'hours': 0, 'minutes': 0, 'seconds': 0, 'milliseconds': 5 } ]
-];
 
 
 // TESTS //
@@ -55,35 +37,116 @@ tape( 'main export is a function', function test( t ) {
 tape( 'the function parses a duration string', function test( t ) {
 	var expected;
 	var actual;
+	var values;
 	var i;
 
-	for ( i = 0; i < VALUES.length; i++ ) {
-		expected = VALUES[ i ][ 1 ];
-		actual = parseDuration( VALUES[ i ][ 0 ] );
-		t.deepEqual( actual, expected, 'returns expected object' );
-	}
-	t.end();
-});
-
-tape( 'the function parses a duration string (lowercase)', function test( t ) {
-	var expected;
-	var actual;
-	var i;
-
-	for ( i = 0; i < VALUES.length; i++ ) {
-		expected = VALUES[ i ][ 1 ];
-		actual = parseDuration( VALUES[ i ][ 0 ].toLowerCase() );
-		t.deepEqual( actual, expected, 'returns expected object' );
+	values = [
+		'1m3s10ms',
+		'3d2h1m',
+		'1d2h3m4s5ms',
+		'2m3s',
+		'1h2m3s4ms',
+		'1m3s10ms',
+		'2ms',
+		'1m',
+		'1h',
+		'1d',
+		''
+	];
+	expected = [
+		{ 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 3, 'milliseconds': 10 },
+		{ 'days': 3, 'hours': 2, 'minutes': 1, 'seconds': 0, 'milliseconds': 0 },
+		{ 'days': 1, 'hours': 2, 'minutes': 3, 'seconds': 4, 'milliseconds': 5 },
+		{ 'days': 0, 'hours': 0, 'minutes': 2, 'seconds': 3, 'milliseconds': 0 },
+		{ 'days': 0, 'hours': 1, 'minutes': 2, 'seconds': 3, 'milliseconds': 4 },
+		{ 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 3, 'milliseconds': 10 },
+		{ 'days': 0, 'hours': 0, 'minutes': 0, 'seconds': 0, 'milliseconds': 2 },
+		{ 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 0, 'milliseconds': 0 },
+		{ 'days': 0, 'hours': 1, 'minutes': 0, 'seconds': 0, 'milliseconds': 0 },
+		{ 'days': 1, 'hours': 0, 'minutes': 0, 'seconds': 0, 'milliseconds': 0 },
+		{ 'days': 0, 'hours': 0, 'minutes': 0, 'seconds': 0, 'milliseconds': 0 }
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		actual = parseDuration( values[ i ] );
+		t.deepEqual( actual, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function parses a duration string (uppercase)', function test( t ) {
 	var expected;
+	var values;
 	var actual;
 	var i;
 
-	for ( i = 0; i < VALUES.length; i++ ) {
-		expected = VALUES[ i ][ 1 ];
-		actual = parseDuration( VALUES[ i ][ 0 ].toUpperCase() );
-		t.deepEqual( actual, expected,
+	values = [
+		'1M3S10MS',
+		'3D2H1M',
+		'1D2H3M4S5MS',
+		'2M3S',
+		'1H2M3S4MS',
+		'1M3S10MS',
+		'2MS',
+		'1M',
+		'1H',
+		'1D',
+		''
+	];
+	expected = [
+		{ 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 3, 'milliseconds': 10 },
+		{ 'days': 3, 'hours': 2, 'minutes': 1, 'seconds': 0, 'milliseconds': 0 },
+		{ 'days': 1, 'hours': 2, 'minutes': 3, 'seconds': 4, 'milliseconds': 5 },
+		{ 'days': 0, 'hours': 0, 'minutes': 2, 'seconds': 3, 'milliseconds': 0 },
+		{ 'days': 0, 'hours': 1, 'minutes': 2, 'seconds': 3, 'milliseconds': 4 },
+		{ 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 3, 'milliseconds': 10 },
+		{ 'days': 0, 'hours': 0, 'minutes': 0, 'seconds': 0, 'milliseconds': 2 },
+		{ 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 0, 'milliseconds': 0 },
+		{ 'days': 0, 'hours': 1, 'minutes': 0, 'seconds': 0, 'milliseconds': 0 },
+		{ 'days': 1, 'hours': 0, 'minutes': 0, 'seconds': 0, 'milliseconds': 0 },
+		{ 'days': 0, 'hours': 0, 'minutes': 0, 'seconds': 0, 'milliseconds': 0 }
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		actual = parseDuration( uppercase( values[ i ] ) );
+		t.deepEqual( actual, expected[ i ], 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function parses a duration string (mixed case)', function test( t ) {
+	var expected;
+	var values;
+	var actual;
+	var i;
+
+	values = [
+		'1M3s10ms',
+		'3D2h1m',
+		'1d2h3m4s5ms',
+		'2m3S',
+		'1h2m3s4MS',
+		'1M3s10MS',
+		'2ms',
+		'1m',
+		'1H',
+		'1d',
+		''
+	];
+	expected = [
+		{ 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 3, 'milliseconds': 10 },
+		{ 'days': 3, 'hours': 2, 'minutes': 1, 'seconds': 0, 'milliseconds': 0 },
+		{ 'days': 1, 'hours': 2, 'minutes': 3, 'seconds': 4, 'milliseconds': 5 },
+		{ 'days': 0, 'hours': 0, 'minutes': 2, 'seconds': 3, 'milliseconds': 0 },
+		{ 'days': 0, 'hours': 1, 'minutes': 2, 'seconds': 3, 'milliseconds': 4 },
+		{ 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 3, 'milliseconds': 10 },
+		{ 'days': 0, 'hours': 0, 'minutes': 0, 'seconds': 0, 'milliseconds': 2 },
+		{ 'days': 0, 'hours': 0, 'minutes': 1, 'seconds': 0, 'milliseconds': 0 },
+		{ 'days': 0, 'hours': 1, 'minutes': 0, 'seconds': 0, 'milliseconds': 0 },
+		{ 'days': 1, 'hours': 0, 'minutes': 0, 'seconds': 0, 'milliseconds': 0 },
+		{ 'days': 0, 'hours': 0, 'minutes': 0, 'seconds': 0, 'milliseconds': 0 }
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		actual = parseDuration( values[ i ] );
+		t.deepEqual( actual, expected[ i ], 'returns expected value' );
+	}
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds a base time utility to parse a duration string into an object.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #
-   fixes #

## Questions

> Any questions for reviewers of this pull request?

Requesting review of `README.md` before rolling out implementation.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
