### PR TITLE
Add C implementation for `@stdlib/number/float32/base/exponent`

### DIFF
--- a/lib/node_modules/@stdlib/number/float32/base/exponent/README.md
+++ b/lib/node_modules/@stdlib/number/float32/base/exponent/README.md
@@ -35,7 +35,7 @@ var exponentf = require( '@stdlib/number/float32/base/exponent' );
 Returns an `integer` corresponding to the unbiased exponent of a [single-precision floating-point number][ieee754].
 
 ```javascript
-var toFloat32 = require( '@stdlib/number/float32/base/to-float32' );
+var toFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 
 var exp = exponentf( toFloat32( 3.14e34 ) ); // => 2^114 ~ 2.08e34
 // returns 114
@@ -67,7 +67,7 @@ exp = exponentf( NaN );
 var randu = require( '@stdlib/random/base/randu' );
 var round = require( '@stdlib/math/base/special/round' );
 var pow = require( '@stdlib/math/base/special/pow' );
-var toFloat32 = require( '@stdlib/number/float32/base/to-float32' );
+var toFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var exponentf = require( '@stdlib/number/float32/base/exponent' );
 
 var frac;

--- a/lib/node_modules/@stdlib/number/float32/base/exponent/README.md
+++ b/lib/node_modules/@stdlib/number/float32/base/exponent/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2018 The Stdlib Authors.
+Copyright (c) 2022 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ var exponentf = require( '@stdlib/number/float32/base/exponent' );
 Returns an `integer` corresponding to the unbiased exponent of a [single-precision floating-point number][ieee754].
 
 ```javascript
-var toFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var toFloat32 = require( '@stdlib/number/float32/base/to-float32' );
 
 var exp = exponentf( toFloat32( 3.14e34 ) ); // => 2^114 ~ 2.08e34
 // returns 114
@@ -67,7 +67,7 @@ exp = exponentf( NaN );
 var randu = require( '@stdlib/random/base/randu' );
 var round = require( '@stdlib/math/base/special/round' );
 var pow = require( '@stdlib/math/base/special/pow' );
-var toFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var toFloat32 = require( '@stdlib/number/float32/base/to-float32' );
 var exponentf = require( '@stdlib/number/float32/base/exponent' );
 
 var frac;
@@ -90,6 +90,94 @@ for ( i = 0; i < 100; i++ ) {
 </section>
 
 <!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/number/float32/base/exponent.h"
+```
+
+#### stdlib_base_float32_exponent( x )
+
+Returns an integer corresponding to the unbiased exponent of a [single-precision floating-point number][ieee754].
+
+```c
+#include <stdint.h>
+
+int32_t out = stdlib_base_float32_exponent( 3.14 );
+```
+
+The function accepts the following arguments:
+
+-   **x**: `[in] double` input value.
+
+```c
+int32_t stdlib_base_float32_exponent( const double x );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/number/float32/base/exponent.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <inttypes.h>
+
+int main() {
+    double x[] = { 4.0, 0.0, -0.0, 1.0, -1.0, 3.14, -3.14, 1.0e308, -1.0e308, 1.0/0.0, -1.0/0.0, 0.0/0.0 };
+
+    int32_t out;
+    int i;
+    for ( i = 0; i < 12; i++ ) {
+        out = stdlib_base_float32_exponent( x[ i ] );
+        printf( "%lf => out: %" PRId32 "\n", x[ i ], out );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
 
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 

--- a/lib/node_modules/@stdlib/number/float32/base/exponent/README.md
+++ b/lib/node_modules/@stdlib/number/float32/base/exponent/README.md
@@ -160,13 +160,13 @@ int32_t stdlib_base_float32_exponent( const float x );
 #include <inttypes.h>
 
 int main() {
-    double x[] = { 4.0, 0.0, -0.0, 1.0, -1.0, 3.14, -3.14, 1.0e308, -1.0e308, 1.0/0.0, -1.0/0.0, 0.0/0.0 };
+    float x[] = { 4.0f, 0.0f, -0.0f, 1.0f, -1.0f, 3.14f, -3.14f, 1.0e38f, -1.0e38f, 1.0f/0.0f, -1.0f/0.0f, 0.0f/0.0f };
 
     int32_t out;
     int i;
     for ( i = 0; i < 12; i++ ) {
         out = stdlib_base_float32_exponent( x[ i ] );
-        printf( "%lf => out: %" PRId32 "\n", x[ i ], out );
+        printf( "%f => out: %" PRId32 "\n", x[ i ], out );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/number/float32/base/exponent/README.md
+++ b/lib/node_modules/@stdlib/number/float32/base/exponent/README.md
@@ -124,15 +124,15 @@ Returns an integer corresponding to the unbiased exponent of a [single-precision
 ```c
 #include <stdint.h>
 
-int32_t out = stdlib_base_float32_exponent( 3.14 );
+int32_t out = stdlib_base_float32_exponent( 3.14f );
 ```
 
 The function accepts the following arguments:
 
--   **x**: `[in] double` input value.
+-   **x**: `[in] float` input value.
 
 ```c
-int32_t stdlib_base_float32_exponent( const double x );
+int32_t stdlib_base_float32_exponent( const float x );
 ```
 
 </section>


### PR DESCRIPTION
## Checklist

- [x] update readme.md
- [ ] include/stdlib/number/float32/base
- [ ] src
- [ ] include.gypi
- [ ] manifest.json
- [ ] binding.gyp
- [ ] examples
- [ ] benchmark
- [ ] test
* * *

@kgryte if you could please assign stdlib bot.