### PR TITLE
Update development process to use Conventional Commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,7 +236,7 @@ where `<branch>` is the name of your branch.
 
 #### Step 8: Pull Request
 
-Once your contribution is ready to be incorporated in the `upstream` repository, open a [pull request][github-pull-request] against the `develop` branch. One ore more project contributors will review the contribution, provide feedback, and potentially request changes.
+Once your contribution is ready to be incorporated in the `upstream` repository, open a [pull request][github-pull-request] against the `develop` branch. One or more project contributors will review the contribution, provide feedback, and potentially request changes.
 
 > Receiving feedback is the most **important**, and often the most **valuable**, part of the submission process. Don't get disheartened!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ limitations under the License.
 
 ## Introduction
 
-Woot woot! If you are new to stdlib, welcome! And thanks for your interest! While this guide focuses on technical development, if you are looking to contribute to the project but are non-technical, you can still contribute! For example, you can contribute by filing issues, writing RFCs (feature requests), updating documentation, providing build and infrastructure support, offering [funding][patreon], and helping market and promote the project, among other things. Every bit helps, and we are grateful for your time and effort!
+Woot woot! If you are new to stdlib, welcome! And thanks for your interest! While this guide focuses on technical development, if you are looking to contribute to the project but are non-technical, you can still contribute! For example, you can contribute by filing issues, writing RFCs (feature requests), updating documentation, providing build and infrastructure support, offering [funding][open-collective-stdlib], and helping market and promote the project, among other things. Every bit helps, and we are grateful for your time and effort!
 
 ## Code of Conduct
 
@@ -43,15 +43,23 @@ When filing new [issues][stdlib-issues] and commenting on existing [issues][stdl
 
 If the source of the problem is a third party package, file a bug report with the relevant package author, rather than on this repository.
 
+We want to fix all issues as soon as possible; however, before fixing a bug, we need to reproduce and confirm the errant behavior. Accordingly, in order to help us reproduce bugs, we require that you provide a minimal reproduction. A minimal reproduction provides us with important information and helps us avoid having to ask follow-up questions and wait for your response.
+
+A minimal reproduction allows us to more quickly confirm a bug (or identify a potential coding problem) and confirm that we are fixing the right problem.
+
+We require a minimal reproduction to save maintainers' time and ultimately to fix more bugs. Often, developers may find coding problems in their original code while preparing a minimal reproduction. We certainly understand that extracting essential bits of code from a larger codebase can be difficult, but we really need to isolate the problem before we can fix it.
+
+Unfortunately, we are not able to investigate or fix bugs without a minimal reproduction. If a bug report does not include a minimal reproduction, the issue will be automatically closed.
+
 When filing an [issues][stdlib-issues], provide the following, where possible:
 
 -   A description of the issue.
 -   Links to any related issues.
 -   The full error message, including the stacktrace.
 -   The sequence of steps required to reproduce the issue.
--   A minimal working example; i.e., the smallest chunk of code that triggers the error. Ideally, the code can be pasted into a REPL or run from a source file. If the code is larger than `50` lines, consider creating a [gist][github-gist].
+-   A minimal working example (i.e., the smallest chunk of code that triggers the error.) Ideally, the code can be pasted into a REPL or run from a source file. If the code is larger than `100` lines, consider creating a [gist][github-gist].
 -   The expected results.
--   List of affected environments; e.g., browser, browser version, `npm` version, Node.js version, operating system, and stdlib version.
+-   List of affected environments (e.g., browser, browser version, `npm` version, Node.js version, operating system, and stdlib version).
 
 When pasting code blocks or output, use triple backticks to enable proper formatting. Surround inline code with single backticks. For other Markdown formatting tips and trips, see GitHub's [Markdown guide][github-markdown-guide].
 
@@ -65,6 +73,7 @@ Be aware that the `@` symbol tags users on GitHub, so **always** surround packag
 
 -   read and understand the [licensing terms][stdlib-license].
 -   read and understand the [style guides][stdlib-style-guides].
+-   read and understand the [doctest guide][stdlib-doctest].
 
 For instructions on how to setup and configure your environment, be sure to
 
@@ -78,21 +87,22 @@ If you have found a bug that you would like to fix,
 
 If you want to contribute a new feature or a breaking change to stdlib, be sure to
 
--   consult the [Gitter][stdlib-gitter] channel to discuss ideas and to gather feedback as to whether a feature would be better developed as an external package.
+-   consult the [Gitter][stdlib-gitter] channel to discuss ideas and to gather feedback as to whether a feature would be better developed as an external package. Discussing the design upfront helps ensure that we're ready to accept to your work.
 -   write an RFC (request for comments) detailing the proposed change and submit as an issue on the project GitHub issue tracker.
 -   wait for RFC approval.
 -   submit a [pull request][stdlib-pull-requests], making sure to adhere to the guidance set forth in the RFC.
 
 If you want to contribute a new package, be sure to
 
--   read and follow the [package development guide][stdlib-docs].
+-   read and follow the [package development guide][stdlib-packages].
+-   read and follow the [REPL text guide][stdlib-repl-text].
 
 If you are unfamiliar with [Git][git], the version control system used by GitHub and this project,
 
 -   see the [Git][git] docs.
 -   try a tutorial, such as the [tutorial][github-git-tutorial] provided by GitHub.
 
-Next, take a look around the project, noting the style and organization of documentation, tests, examples, benchmarks, and source implementations. Consistency is highly **prioritized** within stdlib. Thus, the more you are able to match and adhere to project conventions and style, the more likely your contribution will be accepted. While we have done our best to automate linting and style guidelines, such automation is not perfect and cannot adequately capture the inevitable exceptions and nuance to many rules. In short, the more you study existing practice, the better prepared you will be to contribute to stdlib.
+Next, take a look around the project, noting the style and organization of documentation, tests, examples, benchmarks, and source implementations. Consistency is highly **prioritized** within stdlib. Thus, the more you are able to match and adhere to project conventions and style, the more likely your contribution will be accepted. While we have done our best to automate linting and style guidelines, project automation is not perfect and cannot adequately capture the inevitable exceptions and nuance to many rules. In short, the more you study existing practice, the better prepared you will be to contribute to stdlib.
 
 #### Step 0: GitHub
 
@@ -102,19 +112,25 @@ Create a [GitHub account][github-signup]. The project uses GitHub exclusively fo
 
 [Fork][github-fork] the repository on GitHub and clone the repository to your local machine.
 
+<!-- run-disable -->
+
 ```bash
 $ git clone https://github.com/<username>/stdlib.git
 ```
 
-where `<username>` is your GitHub username. The repository has a large commit history, leading to slow download times. If you are not interested in code archeology, you can reduce the download time by limiting the clone [depth][git-clone-depth].
+where `<username>` is your GitHub username. The repository has a large commit history, leading to slow download times. You can reduce the download time by limiting the clone [depth][git-clone-depth].
+
+<!-- run-disable -->
 
 ```bash
 $ git clone --depth=<depth> https://github.com/<username>/stdlib.git
 ```
 
-where `<depth>` refers to the number of commits you want to download (as few as `1` and as many as the entire project history).
+where `<depth>` refers to the number of commits you want to download (as few as `1` and as many as the entire project history). **However, you should be aware that limiting clone depth can cause difficulties later when attempting to rebase a pull request on the latest development branch.** For simple pull requests, limiting clone depth is likely to work out fine; however, for more complex pull requests, including those depending on upstream changes, limiting clone depth may be a source of Git errors (e.g., due to unrelated Git histories), and, thus, you may be forced to re-clone the repository and start over.
 
 If you are behind a firewall, you may need to use the `https` protocol, rather than the `git` protocol.
+
+<!-- run-disable -->
 
 ```bash
 $ git config --global url."https://".insteadOf git://
@@ -122,11 +138,15 @@ $ git config --global url."https://".insteadOf git://
 
 Once you have finished cloning the repository into the destination directory, you should see the folder `stdlib`. To proceed with configuring your environment, navigate to the project folder.
 
+<!-- run-disable -->
+
 ```bash
 $ cd stdlib
 ```
 
 And finally, add an `upstream` [remote][git-remotes] to allow syncing changes between this repository and your local version.
+
+<!-- run-disable -->
 
 ```bash
 $ git remote add upstream git://github.com/stdlib-js/stdlib.git
@@ -136,19 +156,23 @@ $ git remote add upstream git://github.com/stdlib-js/stdlib.git
 
 For modifications intended to be included in stdlib, create a new local branch.
 
+<!-- run-disable -->
+
 ```bash
 $ git checkout -b <branch>
 ```
 
-where `<branch>` is the branch name. Both the `master` and `develop` branches for the main stdlib project are protected, and direct modifications to these branches will **not** be accepted. Instead, all contributions should be made on non-master and non-develop local branches, including documentation changes and other non-code modifications.
+where `<branch>` is the branch name. Both the `master` and `develop` branches for the main stdlib project are protected, and direct modifications to these branches will **not** be accepted. Instead, all contributions should be made on non-master and non-develop local branches, including documentation changes and other non-code modifications. See the project [branching guide][stdlib-branching] for additional guidance.
 
 #### Step 3: Write
 
-Start making your changes and/or implementing the new feature. Any text you write should follow the [text style guide][stdlib-style-guides], including comments and API documentation.
+Start making your changes and/or implementing the new feature. Any text you write should follow the [text style guide][stdlib-style-guides-text], including comments and API documentation.
 
 #### Step 4: Commit
 
 Ensure that you have configured [Git][git] to know your name and email address.
+
+<!-- run-disable -->
 
 ```bash
 $ git config --global user.name "Jane Doe"
@@ -157,21 +181,25 @@ $ git config --global user.email "jane.doe@example.com"
 
 Add changed files and commit.
 
+<!-- run-disable -->
+
 ```bash
 $ git add files/which/changed
 $ git commit
 ```
 
-When writing commit messages, follow the Git [style guide][stdlib-style-guides].
+When writing commit messages, follow the Git [style guide][stdlib-style-guides-git]. Adherence to project commit conventions is necessary for project automation which automatically generates release notes and changelogs from commit messages.
 
 #### Step 5: Sync
 
 To incorporate recent changes from the `upstream` repository during development, you should [rebase][git-rebase] your local branch, reapplying your local commits on top of the current upstream `HEAD`. This procedure is in contrast to performing a standard [merge][git-merge], which may interleave development histories. The rationale is twofold:
 
-1.  interleaved histories make [squashing][git-rewriting-history] commits more difficult
+1.  interleaved histories make [squashing][git-rewriting-history] commits more difficult.
 2.  a standard merge increases the risk of incomplete/broken commits appearing in the [Git][git] history.
 
 An ideal commit history is one in which, at no point in time, is the project in a broken state. While not always possible (mistakes happen), striving for this ideal facilitates time travel and software archeology.
+
+<!-- run-disable -->
 
 ```bash
 $ git fetch upstream
@@ -183,6 +211,8 @@ $ git rebase upstream/develop
 Tests should accompany **all** bug fixes and features. For guidance on how to write tests, consult existing tests within the project.
 
 **Before** submitting a [pull request][github-pull-request] to the `upstream` repository, ensure that all tests pass, including linting. If [Git][git] hooks have been enabled,
+
+<!-- run-disable -->
 
 ```bash
 $ make init
@@ -196,6 +226,8 @@ Any [pull requests][github-pull-request] which include failing tests and/or lint
 
 Push your changes to your remote GitHub repository.
 
+<!-- run-disable -->
+
 ```bash
 $ git push origin <branch>
 ```
@@ -204,11 +236,13 @@ where `<branch>` is the name of your branch.
 
 #### Step 8: Pull Request
 
-Once your contribution is ready to be incorporated in the `upstream` repository, open a [pull request][github-pull-request] against the `develop` branch. A project contributor will review the contribution, provide feedback, and potentially request changes.
+Once your contribution is ready to be incorporated in the `upstream` repository, open a [pull request][github-pull-request] against the `develop` branch. One ore more project contributors will review the contribution, provide feedback, and potentially request changes.
 
 > Receiving feedback is the most **important**, and often the most **valuable**, part of the submission process. Don't get disheartened!
 
 To make changes to your [pull request][github-pull-request], make changes to your branch. Each time you push changes to your forked repository, GitHub will automatically update the [pull request][github-pull-request].
+
+<!-- run-disable -->
 
 ```bash
 $ git add files/which/changed
@@ -216,7 +250,35 @@ $ git commit
 $ git push origin <branch>
 ```
 
-Note that, once a [pull request][github-pull-request] has been made (i.e., your local repository commits have been pushed to a remote server), you should **not** perform any further [rewriting][git-rewriting-history] of [Git][git] history. If the history needs modification, a contributor will modify the history during the merge process. The rationale for **not** rewriting public history is that doing so invalidates the commit history for anyone else who has pulled your changes, thus imposing additional burdens on collaborators to ensure that their local versions match the modified history.
+Note that, once a [pull request][github-pull-request] has been made (i.e., your local repository commits have been pushed to a remote server), you should **not** perform any further [rewriting][git-rewriting-history] of [Git][git] history. You can, however, use Git's [`squash!`][git-commit-squash] or [`fixup!`][git-commit-fixup] to convey that a commit is intended to be squashed into another commit. For example, to create a fix up on the last commit
+
+<!-- run-disable -->
+
+```bash
+$ git commit --fixup HEAD ...
+```
+
+or a specific commit
+
+<!-- run-disable -->
+
+```bash
+# Find the commit SHA:
+$ git log
+
+# Create a fix up:
+$ git commit --fixup <COMMIT_SHA> ...
+```
+
+Alternatively, you can also create a new commit with a commit message starting with `fixup! <commit header>` followed the commit header of the commit being fixed up. For example,
+
+<!-- run-disable -->
+
+```bash
+$ git commit -m "fixup! feat: add support for computing the absolute value"
+```
+
+If the history needs modification, a contributor will modify the history during the merge process. The rationale for **not** rewriting public history is that doing so invalidates the commit history for anyone else who has pulled your changes, thus imposing additional burdens on collaborators to ensure that their local versions match the modified history.
 
 #### Step 9: Land
 
@@ -251,11 +313,15 @@ The project can **never** have enough tests. To address areas lacking sufficient
 
 5.  To run package tests,
 
+    <!-- run-disable -->
+
     ```bash
     $ make TESTS_FILTER=.*/<pattern>/.* test
     ```
 
     where `<pattern>` is a pattern matching a particular path. For example, to test the base math `sin` package
+
+    <!-- run-disable -->
 
     ```bash
     $ make TESTS_FILTER=.*/math/base/special/sin/.* test
@@ -264,6 +330,8 @@ The project can **never** have enough tests. To address areas lacking sufficient
     where the pattern `.*/math/base/special/sin/.*` matches any test file whose absolute path contains `math/base/special/sin`.
 
 6.  To generate a test coverage report,
+
+    <!-- run-disable -->
 
     ```bash
     $ make TESTS_FILTER=.*/<pattern>/.* test-cov
@@ -279,6 +347,8 @@ The project can **never** have enough tests. To address areas lacking sufficient
 > By contributing documentation to the project, you are agreeing to release it under the project [license][stdlib-license].
 
 Project documentation is localized within each package. Similar to code, you should modify documentation using [Git][git]. Provided you have followed the [development guide][stdlib-development] and enabled [Git][git] hooks,
+
+<!-- run-disable -->
 
 ```bash
 $ make init
@@ -313,9 +383,19 @@ Phew. While the above may be a lot to remember, even for what seem like minor ch
 
 [stdlib-style-guides]: https://github.com/stdlib-js/stdlib/blob/develop/docs/style-guides
 
+[stdlib-style-guides-text]: https://github.com/stdlib-js/stdlib/blob/develop/docs/style-guides/text
+
+[stdlib-style-guides-git]: https://github.com/stdlib-js/stdlib/blob/develop/docs/style-guides/git
+
+[stdlib-doctest]: https://github.com/stdlib-js/stdlib/blob/develop/docs/doctest.md
+
 [stdlib-development]: https://github.com/stdlib-js/stdlib/blob/develop/docs/development.md
 
-[stdlib-docs]: https://github.com/stdlib-js/stdlib/blob/develop/docs
+[stdlib-branching]: https://github.com/stdlib-js/stdlib/blob/develop/docs/branching.md
+
+[stdlib-packages]: https://github.com/stdlib-js/stdlib/blob/develop/docs/packages.md
+
+[stdlib-repl-text]: https://github.com/stdlib-js/stdlib/blob/develop/docs/repl_text.md
 
 [stdlib-faq]: https://github.com/stdlib-js/stdlib/blob/develop/FAQ.md
 
@@ -327,7 +407,7 @@ Phew. While the above may be a lot to remember, even for what seem like minor ch
 
 [stdlib-pull-requests]: https://github.com/stdlib-js/stdlib/pulls
 
-[patreon]: https://www.patreon.com/athan
+[open-collective-stdlib]: https://opencollective.com/stdlib
 
 [github-signup]: https://github.com/signup/free
 
@@ -352,6 +432,10 @@ Phew. While the above may be a lot to remember, even for what seem like minor ch
 [git-merge]: https://git-scm.com/docs/git-merge
 
 [git-rewriting-history]: https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History
+
+[git-commit-squash]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---squashltcommitgt
+
+[git-commit-fixup]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---fixupamendrewordltcommitgt
 
 </section>
 

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -32,6 +32,8 @@ This project follows the branching model articulated in ["A successful Git branc
 
 -   Each commit on the `master` branch should have an associated tag.
 
+    <!-- run-disable -->
+
     ```bash
     $ git tag -a v2.0.0
     $ git push origin --tags
@@ -48,6 +50,8 @@ This project follows the branching model articulated in ["A successful Git branc
 -   A feature branch should use the naming convention: `feature/<name>`.
 
 -   A feature branch should branch from the `develop` branch.
+
+    <!-- run-disable -->
 
     ```bash
     $ git checkout -b feature/<name> develop
@@ -67,6 +71,8 @@ This project follows the branching model articulated in ["A successful Git branc
 
 -   A release branch should branch from the `develop` branch.
 
+    <!-- run-disable -->
+
     ```bash
     $ git checkout -b release-2.0.0 develop
     ```
@@ -84,6 +90,8 @@ This project follows the branching model articulated in ["A successful Git branc
 -   A hotfix branch should use the naming convention: `hotfix/<name>`.
 
 -   The purpose of a hotfix branch is to immediately patch a bug on the `master` branch. Accordingly, a hotfix branch should branch from the `master` branch.
+
+    <!-- run-disable -->
 
     ```bash
     $ git checkout -b hotfix/<name> master

--- a/docs/development.md
+++ b/docs/development.md
@@ -117,7 +117,7 @@ where `<username>` is your GitHub username (assuming you are using GitHub to man
 $ git clone --depth=<depth> https://github.com/<username>/stdlib.git
 ```
 
-where `<depth>` refers to the number of commits you want to download (as few as `1` and as many as the entire project history). **However, you should be aware that limiting clone depth can cause difficulties later when attempting to rebase a pull request on the latest development branch.** For simple pull requests, limiting clone depth is likely to work out fine; however, for more complex pull requests, including those depending on upstream changes, limiting clone depth may be a source of Git errors (e.g., due to unrelated Git histories), and, thus, you may be forced to re-clone the repository and start over.
+where `<depth>` refers to the number of commits you want to download (as few as `1` and as many as the entire project history). **However, limiting clone depth can cause difficulties later when attempting to rebase a pull request on the latest development branch.** For simple pull requests, limiting clone depth is likely to work out fine; however, for more complex pull requests, including those depending on upstream changes, limiting clone depth may be a source of Git errors (e.g., due to unrelated Git histories), and, thus, you may be forced to re-clone the repository and start over.
 
 If you are behind a firewall, you may need to use the `https` protocol, rather than the `git` protocol.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -35,15 +35,25 @@ So, without further ado, let's get you started!
 Developing and running stdlib **requires** the following prerequisites:
 
 -   [Git][git]: version control
+
 -   [GNU make][make]: development utility and task runner
+
 -   [GNU bash][bash]: an sh-compatible shell
+
 -   [curl][curl], [wget][wget], or [fetch][fetch] (FreeBSD): utilities for downloading remote resources
+
 -   [Node.js][node-js]: JavaScript runtime (version `>= 0.10`; although the latest stable version is **strongly** recommended)
--   [npm][npm]: package manager (version `> 2.7.0`; if Node `< 1.0.0`, version `> 2.7.0` and `< 4.0.0`; if Node `< 10.x.x`, version `> 2.7.0` and `< 6.0.0`)
+
+-   [npm][npm]: package manager
+
+    -   version `> 2.7.0`
+    -   if Node `< 1.0.0`, version `> 2.7.0` and `< 4.0.0`
+    -   if Node `< 10.x.x`, version `> 2.7.0` and `< 6.0.0`
+    -   if Node `< 14.17.0`, version `> 2.7.0` and `< 9.0.0`
 
 While not required to run stdlib, the following dependencies **may** be required for testing, benchmarking, and general development:
 
--   [Julia][julia]: language for technical computing (version `>= 0.5` and `<= 0.7`)
+-   [Julia][julia]: language for technical computing (version `>= 1.0`)
 -   [R][r]: language for statistical computing (version `>= 3.4.0`)
 -   [Python][python]: general purpose language (version `>=2.7.x`)
 -   [pip][pip]: Python package manager (version `>= 9.0.0`; **required** for automatically installing Python packages, such as lint tools)
@@ -55,14 +65,14 @@ While not required to run stdlib, the following dependencies **may** be required
 
 Assuming the requisite language is present on the host machine, the following language libraries can be automatically downloaded and installed using `make` (see [installation](#installation)):
 
--   [NumPy][numpy]: general purpose array-processing library for Python (version `>= 1.8.2`)
--   [SciPy][scipy]: Python library containing numerical routines (version `>= 0.17.0`)
--   [Pylint][pylint]: Python source code analyzer (version `>= 1.7.1`)
--   [pycodestyle][pycodestyle]: Python style guide checker against PEP 8 (version `>= 2.3.1`)
--   [pydocstyle][pydocstyle]: Python docstring checker against PEP 257 (version `>= 2.0.0`)
--   [lintr][lintr]: static code analysis for R (version `>= 1.0.0`)
--   [shellcheck][shellcheck]: static code analysis for shell scripts (version `>= 0.5.0`; to install on OS X, either install [Homebrew][homebrew] as a prerequisite or install [shellcheck][shellcheck] manually)
--   [cppcheck][cppcheck]: C/C++ static code analysis (version `>= 2.5`).
+-   [NumPy][numpy]: general purpose array-processing library for Python
+-   [SciPy][scipy]: Python library containing numerical routines
+-   [Pylint][pylint]: Python source code analyzer
+-   [pycodestyle][pycodestyle]: Python style guide checker against PEP 8
+-   [pydocstyle][pydocstyle]: Python docstring checker against PEP 257
+-   [lintr][lintr]: static code analysis for R
+-   [shellcheck][shellcheck]: static code analysis for shell scripts
+-   [cppcheck][cppcheck]: C/C++ static code analysis
 
 The following external libraries can be automatically downloaded and compiled from source using `make` (see [installation](#installation)):
 
@@ -99,7 +109,7 @@ If you are wanting to contribute to stdlib, first [fork][github-fork] the reposi
 $ git clone https://github.com/<username>/stdlib.git
 ```
 
-where `<username>` is your GitHub username (assuming you are using GitHub to manage public repositories). The repository has a large commit history, leading to slow download times. If you are not interested in code archeology, you can reduce the download time by limiting the clone [depth][git-clone-depth].
+where `<username>` is your GitHub username (assuming you are using GitHub to manage public repositories). The repository has a large commit history, leading to slow download times. You can reduce the download time by limiting the clone [depth][git-clone-depth].
 
 <!-- run-disable -->
 
@@ -107,7 +117,7 @@ where `<username>` is your GitHub username (assuming you are using GitHub to man
 $ git clone --depth=<depth> https://github.com/<username>/stdlib.git
 ```
 
-where `<depth>` refers to the number of commits you want to download (as few as `1` and as many as the entire project history).
+where `<depth>` refers to the number of commits you want to download (as few as `1` and as many as the entire project history). **However, you should be aware that limiting clone depth can cause difficulties later when attempting to rebase a pull request on the latest development branch.** For simple pull requests, limiting clone depth is likely to work out fine; however, for more complex pull requests, including those depending on upstream changes, limiting clone depth may be a source of Git errors (e.g., due to unrelated Git histories), and, thus, you may be forced to re-clone the repository and start over.
 
 If you are behind a firewall, you may need to use the `https` protocol, rather than the `git` protocol.
 
@@ -184,8 +194,7 @@ If you are working with a [forked][github-fork] repository and wish to [sync][gi
 <!-- run-disable -->
 
 ```bash
-$ git fetch upstream
-$ git merge upstream/<branch>
+$ git pull --ff upstream <branch>
 ```
 
 where `upstream` is the remote name and `<branch>` refers to the branch you want to merge into your local copy.
@@ -257,7 +266,7 @@ workshops  workshops
 
 ## Editors
 
--   This repository uses [EditorConfig][editorconfig] to maintain consistent coding styles between different editors and IDEs, including [browsers][editorconfig-chrome].
+-   This repository uses [EditorConfig][editorconfig] to maintain consistent coding styles between different editors and IDEs, including [browsers][editorconfig-chrome]. You should be sure to download and setup [EditorConfig][editorconfig] to ensure that files are automatically configured to use expected indentation and line endings.
 
 ## Testing
 

--- a/docs/doctest.md
+++ b/docs/doctest.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # doctest
 
-> A guide for writing documentation tests (aka **doctests**).
+> A guide for writing documentation tests (a.k.a. **doctests**).
 
 Documentation tests (**doctests**) are comment annotations which indicate expected behavior. In the spirit of "literate testing" or "executable documentation", doctests serve three primary purposes:
 
@@ -91,6 +91,8 @@ Markers may be prefixed with `e.g.,` to indicate that an annotation is exemplary
 
 <!-- run-disable -->
 
+<!-- eslint-disable stdlib/doctest -->
+
 ```javascript
 var arr = foo();
 // e.g., returns [ 1, 3, 2 ]
@@ -101,6 +103,8 @@ indicates that `foo()` returns an `array` containing the values `1`, `2`, and `3
 When doctests are evaluated, annotations prefixed with `e.g.,` should be **skipped**. While we could have used a more general annotation
 
 <!-- run-disable -->
+
+<!-- eslint-disable stdlib/doctest -->
 
 ```javascript
 var arr = foo();
@@ -130,6 +134,8 @@ indicates that the two-element array to which `x` refers has been mutated after 
 The `e.g.,` and `{var} =>` prefixes can be used in combination. For example,
 
 <!-- run-disable -->
+
+<!-- eslint-disable stdlib/doctest -->
 
 ```javascript
 foo( x );
@@ -168,7 +174,7 @@ console.log( x );
 // => 3.141592653589793
 ```
 
-asserts that the value `3.141592653589793` is printed to an output destination, e.g., `stdout`.
+asserts that the value `3.141592653589793` is printed to an output destination (e.g., `stdout`).
 
 #### Approximate Equality
 
@@ -194,7 +200,7 @@ console.log( npi( 2 ) );
 // => ~6.28
 ```
 
-asserts that a value approximately equal to `6.28` will be printed to an output destination, e.g., `stdout`.
+asserts that a value approximately equal to `6.28` will be printed to an output destination (e.g., `stdout`).
 
 > **Note**: doctest implementations should use functionality equivalent to [`roundn`][@stdlib/math/base/special/roundn] for deriving actual (approximate) values against which to test.
 
@@ -204,6 +210,8 @@ Equality assertions are extended to more complex natively supported data structu
 
 <!-- run-disable -->
 
+<!-- eslint-disable stdlib/doctest -->
+
 ```javascript
 var o = foo();
 // returns { 'a': [ 1, 2, 3 ] }
@@ -212,6 +220,8 @@ var o = foo();
 indicates that `foo()` returns a JavaScript `object` with known contents. While single-line comment syntax is preferred, doctests asserting deep equality can be used with multi-line comment syntax. For example,
 
 <!-- run-disable -->
+
+<!-- eslint-disable stdlib/doctest -->
 
 ```javascript
 var o = foo();
@@ -233,6 +243,8 @@ Asserting approximately equality is extended to complex data structures. For exa
 
 <!-- run-disable -->
 
+<!-- eslint-disable stdlib/doctest -->
+
 ```javascript
 var o = foo();
 // returns { 'a': [ ~1.1, ~2.2, ~3.3 ] }
@@ -241,6 +253,8 @@ var o = foo();
 indicates that `foo()` returns a JavaScript `object` containing a nested array with approximate values `1.1`, `2.2`, and `3.3`. Similarly,
 
 <!-- run-disable -->
+
+<!-- eslint-disable stdlib/doctest -->
 
 ```javascript
 var o = foo();
@@ -261,6 +275,8 @@ For example,
 
 <!-- run-disable -->
 
+<!-- eslint-disable stdlib/doctest -->
+
 ```javascript
 var str = foo();
 // returns <string>
@@ -275,6 +291,8 @@ asserts that `foo()` returns a value having the type `string`. Type annotations 
 To support the particular use case of homogeneously typed arrays, the array value type should be followed by square brackets `[]`. For example,
 
 <!-- run-disable -->
+
+<!-- eslint-disable stdlib/doctest -->
 
 ```javascript
 var str = foo();
@@ -293,6 +311,8 @@ For example,
 
 <!-- run-disable -->
 
+<!-- eslint-disable stdlib/doctest -->
+
 ```javascript
 var re = foo();
 // returns <RegExp>
@@ -301,6 +321,8 @@ var re = foo();
 indicates that `foo()` returns a value which is an "instance of" `RegExp` (i.e., a JavaScript regular expression).
 
 <!-- run-disable -->
+
+<!-- eslint-disable stdlib/doctest -->
 
 ```javascript
 var z = new Complex128( 1.0, -1.0 );
@@ -341,6 +363,8 @@ In a similar manner, deep approximate equality can be combined with instance equ
 
 <!-- run-disable -->
 
+<!-- eslint-disable stdlib/doctest -->
+
 ```javascript
 var x = foo();
 // returns <Float64Array>[ ~1.0, ~2.0, ~3.0 ]
@@ -354,6 +378,8 @@ In special circumstances, authors may want to express two or more possible retur
 
 <!-- run-disable -->
 
+<!-- eslint-disable stdlib/doctest -->
+
 ```javascript
 var v = foo();
 // returns <number> || null
@@ -364,6 +390,8 @@ indicates that `foo()` may return either a value of type `number` **or** the val
 Similarly, although expected to be a **rare** use case, conditional equality can be applied to printed output. For example,
 
 <!-- run-disable -->
+
+<!-- eslint-disable stdlib/doctest -->
 
 ```javascript
 var v = foo();
@@ -380,6 +408,8 @@ To support abbreviated output, doctest annotations can use ellipsis to indicate 
 
 <!-- run-disable -->
 
+<!-- eslint-disable stdlib/doctest -->
+
 ```javascript
 var v = foo();
 // returns ...
@@ -388,6 +418,8 @@ var v = foo();
 indicates that `foo()` returns a value of undefined/unspecified type (i.e., a value of "any" type).
 
 <!-- run-disable -->
+
+<!-- eslint-disable stdlib/doctest -->
 
 ```javascript
 var s = foo();
@@ -398,6 +430,8 @@ indicates that `foo()` returns a **non-empty** `string` with undefined/unspecifi
 
 <!-- run-disable -->
 
+<!-- eslint-disable stdlib/doctest -->
+
 ```javascript
 var arr = foo();
 // returns [...]
@@ -406,6 +440,8 @@ var arr = foo();
 indicates that `foo()` returns a **non-empty** `array` with undefined/unspecified contents.
 
 <!-- run-disable -->
+
+<!-- eslint-disable stdlib/doctest -->
 
 ```javascript
 var arr = foo();
@@ -416,6 +452,8 @@ indicates that `foo()` returns an `array` whose length is at least `2`, whose fi
 
 <!-- run-disable -->
 
+<!-- eslint-disable stdlib/doctest -->
+
 ```javascript
 var arr = foo();
 // returns [ ~1.1, ..., ~10.5 ]
@@ -424,6 +462,8 @@ var arr = foo();
 indicates that `foo()` returns an `array` whose length is at least `2`, whose first element is approximately `1.1`, and whose last element is approximately `10.5`.
 
 <!-- run-disable -->
+
+<!-- eslint-disable stdlib/doctest -->
 
 ```javascript
 var arr = foo();
@@ -438,6 +478,8 @@ To indicate continued output, especially for larger data structures such as arra
 
 <!-- run-disable -->
 
+<!-- eslint-disable stdlib/doctest -->
+
 ```javascript
 var arr = foo();
 // returns [ 1, 2, ... ]
@@ -446,6 +488,8 @@ var arr = foo();
 indicates that `foo()` returns an `array` whose length is at least `2`, whose first element is `1`, and whose second element is `2`.
 
 <!-- run-disable -->
+
+<!-- eslint-disable stdlib/doctest -->
 
 ```javascript
 var arr = foo();
@@ -524,9 +568,11 @@ stdlib extends doctest annotations to accommodate data structures commonly used 
 
 #### matrices
 
-For matrices (and, more generally, ndarrays), stdlib uses a "slice" syntax to indicate matrix contents. For example, 
+For matrices (and, more generally, ndarrays), stdlib uses a "slice" syntax to indicate matrix contents. For example,
 
 <!-- run-disable -->
+
+<!-- eslint-disable stdlib/doctest -->
 
 ```javascript
 var mat = foo();
@@ -543,6 +589,8 @@ Less commonly, one may want to assert a sub-matrix. For example,
 
 <!-- run-disable -->
 
+<!-- eslint-disable stdlib/doctest -->
+
 ```javascript
 var mat = foo();
 /* returns
@@ -558,6 +606,8 @@ Additionally, matrices can include wildcards. For example,
 
 <!-- run-disable -->
 
+<!-- eslint-disable stdlib/doctest -->
+
 ```javascript
 var mat = foo();
 /* returns
@@ -570,9 +620,11 @@ var mat = foo();
 
 indicates that `foo()` returns a matrix having at least `2` rows and at least `2` columns and whose  contents include the values `1.14`, `-3.14`, `0.00`, and `0.50`.
 
-Lastly, similar to other complex data structures, approximate values are demarcated with a tilde `~`. For example, 
+Lastly, similar to other complex data structures, approximate values are demarcated with a tilde `~`. For example,
 
 <!-- run-disable -->
+
+<!-- eslint-disable stdlib/doctest -->
 
 ```javascript
 var mat = foo();
@@ -588,6 +640,8 @@ var mat = foo();
 ndarrays extend the conventions for matrices to arbitrary dimensions. For example,
 
 <!-- run-disable -->
+
+<!-- eslint-disable stdlib/doctest -->
 
 ```javascript
 var x = foo();

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -76,7 +76,7 @@ The [documentation][stdlib-snippets] folder includes all documentation beside th
 
 ### lib
 
-The [`lib`][stdlib-snippets] folder contains the package implementation. Every `lib` folder should have an `index.js` file, which defines the main package exports, which may be dynamically determined based on the host environment. Typically, the `index.js` does not contain the main implementation, but rather imports the implementation from a separate file.
+The [`lib`][stdlib-snippets] folder contains the package implementation. Every `lib` folder should have an `index.js` file, which defines the main package exports, which may be dynamically determined based on the host environment. Typically, the `index.js` does not contain the main implementation, but rather imports the implementation from a separate file (most commonly named `main.js`).
 
 ### test
 
@@ -96,8 +96,9 @@ Once you are ready to begin creating a new package, we recommend the following o
 4.  **Write the implementation**. While some will argue that tests should come before the implementation, our experience is that writing an implementation against the example is nearly as effective and requires less upfront investment when ideas are still being formed. We too often write tests and then write an implementation against those tests, only to realize that the approach is flawed, necessitating two refactorings, rather than one. Accordingly, our general recommendation is README/example driven development, but you are free to pursue the approach which bests suits your tastes and workflow.
 5.  **Write benchmarks**. Benchmarks typically require less work than unit tests, but they often help flag potential performance cliffs and a need to rethink a particular approach and implementation. In our experience, writing benchmarks before tests helps minimize the number, and extent, of refactorings.
 6.  **Write tests**. Tests are your opportunity to challenge and verify your assumptions and intended behavior. Tests should be thorough and complete and **always** achieve `100%` coverage. Tests should include edge cases and option combinations and confirm that the implementation provides adequate guards against unintended inputs.
-7.  **Write the `repl.txt`**. After solidifying an implementation, write the REPL text according to the REPL text [guide][stdlib-docs]. The stdlib REPL will use this file to display relevant help information during a REPL session.
-8.  **Additional tasks**. Additional tasks may include implementing a command-line interface, ensuring that a command-line interface works as intended, generating equation SVGs, and writing build scripts to support package maintenance (e.g., if a package file needs to be regenerated when a data source updates).
+7.  **Write the `repl.txt`**. After solidifying an implementation, write the REPL text according to the REPL text [guide][stdlib-repl-text]. The stdlib REPL will use this file to display relevant help information during a REPL session.
+8.  **Write TypeScript declarations**. TypeScript declarations assist users who consume stdlib when writing TypeScript. An `index.d.ts` file should contain all declarations relevant to a package. All declarations should be accompanied by a `test.ts` file which tests type expectations (i.e., think of the `test.ts` as a set of unit tests for a package's TypeScript declarations). While JSDoc comments included in the implementation may provide some inspiration for defining TypeScript types, note that the correspondence is not 1-to-1. Be sure to consult other packages to see how JSDoc parameter types map to TypeScript types and vice versa.
+9.  **Additional tasks**. Additional tasks may include implementing a command-line interface, ensuring that a command-line interface works as intended, generating equation SVGs, and writing build scripts to support package maintenance (e.g., if a package file needs to be regenerated when a data source updates).
 
 Throughout the development process, you should use the following commands to run tasks:
 
@@ -113,7 +114,7 @@ Once a package is complete and tested, you are ready to request that your contri
 
 [stdlib-snippets]: https://github.com/stdlib-js/stdlib/tree/develop/tools/snippets
 
-[stdlib-docs]: https://github.com/stdlib-js/stdlib/tree/develop/docs
+[stdlib-repl-text]: https://github.com/stdlib-js/stdlib/tree/develop/docs/repl_text.md
 
 </section>
 

--- a/docs/repl_text.md
+++ b/docs/repl_text.md
@@ -308,6 +308,7 @@ The following parameter types are supported:
 -   `Uint8ClampedArray`: if a parameter must be a `Uint8ClampedArray`.
 -   `ArrayBuffer`: if a parameter must be an `ArrayBuffer`.
 -   `SharedArrayBuffer`: if a parameter must be a `SharedArrayBuffer`.
+-   `ndarray`: if a parameter must be an `ndarray`.
 
 For parameters which may be more than one type, use a `|` separator.
 
@@ -323,7 +324,7 @@ foo( value )
     ...
 ```
 
-In general, avoid specialized and/or uncommon value types; e.g., `NonNegativeInteger`, `Probability`, etc. Users are unable to discern the meaning of specialized types without access to external (possibly out-of-band) documentation.
+In general, avoid specialized and/or uncommon value types (e.g., `NonNegativeInteger`, `Probability`, etc). Users are unable to discern the meaning of specialized types without access to external (possibly out-of-band) documentation.
 
 A few notes:
 
@@ -364,6 +365,20 @@ For return values which can be more than one type, use a `|` separator.
     -------
     out: Buffer|Error
         A short description.
+
+    ...
+```
+
+For constructors returning class instances, the class name may be used as the return type.
+
+```text
+Foo()
+    Returns a new instance.
+
+    Returns
+    -------
+    out: Foo
+        A new instance.
 
     ...
 ```

--- a/docs/style-guides/git/README.md
+++ b/docs/style-guides/git/README.md
@@ -1,199 +1,288 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2023 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
 # Git Style Guide
 
 > Style guide for [Git][git].
 
 ## Commits
 
-All commits should follow the [seven rules][git-seven-rules] of a [Git][git] commit message:
+### Overview
 
-1.  Use the [imperative mood][imperative-mood] in the [Git][git] commit subject line.
+Commits should be clearly documented for how they affect consumers of and contributors to this project. To this end, we adhere to the [Conventional Commits][conventional-commits] specification, which details structured commit messages for clarifying the impact of each commit.
 
-    ```text
-    # Do not...
-    Fixed Markdown lint errors
-    ```
+### Motivation
 
-    ```text
-    # Do...
-    Fix Markdown lint errors
-    ```
+Contributors to this project should describe the changes they make. Detailed descriptions are valuable to various stakeholders, including other contributors, downstream consumers, library authors, individuals needing to deploy and/or integrate the project, and others. Commit authors are best positioned to accurately describe their work and its implications.
 
-2.  Capitalize the first word of the subject line.
+The closer to the change one captures information pertaining to a change's context, motivation, and impact, the easier such information will be to write and the more accurate such information will be. Many individuals consume the changes introduced by contributors, from pull request reviewers to library authors to end consumers of this project. The more a contributor can explain a change, the more readily a change can be understood and used, and the more efficient the development process will be.
 
-    ```text
-    # Do not...
-    fix Markdown lint errors
-    ```
+Commit messages are the closest text to the change itself. The more information-rich a commit message is, the more useful it will be.
 
-    ```text
-    # Do...
-    Fix Markdown lint errors
-    ```
+### Specification
 
-3.  Do **not** end the subject line with a period.
+This project adheres to the [Conventional Commits][conventional-commits] specification, with our own specific requirements. We have very precise rules over how our Git commit messages must be formatted. This format leads to a commit history which is easier to read and easier to consume as part of automated build processes.
 
-    ```text
-    # Do not...
-    Fix Markdown lint errors.
-    ```
+Each commit message consists of three parts: a **header**, a **body** (optional), and a **footer** (optional). Each part **must** be separated from the other parts by a **blank line**.
 
-    ```text
-    # Do...
-    Fix Markdown lint errors
-    ```
+```text
+<header>
 
-4.  Separate the subject line from the body with a blank line.
+<body>
 
-    ```text
-    # Do not...
-    This is the subject line
-    This is the body body body body body body body body body body body body
-    body body body body body body body body body body body body body body
-    ```
+<footer>
+```
 
-    ```text
-    # Do...
-    This is the subject line
+The **header** is **mandatory** and must conform to the [commit message header](#commit-message-header) format.
 
-    This is the body body body body body body body body body body body body
-    body body body body body body body body body body body body body body
-    ```
+The **body** is **mandatory** for all non-trivial commits. When present, the body must be at least 20 characters in length and must conform to the [commit message body](#commit-message-body) format.
 
-5.  Try to limit the subject line to `50` characters.
+The **footer** is **optional**. When present, the footer must conform to the [commit message footer](#commit-message-footer) format.
 
-    ```text
-    # Do not...
-    This is the subject line line line line line line line line line line line line line line
-    ```
+#### Commit Message Header
 
-    ```text
-    # Do...
-    This is the subject line
-    ```
+```text
+<type>(<scope>): <short summary>
+  │       │             │
+  │       │             └─▶︎ Summary in imperative mood. Not capitalized. No period at the end.
+  │       │
+  │       └─▶︎ Commit Scope: noun describing section of the codebase
+  │
+  └─▶︎ Commit Type: bench|build|chore|deprecate|docs|feat|fix|perf|refactor|remove|revert|style|test|temp
+```
 
-6.  Use the body to explain the _what_ and _why_, and not the _how_.
+The **type** and **short summary** fields are **mandatory**, and the **scope** field is **optional**.
 
-    ```text
-    # Do not...
-    Change Markdown heading style
+##### type
 
-    Update various Markdown files to stop lint errors. Change the heading
-    style from `===` to `#`.
-    ```
+The **type** field labels a commit and indicates the category of change introduced by a commit. We use the following commit types:
+
+-   **bench**: benchmark-only changes, such as adding missing benchmarks or correcting existing benchmarks. This type has lower precedence than other types, and, thus, benchmarks accompanying other types of changes can be categorized according to those other types. 
+
+-   **build**: anything to do with building and releasing the project, including changes to automation and continuous integration configuration files and scripts (e.g., GitHub actions, CircleCI, Azure, etc).
+
+-   **chore**: neither a fix, feature, or refactor; a repetitive mechanical task, such as updating package meta data or updating external dependencies.
+
+-   **deprecate**: a change that deprecates an existing feature. This type correlates with `MINOR` in [Semantic Versioning][semver].
+
+-   **docs**: documentation-only changes. Documentation changes include changes to the following: READMEs, JSDoc/Doxygen-style comments, annotations, comments, and examples (including examples files). Note that changes to TypeScript declarations files are **not** documentation-only changes, as TypeScript declarations are part of a package's public API and are consumed by downstream project consumers.
+
+-   **feat**: a new feature. This type typically correlates with `MINOR` in [Semantic Versioning][semver]; however, a new feature may introduce a breaking change and thus correlate with `MAJOR` in [Semantic Versioning][semver] (e.g., if an existing user-facing API is completely changed to support new behaviors and existing behaviors are not preserved).
+
+-   **fix**: bug fixes, including changes to the behavior of existing features and including changes that remove or mitigate security vulnerabilities. This type correlates with `PATCH` in [Semantic Versioning][semver].
+
+-   **perf**: a change that improves performance.
+
+-   **refactor**: neither a fix or a feature; a change that does not change behavior from the perspective of downstream consumers of the project. If refactoring improves performance, **perf** takes higher priority.
+
+-   **remove**: removes a feature. This type correlates with `MAJOR` in [Semantic Versioning][semver].
+
+-   **revert**: a change which undoes a previous change. The **short summary** must include the previous commit message short summary and the type label. For example, if the initial commit is
 
     ```text
-    # Do...
-    Change Markdown heading style
-
-    Change the heading style to ensure consistency with `remark` output.
-    This ensures that all Markdown files are all of the same style, thus
-    reducing the number of edge cases Markdown parsers need to consider.
+    fix(tools): address race condition when iterating over files
     ```
 
-7.  Try to wrap the body at `72` characters.
+    the revert commit **header** would be
 
     ```text
-    # Do not...
-    This is the subject line
-
-    This is the body body body body body body body body body body body body body body body body body body body body body body body body body body
+    revert(tools): address race condition when iterating over files
     ```
+
+-   **style**: a change which improves code style (e.g., whitespace, formatting, semicolons, etc) and does not affect the meaning of code.
+
+-   **test**: test-only changes, such as adding missing tests or correcting existing tests. This type has lower precedence than other types, and, thus, tests accompanying other types of changes can be categorized according to those other types. 
+
+-   **temp**: temporary, experimental, or exploratory changes that are not intended to be permanent. Occasionally, one may want to push changes to GitHub that are intended to be short-lived, such as when debugging continuous integration or ad-hoc debugging on live systems.
+
+Breaking changes **must** include an exclamation point as part of the **type**. For example,
+
+```text
+feat!: refactor the `cabs` API to support complex number instances
+```
+
+Breaking changes correlate with `MAJOR` in [Semantic Versioning][semver].
+
+Contributors should separate commits into consistent logical units (e.g., bug fixes should **not** be combined with new features). Some types of changes may be included in a combined commit, such as a new feature (**feat**) and its associated tests (**test**), benchmarks (**bench**), and documentation (**docs**); however, **refactor**, **style**, **chore**, and **temp** should be kept separate from more significant work.
+
+If a commit mixes types, contributors should use the most important type label in the commit message. The priority order is generally:
+
+1.  **revert**
+2.  **feat**
+3.  **fix**
+4.  **remove**
+5.  **deprecate**
+6.  **perf**
+7.  **docs**
+8.  **test**
+9.  **bench**
+10. **build**
+11. **refactor**
+12. **style**
+13. **chore**
+14. **temp**
+
+##### Scope
+
+The [Conventional Commits][conventional-commits] specification includes support for an optional parenthesized scope following the commit type. A contributor may choose to include a scope in order to provide additional contextual information, if doing so helps clarify a commit. If provided, a scope **must** be a noun describing the section of the codebase affected by the commit.
+
+##### Short Summary
+
+The short summary **must** provide a succinct description of a change and adhere to the following conventions:
+
+-   Use the [imperative][imperative-mood], present tense (e.g., "change", not "changed" or "changes").
+-   Do **not** capitalize the first letter.
+-   Do **not** include a period at the end.
+-   Should be less than **72** characters.
+
+A properly formed short summary should complete the following sentence:
+
+```text
+If applied, this commit will <short summary>
+```
+
+For example, given the commit message header
+
+```text
+feat!: refactor the `cabs` API to support complex number instances
+```
+
+the short summary completes the following sentence:
+
+```text
+If applied, this commit will refactor the `cabs` API to support complex number instances
+```
+
+A short summary should be short enough to fit on a single line. While this project does not enforce a hard limit on character length, if a short summary is longer than 72 characters, one should consider moving content to, and including more information in, the commit message body in order to more fully explain the change. In **no** circumstances should the short summary contain references to an external system that is not accessible to all members of the stdlib community (e.g., private repository issue trackers, Slack discussions, etc).
+
+Do **not** include GitHub issue numbers in the short summary. Links to issue trackers should be included in the commit message body or in the commit message footer. In general, the short summary should only contain words.
+
+#### Commit Message Body
+
+For significant changes to the codebase, the short summary is unlikely to provide enough information to fully understand the commit. Use the commit message body to more fully explain the motivation for the change and include comparisons of previous behavior with new behavior in order to illustrate the impact of the change. The commit message body should explain the _what_ and _why_, and not the _how_.
+
+```text
+# Do not...
+docs: change Markdown heading style
+
+Update various Markdown files to stop lint errors. Change the heading
+style from `===` to `#`.
+```
+
+```text
+# Do...
+docs: change Markdown heading style
+
+Change the heading style to ensure consistency with `remark` output.
+This ensures that all Markdown files are all of the same style, thus
+reducing the number of edge cases Markdown parsers need to consider.
+```
+
+The project does **not** enforce a hard limit on commit message body character length. Be generous. Including two paragraphs of explanation is not unreasonable. When writing the commit message body, a contributor should take a moment to consider what information she would want to know if someone else had authored the commit. The more information, the better.
+
+Breaking changes especially should include detailed information about the impact of the change, implications, and alternatives, and should be accompanied by a `BREAKING CHANGE` footer.
+
+In the commit message body, a contributor may include references and links to supporting information, such as public GitHub issues (although these may be better placed in the commit message footer). However, the body should be sufficient for understanding the commit. Links to private issues should **not** be included in the commit message body and should instead be included in the commit message footer using the [Git trailer format][git-trailer-format], as documented below in the [commit message footer](#commit-message-footer) format. In general, contributors should prefer linking to public issues, rather than private issues.
+
+Commit message lines should be wrapped at **72** characters (except for long URLs).
+
+#### Commit Message Footer
+
+The commit message footer may include information about breaking changes and deprecations and is the place to reference GitHub issues and related PRs (including any issues that a commit closes). For example,
+
+```text
+feat!: refactor the `cabs` API to support complex number instances
+
+This commit removes support for providing an array-like object as the first
+argument and instead refactors the API to only accept complex number instances.
+The previous API was not ergonomic and proved awkward to work with when writing
+ndarray loop iteration logic and over-complicated the interface from a user-
+experience perspective.
+
+BREAKING CHANGE: remove out argument support
+
+Users should migrate by providing complex number instances to refactored APIs.
+
+Fixes: #403
+Private-ref: https://github.com/stdlib-js/todo/issues/987
+Co-authored-by: Jane Doe <jane@doe.com>
+Reviewed-by: John Doe <john@doe.com>
+```
+
+Breaking changes **must** have a `BREAKING CHANGE` token in the commit message body, followed by a colon `:` and short summary of the breaking change. If more detail is warranted, the short summary **must** be followed by a blank line and a detailed description, which may include migration instructions.
+
+```text
+BREAKING CHANGE: <short summary>
+
+<detailed description + migration instructions>
+```
+
+Similarly, deprecations **must** have a `DEPRECATED` token in the commit message body, followed by a colon `:` and short summary of what is deprecated. If more detail is warranted, the short summary **must** be followed by a blank line and a detailed description, which should include a recommended update path.
+
+```text
+DEPRECATED: <short summary>
+
+<detailed description + recommended update path>
+```
+
+A commit message footer may include other structured information using the [Git trailer format][git-trailer-format] (`token: value`). For example,
+
+-   `Fixes:` link to a GitHub issue describing a bug that the commit fixes.
+-   `Closes:` link to a GitHub issue or pull request that the commit closes.
+-   `PR-URL:` link to the GitHub pull request responsible for the commit (e.g., upon squash and merge).
+-   `Reviewed-by:` the name and e-mail of a commit reviewer (e.g., `Jane Doe <jane@doe.com>`).
+-   `Co-authored-by:` the name and e-mail of a contributor who collaborated on the commit.
+-   `Ref:` link to a public resource (e.g., commit SHA, external documentation, reference implementation, etc).
+-   `Private-ref:` link to a private resource (e.g., issue tracker, pull request, discussion, etc) related to the commit. Private references should only be included in the commit message body using the `Private-ref` token.
+
+Each token may be repeated; however, only one token is allowed per line. Tokens **must** begin with a capital letter followed by all lowercase letters, a colon `:`, and a space. A token **must** not include whitespace, and individual words **must** be separated by a hyphen `-` (e.g., `Reviewed-by`, not `Reviewed by`).
+
+The only exceptions to the restrictions on token case and inclusion of whitespace are `BREAKING CHANGE`, which must be in uppercase and include a single whitespace character, and `DEPRECATED`, which must be in uppercase. Both `BREAKING CHANGE` and `DEPRECATED` **must** come before all other tokens.
+
+### Revert Commits
+
+If a commit reverts a previous commit, the commit type **must** be **revert**, followed by the header of the reverted commit. The commit message body should contain:
+
+-   Information about the commit SHA being reverted in the following format:
 
     ```text
-    # Do...
-    This is the subject line
-
-    This is the body body body body body body body body body body body body
-    body body body body body body body body body body body body body body
+    This reverts commit <SHA>.
     ```
 
-* * *
+-   A clear description of the reason for reverting the previous commit.
 
-## Branching
+For example,
 
-This project follows the branching model articulated in ["A successful Git branching model"][git-flow].
+```text
+revert: chore: update README
 
-### Master
+This reverts commit b3befad91a6e39288ea53d540a4a483b0898fb49.
+```
 
--   The `master` branch is **protected**.
+### Discussion
 
--   The `master` branch should **only** include source code which is stable, tested, and peer reviewed. In short, the source code should **always** reflect a "production-ready" state.
+The [Conventional Commits][conventional-commits] specification requires contributors to categorize changes according to a limited number of commit types. Inevitably, situations will arise in which a relevant commit type is not obvious. While choosing an appropriate commit type is important, choosing a commit type is only the first step of writing a commit message. When in doubt, a contributor should choose the highest-priority type which is applicable, and then write a detailed commit message body explaining the full complexity the change.
 
--   Each commit on the `master` branch should have an associated tag.
+**squash!/fixup! vs temp**: use Git's [`squash!`][git-commit-squash] or [`fixup!`][git-commit-fixup] when a commit is temporary, but you intend to squash the commit into another commit. Use **temp** when a change is temporary, but you intend for the change to be preserved in the commit history.
 
-    ```bash
-    $ git tag -a 2.0.0
-    $ git push origin --tags
-    ```
-
-### Develop
-
--   The `develop` branch is **protected**.
--   The `develop` branch should **only** include code which is tested, peer reviewed, and passes continuous integration tests.
--   The source code should **always** reflect the latest development changes for the **next** release.
-
-### Features
-
--   A feature branch should use the naming convention: `feature/<name>`.
-
--   A feature branch should branch from the `develop` branch.
-
-    ```bash
-    $ git checkout -b feature/<name> develop
-    ```
-
--   Once a feature is complete, [squash][git-squash] commits into a single commit.
-
--   In order to merge a feature branch into the `develop` branch, submit a pull request against the `develop` branch.
-
--   Before merging a feature branch into the `develop` branch, the source code **must** be peer reviewed and pass continuous integration tests.
-
-### Releases
-
--   A release branch should use the naming convention: `release-<major>.<minor>.<patch>`.
-
--   The release number should follow [semantic versioning][semver].
-
--   A release branch should branch from the `develop` branch.
-
-    ```bash
-    $ git checkout -b release-2.0.0 develop
-    ```
-
--   Active development should **not** occur on a release branch. A release branch is a preparation branch (vetting, testing, updating meta data, et cetera) before merging into the `master` branch.
-
--   Once a release branch is complete, submit a pull request against the `master` branch.
-
--   Before merging the release branch into the `master` branch, the changes **must** be peer reviewed and pass continuous integration tests.
-
--   Once merged into `master`, submit a pull request against the `develop` branch to retain the changes made in the release branch.
-
-### Hotfixes
-
--   A hotfix branch should use the naming convention: `hotfix/<name>`.
-
--   The purpose of a hotfix branch is to immediately patch a bug on the `master` branch. Accordingly, a hotfix branch should branch from the `master` branch.
-
-    ```bash
-    $ git checkout -b hotfix/<name> master
-    ```
-
--   The hotfix branch should increment the ["patch"][semver] version number.
-
--   Once a hotfix is complete, [squash][git-squash] commits into a single commit.
-
--   Submit a pull request against the `master` branch.
-
--   Before merging a hotfix branch into the `master` branch, the changes **must** be peer reviewed and pass continuous integration tests.
-
--   Once merged into `master`, if a release branch currently exists, submit a pull request against the `release` branch. Otherwise, submit a pull request against the `develop` branch. By merging a hotfix into a release branch, the hotfix changes should be propagated to the `develop` branch upon merging the release branch into the `develop` branch. 
-
-* * *
-
-## Pull Requests
-
--   All feature pull requests should be [rebased][git-rebase] against the latest `develop` branch.
--   All feature pull requests should be submitted against the `develop` branch.
+**Merge commits**: Git generated commits, such as merge commits, do not follow the above guidelines, but this does not mean that these commits should be avoided. When analyzing commit history (e.g., as part of automation and changelog generation), Git generated commits will be ignored.
 
 * * *
 
@@ -203,17 +292,17 @@ This document may be reused under a [Creative Commons Attribution-ShareAlike Lic
 
 <section class="links">
 
+[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
+
 [git]: https://git-scm.com/
 
-[git-rebase]: https://git-scm.com/docs/git-rebase
+[git-commit-squash]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---squashltcommitgt
 
-[git-squash]: https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Squashing-Commits
+[git-commit-fixup]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---fixupamendrewordltcommitgt
 
-[git-seven-rules]: http://chris.beams.io/posts/git-commit/
+[git-trailer-format]: https://git-scm.com/docs/git-interpret-trailers
 
 [imperative-mood]: https://en.wikipedia.org/wiki/Imperative_mood
-
-[git-flow]: http://nvie.com/posts/a-successful-git-branching-model/
 
 [semver]: http://semver.org/
 

--- a/docs/style-guides/git/README.md
+++ b/docs/style-guides/git/README.md
@@ -271,7 +271,8 @@ For example,
 ```text
 revert: chore: update README
 
-This reverts commit b3befad91a6e39288ea53d540a4a483b0898fb49.
+This reverts commit b3befad91a6e39288ea53d540a4a483b0898fb49. The previous
+guidance was too restrictive.
 ```
 
 * * *

--- a/docs/style-guides/git/README.md
+++ b/docs/style-guides/git/README.md
@@ -24,7 +24,7 @@ limitations under the License.
 
 ## Overview
 
-Commits should be clearly documented for how they affect consumers of and contributors to this project. To this end, we adhere to the [Conventional Commits][conventional-commits] specification, which details structured commit messages for clarifying the impact of each commit.
+Commits should be clearly documented for how they affect consumers of and contributors to this project. To this end, the project adheres to the [Conventional Commits][conventional-commits] specification, which details structured commit messages for clarifying the impact of each commit.
 
 ## Motivation
 
@@ -36,7 +36,7 @@ Commit messages are the closest text to the change itself. The more information-
 
 ## Specification
 
-This project adheres to the [Conventional Commits][conventional-commits] specification, with our own specific requirements. We have very precise rules over how our Git commit messages must be formatted. This format leads to a commit history which is easier to read and easier to consume as part of automated build processes.
+This project adheres to the [Conventional Commits][conventional-commits] specification, with additional project-specific requirements. The project has very precise rules over how Git commit messages must be formatted. This format leads to a commit history which is easier to read and easier to consume as part of automated build processes.
 
 Each commit message consists of three parts: a **header**, a **body** (optional), and a **footer** (optional). Each part **must** be separated from the other parts by a **blank line**.
 
@@ -70,7 +70,7 @@ The **type** and **short summary** fields are **mandatory**, and the **scope** f
 
 #### type
 
-The **type** field labels a commit and indicates the category of change introduced by a commit. We use the following commit types:
+The **type** field labels a commit and indicates the category of change introduced by a commit. The project uses the following commit types:
 
 -   **bench**: benchmark-only changes, such as adding missing benchmarks or correcting existing benchmarks. This type has lower precedence than other types, and, thus, benchmarks accompanying other types of changes can be categorized according to those other types. 
 
@@ -80,7 +80,7 @@ The **type** field labels a commit and indicates the category of change introduc
 
 -   **deprecate**: a change that deprecates an existing feature. This type correlates with `MINOR` in [Semantic Versioning][semver].
 
--   **docs**: documentation-only changes. Documentation changes include changes to the following: READMEs, JSDoc/Doxygen-style comments, annotations, comments, and examples (including examples files). Note that changes to TypeScript declarations files are **not** documentation-only changes, as TypeScript declarations are part of a package's public API and are consumed by downstream project consumers.
+-   **docs**: documentation-only changes. Documentation changes include changes to the following: READMEs, JSDoc/Doxygen-style comments, annotations, source comments, and examples (including examples files). Note that changes to TypeScript declarations files are **not** documentation-only changes, as TypeScript declarations are part of a package's public API and are consumed by downstream project consumers.
 
 -   **feat**: a new feature. This type typically correlates with `MINOR` in [Semantic Versioning][semver]; however, a new feature may introduce a breaking change and thus correlate with `MAJOR` in [Semantic Versioning][semver] (e.g., if an existing user-facing API is completely changed to support new behaviors and existing behaviors are not preserved).
 
@@ -101,7 +101,7 @@ The **type** field labels a commit and indicates the category of change introduc
     the revert commit **header** would be
 
     ```text
-    revert(tools): address race condition when iterating over files
+    revert: fix(tools): address race condition when iterating over files
     ```
 
 -   **style**: a change which improves code style (e.g., whitespace, formatting, semicolons, etc) and does not affect the meaning of code.
@@ -197,7 +197,7 @@ The project does **not** enforce a hard limit on commit message body character l
 
 Breaking changes especially should include detailed information about the impact of the change, implications, and alternatives, and should be accompanied by a `BREAKING CHANGE` footer.
 
-In the commit message body, a contributor may include references and links to supporting information, such as public GitHub issues (although these may be better placed in the commit message footer). However, the body should be sufficient for understanding the commit. Links to private issues should **not** be included in the commit message body and should instead be included in the commit message footer using the [Git trailer format][git-trailer-format], as documented below in the [commit message footer](#commit-message-footer) format. In general, contributors should prefer linking to public issues, rather than private issues.
+In the commit message body, a contributor may include references and links to supporting information, such as public GitHub issues (although these may be better placed in the commit message footer). However, the body alone should be sufficient for understanding the commit. Links to private issues should **not** be included in the commit message body and should instead be included in the commit message footer using the [Git trailer format][git-trailer-format], as documented below in the [commit message footer](#commit-message-footer) format. In general, contributors should prefer linking to public issues, rather than private issues.
 
 Commit message lines should be wrapped at **72** characters (except for long URLs).
 
@@ -278,9 +278,9 @@ This reverts commit b3befad91a6e39288ea53d540a4a483b0898fb49.
 
 ## Discussion
 
-The [Conventional Commits][conventional-commits] specification requires contributors to categorize changes according to a limited number of commit types. Inevitably, situations will arise in which a relevant commit type is not obvious. While choosing an appropriate commit type is important, choosing a commit type is only the first step of writing a commit message. When in doubt, a contributor should choose the highest-priority type which is applicable, and then write a detailed commit message body explaining the full complexity the change.
+The [Conventional Commits][conventional-commits] specification requires contributors to categorize changes according to a limited number of commit types. Inevitably, situations will arise in which a relevant commit type is not obvious. While choosing an appropriate commit type is important, choosing a commit type is only the first step in writing a commit message. When in doubt, a contributor should choose the highest-priority type which is applicable, and then write a detailed commit message body explaining the full complexity the change.
 
-**squash!/fixup! vs temp**: use Git's [`squash!`][git-commit-squash] or [`fixup!`][git-commit-fixup] when a commit is temporary, but you intend to squash the commit into another commit. Use **temp** when a change is temporary, but you intend for the change to be preserved in the commit history.
+**squash! or fixup! vs temp**: use Git's [`squash!`][git-commit-squash] or [`fixup!`][git-commit-fixup] when a commit is temporary, but you intend to squash the commit into another commit. Use **temp** when a change is temporary, but you intend for the change to be preserved in the commit history.
 
 **Merge commits**: Git generated commits, such as merge commits, do not follow the above guidelines, but this does not mean that these commits should be avoided. When analyzing commit history (e.g., as part of automation and changelog generation), Git generated commits will be ignored.
 

--- a/docs/style-guides/git/README.md
+++ b/docs/style-guides/git/README.md
@@ -76,7 +76,7 @@ The **type** field labels a commit and indicates the category of change introduc
 
 -   **build**: anything to do with building and releasing the project, including changes to automation and continuous integration configuration files and scripts (e.g., GitHub actions, CircleCI, Azure, etc).
 
--   **chore**: neither a fix, feature, or refactor; a repetitive mechanical task, such as updating package meta data or updating external dependencies.
+-   **chore**: neither a fix, a feature, nor a refactor; a repetitive mechanical task, such as updating package meta data or updating external dependencies.
 
 -   **deprecate**: a change that deprecates an existing feature. This type correlates with `MINOR` in [Semantic Versioning][semver].
 
@@ -88,7 +88,7 @@ The **type** field labels a commit and indicates the category of change introduc
 
 -   **perf**: a change that improves performance.
 
--   **refactor**: neither a fix or a feature; a change that does not change behavior from the perspective of downstream consumers of the project. If refactoring improves performance, **perf** takes higher priority.
+-   **refactor**: neither a fix nor a feature; a change that does not change behavior from the perspective of downstream consumers of the project. If refactoring improves performance, **perf** takes higher priority.
 
 -   **remove**: removes a feature. This type correlates with `MAJOR` in [Semantic Versioning][semver].
 

--- a/docs/style-guides/git/README.md
+++ b/docs/style-guides/git/README.md
@@ -279,7 +279,7 @@ guidance was too restrictive.
 
 ## Discussion
 
-The [Conventional Commits][conventional-commits] specification requires contributors to categorize changes according to a limited number of commit types. Inevitably, situations will arise in which a relevant commit type is not obvious. While choosing an appropriate commit type is important, choosing a commit type is only the first step in writing a commit message. When in doubt, a contributor should choose the highest-priority type which is applicable, and then write a detailed commit message body explaining the full complexity the change.
+The [Conventional Commits][conventional-commits] specification requires contributors to categorize changes according to a limited number of commit types. Inevitably, situations will arise in which a relevant commit type is not obvious. While choosing an appropriate commit type is important, choosing a commit type is only the first step in writing a commit message. When in doubt, a contributor should choose the highest-priority type which is applicable, and then write a detailed commit message body explaining the full complexity of the change.
 
 **squash! or fixup! vs temp**: use Git's [`squash!`][git-commit-squash] or [`fixup!`][git-commit-fixup] when a commit is temporary, but you intend to squash the commit into another commit. Use **temp** when a change is temporary, but you intend for the change to be preserved in the commit history.
 

--- a/docs/style-guides/git/README.md
+++ b/docs/style-guides/git/README.md
@@ -18,17 +18,15 @@ limitations under the License.
 
 -->
 
-# Git Style Guide
+# Git Commit Messages
 
-> Style guide for [Git][git].
+> Guide for writing [Git][git] commit messages.
 
-## Commits
-
-### Overview
+## Overview
 
 Commits should be clearly documented for how they affect consumers of and contributors to this project. To this end, we adhere to the [Conventional Commits][conventional-commits] specification, which details structured commit messages for clarifying the impact of each commit.
 
-### Motivation
+## Motivation
 
 Contributors to this project should describe the changes they make. Detailed descriptions are valuable to various stakeholders, including other contributors, downstream consumers, library authors, individuals needing to deploy and/or integrate the project, and others. Commit authors are best positioned to accurately describe their work and its implications.
 
@@ -36,7 +34,7 @@ The closer to the change one captures information pertaining to a change's conte
 
 Commit messages are the closest text to the change itself. The more information-rich a commit message is, the more useful it will be.
 
-### Specification
+## Specification
 
 This project adheres to the [Conventional Commits][conventional-commits] specification, with our own specific requirements. We have very precise rules over how our Git commit messages must be formatted. This format leads to a commit history which is easier to read and easier to consume as part of automated build processes.
 
@@ -56,7 +54,7 @@ The **body** is **mandatory** for all non-trivial commits. When present, the bod
 
 The **footer** is **optional**. When present, the footer must conform to the [commit message footer](#commit-message-footer) format.
 
-#### Commit Message Header
+### Commit Message Header
 
 ```text
 <type>(<scope>): <short summary>
@@ -70,7 +68,7 @@ The **footer** is **optional**. When present, the footer must conform to the [co
 
 The **type** and **short summary** fields are **mandatory**, and the **scope** field is **optional**.
 
-##### type
+#### type
 
 The **type** field labels a commit and indicates the category of change introduced by a commit. We use the following commit types:
 
@@ -139,11 +137,11 @@ If a commit mixes types, contributors should use the most important type label i
 13. **chore**
 14. **temp**
 
-##### Scope
+#### Scope
 
 The [Conventional Commits][conventional-commits] specification includes support for an optional parenthesized scope following the commit type. A contributor may choose to include a scope in order to provide additional contextual information, if doing so helps clarify a commit. If provided, a scope **must** be a noun describing the section of the codebase affected by the commit.
 
-##### Short Summary
+#### Short Summary
 
 The short summary **must** provide a succinct description of a change and adhere to the following conventions:
 
@@ -174,7 +172,7 @@ A short summary should be short enough to fit on a single line. While this proje
 
 Do **not** include GitHub issue numbers in the short summary. Links to issue trackers should be included in the commit message body or in the commit message footer. In general, the short summary should only contain words.
 
-#### Commit Message Body
+### Commit Message Body
 
 For significant changes to the codebase, the short summary is unlikely to provide enough information to fully understand the commit. Use the commit message body to more fully explain the motivation for the change and include comparisons of previous behavior with new behavior in order to illustrate the impact of the change. The commit message body should explain the _what_ and _why_, and not the _how_.
 
@@ -203,7 +201,7 @@ In the commit message body, a contributor may include references and links to su
 
 Commit message lines should be wrapped at **72** characters (except for long URLs).
 
-#### Commit Message Footer
+### Commit Message Footer
 
 The commit message footer may include information about breaking changes and deprecations and is the place to reference GitHub issues and related PRs (including any issues that a commit closes). For example,
 
@@ -256,7 +254,7 @@ Each token may be repeated; however, only one token is allowed per line. Tokens 
 
 The only exceptions to the restrictions on token case and inclusion of whitespace are `BREAKING CHANGE`, which must be in uppercase and include a single whitespace character, and `DEPRECATED`, which must be in uppercase. Both `BREAKING CHANGE` and `DEPRECATED` **must** come before all other tokens.
 
-### Revert Commits
+## Revert Commits
 
 If a commit reverts a previous commit, the commit type **must** be **revert**, followed by the header of the reverted commit. The commit message body should contain:
 
@@ -276,7 +274,9 @@ revert: chore: update README
 This reverts commit b3befad91a6e39288ea53d540a4a483b0898fb49.
 ```
 
-### Discussion
+* * *
+
+## Discussion
 
 The [Conventional Commits][conventional-commits] specification requires contributors to categorize changes according to a limited number of commit types. Inevitably, situations will arise in which a relevant commit type is not obvious. While choosing an appropriate commit type is important, choosing a commit type is only the first step of writing a commit message. When in doubt, a contributor should choose the highest-priority type which is applicable, and then write a detailed commit message body explaining the full complexity the change.
 

--- a/docs/style-guides/git/README.md
+++ b/docs/style-guides/git/README.md
@@ -252,7 +252,7 @@ A commit message footer may include other structured information using the [Git 
 
 Each token may be repeated; however, only one token is allowed per line. Tokens **must** begin with a capital letter followed by all lowercase letters, a colon `:`, and a space. A token **must** not include whitespace, and individual words **must** be separated by a hyphen `-` (e.g., `Reviewed-by`, not `Reviewed by`).
 
-The only exceptions to the restrictions on token case and inclusion of whitespace are `BREAKING CHANGE`, which must be in uppercase and include a single whitespace character, and `DEPRECATED`, which must be in uppercase. Both `BREAKING CHANGE` and `DEPRECATED` **must** come before all other tokens.
+The only exceptions to the restrictions on token case and inclusion of whitespace are `BREAKING CHANGE`, which **must** be in uppercase and include a single whitespace character, and `DEPRECATED`, which **must** be in uppercase. Both `BREAKING CHANGE` and `DEPRECATED` **must** come before all other tokens.
 
 ## Revert Commits
 

--- a/docs/style-guides/git/branching.md
+++ b/docs/style-guides/git/branching.md
@@ -1,0 +1,131 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2023 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# Branching
+
+> Guide for [Git][git] branching.
+
+This project follows the branching model articulated in ["A successful Git branching model"][git-flow].
+
+## Master
+
+-   The `master` branch is **protected**.
+
+-   The `master` branch should **only** include source code which is stable, tested, and peer reviewed. In short, the source code should **always** reflect a "production-ready" state.
+
+-   Each commit on the `master` branch should have an associated tag.
+
+    ```bash
+    $ git tag -a v2.0.0
+    $ git push origin --tags
+    ```
+
+## Develop
+
+-   The `develop` branch is **protected**.
+-   The `develop` branch should **only** include code which is tested, peer reviewed, and passes continuous integration tests.
+-   The source code should **always** reflect the latest development changes for the **next** release.
+
+## Features
+
+-   A feature branch should use the naming convention: `feature/<name>`.
+
+-   A feature branch should branch from the `develop` branch.
+
+    ```bash
+    $ git checkout -b feature/<name> develop
+    ```
+
+-   Once a feature is complete, [squash][git-squash] commits into a single commit.
+
+-   In order to merge a feature branch into the `develop` branch, submit a pull request against the `develop` branch.
+
+-   Before merging a feature branch into the `develop` branch, the source code **must** be peer reviewed and pass continuous integration tests.
+
+## Releases
+
+-   A release branch should use the naming convention: `release-<major>.<minor>.<patch>`.
+
+-   The release number should follow [semantic versioning][semver].
+
+-   A release branch should branch from the `develop` branch.
+
+    ```bash
+    $ git checkout -b release-2.0.0 develop
+    ```
+
+-   Active development should **not** occur on a release branch. A release branch is a preparation branch (vetting, testing, updating meta data, et cetera) before merging into the `master` branch.
+
+-   Once a release branch is complete, submit a pull request against the `master` branch.
+
+-   Before merging the release branch into the `master` branch, the changes **must** be peer reviewed and pass continuous integration tests.
+
+-   Once merged into `master`, submit a pull request against the `develop` branch to retain the changes made in the release branch.
+
+## Hotfixes
+
+-   A hotfix branch should use the naming convention: `hotfix/<name>`.
+
+-   The purpose of a hotfix branch is to immediately patch a bug on the `master` branch. Accordingly, a hotfix branch should branch from the `master` branch.
+
+    ```bash
+    $ git checkout -b hotfix/<name> master
+    ```
+
+-   The hotfix branch should increment the ["patch"][semver] version number.
+
+-   Once a hotfix is complete, [squash][git-squash] commits into a single commit.
+
+-   Submit a pull request against the `master` branch.
+
+-   Before merging a hotfix branch into the `master` branch, the changes **must** be peer reviewed and pass continuous integration tests.
+
+-   Once merged into `master`, if a release branch currently exists, submit a pull request against the `release` branch. Otherwise, submit a pull request against the `develop` branch. By merging a hotfix into a release branch, the hotfix changes should be propagated to the `develop` branch upon merging the release branch into the `develop` branch. 
+
+* * *
+
+## Pull Requests
+
+-   All feature pull requests should be [rebased][git-rebase] against the latest `develop` branch.
+-   All feature pull requests should be submitted against the `develop` branch.
+
+* * *
+
+## License
+
+This document may be reused under a [Creative Commons Attribution-ShareAlike License][license].
+
+<section class="links">
+
+[git]: https://git-scm.com/
+
+[git-rebase]: https://git-scm.com/docs/git-rebase
+
+[git-squash]: https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Squashing-Commits
+
+[git-flow]: http://nvie.com/posts/a-successful-git-branching-model/
+
+[semver]: http://semver.org/
+
+[license]: https://creativecommons.org/licenses/by-sa/4.0/
+
+</section>
+
+<!-- /.links -->

--- a/docs/style-guides/text/README.md
+++ b/docs/style-guides/text/README.md
@@ -1,3 +1,23 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2023 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
 # Style Guide
 
 > Style guide for writing text.
@@ -6,7 +26,7 @@
 
 -   Filenames should be snake_case.
 
--   Use American English spelling; e.g., "Capitalize" vs. "Capitalise", "color" vs. "colour", etc.
+-   Use American English spelling (e.g., "Capitalize" versus "Capitalise", "color" versus "colour", etc).
 
 -   Insofar as is possible, spelling and grammar issues should be identified using tools, and, if not caught by a tool, should be identified by human reviewers.
 
@@ -23,17 +43,17 @@
 
     Exclusive use of female pronoun forms is permitted.
 
--   Place end-of-sentence punctuation inside wrapping elements; e.g., periods should be placed inside parentheses and quotes, not after.
+-   Place end-of-sentence punctuation inside wrapping elements (e.g., periods should be placed inside parentheses and quotes, not after).
 
 -   Markdown documents must start with a level-one heading, such as in this document.
 
--   Use definitions rather than in-lining; e.g., prefer `[link][]` over `[link](http://example.com)`.
+-   Use definitions rather than in-lining (e.g., prefer `[link][]` over `[link](http://example.com)`).
 
 -   References to constructor functions should use PascalCase.
 
 -   References to constructor instances should use camelCase.
 
--   References to functions and methods should use parentheses; e.g., `foo.factory()` versus `foo.factory`.
+-   References to functions and methods should use parentheses (e.g., `foo.factory()` versus `foo.factory`).
 
 <section class="links">
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

- updates Git commit guidance to use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), which will allow us to eventually automate release and changelog generation for both the main project and all standalone repositories. This migration presents a sizable change from the current practice of relatively freeform commits to a practice in which commits must adhere to a fairly strict structure.
- updates contribution and development guidance. Notably, the development guide now includes a warning regarding limiting the clone depth, in light of recent difficulties encountered by new contributors wanting to rebase on the latest `develop` branch.
- adds license headers to various contribution guides.
- updates copy based on current prose conventions (e.g., instead of "beep boop; e.g., foo bar", do "beep boop (e.g., foo bar)").
- includes a link to the doctest guide in the development guide.
- disables ESLint rules where examples are intended to be illustrative.
- adds guidance for authoring `fixup!` commits.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

- Are we satisfied with the list of commit "types" as set forth in the Git commit guide? Too many? Too few?
- Should we update our contributing guide in other ways?

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

- Provided this PR is accepted, we'll add support for commit message linting to enforce adherence to the new conventions.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

cc @Planeshifter @steff456 @Pranavchiku 

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
