### PR TITLE
Refactor `minmax` API to non-variadic interface

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/minmax/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/minmax/README.md
@@ -40,7 +40,7 @@ limitations under the License.
 var minmax = require( '@stdlib/math/base/special/minmax' );
 ```
 
-#### minmax( x\[, y\[, ...args]] )
+#### minmax( x, y )
 
 Returns the minimum and maximum values in a single pass.
 
@@ -50,9 +50,6 @@ var v = minmax( 4.2, 3.14 );
 
 v = minmax( +0.0, -0.0 );
 // returns [ -0.0, +0.0 ]
-
-v = minmax( 4.2, 3.14, -1.0, 6.8 );
-// returns [ -1.0, 6.8 ]
 ```
 
 If any argument is `NaN`, the function returns `NaN` for both the minimum value and the maximum value.
@@ -65,7 +62,7 @@ v = minmax( NaN, 3.14 );
 // returns [ NaN, NaN ]
 ```
 
-#### minmax.assign( x\[, y\[, ...args]], out, stride, offset )
+#### minmax.assign( x, y, out, stride, offset )
 
 Returns the minimum and maximum values in a single pass and assigns results to a provided output array.
 
@@ -74,7 +71,7 @@ var Float64Array = require( '@stdlib/array/float64' );
 
 var out = new Float64Array( 2 );
 
-var v = minmax.assign( 5.0, 3.0, -2.0, 1.0, out, 1, 0 );
+var v = minmax.assign( 5.0, -2.0, out, 1, 0 );
 // returns <Float64Array>[ -2.0, 5.0 ]
 
 var bool = ( v === out );

--- a/lib/node_modules/@stdlib/math/base/special/minmax/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/minmax/docs/repl.txt
@@ -1,5 +1,5 @@
 
-{{alias}}( x[, y[, ...args]] )
+{{alias}}( x, y )
     Returns the minimum and maximum values.
 
     If any argument is `NaN`, the function returns `NaN` for both the minimum
@@ -10,11 +10,8 @@
     x: number
         First number.
 
-    y: number (optional)
+    y: number
         Second number.
-
-    args: ...number (optional)
-        Numbers.
 
     Returns
     -------
@@ -25,17 +22,13 @@
     --------
     > var v = {{alias}}( 3.14, 4.2 )
     [ 3.14, 4.2 ]
-    > v = {{alias}}( 5.9, 3.14, 4.2 )
-    [ 3.14, 5.9 ]
     > v = {{alias}}( 3.14, NaN )
     [ NaN, NaN ]
     > v = {{alias}}( +0.0, -0.0 )
     [ -0.0, +0.0 ]
-    > v = {{alias}}( 3.14 )
-    [ 3.14, 3.14 ]
 
 
-{{alias}}.assign( x[, y[, ...args]], out, stride, offset )
+{{alias}}.assign( x, y, out, stride, offset )
     Returns the minimum and maximum values and assigns results to a provided
     output array.
 
@@ -47,11 +40,8 @@
     x: number
         First number.
 
-    y: number (optional)
+    y: number
         Second number.
-
-    args: ...number (optional)
-        Numbers.
 
     out: Array|TypedArray|Object
         Output object.

--- a/lib/node_modules/@stdlib/math/base/special/minmax/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/minmax/docs/types/index.d.ts
@@ -29,28 +29,6 @@ import { Collection } from '@stdlib/types/object';
 	/**
 	* Returns the minimum and maximum values.
 	*
-	* @returns minimum and maximum values
-	*
-	* @example
-	* var v = minmax();
-	* // returns [ Infinity, -Infinity ]
-	*/
-	(): Array<number>;
-
-	/**
-	* Returns the minimum and maximum values.
-	*
-	* @param x - first number
-	* @returns minimum and maximum values
-	*
-	* @example
-	* var v = minmax( 3.14 );
-	* // returns [ 3.14, 3.14 ]
-	*/
-	( x: number ): Array<number>; // tslint:disable-line unified-signatures
-	/**
-	* Returns the minimum and maximum values.
-	*
 	* @param x - first number
 	* @param y - second number
 	* @returns minimum and maximum values
@@ -66,110 +44,7 @@ import { Collection } from '@stdlib/types/object';
 	* var v = minmax( +0.0, -0.0 );
 	* // returns [ -0.0, 0.0 ]
 	*/
-	( x: number, y: number ): Array<number>; // tslint:disable-line unified-signatures
-
-	/**
-	* Returns the minimum and maximum values.
-	*
-	* @param x - first number
-	* @param y - second number
-	* @param z - third number
-	* @returns minimum and maximum values
-	*
-	* @example
-	* var v = minmax( 3.14, 4.2, -1.0 );
-	* // returns [ -1.0, 4.2 ]
-	*/
-	( x: number, y: number, z: number ): Array<number>; // tslint:disable-line unified-signatures
-
-	/**
-	* Returns the minimum and maximum values.
-	*
-	* @param x - first number
-	* @param y - second number
-	* @param z - third number
-	* @param w - fourth number
-	* @returns minimum and maximum values
-	*
-	* @example
-	* var v = minmax( 3.14, 4.2, -1.0, 2.0 );
-	* // returns [ -1.0, 4.2 ]
-	*/
-	( x: number, y: number, z: number, w: number ): Array<number>; // tslint:disable-line unified-signatures
-
-	/**
-	* Returns the minimum and maximum values.
-	*
-	* @param x - first number
-	* @param y - second number
-	* @param z - third number
-	* @param w - fourth number
-	* @param v - fifth number
-	* @returns minimum and maximum values
-	*
-	* @example
-	* var v = minmax( 3.14, 4.2, -1.0, 2.0, 1.0 );
-	* // returns [ -1.0, 4.2 ]
-	*/
-	( x: number, y: number, z: number, w: number, v: number ): Array<number>; // tslint:disable-line unified-signatures
-
-	/**
-	* Returns the minimum and maximum values.
-	*
-	* @param x - first number
-	* @param y - second number
-	* @param args - numbers
-	* @returns minimum and maximum values
-	*
-	* @example
-	* var v = minmax( 3.14, 4.2 );
-	* // returns [ 3.14, 4.2 ]
-	*
-	* var v = minmax( 3.14, NaN );
-	* // returns [ NaN, NaN ]
-	*
-	* @example
-	* var v = minmax( +0.0, -0.0 );
-	* // returns [ -0.0, 0.0 ]
-	*/
-	( x: number, y: number, ...args: Array<number> ): Array<number>; // tslint:disable-line unified-signatures
-
-	/**
-	* Returns the minimum and maximum values and assigns results to a provided output array.
-	*
-	* @param out - output object
-	* @param stride - output array stride
-	* @param offset - output array index offset
-	* @returns minimum and maximum values
-	*
-	* @example
-	* var out = [ 0.0, 0.0 ];
-	* var v = minmax( out, 1, 0 );
-	* // returns [ Infinity, -Infinity ]
-	*
-	* var bool = ( v === out );
-	* // returns true
-	*/
-	assign( out: Collection, stride: number, offset: number ): Collection;
-
-	/**
-	* Returns the minimum and maximum values and assigns results to a provided output array.
-	*
-	* @param x - first number
-	* @param out - output object
-	* @param stride - output array stride
-	* @param offset - output array index offset
-	* @returns minimum and maximum values
-	*
-	* @example
-	* var out = [ 0.0, 0.0 ];
-	* var v = minmax( 5.9, out, 1, 0 );
-	* // returns [ 5.9, 5.9 ]
-	*
-	* var bool = ( v === out );
-	* // returns true
-	*/
-	assign( x: number, out: Collection, stride: number, offset: number ): Collection; // tslint-disable-line max-line-length
+	( x: number, y: number ): Array<number>;
 
 	/**
 	* Returns the minimum and maximum values and assigns results to a provided output array.
@@ -190,93 +65,6 @@ import { Collection } from '@stdlib/types/object';
 	* // returns true
 	*/
 	assign( x: number, y: number, out: Collection, stride: number, offset: number ): Collection; // tslint-disable-line max-line-length
-
-	/**
-	* Returns the minimum and maximum values and assigns results to a provided output array.
-	*
-	* @param x - first number
-	* @param y - second number
-	* @param z - third number
-	* @param out - output object
-	* @param stride - output array stride
-	* @param offset - output array index offset
-	* @returns minimum and maximum values
-	*
-	* @example
-	* var out = [ 0.0, 0.0 ];
-	* var v = minmax( 5.9, 3.14, 4.2, out, 1, 0 );
-	* // returns [ 3.14, 5.9 ]
-	*
-	* var bool = ( v === out );
-	* // returns true
-	*/
-	assign( x: number, y: number, z: number, out: Collection, stride: number, offset: number ): Collection; // tslint-disable-line max-line-length
-
-	/**
-	* Returns the minimum and maximum values and assigns results to a provided output array.
-	*
-	* @param x - first number
-	* @param y - second number
-	* @param z - third number
-	* @param w - fourth number
-	* @param out - output object
-	* @param stride - output array stride
-	* @param offset - output array index offset
-	* @returns minimum and maximum values
-	*
-	* @example
-	* var out = [ 0.0, 0.0 ];
-	* var v = minmax( 5.9, 3.14, 4.2, 3.9, out, 1, 0 );
-	* // returns [ 3.14, 5.9 ]
-	*
-	* var bool = ( v === out );
-	* // returns true
-	*/
-	assign( x: number, y: number, z: number, w: number, out: Collection, stride: number, offset: number ): Collection; // tslint-disable-line max-line-length
-
-	/**
-	* Returns the minimum and maximum values and assigns results to a provided output array.
-	*
-	* @param x - first number
-	* @param y - second number
-	* @param z - third number
-	* @param w - fourth number
-	* @param v - fifth number
-	* @param out - output object
-	* @param stride - output array stride
-	* @param offset - output array index offset
-	* @returns minimum and maximum values
-	*
-	* @example
-	* var out = [ 0.0, 0.0 ];
-	* var v = minmax( 5.9, 3.14, 4.2, 3.9, 3.8, out, 1, 0 );
-	* // returns [ 3.14, 5.9 ]
-	*
-	* var bool = ( v === out );
-	* // returns true
-	*/
-	assign( x: number, y: number, z: number, w: number, v: number, out: Collection, stride: number, offset: number ): Collection; // tslint-disable-line max-line-length
-
-	/**
-	* Returns the minimum and maximum values and assigns results to a provided output array.
-	*
-	* @param x - first number
-	* @param y - second number
-	* @param args - numbers
-	* @param out - output object
-	* @param stride - output array stride
-	* @param offset - output array index offset
-	* @returns minimum and maximum values
-	*
-	* @example
-	* var out = [ 0.0, 0.0 ];
-	* var v = minmax( 5.9, 3.14, 4.2, 3.9, 3.8, 3.7, out, 1, 0 );
-	* // returns [ 3.14, 5.9 ]
-	*
-	* var bool = ( v === out );
-	* // returns true
-	*/
-	assign( x: number, y: number, ...args: Array<number|Collection> ): Collection; // tslint-disable-line max-line-length
 }
 
 /**
@@ -284,7 +72,6 @@ import { Collection } from '@stdlib/types/object';
 *
 * @param x - first number
 * @param y - second number
-* @param args - numbers
 * @returns minimum and maximum values
 *
 * @example

--- a/lib/node_modules/@stdlib/math/base/special/minmax/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/math/base/special/minmax/docs/types/test.ts
@@ -23,23 +23,17 @@ import minmax = require( './index' );
 
 // The function returns an array of numbers...
 {
-	minmax(); // $ExpectType number[]
-	minmax( -0.2 ); // $ExpectType number[]
 	minmax( 3.0, -0.2 ); // $ExpectType number[]
-	minmax( 3.0, -0.2, 1.0 ); // $ExpectType number[]
-	minmax( 3.0, -0.2, -1.2, -4.0 ); // $ExpectType number[]
-	minmax( 3.0, -0.2, -1.2, -4.0, 5.0 ); // $ExpectType number[]
-	minmax( 3.0, -0.2, -1.2, -4.0, 5.0, 6.0 ); // $ExpectType number[]
 }
 
 // The compiler throws an error if the function is provided an argument which is not a number...
 {
-	minmax( true ); // $ExpectError
-	minmax( false ); // $ExpectError
-	minmax( [] ); // $ExpectError
-	minmax( {} ); // $ExpectError
-	minmax( 'abc' ); // $ExpectError
-	minmax( ( x: number ): number => x ); // $ExpectError
+	minmax( true, 1.2 ); // $ExpectError
+	minmax( false, 1.2 ); // $ExpectError
+	minmax( [], 1.2 ); // $ExpectError
+	minmax( {}, 1.2 ); // $ExpectError
+	minmax( 'abc', 1.2 ); // $ExpectError
+	minmax( ( x: number ): number => x, 1.2 ); // $ExpectError
 
 	minmax( 1.2, true ); // $ExpectError
 	minmax( 1.2, false ); // $ExpectError
@@ -47,67 +41,36 @@ import minmax = require( './index' );
 	minmax( 1.2, {} ); // $ExpectError
 	minmax( 1.2, 'abc' ); // $ExpectError
 	minmax( 1.2, ( x: number ): number => x ); // $ExpectError
+}
 
-	minmax( 1.2, 3.0, true ); // $ExpectError
-	minmax( 1.2, 3.0, false ); // $ExpectError
-	minmax( 1.2, 3.0, [] ); // $ExpectError
-	minmax( 1.2, 3.0, {} ); // $ExpectError
-	minmax( 1.2, 3.0, 'abc' ); // $ExpectError
-	minmax( 1.2, 3.0, ( x: number ): number => x ); // $ExpectError
-
-	minmax( 1.2, 3.0, 4.0, true ); // $ExpectError
-	minmax( 1.2, 3.0, 4.0, false ); // $ExpectError
-	minmax( 1.2, 3.0, 4.0, [] ); // $ExpectError
-	minmax( 1.2, 3.0, 4.0, {} ); // $ExpectError
-	minmax( 1.2, 3.0, 4.0, 'abc' ); // $ExpectError
-	minmax( 1.2, 3.0, 4.0, ( x: number ): number => x ); // $ExpectError
-
-	minmax( 1.2, 3.0, 4.0, 5.0, true ); // $ExpectError
-	minmax( 1.2, 3.0, 4.0, 5.0, false ); // $ExpectError
-	minmax( 1.2, 3.0, 4.0, 5.0, [] ); // $ExpectError
-	minmax( 1.2, 3.0, 4.0, 5.0, {} ); // $ExpectError
-	minmax( 1.2, 3.0, 4.0, 5.0, 'abc' ); // $ExpectError
-	minmax( 1.2, 3.0, 4.0, 5.0, ( x: number ): number => x ); // $ExpectError
-
-	minmax( 1.2, 3.0, 4.0, 5.0, 6.0, true ); // $ExpectError
-	minmax( 1.2, 3.0, 4.0, 5.0, 6.0, false ); // $ExpectError
-	minmax( 1.2, 3.0, 4.0, 5.0, 6.0, [] ); // $ExpectError
-	minmax( 1.2, 3.0, 4.0, 5.0, 6.0, {} ); // $ExpectError
-	minmax( 1.2, 3.0, 4.0, 5.0, 6.0, 'abc' ); // $ExpectError
-	minmax( 1.2, 3.0, 4.0, 5.0, 6.0, ( x: number ): number => x ); // $ExpectError
-
-	minmax( 1.2, 3.0, 4.0, 5.0, 6.0, 7.0, true ); // $ExpectError
-	minmax( 1.2, 3.0, 4.0, 5.0, 6.0, 7.0, false ); // $ExpectError
-	minmax( 1.2, 3.0, 4.0, 5.0, 6.0, 7.0, [] ); // $ExpectError
-	minmax( 1.2, 3.0, 4.0, 5.0, 6.0, 7.0, {} ); // $ExpectError
-	minmax( 1.2, 3.0, 4.0, 5.0, 6.0, 7.0, 'abc' ); // $ExpectError
-	minmax( 1.2, 3.0, 4.0, 5.0, 6.0, 7.0, ( x: number ): number => x ); // $ExpectError
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	minmax(); // $ExpectError
+	minmax( -0.2 ); // $ExpectError
+	minmax( 3.0, -0.2, 1.0 ); // $ExpectError
+	minmax( 3.0, -0.2, -1.2, -4.0 ); // $ExpectError
+	minmax( 3.0, -0.2, -1.2, -4.0, 5.0 ); // $ExpectError
+	minmax( 3.0, -0.2, -1.2, -4.0, 5.0, 6.0 ); // $ExpectError
 }
 
 // Attached to the main export is an `assign` method which returns an array-like object containing numbers...
 {
 	const out = [ 0.0, 0.0 ];
 
-	minmax.assign( out, 1, 0 ); // $ExpectType Collection
-	minmax.assign( 3.0, out, 1, 0 ); // $ExpectType Collection
 	minmax.assign( 3.0, -0.2, out, 1, 0 ); // $ExpectType Collection
-	minmax.assign( 3.0, -0.2, 1.0, out, 1, 0 ); // $ExpectType Collection
-	minmax.assign( 3.0, -0.2, -1.2, -4.0, out, 1, 0 ); // $ExpectType Collection
-	minmax.assign( 3.0, -0.2, -1.2, -4.0, 5.0, out, 1, 0 ); // $ExpectType Collection
-	minmax.assign( 3.0, -0.2, -1.2, -4.0, 5.0, 6.0, out, 1, 0 ); // $ExpectType Collection
 }
 
 // The compiler throws an error if the `assign` method is provided a first argument which is not a number...
 {
 	const out = [ 0.0, 0.0 ];
 
-	minmax.assign( true, out, 1, 0 ); // $ExpectError
-	minmax.assign( false, out, 1, 0 ); // $ExpectError
+	minmax.assign( true, -0.2, out, 1, 0 ); // $ExpectError
+	minmax.assign( false, -0.2, out, 1, 0 ); // $ExpectError
 	minmax.assign( '5', -0.2, out, 1, 0 ); // $ExpectError
-	minmax.assign( null, -0.2, 1.0, out, 1, 0 ); // $ExpectError
-	minmax.assign( [], -0.2, -1.2, -4.0, out, 1, 0 ); // $ExpectError
-	minmax.assign( {}, -0.2, -1.2, -4.0, 5.0, out, 1, 0 ); // $ExpectError
-	minmax.assign( ( x: number ): number => x, -0.2, -1.2, -4.0, 5.0, 6.0, out, 1, 0 ); // $ExpectError
+	minmax.assign( null, -0.2, out, 1, 0 ); // $ExpectError
+	minmax.assign( [], -0.2, out, 1, 0 ); // $ExpectError
+	minmax.assign( {}, -0.2, out, 1, 0 ); // $ExpectError
+	minmax.assign( ( x: number ): number => x, -0.2, out, 1, 0 ); // $ExpectError
 }
 
 // The compiler throws an error if the `assign` method is provided a second argument which is not a number...
@@ -115,45 +78,49 @@ import minmax = require( './index' );
 	const out = [ 0.0, 0.0 ];
 
 	minmax.assign( 1.0, false, out, 1, 0 ); // $ExpectError
-	minmax.assign( 1.0, '5', -0.2, out, 1, 0 ); // $ExpectError
-	minmax.assign( 1.0, null, -0.2, 1.0, out, 1, 0 ); // $ExpectError
-	minmax.assign( 1.0, [], -0.2, -1.2, -4.0, out, 1, 0 ); // $ExpectError
-	minmax.assign( 1.0, {}, -0.2, -1.2, -4.0, 5.0, out, 1, 0 ); // $ExpectError
-	minmax.assign( 1.0, ( x: number ): number => x, -0.2, -1.2, -4.0, 5.0, 6.0, out, 1, 0 ); // $ExpectError
+	minmax.assign( 1.0, '5', out, 1, 0 ); // $ExpectError
+	minmax.assign( 1.0, null, out, 1, 0 ); // $ExpectError
+	minmax.assign( 1.0, [], out, 1, 0 ); // $ExpectError
+	minmax.assign( 1.0, {}, out, 1, 0 ); // $ExpectError
+	minmax.assign( 1.0, ( x: number ): number => x, out, 1, 0 ); // $ExpectError
 }
 
 // The compiler throws an error if the `assign` method is provided an invalid third argument...
 {
-	const out = [ 0.0, 0.0 ];
-
-	minmax.assign( 1.0, 2.0, false, out, 1, 0 ); // $ExpectError
-	minmax.assign( 1.0, 2.0, null, -0.2, 1.0, out, 1, 0 ); // $ExpectError
-	minmax.assign( 1.0, 2.0, {}, -0.2, -1.2, -4.0, 5.0, out, 1, 0 ); // $ExpectError
+	minmax.assign( 1.0, 2.0, false, 1, 0 ); // $ExpectError
+	minmax.assign( 1.0, 2.0, null, 1, 0 ); // $ExpectError
 }
 
 // The compiler throws an error if the `assign` method is provided an invalid fourth argument...
 {
 	const out = [ 0.0, 0.0 ];
 
-	minmax.assign( 1.0, 2.0, 3.0, false, out, 1, 0 ); // $ExpectError
-	minmax.assign( 1.0, 2.0, 3.0, null, -0.2, 1.0, out, 1, 0 ); // $ExpectError
-	minmax.assign( 1.0, 2.0, 3.0, {}, -0.2, -1.2, -4.0, 5.0, out, 1, 0 ); // $ExpectError
+	minmax.assign( 1.0, 2.0, out, false, 0 ); // $ExpectError
+	minmax.assign( 1.0, 2.0, out, null, 0 ); // $ExpectError
+	minmax.assign( 1.0, 2.0, out, '5', 0 ); // $ExpectError
+	minmax.assign( 1.0, 2.0, out, [], 0 ); // $ExpectError
+	minmax.assign( 1.0, 2.0, out, {}, 0 ); // $ExpectError
 }
 
 // The compiler throws an error if the `assign` method is provided an invalid fifth argument...
 {
 	const out = [ 0.0, 0.0 ];
 
-	minmax.assign( 1.0, 2.0, 3.0, 4.0, false, out, 1, 0 ); // $ExpectError
-	minmax.assign( 1.0, 2.0, 3.0, 4.0, null, -0.2, 1.0, out, 1, 0 ); // $ExpectError
-	minmax.assign( 1.0, 2.0, 3.0, 4.0, {}, -0.2, -1.2, -4.0, 5.0, out, 1, 0 ); // $ExpectError
+	minmax.assign( 1.0, 2.0, out, 1, false ); // $ExpectError
+	minmax.assign( 1.0, 2.0, out, 1, null ); // $ExpectError
+	minmax.assign( 1.0, 2.0, out, 1, '5' ); // $ExpectError
+	minmax.assign( 1.0, 2.0, out, 1, [] ); // $ExpectError
+	minmax.assign( 1.0, 2.0, out, 1, {} ); // $ExpectError
 }
 
-// The compiler throws an error if the `assign` method is provided an invalid sixth argument...
+// The compiler throws an error if the function is provided an unsupported number of arguments...
 {
 	const out = [ 0.0, 0.0 ];
 
-	minmax.assign( 1.0, 2.0, 3.0, 4.0, 5.0, false, out, 1, 0 ); // $ExpectError
-	minmax.assign( 1.0, 2.0, 3.0, 4.0, 5.0, null, -0.2, 1.0, out, 1, 0 ); // $ExpectError
-	minmax.assign( 1.0, 2.0, 3.0, 4.0, 5.0, {}, -0.2, -1.2, -4.0, 5.0, out, 1, 0 ); // $ExpectError
+	minmax.assign( out, 1, 0 ); // $ExpectError
+	minmax.assign( 3.0, out, 1, 0 ); // $ExpectError
+	minmax.assign( 3.0, -0.2, 1.0, out, 1, 0 ); // $ExpectError
+	minmax.assign( 3.0, -0.2, -1.2, -4.0, out, 1, 0 ); // $ExpectError
+	minmax.assign( 3.0, -0.2, -1.2, -4.0, 5.0, out, 1, 0 ); // $ExpectError
+	minmax.assign( 3.0, -0.2, -1.2, -4.0, 5.0, 6.0, out, 1, 0 ); // $ExpectError
 }

--- a/lib/node_modules/@stdlib/math/base/special/minmax/lib/assign.js
+++ b/lib/node_modules/@stdlib/math/base/special/minmax/lib/assign.js
@@ -21,10 +21,7 @@
 // MODULES //
 
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
-var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var NINF = require( '@stdlib/constants/float64/ninf' );
-var PINF = require( '@stdlib/constants/float64/pinf' );
 
 
 // MAIN //
@@ -34,7 +31,7 @@ var PINF = require( '@stdlib/constants/float64/pinf' );
 *
 * @private
 * @param {number} x - first number
-* @param {number} [y] - second number
+* @param {number} y - second number
 * @param {Collection} out - output array
 * @param {integer} stride - output array stride
 * @param {NonNegativeInteger} offset - output array index offset
@@ -50,11 +47,6 @@ var PINF = require( '@stdlib/constants/float64/pinf' );
 *
 * @example
 * var out = [ 0.0, 0.0 ];
-* var v = minmax( 5.9, 3.14, 4.2, out, 1, 0 );
-* // returns [ 3.14, 5.9 ]
-*
-* @example
-* var out = [ 0.0, 0.0 ];
 * var v = minmax( 3.14, NaN, out, 1, 0 );
 * // returns [ NaN, NaN ]
 *
@@ -64,40 +56,13 @@ var PINF = require( '@stdlib/constants/float64/pinf' );
 * // returns [ -0.0, 0.0 ]
 */
 function minmax( x, y, out, stride, offset ) {
-	var len;
-	var min;
-	var max;
-	var v;
-	var i;
-
-	len = arguments.length;
-
-	out = arguments[ len - 3 ];
-	stride = arguments[ len - 2 ];
-	offset = arguments[ len - 1 ];
-
-	if ( len === 4 ) {
-		out[ offset ] = x;
-		out[ offset + stride ] = x;
+	if ( isnan( x ) || isnan( y ) ) {
+		out[ offset ] = NaN;
+		out[ offset + stride ] = NaN;
 		return out;
 	}
-	if ( len === 5 ) {
-		if ( isnan( x ) || isnan( y ) ) {
-			out[ offset ] = NaN;
-			out[ offset + stride ] = NaN;
-			return out;
-		}
-		if ( x === y && x === 0.0 ) {
-			if ( isNegativeZero( x ) ) {
-				out[ offset ] = x;
-				out[ offset + stride ] = y;
-				return out;
-			}
-			out[ offset ] = y;
-			out[ offset + stride ] = x;
-			return out;
-		}
-		if ( x < y ) {
+	if ( x === y && x === 0.0 ) {
+		if ( isNegativeZero( x ) ) {
 			out[ offset ] = x;
 			out[ offset + stride ] = y;
 			return out;
@@ -106,36 +71,13 @@ function minmax( x, y, out, stride, offset ) {
 		out[ offset + stride ] = x;
 		return out;
 	}
-	min = PINF;
-	max = NINF;
-	for ( i = 0; i < len - 3; i++ ) {
-		v = arguments[ i ];
-		if ( isnan( v ) ) {
-			out[ offset ] = NaN;
-			out[ offset + stride ] = NaN;
-			return out;
-		}
-		if ( v < min ) {
-			min = v;
-		} else if (
-			v === 0.0 &&
-			v === min &&
-			isNegativeZero( v )
-		) {
-			min = v;
-		}
-		if ( v > max ) {
-			max = v;
-		} else if (
-			v === 0.0 &&
-			v === max &&
-			isPositiveZero( v )
-		) {
-			max = v;
-		}
+	if ( x < y ) {
+		out[ offset ] = x;
+		out[ offset + stride ] = y;
+		return out;
 	}
-	out[ offset ] = min;
-	out[ offset + stride ] = max;
+	out[ offset ] = y;
+	out[ offset + stride ] = x;
 	return out;
 }
 

--- a/lib/node_modules/@stdlib/math/base/special/minmax/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/minmax/lib/index.js
@@ -29,17 +29,12 @@
 * var v = minmax( 3.14, 4.2 );
 * // returns [ 3.14, 4.2 ]
 *
-* v = minmax( 5.9, 3.14, 4.2 );
-* // returns [ 3.14, 5.9 ]
-*
 * v = minmax( 3.14, NaN );
 * // returns [ NaN, NaN ]
 *
 * v = minmax( +0.0, -0.0 );
 * // returns [ -0.0, 0.0 ]
 *
-* v = minmax( 3.14 );
-* // returns [ 3.14, 3.14 ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/math/base/special/minmax/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/minmax/lib/main.js
@@ -29,8 +29,7 @@ var assign = require( './assign.js' );
 * Returns the minimum and maximum values.
 *
 * @param {number} x - first number
-* @param {number} [y] - second number
-* @param {...number} [args] - numbers
+* @param {number} y - second number
 * @returns {Array<number>} minimum and maximum values
 *
 * @example
@@ -45,16 +44,8 @@ var assign = require( './assign.js' );
 * var v = minmax( +0.0, -0.0 );
 * // returns [ -0.0, 0.0 ]
 */
-function minmax() {
-	var args;
-	var i;
-
-	args = [];
-	for ( i = 0; i < arguments.length; i++ ) {
-		args.push( arguments[ i ] );
-	}
-	args.push( [ 0.0, 0.0 ], 1, 0 );
-	return assign.apply( null, args );
+function minmax( x, y ) {
+	return assign( x, y, [ 0.0, 0.0 ], 1, 0 );
 }
 
 

--- a/lib/node_modules/@stdlib/math/base/special/minmax/test/test.assign.js
+++ b/lib/node_modules/@stdlib/math/base/special/minmax/test/test.assign.js
@@ -60,30 +60,6 @@ tape( 'the function returns `NaN` for both the minimum and maximum value if prov
 	t.strictEqual( isnan( v[ 0 ] ), true, 'returns NaN' );
 	t.strictEqual( isnan( v[ 1 ] ), true, 'returns NaN' );
 
-	out = new Float64Array( 2 );
-	v = minmax( NaN, out, 1, 0 );
-	t.strictEqual( v, out, 'returns output array' );
-	t.strictEqual( isnan( v[ 0 ] ), true, 'returns NaN' );
-	t.strictEqual( isnan( v[ 1 ] ), true, 'returns NaN' );
-
-	out = new Float64Array( 2 );
-	v = minmax( 3.14, 4.2, NaN, out, 1, 0 );
-	t.strictEqual( v, out, 'returns output array' );
-	t.strictEqual( isnan( v[ 0 ] ), true, 'returns NaN' );
-	t.strictEqual( isnan( v[ 1 ] ), true, 'returns NaN' );
-
-	out = new Float64Array( 2 );
-	v = minmax( NaN, 4.2, NaN, out, 1, 0 );
-	t.strictEqual( v, out, 'returns output array' );
-	t.strictEqual( isnan( v[ 0 ] ), true, 'returns NaN' );
-	t.strictEqual( isnan( v[ 1 ] ), true, 'returns NaN' );
-
-	out = new Float64Array( 2 );
-	v = minmax( NaN, NaN, NaN, out, 1, 0 );
-	t.strictEqual( v, out, 'returns output array' );
-	t.strictEqual( isnan( v[ 0 ] ), true, 'returns NaN' );
-	t.strictEqual( isnan( v[ 1 ] ), true, 'returns NaN' );
-
 	t.end();
 });
 
@@ -103,18 +79,6 @@ tape( 'the function returns `-Infinity` as the minimum value if provided `-Infin
 	t.strictEqual( v[ 0 ], NINF, 'returns -infinity' );
 	t.strictEqual( v[ 1 ], 3.14, 'returns expected value' );
 
-	out = new Float64Array( 2 );
-	v = minmax( NINF, out, 1, 0 );
-	t.strictEqual( v, out, 'returns output array' );
-	t.strictEqual( v[ 0 ], NINF, 'returns -infinity' );
-	t.strictEqual( v[ 1 ], NINF, 'returns expected value' );
-
-	out = new Float64Array( 2 );
-	v = minmax( 3.14, 4.2, NINF, out, 1, 0 );
-	t.strictEqual( v, out, 'returns output array' );
-	t.strictEqual( v[ 0 ], NINF, 'returns -infinity' );
-	t.strictEqual( v[ 1 ], 4.2, 'returns expected value' );
-
 	t.end();
 });
 
@@ -130,18 +94,6 @@ tape( 'the function returns `+Infinity` as the maximum value if provided `+Infin
 
 	out = new Float64Array( 2 );
 	v = minmax( 3.14, PINF, out, 1, 0 );
-	t.strictEqual( v, out, 'returns output array' );
-	t.strictEqual( v[ 0 ], 3.14, 'returns expected value' );
-	t.strictEqual( v[ 1 ], PINF, 'returns +infinity' );
-
-	out = new Float64Array( 2 );
-	v = minmax( PINF, out, 1, 0 );
-	t.strictEqual( v, out, 'returns output array' );
-	t.strictEqual( v[ 0 ], PINF, 'returns expected value' );
-	t.strictEqual( v[ 1 ], PINF, 'returns +infinity' );
-
-	out = new Float64Array( 2 );
-	v = minmax( 3.14, 4.2, PINF, out, 1, 0 );
 	t.strictEqual( v, out, 'returns output array' );
 	t.strictEqual( v[ 0 ], 3.14, 'returns expected value' );
 	t.strictEqual( v[ 1 ], PINF, 'returns +infinity' );
@@ -177,24 +129,6 @@ tape( 'the function returns correctly signed zeros', function test( t ) {
 	t.strictEqual( isPositiveZero( v[ 0 ] ), true, 'returns +0' );
 	t.strictEqual( isPositiveZero( v[ 1 ] ), true, 'returns +0' );
 
-	out = new Float64Array( 2 );
-	v = minmax( -0.0, out, 1, 0 );
-	t.strictEqual( v, out, 'returns output array' );
-	t.strictEqual( isNegativeZero( v[ 0 ] ), true, 'returns -0' );
-	t.strictEqual( isNegativeZero( v[ 1 ] ), true, 'returns +0' );
-
-	out = new Float64Array( 2 );
-	v = minmax( +0.0, out, 1, 0 );
-	t.strictEqual( v, out, 'returns output array' );
-	t.strictEqual( isPositiveZero( v[ 0 ] ), true, 'returns +0' );
-	t.strictEqual( isPositiveZero( v[ 1 ] ), true, 'returns +0' );
-
-	out = new Float64Array( 2 );
-	v = minmax( +0.0, -0.0, +0.0, out, 1, 0 );
-	t.strictEqual( v, out, 'returns output array' );
-	t.strictEqual( isNegativeZero( v[ 0 ] ), true, 'returns -0' );
-	t.strictEqual( isPositiveZero( v[ 1 ] ), true, 'returns +0' );
-
 	t.end();
 });
 
@@ -213,30 +147,6 @@ tape( 'the function returns the minimum and maximum values', function test( t ) 
 	t.strictEqual( v, out, 'returns output array' );
 	t.strictEqual( v[ 0 ], -4.2, 'returns min value' );
 	t.strictEqual( v[ 1 ], 3.14, 'returns max value' );
-
-	out = new Float64Array( 2 );
-	v = minmax( 3.14, out, 1, 0 );
-	t.strictEqual( v, out, 'returns output array' );
-	t.strictEqual( v[ 0 ], 3.14, 'returns min value' );
-	t.strictEqual( v[ 1 ], 3.14, 'returns max value' );
-
-	out = new Float64Array( 2 );
-	v = minmax( PINF, out, 1, 0 );
-	t.strictEqual( v, out, 'returns output array' );
-	t.strictEqual( v[ 0 ], PINF, 'returns min value' );
-	t.strictEqual( v[ 1 ], PINF, 'returns max value' );
-
-	out = new Float64Array( 2 );
-	v = minmax( 4.2, 3.14, -1.0, out, 1, 0 );
-	t.strictEqual( v, out, 'returns output array' );
-	t.strictEqual( v[ 0 ], -1.0, 'returns min value' );
-	t.strictEqual( v[ 1 ], 4.2, 'returns max value' );
-
-	out = new Float64Array( 2 );
-	v = minmax( 4.2, 3.14, -1.0, -3.14, out, 1, 0 );
-	t.strictEqual( v, out, 'returns output array' );
-	t.strictEqual( v[ 0 ], -3.14, 'returns min value' );
-	t.strictEqual( v[ 1 ], 4.2, 'returns max value' );
 
 	t.end();
 });
@@ -257,30 +167,6 @@ tape( 'the function supports providing an output object (array)', function test(
 	t.strictEqual( v[ 0 ], -4.2, 'returns min value' );
 	t.strictEqual( v[ 1 ], 3.14, 'returns max value' );
 
-	out = [ 0.0, 0.0 ];
-	v = minmax( 3.14, out, 1, 0 );
-	t.strictEqual( v, out, 'returns output array' );
-	t.strictEqual( v[ 0 ], 3.14, 'returns min value' );
-	t.strictEqual( v[ 1 ], 3.14, 'returns max value' );
-
-	out = [ 0.0, 0.0 ];
-	v = minmax( PINF, out, 1, 0 );
-	t.strictEqual( v, out, 'returns output array' );
-	t.strictEqual( v[ 0 ], PINF, 'returns min value' );
-	t.strictEqual( v[ 1 ], PINF, 'returns max value' );
-
-	out = [ 0.0, 0.0 ];
-	v = minmax( 4.2, 3.14, -1.0, out, 1, 0 );
-	t.strictEqual( v, out, 'returns output array' );
-	t.strictEqual( v[ 0 ], -1.0, 'returns min value' );
-	t.strictEqual( v[ 1 ], 4.2, 'returns max value' );
-
-	out = [ 0.0, 0.0 ];
-	v = minmax( 4.2, 3.14, -1.0, -3.14, out, 1, 0 );
-	t.strictEqual( v, out, 'returns output array' );
-	t.strictEqual( v[ 0 ], -3.14, 'returns min value' );
-	t.strictEqual( v[ 1 ], 4.2, 'returns max value' );
-
 	t.end();
 });
 
@@ -299,30 +185,6 @@ tape( 'the function supports providing an output object (typed array)', function
 	t.strictEqual( v, out, 'returns output array' );
 	t.strictEqual( v[ 0 ], -4.2, 'returns min value' );
 	t.strictEqual( v[ 1 ], 3.14, 'returns max value' );
-
-	out = new Float64Array( 2 );
-	v = minmax( 3.14, out, 1, 0 );
-	t.strictEqual( v, out, 'returns output array' );
-	t.strictEqual( v[ 0 ], 3.14, 'returns min value' );
-	t.strictEqual( v[ 1 ], 3.14, 'returns max value' );
-
-	out = new Float64Array( 2 );
-	v = minmax( PINF, out, 1, 0 );
-	t.strictEqual( v, out, 'returns output array' );
-	t.strictEqual( v[ 0 ], PINF, 'returns min value' );
-	t.strictEqual( v[ 1 ], PINF, 'returns max value' );
-
-	out = new Float64Array( 2 );
-	v = minmax( 4.2, 3.14, -1.0, out, 1, 0 );
-	t.strictEqual( v, out, 'returns output array' );
-	t.strictEqual( v[ 0 ], -1.0, 'returns min value' );
-	t.strictEqual( v[ 1 ], 4.2, 'returns max value' );
-
-	out = new Float64Array( 2 );
-	v = minmax( 4.2, 3.14, -1.0, -3.14, out, 1, 0 );
-	t.strictEqual( v, out, 'returns output array' );
-	t.strictEqual( v[ 0 ], -3.14, 'returns min value' );
-	t.strictEqual( v[ 1 ], 4.2, 'returns max value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/minmax/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/base/special/minmax/test/test.main.js
@@ -52,22 +52,6 @@ tape( 'the function returns `NaN` for both the minimum and maximum value if prov
 	t.strictEqual( isnan( v[ 0 ] ), true, 'returns NaN' );
 	t.strictEqual( isnan( v[ 1 ] ), true, 'returns NaN' );
 
-	v = minmax( NaN );
-	t.strictEqual( isnan( v[ 0 ] ), true, 'returns NaN' );
-	t.strictEqual( isnan( v[ 1 ] ), true, 'returns NaN' );
-
-	v = minmax( 3.14, 4.2, NaN );
-	t.strictEqual( isnan( v[ 0 ] ), true, 'returns NaN' );
-	t.strictEqual( isnan( v[ 1 ] ), true, 'returns NaN' );
-
-	v = minmax( NaN, 4.2, NaN );
-	t.strictEqual( isnan( v[ 0 ] ), true, 'returns NaN' );
-	t.strictEqual( isnan( v[ 1 ] ), true, 'returns NaN' );
-
-	v = minmax( NaN, NaN, NaN );
-	t.strictEqual( isnan( v[ 0 ] ), true, 'returns NaN' );
-	t.strictEqual( isnan( v[ 1 ] ), true, 'returns NaN' );
-
 	t.end();
 });
 
@@ -82,14 +66,6 @@ tape( 'the function returns `-Infinity` as the minimum value if provided `-Infin
 	t.strictEqual( v[ 0 ], NINF, 'returns -infinity' );
 	t.strictEqual( v[ 1 ], 3.14, 'returns expected value' );
 
-	v = minmax( NINF );
-	t.strictEqual( v[ 0 ], NINF, 'returns -infinity' );
-	t.strictEqual( v[ 1 ], NINF, 'returns expected value' );
-
-	v = minmax( 3.14, 4.2, NINF );
-	t.strictEqual( v[ 0 ], NINF, 'returns -infinity' );
-	t.strictEqual( v[ 1 ], 4.2, 'returns expected value' );
-
 	t.end();
 });
 
@@ -101,14 +77,6 @@ tape( 'the function returns `+Infinity` as the maximum value if provided `+Infin
 	t.strictEqual( v[ 1 ], PINF, 'returns +infinity' );
 
 	v = minmax( 3.14, PINF );
-	t.strictEqual( v[ 0 ], 3.14, 'returns expected value' );
-	t.strictEqual( v[ 1 ], PINF, 'returns +infinity' );
-
-	v = minmax( PINF );
-	t.strictEqual( v[ 0 ], PINF, 'returns expected value' );
-	t.strictEqual( v[ 1 ], PINF, 'returns +infinity' );
-
-	v = minmax( 3.14, 4.2, PINF );
 	t.strictEqual( v[ 0 ], 3.14, 'returns expected value' );
 	t.strictEqual( v[ 1 ], PINF, 'returns +infinity' );
 
@@ -134,18 +102,6 @@ tape( 'the function returns correctly signed zeros', function test( t ) {
 	t.strictEqual( isPositiveZero( v[ 0 ] ), true, 'returns +0' );
 	t.strictEqual( isPositiveZero( v[ 1 ] ), true, 'returns +0' );
 
-	v = minmax( -0.0 );
-	t.strictEqual( isNegativeZero( v[ 0 ] ), true, 'returns -0' );
-	t.strictEqual( isNegativeZero( v[ 1 ] ), true, 'returns +0' );
-
-	v = minmax( +0.0 );
-	t.strictEqual( isPositiveZero( v[ 0 ] ), true, 'returns +0' );
-	t.strictEqual( isPositiveZero( v[ 1 ] ), true, 'returns +0' );
-
-	v = minmax( +0.0, -0.0, +0.0 );
-	t.strictEqual( isNegativeZero( v[ 0 ] ), true, 'returns -0' );
-	t.strictEqual( isPositiveZero( v[ 1 ] ), true, 'returns +0' );
-
 	t.end();
 });
 
@@ -159,22 +115,6 @@ tape( 'the function returns the minimum and maximum values', function test( t ) 
 	v = minmax( -4.2, 3.14 );
 	t.strictEqual( v[ 0 ], -4.2, 'returns min value' );
 	t.strictEqual( v[ 1 ], 3.14, 'returns max value' );
-
-	v = minmax( 3.14 );
-	t.strictEqual( v[ 0 ], 3.14, 'returns min value' );
-	t.strictEqual( v[ 1 ], 3.14, 'returns max value' );
-
-	v = minmax( PINF );
-	t.strictEqual( v[ 0 ], PINF, 'returns min value' );
-	t.strictEqual( v[ 1 ], PINF, 'returns max value' );
-
-	v = minmax( 4.2, 3.14, -1.0 );
-	t.strictEqual( v[ 0 ], -1.0, 'returns min value' );
-	t.strictEqual( v[ 1 ], 4.2, 'returns max value' );
-
-	v = minmax( 4.2, 3.14, -1.0, -3.14 );
-	t.strictEqual( v[ 0 ], -3.14, 'returns min value' );
-	t.strictEqual( v[ 1 ], 4.2, 'returns max value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/minmaxn/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/minmaxn/README.md
@@ -1,0 +1,166 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2018 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# minmaxn
+
+> Return the minimum and maximum values.
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var minmaxn = require( '@stdlib/math/base/special/minmaxn' );
+```
+
+#### minmaxn( x\[, y\[, ...args]] )
+
+Returns the minimum and maximum values in a single pass.
+
+```javascript
+var v = minmaxn( 4.2, 3.14 );
+// returns [ 3.14, 4.2 ]
+
+v = minmaxn( +0.0, -0.0 );
+// returns [ -0.0, +0.0 ]
+
+v = minmaxn( 4.2, 3.14, -1.0, 6.8 );
+// returns [ -1.0, 6.8 ]
+```
+
+If any argument is `NaN`, the function returns `NaN` for both the minimum value and the maximum value.
+
+```javascript
+var v = minmaxn( 4.2, NaN );
+// returns [ NaN, NaN ]
+
+v = minmaxn( NaN, 3.14 );
+// returns [ NaN, NaN ]
+```
+
+#### minmaxn.assign( x\[, y\[, ...args]], out, stride, offset )
+
+Returns the minimum and maximum values in a single pass and assigns results to a provided output array.
+
+```javascript
+var Float64Array = require( '@stdlib/array/float64' );
+
+var out = new Float64Array( 2 );
+
+var v = minmaxn.assign( 5.0, 3.0, -2.0, 1.0, out, 1, 0 );
+// returns <Float64Array>[ -2.0, 5.0 ]
+
+var bool = ( v === out );
+// returns true
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var minstd = require( '@stdlib/random/base/minstd-shuffle' );
+var minmaxn = require( '@stdlib/math/base/special/minmaxn' );
+
+var x;
+var y;
+var v;
+var i;
+
+for ( i = 0; i < 100; i++ ) {
+    x = minstd();
+    y = minstd();
+    v = minmaxn( x, y );
+    console.log( 'minmax(%d,%d) = [%d, %d]', x, y, v[0], v[1] );
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/math/base/special/max`][@stdlib/math/base/special/max]</span><span class="delimiter">: </span><span class="description">return the maximum value.</span>
+-   <span class="package-name">[`@stdlib/math/base/special/min`][@stdlib/math/base/special/min]</span><span class="delimiter">: </span><span class="description">return the minimum value.</span>
+-   <span class="package-name">[`@stdlib/math/base/special/minmaxabs`][@stdlib/math/base/special/minmaxabs]</span><span class="delimiter">: </span><span class="description">return the minimum and maximum absolute values.</span>
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+<!-- <related-links> -->
+
+[@stdlib/math/base/special/max]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/max
+
+[@stdlib/math/base/special/min]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/min
+
+[@stdlib/math/base/special/minmaxabs]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/minmaxabs
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->
+

--- a/lib/node_modules/@stdlib/math/base/special/minmaxn/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/minmaxn/benchmark/benchmark.js
@@ -1,0 +1,130 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var isArray = require( '@stdlib/assert/is-array' );
+var min = require( '@stdlib/math/base/special/min' );
+var max = require( '@stdlib/math/base/special/max' );
+var pkg = require( './../package.json' ).name;
+var minmaxn = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var x;
+	var y;
+	var z;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		x = ( randu()*1000.0 ) - 500.0;
+		y = ( randu()*1000.0 ) - 500.0;
+		z = minmaxn( x, y );
+		if ( z.length !== 2 ) {
+			b.fail( 'should have expected length' );
+		}
+	}
+	b.toc();
+	if ( !isArray( z ) ) {
+		b.fail( 'should return an array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+':assign', function benchmark( b ) {
+	var out;
+	var x;
+	var y;
+	var z;
+	var i;
+
+	out = [ 0.0, 0.0 ];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		x = ( randu()*1000.0 ) - 500.0;
+		y = ( randu()*1000.0 ) - 500.0;
+		z = minmaxn.assign( x, y, out, 1, 0 );
+		if ( z.length !== 2 ) {
+			b.fail( 'should have expected length' );
+		}
+	}
+	b.toc();
+	if ( !isArray( z ) ) {
+		b.fail( 'should return an array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::min,max', function benchmark( b ) {
+	var x;
+	var y;
+	var z;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		x = ( randu()*1000.0 ) - 500.0;
+		y = ( randu()*1000.0 ) - 500.0;
+		z = [ min( x, y ), max( x, y ) ];
+		if ( z.length !== 2 ) {
+			b.fail( 'should have expected length' );
+		}
+	}
+	b.toc();
+	if ( !isArray( z ) ) {
+		b.fail( 'should return an array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::min,max,memory_reuse', function benchmark( b ) {
+	var x;
+	var y;
+	var z;
+	var i;
+
+	z = [ 0.0, 0.0 ];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		x = ( randu()*1000.0 ) - 500.0;
+		y = ( randu()*1000.0 ) - 500.0;
+		z[ 0 ] = min( x, y );
+		z[ 1 ] = max( x, y );
+		if ( z.length !== 2 ) {
+			b.fail( 'should have expected length' );
+		}
+	}
+	b.toc();
+	if ( !isArray( z ) ) {
+		b.fail( 'should return an array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/minmaxn/benchmark/julia/REQUIRE
+++ b/lib/node_modules/@stdlib/math/base/special/minmaxn/benchmark/julia/REQUIRE
@@ -1,0 +1,2 @@
+julia 1.5
+BenchmarkTools 0.5.0

--- a/lib/node_modules/@stdlib/math/base/special/minmaxn/benchmark/julia/benchmark.jl
+++ b/lib/node_modules/@stdlib/math/base/special/minmaxn/benchmark/julia/benchmark.jl
@@ -1,0 +1,144 @@
+#!/usr/bin/env julia
+#
+# @license Apache-2.0
+#
+# Copyright (c) 2018 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import BenchmarkTools
+using Printf
+
+# Benchmark variables:
+name = "minmax";
+repeats = 3;
+
+"""
+	print_version()
+
+Prints the TAP version.
+
+# Examples
+
+``` julia
+julia> print_version()
+```
+"""
+function print_version()
+	@printf( "TAP version 13\n" );
+end
+
+"""
+	print_summary( total, passing )
+
+Print the benchmark summary.
+
+# Arguments
+
+* `total`: total number of tests
+* `passing`: number of passing tests
+
+# Examples
+
+``` julia
+julia> print_summary( 3, 3 )
+```
+"""
+function print_summary( total, passing )
+	@printf( "#\n" );
+	@printf( "1..%d\n", total ); # TAP plan
+	@printf( "# total %d\n", total );
+	@printf( "# pass  %d\n", passing );
+	@printf( "#\n" );
+	@printf( "# ok\n" );
+end
+
+"""
+	print_results( iterations, elapsed )
+
+Print benchmark results.
+
+# Arguments
+
+* `iterations`: number of iterations
+* `elapsed`: elapsed time (in seconds)
+
+# Examples
+
+``` julia
+julia> print_results( 1000000, 0.131009101868 )
+```
+"""
+function print_results( iterations, elapsed )
+	rate = iterations / elapsed
+
+	@printf( "  ---\n" );
+	@printf( "  iterations: %d\n", iterations );
+	@printf( "  elapsed: %0.9f\n", elapsed );
+	@printf( "  rate: %0.9f\n", rate );
+	@printf( "  ...\n" );
+end
+
+"""
+	benchmark()
+
+Run a benchmark.
+
+# Notes
+
+* Benchmark results are returned as a two-element array: [ iterations, elapsed ].
+* The number of iterations is not the true number of iterations. Instead, an 'iteration' is defined as a 'sample', which is a computed estimate for a single evaluation.
+* The elapsed time is in seconds.
+
+# Examples
+
+``` julia
+julia> out = benchmark();
+```
+"""
+function benchmark()
+	t = BenchmarkTools.@benchmark minmax( (1000.0*rand()) - 500.0, (1000.0*rand()) - 500.0 ) samples=1e6
+
+	# Compute the total "elapsed" time and convert from nanoseconds to seconds:
+	s = sum( t.times ) / 1.0e9;
+
+	# Determine the number of "iterations":
+	iter = length( t.times );
+
+	# Return the results:
+	[ iter, s ];
+end
+
+"""
+	main()
+
+Run benchmarks.
+
+# Examples
+
+``` julia
+julia> main();
+```
+"""
+function main()
+	print_version();
+	for i in 1:repeats
+		@printf( "# julia::%s\n", name );
+		results = benchmark();
+		print_results( results[ 1 ], results[ 2 ] );
+		@printf( "ok %d benchmark finished\n", i );
+	end
+	print_summary( repeats, repeats );
+end
+
+main();

--- a/lib/node_modules/@stdlib/math/base/special/minmaxn/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/minmaxn/docs/repl.txt
@@ -1,0 +1,79 @@
+
+{{alias}}( x[, y[, ...args]] )
+    Returns the minimum and maximum values.
+
+    If any argument is `NaN`, the function returns `NaN` for both the minimum
+    and maximum values.
+
+    Parameters
+    ----------
+    x: number
+        First number.
+
+    y: number (optional)
+        Second number.
+
+    args: ...number (optional)
+        Numbers.
+
+    Returns
+    -------
+    out: Array<number>
+        Minimum and maximum values.
+
+    Examples
+    --------
+    > var v = {{alias}}( 3.14, 4.2 )
+    [ 3.14, 4.2 ]
+    > v = {{alias}}( 5.9, 3.14, 4.2 )
+    [ 3.14, 5.9 ]
+    > v = {{alias}}( 3.14, NaN )
+    [ NaN, NaN ]
+    > v = {{alias}}( +0.0, -0.0 )
+    [ -0.0, +0.0 ]
+    > v = {{alias}}( 3.14 )
+    [ 3.14, 3.14 ]
+
+
+{{alias}}.assign( x[, y[, ...args]], out, stride, offset )
+    Returns the minimum and maximum values and assigns results to a provided
+    output array.
+
+    If any argument is `NaN`, the function returns `NaN` for both the minimum
+    and maximum values.
+
+    Parameters
+    ----------
+    x: number
+        First number.
+
+    y: number (optional)
+        Second number.
+
+    args: ...number (optional)
+        Numbers.
+
+    out: Array|TypedArray|Object
+        Output object.
+
+    stride: integer
+        Output array stride.
+
+    offset: integer
+        Output array index offset.
+
+    Returns
+    -------
+    out: Array|TypedArray|Object
+        Minimum and maximum values.
+
+    Examples
+    --------
+    > var out = [ 0.0, 0.0 ];
+    > var v = {{alias}}.assign( 3.14, -1.5, out, 1, 0 )
+    [ -1.5, 3.14 ]
+    > var bool = ( v === out )
+    true
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/math/base/special/minmaxn/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/minmaxn/docs/types/index.d.ts
@@ -1,0 +1,306 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2019 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 2.0
+
+/// <reference types="@stdlib/types"/>
+
+import { Collection } from '@stdlib/types/object';
+
+/**
+ * Interface describing an interface for computing minimum and maximum values.
+ */
+ interface MinMaxN {
+	/**
+	* Returns the minimum and maximum values.
+	*
+	* @returns minimum and maximum values
+	*
+	* @example
+	* var v = minmaxn();
+	* // returns [ Infinity, -Infinity ]
+	*/
+	(): Array<number>;
+
+	/**
+	* Returns the minimum and maximum values.
+	*
+	* @param x - first number
+	* @returns minimum and maximum values
+	*
+	* @example
+	* var v = minmaxn( 3.14 );
+	* // returns [ 3.14, 3.14 ]
+	*/
+	( x: number ): Array<number>; // tslint:disable-line unified-signatures
+	/**
+	* Returns the minimum and maximum values.
+	*
+	* @param x - first number
+	* @param y - second number
+	* @returns minimum and maximum values
+	*
+	* @example
+	* var v = minmaxn( 3.14, 4.2 );
+	* // returns [ 3.14, 4.2 ]
+	*
+	* var v = minmaxn( 3.14, NaN );
+	* // returns [ NaN, NaN ]
+	*
+	* @example
+	* var v = minmaxn( +0.0, -0.0 );
+	* // returns [ -0.0, 0.0 ]
+	*/
+	( x: number, y: number ): Array<number>; // tslint:disable-line unified-signatures
+
+	/**
+	* Returns the minimum and maximum values.
+	*
+	* @param x - first number
+	* @param y - second number
+	* @param z - third number
+	* @returns minimum and maximum values
+	*
+	* @example
+	* var v = minmaxn( 3.14, 4.2, -1.0 );
+	* // returns [ -1.0, 4.2 ]
+	*/
+	( x: number, y: number, z: number ): Array<number>; // tslint:disable-line unified-signatures
+
+	/**
+	* Returns the minimum and maximum values.
+	*
+	* @param x - first number
+	* @param y - second number
+	* @param z - third number
+	* @param w - fourth number
+	* @returns minimum and maximum values
+	*
+	* @example
+	* var v = minmaxn( 3.14, 4.2, -1.0, 2.0 );
+	* // returns [ -1.0, 4.2 ]
+	*/
+	( x: number, y: number, z: number, w: number ): Array<number>; // tslint:disable-line unified-signatures
+
+	/**
+	* Returns the minimum and maximum values.
+	*
+	* @param x - first number
+	* @param y - second number
+	* @param z - third number
+	* @param w - fourth number
+	* @param v - fifth number
+	* @returns minimum and maximum values
+	*
+	* @example
+	* var v = minmaxn( 3.14, 4.2, -1.0, 2.0, 1.0 );
+	* // returns [ -1.0, 4.2 ]
+	*/
+	( x: number, y: number, z: number, w: number, v: number ): Array<number>; // tslint:disable-line unified-signatures
+
+	/**
+	* Returns the minimum and maximum values.
+	*
+	* @param x - first number
+	* @param y - second number
+	* @param args - numbers
+	* @returns minimum and maximum values
+	*
+	* @example
+	* var v = minmaxn( 3.14, 4.2 );
+	* // returns [ 3.14, 4.2 ]
+	*
+	* var v = minmaxn( 3.14, NaN );
+	* // returns [ NaN, NaN ]
+	*
+	* @example
+	* var v = minmaxn( +0.0, -0.0 );
+	* // returns [ -0.0, 0.0 ]
+	*/
+	( x: number, y: number, ...args: Array<number> ): Array<number>; // tslint:disable-line unified-signatures
+
+	/**
+	* Returns the minimum and maximum values and assigns results to a provided output array.
+	*
+	* @param out - output object
+	* @param stride - output array stride
+	* @param offset - output array index offset
+	* @returns minimum and maximum values
+	*
+	* @example
+	* var out = [ 0.0, 0.0 ];
+	* var v = minmaxn( out, 1, 0 );
+	* // returns [ Infinity, -Infinity ]
+	*
+	* var bool = ( v === out );
+	* // returns true
+	*/
+	assign( out: Collection, stride: number, offset: number ): Collection;
+
+	/**
+	* Returns the minimum and maximum values and assigns results to a provided output array.
+	*
+	* @param x - first number
+	* @param out - output object
+	* @param stride - output array stride
+	* @param offset - output array index offset
+	* @returns minimum and maximum values
+	*
+	* @example
+	* var out = [ 0.0, 0.0 ];
+	* var v = minmaxn( 5.9, out, 1, 0 );
+	* // returns [ 5.9, 5.9 ]
+	*
+	* var bool = ( v === out );
+	* // returns true
+	*/
+	assign( x: number, out: Collection, stride: number, offset: number ): Collection; // tslint-disable-line max-line-length
+
+	/**
+	* Returns the minimum and maximum values and assigns results to a provided output array.
+	*
+	* @param x - first number
+	* @param y - second number
+	* @param out - output object
+	* @param stride - output array stride
+	* @param offset - output array index offset
+	* @returns minimum and maximum values
+	*
+	* @example
+	* var out = [ 0.0, 0.0 ];
+	* var v = minmaxn( 5.9, 3.14, out, 1, 0 );
+	* // returns [ 3.14, 5.9 ]
+	*
+	* var bool = ( v === out );
+	* // returns true
+	*/
+	assign( x: number, y: number, out: Collection, stride: number, offset: number ): Collection; // tslint-disable-line max-line-length
+
+	/**
+	* Returns the minimum and maximum values and assigns results to a provided output array.
+	*
+	* @param x - first number
+	* @param y - second number
+	* @param z - third number
+	* @param out - output object
+	* @param stride - output array stride
+	* @param offset - output array index offset
+	* @returns minimum and maximum values
+	*
+	* @example
+	* var out = [ 0.0, 0.0 ];
+	* var v = minmaxn( 5.9, 3.14, 4.2, out, 1, 0 );
+	* // returns [ 3.14, 5.9 ]
+	*
+	* var bool = ( v === out );
+	* // returns true
+	*/
+	assign( x: number, y: number, z: number, out: Collection, stride: number, offset: number ): Collection; // tslint-disable-line max-line-length
+
+	/**
+	* Returns the minimum and maximum values and assigns results to a provided output array.
+	*
+	* @param x - first number
+	* @param y - second number
+	* @param z - third number
+	* @param w - fourth number
+	* @param out - output object
+	* @param stride - output array stride
+	* @param offset - output array index offset
+	* @returns minimum and maximum values
+	*
+	* @example
+	* var out = [ 0.0, 0.0 ];
+	* var v = minmaxn( 5.9, 3.14, 4.2, 3.9, out, 1, 0 );
+	* // returns [ 3.14, 5.9 ]
+	*
+	* var bool = ( v === out );
+	* // returns true
+	*/
+	assign( x: number, y: number, z: number, w: number, out: Collection, stride: number, offset: number ): Collection; // tslint-disable-line max-line-length
+
+	/**
+	* Returns the minimum and maximum values and assigns results to a provided output array.
+	*
+	* @param x - first number
+	* @param y - second number
+	* @param z - third number
+	* @param w - fourth number
+	* @param v - fifth number
+	* @param out - output object
+	* @param stride - output array stride
+	* @param offset - output array index offset
+	* @returns minimum and maximum values
+	*
+	* @example
+	* var out = [ 0.0, 0.0 ];
+	* var v = minmaxn( 5.9, 3.14, 4.2, 3.9, 3.8, out, 1, 0 );
+	* // returns [ 3.14, 5.9 ]
+	*
+	* var bool = ( v === out );
+	* // returns true
+	*/
+	assign( x: number, y: number, z: number, w: number, v: number, out: Collection, stride: number, offset: number ): Collection; // tslint-disable-line max-line-length
+
+	/**
+	* Returns the minimum and maximum values and assigns results to a provided output array.
+	*
+	* @param x - first number
+	* @param y - second number
+	* @param args - numbers
+	* @param out - output object
+	* @param stride - output array stride
+	* @param offset - output array index offset
+	* @returns minimum and maximum values
+	*
+	* @example
+	* var out = [ 0.0, 0.0 ];
+	* var v = minmaxn( 5.9, 3.14, 4.2, 3.9, 3.8, 3.7, out, 1, 0 );
+	* // returns [ 3.14, 5.9 ]
+	*
+	* var bool = ( v === out );
+	* // returns true
+	*/
+	assign( x: number, y: number, ...args: Array<number|Collection> ): Collection; // tslint-disable-line max-line-length
+}
+
+/**
+* Returns the minimum and maximum values.
+*
+* @param x - first number
+* @param y - second number
+* @param args - numbers
+* @returns minimum and maximum values
+*
+* @example
+* var v = minmaxn( 3.14, 4.2 );
+* // returns [ 3.14, 4.2 ]
+*
+* var v = minmaxn( 3.14, NaN );
+* // returns [ NaN, NaN ]
+*
+* @example
+* var v = minmaxn( +0.0, -0.0 );
+* // returns [ -0.0, 0.0 ]
+*/
+declare var minmaxn: MinMaxN;
+
+
+// EXPORTS //
+
+export = minmaxn;

--- a/lib/node_modules/@stdlib/math/base/special/minmaxn/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/math/base/special/minmaxn/docs/types/test.ts
@@ -1,0 +1,159 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2019 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import minmaxn = require( './index' );
+
+
+// TESTS //
+
+// The function returns an array of numbers...
+{
+	minmaxn(); // $ExpectType number[]
+	minmaxn( -0.2 ); // $ExpectType number[]
+	minmaxn( 3.0, -0.2 ); // $ExpectType number[]
+	minmaxn( 3.0, -0.2, 1.0 ); // $ExpectType number[]
+	minmaxn( 3.0, -0.2, -1.2, -4.0 ); // $ExpectType number[]
+	minmaxn( 3.0, -0.2, -1.2, -4.0, 5.0 ); // $ExpectType number[]
+	minmaxn( 3.0, -0.2, -1.2, -4.0, 5.0, 6.0 ); // $ExpectType number[]
+}
+
+// The compiler throws an error if the function is provided an argument which is not a number...
+{
+	minmaxn( true ); // $ExpectError
+	minmaxn( false ); // $ExpectError
+	minmaxn( [] ); // $ExpectError
+	minmaxn( {} ); // $ExpectError
+	minmaxn( 'abc' ); // $ExpectError
+	minmaxn( ( x: number ): number => x ); // $ExpectError
+
+	minmaxn( 1.2, true ); // $ExpectError
+	minmaxn( 1.2, false ); // $ExpectError
+	minmaxn( 1.2, [] ); // $ExpectError
+	minmaxn( 1.2, {} ); // $ExpectError
+	minmaxn( 1.2, 'abc' ); // $ExpectError
+	minmaxn( 1.2, ( x: number ): number => x ); // $ExpectError
+
+	minmaxn( 1.2, 3.0, true ); // $ExpectError
+	minmaxn( 1.2, 3.0, false ); // $ExpectError
+	minmaxn( 1.2, 3.0, [] ); // $ExpectError
+	minmaxn( 1.2, 3.0, {} ); // $ExpectError
+	minmaxn( 1.2, 3.0, 'abc' ); // $ExpectError
+	minmaxn( 1.2, 3.0, ( x: number ): number => x ); // $ExpectError
+
+	minmaxn( 1.2, 3.0, 4.0, true ); // $ExpectError
+	minmaxn( 1.2, 3.0, 4.0, false ); // $ExpectError
+	minmaxn( 1.2, 3.0, 4.0, [] ); // $ExpectError
+	minmaxn( 1.2, 3.0, 4.0, {} ); // $ExpectError
+	minmaxn( 1.2, 3.0, 4.0, 'abc' ); // $ExpectError
+	minmaxn( 1.2, 3.0, 4.0, ( x: number ): number => x ); // $ExpectError
+
+	minmaxn( 1.2, 3.0, 4.0, 5.0, true ); // $ExpectError
+	minmaxn( 1.2, 3.0, 4.0, 5.0, false ); // $ExpectError
+	minmaxn( 1.2, 3.0, 4.0, 5.0, [] ); // $ExpectError
+	minmaxn( 1.2, 3.0, 4.0, 5.0, {} ); // $ExpectError
+	minmaxn( 1.2, 3.0, 4.0, 5.0, 'abc' ); // $ExpectError
+	minmaxn( 1.2, 3.0, 4.0, 5.0, ( x: number ): number => x ); // $ExpectError
+
+	minmaxn( 1.2, 3.0, 4.0, 5.0, 6.0, true ); // $ExpectError
+	minmaxn( 1.2, 3.0, 4.0, 5.0, 6.0, false ); // $ExpectError
+	minmaxn( 1.2, 3.0, 4.0, 5.0, 6.0, [] ); // $ExpectError
+	minmaxn( 1.2, 3.0, 4.0, 5.0, 6.0, {} ); // $ExpectError
+	minmaxn( 1.2, 3.0, 4.0, 5.0, 6.0, 'abc' ); // $ExpectError
+	minmaxn( 1.2, 3.0, 4.0, 5.0, 6.0, ( x: number ): number => x ); // $ExpectError
+
+	minmaxn( 1.2, 3.0, 4.0, 5.0, 6.0, 7.0, true ); // $ExpectError
+	minmaxn( 1.2, 3.0, 4.0, 5.0, 6.0, 7.0, false ); // $ExpectError
+	minmaxn( 1.2, 3.0, 4.0, 5.0, 6.0, 7.0, [] ); // $ExpectError
+	minmaxn( 1.2, 3.0, 4.0, 5.0, 6.0, 7.0, {} ); // $ExpectError
+	minmaxn( 1.2, 3.0, 4.0, 5.0, 6.0, 7.0, 'abc' ); // $ExpectError
+	minmaxn( 1.2, 3.0, 4.0, 5.0, 6.0, 7.0, ( x: number ): number => x ); // $ExpectError
+}
+
+// Attached to the main export is an `assign` method which returns an array-like object containing numbers...
+{
+	const out = [ 0.0, 0.0 ];
+
+	minmaxn.assign( out, 1, 0 ); // $ExpectType Collection
+	minmaxn.assign( 3.0, out, 1, 0 ); // $ExpectType Collection
+	minmaxn.assign( 3.0, -0.2, out, 1, 0 ); // $ExpectType Collection
+	minmaxn.assign( 3.0, -0.2, 1.0, out, 1, 0 ); // $ExpectType Collection
+	minmaxn.assign( 3.0, -0.2, -1.2, -4.0, out, 1, 0 ); // $ExpectType Collection
+	minmaxn.assign( 3.0, -0.2, -1.2, -4.0, 5.0, out, 1, 0 ); // $ExpectType Collection
+	minmaxn.assign( 3.0, -0.2, -1.2, -4.0, 5.0, 6.0, out, 1, 0 ); // $ExpectType Collection
+}
+
+// The compiler throws an error if the `assign` method is provided a first argument which is not a number...
+{
+	const out = [ 0.0, 0.0 ];
+
+	minmaxn.assign( true, out, 1, 0 ); // $ExpectError
+	minmaxn.assign( false, out, 1, 0 ); // $ExpectError
+	minmaxn.assign( '5', -0.2, out, 1, 0 ); // $ExpectError
+	minmaxn.assign( null, -0.2, 1.0, out, 1, 0 ); // $ExpectError
+	minmaxn.assign( [], -0.2, -1.2, -4.0, out, 1, 0 ); // $ExpectError
+	minmaxn.assign( {}, -0.2, -1.2, -4.0, 5.0, out, 1, 0 ); // $ExpectError
+	minmaxn.assign( ( x: number ): number => x, -0.2, -1.2, -4.0, 5.0, 6.0, out, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `assign` method is provided a second argument which is not a number...
+{
+	const out = [ 0.0, 0.0 ];
+
+	minmaxn.assign( 1.0, false, out, 1, 0 ); // $ExpectError
+	minmaxn.assign( 1.0, '5', -0.2, out, 1, 0 ); // $ExpectError
+	minmaxn.assign( 1.0, null, -0.2, 1.0, out, 1, 0 ); // $ExpectError
+	minmaxn.assign( 1.0, [], -0.2, -1.2, -4.0, out, 1, 0 ); // $ExpectError
+	minmaxn.assign( 1.0, {}, -0.2, -1.2, -4.0, 5.0, out, 1, 0 ); // $ExpectError
+	minmaxn.assign( 1.0, ( x: number ): number => x, -0.2, -1.2, -4.0, 5.0, 6.0, out, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `assign` method is provided an invalid third argument...
+{
+	const out = [ 0.0, 0.0 ];
+
+	minmaxn.assign( 1.0, 2.0, false, out, 1, 0 ); // $ExpectError
+	minmaxn.assign( 1.0, 2.0, null, -0.2, 1.0, out, 1, 0 ); // $ExpectError
+	minmaxn.assign( 1.0, 2.0, {}, -0.2, -1.2, -4.0, 5.0, out, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `assign` method is provided an invalid fourth argument...
+{
+	const out = [ 0.0, 0.0 ];
+
+	minmaxn.assign( 1.0, 2.0, 3.0, false, out, 1, 0 ); // $ExpectError
+	minmaxn.assign( 1.0, 2.0, 3.0, null, -0.2, 1.0, out, 1, 0 ); // $ExpectError
+	minmaxn.assign( 1.0, 2.0, 3.0, {}, -0.2, -1.2, -4.0, 5.0, out, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `assign` method is provided an invalid fifth argument...
+{
+	const out = [ 0.0, 0.0 ];
+
+	minmaxn.assign( 1.0, 2.0, 3.0, 4.0, false, out, 1, 0 ); // $ExpectError
+	minmaxn.assign( 1.0, 2.0, 3.0, 4.0, null, -0.2, 1.0, out, 1, 0 ); // $ExpectError
+	minmaxn.assign( 1.0, 2.0, 3.0, 4.0, {}, -0.2, -1.2, -4.0, 5.0, out, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `assign` method is provided an invalid sixth argument...
+{
+	const out = [ 0.0, 0.0 ];
+
+	minmaxn.assign( 1.0, 2.0, 3.0, 4.0, 5.0, false, out, 1, 0 ); // $ExpectError
+	minmaxn.assign( 1.0, 2.0, 3.0, 4.0, 5.0, null, -0.2, 1.0, out, 1, 0 ); // $ExpectError
+	minmaxn.assign( 1.0, 2.0, 3.0, 4.0, 5.0, {}, -0.2, -1.2, -4.0, 5.0, out, 1, 0 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/math/base/special/minmaxn/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/minmaxn/examples/index.js
@@ -1,0 +1,34 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var minstd = require( '@stdlib/random/base/minstd-shuffle' );
+var minmaxn = require( './../lib' );
+
+var x;
+var y;
+var v;
+var i;
+
+for ( i = 0; i < 100; i++ ) {
+	x = minstd();
+	y = minstd();
+	v = minmaxn( x, y );
+	console.log( 'minmax(%d,%d) = [%d, %d]', x, y, v[0], v[1] );
+}

--- a/lib/node_modules/@stdlib/math/base/special/minmaxn/lib/assign.js
+++ b/lib/node_modules/@stdlib/math/base/special/minmaxn/lib/assign.js
@@ -1,0 +1,145 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
+var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+
+
+// MAIN //
+
+/**
+* Returns the minimum and maximum values and assigns results to a provided output array.
+*
+* @private
+* @param {number} x - first number
+* @param {number} [y] - second number
+* @param {Collection} out - output array
+* @param {integer} stride - output array stride
+* @param {NonNegativeInteger} offset - output array index offset
+* @returns {Collection} minimum and maximum values
+*
+* @example
+* var out = [ 0.0, 0.0 ];
+* var v = minmaxn( 3.14, 4.2, out, 1, 0 );
+* // returns [ 3.14, 4.2 ]
+*
+* var bool = ( v === out );
+* // returns true
+*
+* @example
+* var out = [ 0.0, 0.0 ];
+* var v = minmaxn( 5.9, 3.14, 4.2, out, 1, 0 );
+* // returns [ 3.14, 5.9 ]
+*
+* @example
+* var out = [ 0.0, 0.0 ];
+* var v = minmaxn( 3.14, NaN, out, 1, 0 );
+* // returns [ NaN, NaN ]
+*
+* @example
+* var out = [ 0.0, 0.0 ];
+* var v = minmaxn( +0.0, -0.0, out, 1, 0 );
+* // returns [ -0.0, 0.0 ]
+*/
+function minmaxn( x, y, out, stride, offset ) {
+	var len;
+	var min;
+	var max;
+	var v;
+	var i;
+
+	len = arguments.length;
+
+	out = arguments[ len - 3 ];
+	stride = arguments[ len - 2 ];
+	offset = arguments[ len - 1 ];
+
+	if ( len === 4 ) {
+		out[ offset ] = x;
+		out[ offset + stride ] = x;
+		return out;
+	}
+	if ( len === 5 ) {
+		if ( isnan( x ) || isnan( y ) ) {
+			out[ offset ] = NaN;
+			out[ offset + stride ] = NaN;
+			return out;
+		}
+		if ( x === y && x === 0.0 ) {
+			if ( isNegativeZero( x ) ) {
+				out[ offset ] = x;
+				out[ offset + stride ] = y;
+				return out;
+			}
+			out[ offset ] = y;
+			out[ offset + stride ] = x;
+			return out;
+		}
+		if ( x < y ) {
+			out[ offset ] = x;
+			out[ offset + stride ] = y;
+			return out;
+		}
+		out[ offset ] = y;
+		out[ offset + stride ] = x;
+		return out;
+	}
+	min = PINF;
+	max = NINF;
+	for ( i = 0; i < len - 3; i++ ) {
+		v = arguments[ i ];
+		if ( isnan( v ) ) {
+			out[ offset ] = NaN;
+			out[ offset + stride ] = NaN;
+			return out;
+		}
+		if ( v < min ) {
+			min = v;
+		} else if (
+			v === 0.0 &&
+			v === min &&
+			isNegativeZero( v )
+		) {
+			min = v;
+		}
+		if ( v > max ) {
+			max = v;
+		} else if (
+			v === 0.0 &&
+			v === max &&
+			isPositiveZero( v )
+		) {
+			max = v;
+		}
+	}
+	out[ offset ] = min;
+	out[ offset + stride ] = max;
+	return out;
+}
+
+
+// EXPORTS //
+
+module.exports = minmaxn;

--- a/lib/node_modules/@stdlib/math/base/special/minmaxn/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/minmaxn/lib/index.js
@@ -1,0 +1,59 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Return the minimum and maximum values.
+*
+* @module @stdlib/math/base/special/minmaxn
+*
+* @example
+* var minmaxn = require( '@stdlib/math/base/special/minmaxn' );
+*
+* var v = minmaxn( 3.14, 4.2 );
+* // returns [ 3.14, 4.2 ]
+*
+* v = minmaxn( 5.9, 3.14, 4.2 );
+* // returns [ 3.14, 5.9 ]
+*
+* v = minmaxn( 3.14, NaN );
+* // returns [ NaN, NaN ]
+*
+* v = minmaxn( +0.0, -0.0 );
+* // returns [ -0.0, 0.0 ]
+*
+* v = minmaxn( 3.14 );
+* // returns [ 3.14, 3.14 ]
+*/
+
+// MODULES //
+
+var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
+var assign = require( './assign.js' );
+var minmaxn = require( './main.js' );
+
+
+// MAIN //
+
+setReadOnly( minmaxn, 'assign', assign );
+
+
+// EXPORTS //
+
+module.exports = minmaxn;

--- a/lib/node_modules/@stdlib/math/base/special/minmaxn/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/minmaxn/lib/main.js
@@ -1,0 +1,63 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var assign = require( './assign.js' );
+
+
+// MAIN //
+
+/**
+* Returns the minimum and maximum values.
+*
+* @param {number} x - first number
+* @param {number} [y] - second number
+* @param {...number} [args] - numbers
+* @returns {Array<number>} minimum and maximum values
+*
+* @example
+* var v = minmaxn( 3.14, 4.2 );
+* // returns [ 3.14, 4.2 ]
+*
+* @example
+* var v = minmaxn( 3.14, NaN );
+* // returns [ NaN, NaN ]
+*
+* @example
+* var v = minmaxn( +0.0, -0.0 );
+* // returns [ -0.0, 0.0 ]
+*/
+function minmaxn() {
+	var args;
+	var i;
+
+	args = [];
+	for ( i = 0; i < arguments.length; i++ ) {
+		args.push( arguments[ i ] );
+	}
+	args.push( [ 0.0, 0.0 ], 1, 0 );
+	return assign.apply( null, args );
+}
+
+
+// EXPORTS //
+
+module.exports = minmaxn;

--- a/lib/node_modules/@stdlib/math/base/special/minmaxn/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/minmaxn/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@stdlib/math/base/special/minmaxn",
+  "version": "0.0.0",
+  "description": "Return the minimum and maximum values.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
+    "math.min",
+    "math.max",
+    "minimum",
+    "maximum",
+    "extremum",
+    "min",
+    "max",
+    "smallest",
+    "largest",
+    "extrema"
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/special/minmaxn/test/test.assign.js
+++ b/lib/node_modules/@stdlib/math/base/special/minmaxn/test/test.assign.js
@@ -1,0 +1,360 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
+var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+var Float64Array = require( '@stdlib/array/float64' );
+var minmaxn = require( './../lib/assign.js' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof minmaxn, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `NaN` for both the minimum and maximum value if provided a `NaN`', function test( t ) {
+	var out;
+	var v;
+
+	out = new Float64Array( 2 );
+	v = minmaxn( NaN, 3.14, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( isnan( v[ 0 ] ), true, 'returns NaN' );
+	t.strictEqual( isnan( v[ 1 ] ), true, 'returns NaN' );
+
+	out = new Float64Array( 2 );
+	v = minmaxn( 3.14, NaN, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( isnan( v[ 0 ] ), true, 'returns NaN' );
+	t.strictEqual( isnan( v[ 1 ] ), true, 'returns NaN' );
+
+	out = new Float64Array( 2 );
+	v = minmaxn( NaN, NaN, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( isnan( v[ 0 ] ), true, 'returns NaN' );
+	t.strictEqual( isnan( v[ 1 ] ), true, 'returns NaN' );
+
+	out = new Float64Array( 2 );
+	v = minmaxn( NaN, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( isnan( v[ 0 ] ), true, 'returns NaN' );
+	t.strictEqual( isnan( v[ 1 ] ), true, 'returns NaN' );
+
+	out = new Float64Array( 2 );
+	v = minmaxn( 3.14, 4.2, NaN, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( isnan( v[ 0 ] ), true, 'returns NaN' );
+	t.strictEqual( isnan( v[ 1 ] ), true, 'returns NaN' );
+
+	out = new Float64Array( 2 );
+	v = minmaxn( NaN, 4.2, NaN, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( isnan( v[ 0 ] ), true, 'returns NaN' );
+	t.strictEqual( isnan( v[ 1 ] ), true, 'returns NaN' );
+
+	out = new Float64Array( 2 );
+	v = minmaxn( NaN, NaN, NaN, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( isnan( v[ 0 ] ), true, 'returns NaN' );
+	t.strictEqual( isnan( v[ 1 ] ), true, 'returns NaN' );
+
+	t.end();
+});
+
+tape( 'the function returns `-Infinity` as the minimum value if provided `-Infinity`', function test( t ) {
+	var out;
+	var v;
+
+	out = new Float64Array( 2 );
+	v = minmaxn( NINF, 3.14, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( v[ 0 ], NINF, 'returns -infinity' );
+	t.strictEqual( v[ 1 ], 3.14, 'returns expected value' );
+
+	out = new Float64Array( 2 );
+	v = minmaxn( 3.14, NINF, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( v[ 0 ], NINF, 'returns -infinity' );
+	t.strictEqual( v[ 1 ], 3.14, 'returns expected value' );
+
+	out = new Float64Array( 2 );
+	v = minmaxn( NINF, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( v[ 0 ], NINF, 'returns -infinity' );
+	t.strictEqual( v[ 1 ], NINF, 'returns expected value' );
+
+	out = new Float64Array( 2 );
+	v = minmaxn( 3.14, 4.2, NINF, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( v[ 0 ], NINF, 'returns -infinity' );
+	t.strictEqual( v[ 1 ], 4.2, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `+Infinity` as the maximum value if provided `+Infinity`', function test( t ) {
+	var out;
+	var v;
+
+	out = new Float64Array( 2 );
+	v = minmaxn( PINF, 3.14, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( v[ 0 ], 3.14, 'returns expected value' );
+	t.strictEqual( v[ 1 ], PINF, 'returns +infinity' );
+
+	out = new Float64Array( 2 );
+	v = minmaxn( 3.14, PINF, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( v[ 0 ], 3.14, 'returns expected value' );
+	t.strictEqual( v[ 1 ], PINF, 'returns +infinity' );
+
+	out = new Float64Array( 2 );
+	v = minmaxn( PINF, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( v[ 0 ], PINF, 'returns expected value' );
+	t.strictEqual( v[ 1 ], PINF, 'returns +infinity' );
+
+	out = new Float64Array( 2 );
+	v = minmaxn( 3.14, 4.2, PINF, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( v[ 0 ], 3.14, 'returns expected value' );
+	t.strictEqual( v[ 1 ], PINF, 'returns +infinity' );
+
+	t.end();
+});
+
+tape( 'the function returns correctly signed zeros', function test( t ) {
+	var out;
+	var v;
+
+	out = new Float64Array( 2 );
+	v = minmaxn( +0.0, -0.0, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( isNegativeZero( v[ 0 ] ), true, 'returns -0' );
+	t.strictEqual( isPositiveZero( v[ 1 ] ), true, 'returns +0' );
+
+	out = new Float64Array( 2 );
+	v = minmaxn( -0.0, +0.0, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( isNegativeZero( v[ 0 ] ), true, 'returns -0' );
+	t.strictEqual( isPositiveZero( v[ 1 ] ), true, 'returns +0' );
+
+	out = new Float64Array( 2 );
+	v = minmaxn( -0.0, -0.0, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( isNegativeZero( v[ 0 ] ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( v[ 1 ] ), true, 'returns -0' );
+
+	out = new Float64Array( 2 );
+	v = minmaxn( +0.0, +0.0, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( isPositiveZero( v[ 0 ] ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v[ 1 ] ), true, 'returns +0' );
+
+	out = new Float64Array( 2 );
+	v = minmaxn( -0.0, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( isNegativeZero( v[ 0 ] ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( v[ 1 ] ), true, 'returns +0' );
+
+	out = new Float64Array( 2 );
+	v = minmaxn( +0.0, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( isPositiveZero( v[ 0 ] ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v[ 1 ] ), true, 'returns +0' );
+
+	out = new Float64Array( 2 );
+	v = minmaxn( +0.0, -0.0, +0.0, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( isNegativeZero( v[ 0 ] ), true, 'returns -0' );
+	t.strictEqual( isPositiveZero( v[ 1 ] ), true, 'returns +0' );
+
+	t.end();
+});
+
+tape( 'the function returns the minimum and maximum values', function test( t ) {
+	var out;
+	var v;
+
+	out = new Float64Array( 2 );
+	v = minmaxn( 4.2, 3.14, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( v[ 0 ], 3.14, 'returns min value' );
+	t.strictEqual( v[ 1 ], 4.2, 'returns max value' );
+
+	out = new Float64Array( 2 );
+	v = minmaxn( -4.2, 3.14, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( v[ 0 ], -4.2, 'returns min value' );
+	t.strictEqual( v[ 1 ], 3.14, 'returns max value' );
+
+	out = new Float64Array( 2 );
+	v = minmaxn( 3.14, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( v[ 0 ], 3.14, 'returns min value' );
+	t.strictEqual( v[ 1 ], 3.14, 'returns max value' );
+
+	out = new Float64Array( 2 );
+	v = minmaxn( PINF, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( v[ 0 ], PINF, 'returns min value' );
+	t.strictEqual( v[ 1 ], PINF, 'returns max value' );
+
+	out = new Float64Array( 2 );
+	v = minmaxn( 4.2, 3.14, -1.0, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( v[ 0 ], -1.0, 'returns min value' );
+	t.strictEqual( v[ 1 ], 4.2, 'returns max value' );
+
+	out = new Float64Array( 2 );
+	v = minmaxn( 4.2, 3.14, -1.0, -3.14, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( v[ 0 ], -3.14, 'returns min value' );
+	t.strictEqual( v[ 1 ], 4.2, 'returns max value' );
+
+	t.end();
+});
+
+tape( 'the function supports providing an output object (array)', function test( t ) {
+	var out;
+	var v;
+
+	out = [ 0.0, 0.0 ];
+	v = minmaxn( 4.2, 3.14, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( v[ 0 ], 3.14, 'returns min value' );
+	t.strictEqual( v[ 1 ], 4.2, 'returns max value' );
+
+	out = [ 0.0, 0.0 ];
+	v = minmaxn( -4.2, 3.14, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( v[ 0 ], -4.2, 'returns min value' );
+	t.strictEqual( v[ 1 ], 3.14, 'returns max value' );
+
+	out = [ 0.0, 0.0 ];
+	v = minmaxn( 3.14, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( v[ 0 ], 3.14, 'returns min value' );
+	t.strictEqual( v[ 1 ], 3.14, 'returns max value' );
+
+	out = [ 0.0, 0.0 ];
+	v = minmaxn( PINF, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( v[ 0 ], PINF, 'returns min value' );
+	t.strictEqual( v[ 1 ], PINF, 'returns max value' );
+
+	out = [ 0.0, 0.0 ];
+	v = minmaxn( 4.2, 3.14, -1.0, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( v[ 0 ], -1.0, 'returns min value' );
+	t.strictEqual( v[ 1 ], 4.2, 'returns max value' );
+
+	out = [ 0.0, 0.0 ];
+	v = minmaxn( 4.2, 3.14, -1.0, -3.14, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( v[ 0 ], -3.14, 'returns min value' );
+	t.strictEqual( v[ 1 ], 4.2, 'returns max value' );
+
+	t.end();
+});
+
+tape( 'the function supports providing an output object (typed array)', function test( t ) {
+	var out;
+	var v;
+
+	out = new Float64Array( 2 );
+	v = minmaxn( 4.2, 3.14, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( v[ 0 ], 3.14, 'returns min value' );
+	t.strictEqual( v[ 1 ], 4.2, 'returns max value' );
+
+	out = new Float64Array( 2 );
+	v = minmaxn( -4.2, 3.14, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( v[ 0 ], -4.2, 'returns min value' );
+	t.strictEqual( v[ 1 ], 3.14, 'returns max value' );
+
+	out = new Float64Array( 2 );
+	v = minmaxn( 3.14, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( v[ 0 ], 3.14, 'returns min value' );
+	t.strictEqual( v[ 1 ], 3.14, 'returns max value' );
+
+	out = new Float64Array( 2 );
+	v = minmaxn( PINF, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( v[ 0 ], PINF, 'returns min value' );
+	t.strictEqual( v[ 1 ], PINF, 'returns max value' );
+
+	out = new Float64Array( 2 );
+	v = minmaxn( 4.2, 3.14, -1.0, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( v[ 0 ], -1.0, 'returns min value' );
+	t.strictEqual( v[ 1 ], 4.2, 'returns max value' );
+
+	out = new Float64Array( 2 );
+	v = minmaxn( 4.2, 3.14, -1.0, -3.14, out, 1, 0 );
+	t.strictEqual( v, out, 'returns output array' );
+	t.strictEqual( v[ 0 ], -3.14, 'returns min value' );
+	t.strictEqual( v[ 1 ], 4.2, 'returns max value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying a stride', function test( t ) {
+	var out;
+	var val;
+
+	out = new Float64Array( 4 );
+	val = minmaxn( -4.2, 3.14, out, 2, 0 );
+
+	t.strictEqual( val, out, 'returns output array' );
+	t.strictEqual( val[ 0 ], -4.2, 'returns expected value' );
+	t.strictEqual( val[ 1 ], 0, 'returns expected value' );
+	t.strictEqual( val[ 2 ], 3.14, 'returns expected value' );
+	t.strictEqual( val[ 3 ], 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying an offset', function test( t ) {
+	var out;
+	var val;
+
+	out = new Float64Array( 4 );
+	val = minmaxn( -4.2, 3.14, out, 2, 1 );
+
+	t.strictEqual( val, out, 'returns output array' );
+	t.strictEqual( val[ 0 ], 0, 'returns expected value' );
+	t.strictEqual( val[ 1 ], -4.2, 'returns expected value' );
+	t.strictEqual( val[ 2 ], 0, 'returns expected value' );
+	t.strictEqual( val[ 3 ], 3.14, 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/minmaxn/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/minmaxn/test/test.js
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2022 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var minmaxn = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof minmaxn, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the main export is an `assign` method', function test( t ) {
+	t.strictEqual( hasOwnProp( minmaxn, 'assign' ), true, 'has property' );
+	t.strictEqual( typeof minmaxn.assign, 'function', 'has method' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/minmaxn/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/base/special/minmaxn/test/test.main.js
@@ -1,0 +1,180 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
+var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+var minmaxn = require( './../lib/main.js' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof minmaxn, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `NaN` for both the minimum and maximum value if provided a `NaN`', function test( t ) {
+	var v;
+
+	v = minmaxn( NaN, 3.14 );
+	t.strictEqual( isnan( v[ 0 ] ), true, 'returns NaN' );
+	t.strictEqual( isnan( v[ 1 ] ), true, 'returns NaN' );
+
+	v = minmaxn( 3.14, NaN );
+	t.strictEqual( isnan( v[ 0 ] ), true, 'returns NaN' );
+	t.strictEqual( isnan( v[ 1 ] ), true, 'returns NaN' );
+
+	v = minmaxn( NaN, NaN );
+	t.strictEqual( isnan( v[ 0 ] ), true, 'returns NaN' );
+	t.strictEqual( isnan( v[ 1 ] ), true, 'returns NaN' );
+
+	v = minmaxn( NaN );
+	t.strictEqual( isnan( v[ 0 ] ), true, 'returns NaN' );
+	t.strictEqual( isnan( v[ 1 ] ), true, 'returns NaN' );
+
+	v = minmaxn( 3.14, 4.2, NaN );
+	t.strictEqual( isnan( v[ 0 ] ), true, 'returns NaN' );
+	t.strictEqual( isnan( v[ 1 ] ), true, 'returns NaN' );
+
+	v = minmaxn( NaN, 4.2, NaN );
+	t.strictEqual( isnan( v[ 0 ] ), true, 'returns NaN' );
+	t.strictEqual( isnan( v[ 1 ] ), true, 'returns NaN' );
+
+	v = minmaxn( NaN, NaN, NaN );
+	t.strictEqual( isnan( v[ 0 ] ), true, 'returns NaN' );
+	t.strictEqual( isnan( v[ 1 ] ), true, 'returns NaN' );
+
+	t.end();
+});
+
+tape( 'the function returns `-Infinity` as the minimum value if provided `-Infinity`', function test( t ) {
+	var v;
+
+	v = minmaxn( NINF, 3.14 );
+	t.strictEqual( v[ 0 ], NINF, 'returns -infinity' );
+	t.strictEqual( v[ 1 ], 3.14, 'returns expected value' );
+
+	v = minmaxn( 3.14, NINF );
+	t.strictEqual( v[ 0 ], NINF, 'returns -infinity' );
+	t.strictEqual( v[ 1 ], 3.14, 'returns expected value' );
+
+	v = minmaxn( NINF );
+	t.strictEqual( v[ 0 ], NINF, 'returns -infinity' );
+	t.strictEqual( v[ 1 ], NINF, 'returns expected value' );
+
+	v = minmaxn( 3.14, 4.2, NINF );
+	t.strictEqual( v[ 0 ], NINF, 'returns -infinity' );
+	t.strictEqual( v[ 1 ], 4.2, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `+Infinity` as the maximum value if provided `+Infinity`', function test( t ) {
+	var v;
+
+	v = minmaxn( PINF, 3.14 );
+	t.strictEqual( v[ 0 ], 3.14, 'returns expected value' );
+	t.strictEqual( v[ 1 ], PINF, 'returns +infinity' );
+
+	v = minmaxn( 3.14, PINF );
+	t.strictEqual( v[ 0 ], 3.14, 'returns expected value' );
+	t.strictEqual( v[ 1 ], PINF, 'returns +infinity' );
+
+	v = minmaxn( PINF );
+	t.strictEqual( v[ 0 ], PINF, 'returns expected value' );
+	t.strictEqual( v[ 1 ], PINF, 'returns +infinity' );
+
+	v = minmaxn( 3.14, 4.2, PINF );
+	t.strictEqual( v[ 0 ], 3.14, 'returns expected value' );
+	t.strictEqual( v[ 1 ], PINF, 'returns +infinity' );
+
+	t.end();
+});
+
+tape( 'the function returns correctly signed zeros', function test( t ) {
+	var v;
+
+	v = minmaxn( +0.0, -0.0 );
+	t.strictEqual( isNegativeZero( v[ 0 ] ), true, 'returns -0' );
+	t.strictEqual( isPositiveZero( v[ 1 ] ), true, 'returns +0' );
+
+	v = minmaxn( -0.0, +0.0 );
+	t.strictEqual( isNegativeZero( v[ 0 ] ), true, 'returns -0' );
+	t.strictEqual( isPositiveZero( v[ 1 ] ), true, 'returns +0' );
+
+	v = minmaxn( -0.0, -0.0 );
+	t.strictEqual( isNegativeZero( v[ 0 ] ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( v[ 1 ] ), true, 'returns -0' );
+
+	v = minmaxn( +0.0, +0.0 );
+	t.strictEqual( isPositiveZero( v[ 0 ] ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v[ 1 ] ), true, 'returns +0' );
+
+	v = minmaxn( -0.0 );
+	t.strictEqual( isNegativeZero( v[ 0 ] ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( v[ 1 ] ), true, 'returns +0' );
+
+	v = minmaxn( +0.0 );
+	t.strictEqual( isPositiveZero( v[ 0 ] ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v[ 1 ] ), true, 'returns +0' );
+
+	v = minmaxn( +0.0, -0.0, +0.0 );
+	t.strictEqual( isNegativeZero( v[ 0 ] ), true, 'returns -0' );
+	t.strictEqual( isPositiveZero( v[ 1 ] ), true, 'returns +0' );
+
+	t.end();
+});
+
+tape( 'the function returns the minimum and maximum values', function test( t ) {
+	var v;
+
+	v = minmaxn( 4.2, 3.14 );
+	t.strictEqual( v[ 0 ], 3.14, 'returns min value' );
+	t.strictEqual( v[ 1 ], 4.2, 'returns max value' );
+
+	v = minmaxn( -4.2, 3.14 );
+	t.strictEqual( v[ 0 ], -4.2, 'returns min value' );
+	t.strictEqual( v[ 1 ], 3.14, 'returns max value' );
+
+	v = minmaxn( 3.14 );
+	t.strictEqual( v[ 0 ], 3.14, 'returns min value' );
+	t.strictEqual( v[ 1 ], 3.14, 'returns max value' );
+
+	v = minmaxn( PINF );
+	t.strictEqual( v[ 0 ], PINF, 'returns min value' );
+	t.strictEqual( v[ 1 ], PINF, 'returns max value' );
+
+	v = minmaxn( 4.2, 3.14, -1.0 );
+	t.strictEqual( v[ 0 ], -1.0, 'returns min value' );
+	t.strictEqual( v[ 1 ], 4.2, 'returns max value' );
+
+	v = minmaxn( 4.2, 3.14, -1.0, -3.14 );
+	t.strictEqual( v[ 0 ], -3.14, 'returns min value' );
+	t.strictEqual( v[ 1 ], 4.2, 'returns max value' );
+
+	t.end();
+});


### PR DESCRIPTION
Part of https://github.com/stdlib-js/stdlib/issues/660.

## Description

> What is the purpose of this pull request?

This pull request:

- Renames the existent `minmax` API to `minmaxn`
- Refactors `minmax` API to non-variadic interface
- Reviewed downstream usage to check that it matches the new API

## Related Issues

> Does this pull request have any related issues?

This pull request:

-  part of https://github.com/stdlib-js/stdlib/issues/660

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
