### PR TITLE
feat: add native addon to `cphase` API

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cphase/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # phase
 
-> Compute the [argument][complex-number-argument] of a complex number in radians.
+> Compute the [argument][complex-number-argument] of a double-precision complex floating-point number in radians.
 
 <section class="intro">
 
@@ -61,21 +61,14 @@ var phi = cphase( new Complex128( 5.0, 3.0 ) );
 
 ```javascript
 var Complex128 = require( '@stdlib/complex/float64' );
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
-var real = require( '@stdlib/complex/real' );
-var imag = require( '@stdlib/complex/imag' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var cphase = require( '@stdlib/math/base/special/cphase' );
 
-var re;
-var im;
 var z;
 var i;
 
 for ( i = 0; i < 100; i++ ) {
-    re = round( randu()*100.0 ) - 50.0;
-    im = round( randu()*100.0 ) - 50.0;
-    z = new Complex128( re, im );
+    z = new Complex128( uniform( -500.0, 500.0 ), uniform( -500.0, 500.0 ) );
     console.log( 'arg(%s) = %d', z.toString(), cphase( z ) );
 }
 ```
@@ -176,7 +169,7 @@ int main( void ) {
         y = stdlib_base_cphase( v );
         stdlib_reim( v, &re1, &im1 );
         stdlib_reim( y, &re2, &im2 );
-        printf( "cphase(%lf + %lfi) = %lf + %lfi\n", re1, im1, re2, im2 );
+        printf( "fcphase(%lf + %lfi) = %lf\n", re, im, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/math/base/special/cphase/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/README.md
@@ -18,7 +18,7 @@ limitations under the License.
 
 -->
 
-# phase
+# cphase
 
 > Compute the [argument][complex-number-argument] of a double-precision complex floating-point number in radians.
 
@@ -169,7 +169,7 @@ int main( void ) {
         y = stdlib_base_cphase( v );
         stdlib_reim( v, &re1, &im1 );
         stdlib_reim( y, &re2, &im2 );
-        printf( "fcphase(%lf + %lfi) = %lf\n", re, im, y );
+        printf( "cphase(%lf + %lfi) = %lf\n", re, im, y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/math/base/special/cphase/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/README.md
@@ -38,12 +38,14 @@ The [argument][complex-number-argument] of a complex number, also known as the *
 var cphase = require( '@stdlib/math/base/special/cphase' );
 ```
 
-#### cphase( re, im )
+#### cphase( z )
 
-Computes the [argument][complex-number-argument] of a `complex` number comprised of a **real** component `re` and an **imaginary** component `im`.
+Computes the [argument][complex-number-argument] of a double-precision complex floating-point number.
 
 ```javascript
-var phi = cphase( 5.0, 3.0 );
+var Complex128 = require( '@stdlib/complex/float64' );
+
+var phi = cphase( new Complex128( 5.0, 3.0 ) );
 // returns ~0.5404
 ```
 
@@ -74,13 +76,118 @@ for ( i = 0; i < 100; i++ ) {
     re = round( randu()*100.0 ) - 50.0;
     im = round( randu()*100.0 ) - 50.0;
     z = new Complex128( re, im );
-    console.log( 'arg(%s) = %d', z.toString(), cphase( real(z), imag(z) ) );
+    console.log( 'arg(%s) = %d', z.toString(), cphase( z ) );
 }
 ```
 
 </section>
 
 <!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/math/base/special/cphase.h"
+```
+
+#### stdlib_base_cphase( z )
+
+Computes the [argument][complex-number-argument] of a double-precision complex floating-point number.
+
+```c
+#include "stdlib/complex/float64.h"
+#include "stdlib/complex/real.h"
+#include "stdlib/complex/imag.h"
+
+stdlib_complex128_t z = stdlib_complex128( 5.0, 3.0 );
+double out = stdlib_base_cphase( z );
+// returns ~0.5404
+```
+
+The function accepts the following arguments:
+
+-   **z**: `[in] stdlib_complex128_t` input value.
+
+```c
+double stdlib_base_cphase( const stdlib_complex128_t z );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/math/base/special/cphase.h"
+#include "stdlib/complex/float64.h"
+#include "stdlib/complex/reim.h"
+#include <stdio.h>
+
+int main( void ) {
+    const stdlib_complex128_t x[] = {
+        stdlib_complex128( 3.14, 1.5 ),
+        stdlib_complex128( -3.14, -1.5 ),
+        stdlib_complex128( 0.0, 0.0 ),
+        stdlib_complex128( 0.0/0.0, 0.0/0.0 )
+    };
+
+    stdlib_complex128_t v;
+    stdlib_complex128_t y;
+    double re1;
+    double im1;
+    double re2;
+    double im2;
+    int i;
+    for ( i = 0; i < 4; i++ ) {
+        v = x[ i ];
+        y = stdlib_base_cphase( v );
+        stdlib_reim( v, &re1, &im1 );
+        stdlib_reim( y, &re2, &im2 );
+        printf( "cphase(%lf + %lfi) = %lf + %lfi\n", re1, im1, re2, im2 );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
 
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 

--- a/lib/node_modules/@stdlib/math/base/special/cphase/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/benchmark/benchmark.native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2023 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -20,17 +20,26 @@
 
 // MODULES //
 
+var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/base/uniform' );
-var Complex128 = require( '@stdlib/complex/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var Complex128 = require( '@stdlib/complex/float64' );
+var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
-var cphase = require( './../lib' );
+
+
+// VARIABLES //
+
+var cphase = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( cphase instanceof Error )
+};
 
 
 // MAIN //
 
-bench( pkg, function benchmark( b ) {
+bench( pkg+'::native', opts, function benchmark( b ) {
 	var values;
 	var y;
 	var i;

--- a/lib/node_modules/@stdlib/math/base/special/cphase/benchmark/c/native/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/benchmark/c/native/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2023 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/cphase/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/benchmark/c/native/benchmark.c
@@ -1,0 +1,143 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/**
+* Benchmark `cphase`.
+*/
+#include "stdlib/math/base/special/cphase.h"
+#include "stdlib/complex/float64.h"
+#include "stdlib/complex/reim.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "cphase"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+void print_version() {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+double tic() {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1].
+*
+* @return random number
+*/
+double rand_double() {
+	int r = rand();
+	return (double)r / ( (double)RAND_MAX + 1.0 );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+double benchmark() {
+	double elapsed;
+	double re;
+	double im;
+	double y;
+	double t;
+	int i;
+
+	stdlib_complex128_t z;
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		re = ( 1000.0*rand_double() ) - 500.0;
+		im = ( 1000.0*rand_double() ) - 500.0;
+		z = stdlib_complex128( re, im );
+		y = stdlib_base_cphase( z );
+		if ( y != y ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( y != y ) {
+		printf( "should not return NaN\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::native::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/math/base/special/cphase/binding.gyp
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2023 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/math/base/special/cphase/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/docs/repl.txt
@@ -1,5 +1,5 @@
 
-{{alias}}( re, im )
+{{alias}}( z )
     Computes the argument of a complex number in radians.
 
     The argument of a complex number, also known as the phase, is the angle of
@@ -8,11 +8,8 @@
 
     Parameters
     ----------
-    re: number
-        Real component.
-
-    im: number
-        Imaginary component.
+    z: Complex128
+        Complex number.
 
     Returns
     -------
@@ -21,7 +18,7 @@
 
     Examples
     --------
-    > var phi = {{alias}}( 5.0, 3.0 )
+    > var phi = {{alias}}( new {{alias:@stdlib/complex/float64}}( 5.0, 3.0 ) )
     ~0.5404
 
     See Also

--- a/lib/node_modules/@stdlib/math/base/special/cphase/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/docs/repl.txt
@@ -1,6 +1,7 @@
 
 {{alias}}( z )
-    Computes the argument of a complex number in radians.
+    Computes the argument of a double-precision complex floating-point number
+    in radians.
 
     The argument of a complex number, also known as the phase, is the angle of
     the radius extending from the origin to the complex number plotted in the

--- a/lib/node_modules/@stdlib/math/base/special/cphase/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/docs/types/index.d.ts
@@ -18,6 +18,10 @@
 
 // TypeScript Version: 2.0
 
+/// <reference types="@stdlib/types"/>
+
+import { Complex128 } from '@stdlib/types/object';
+
 /**
 * Computes the argument of a complex number in radians.
 *
@@ -25,15 +29,16 @@
 *
 * -   The argument of a complex number, also known as the phase, is the angle of the radius extending from the origin to the complex number plotted in the complex plane and the positive real axis.
 *
-* @param re - real component
-* @param im - imaginary component
+* @param z - complex number
 * @returns argument
 *
 * @example
-* var phi = cphase( 5.0, 3.0 );
+* var Complex128 = require( `@stdlib/complex/float64` );
+*
+* var phi = cphase( new Complex128( 5.0, 3.0 ) );
 * // returns ~0.5404
 */
-declare function cphase( re: number, im: number ): number;
+declare function cphase( z: Complex128 ): number;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/math/base/special/cphase/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/docs/types/index.d.ts
@@ -23,7 +23,7 @@
 import { Complex128 } from '@stdlib/types/object';
 
 /**
-* Computes the argument of a complex number in radians.
+* Computes the argument of a double-precision complex floating-point number in radians.
 *
 * ## Notes
 *

--- a/lib/node_modules/@stdlib/math/base/special/cphase/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/docs/types/test.ts
@@ -16,6 +16,7 @@
 * limitations under the License.
 */
 
+import Complex128 = require( '@stdlib/complex/float64' );
 import cphase = require( './index' );
 
 
@@ -23,31 +24,19 @@ import cphase = require( './index' );
 
 // The function returns a number...
 {
-	cphase( 5, 3 ); // $ExpectType number
+	cphase( new Complex128( 5.0, 3.0 ) ); // $ExpectType number
 }
 
-// The compiler throws an error if the function is provided a first argument which is not a number...
+// The compiler throws an error if the function is not provided a complex number...
 {
-	cphase( true, 3 ); // $ExpectError
-	cphase( false, 3 ); // $ExpectError
-	cphase( null, 3 ); // $ExpectError
-	cphase( undefined, 3 ); // $ExpectError
-	cphase( '5', 3 ); // $ExpectError
-	cphase( [], 3 ); // $ExpectError
-	cphase( {}, 3 ); // $ExpectError
-	cphase( ( x: number ): number => x, 3 ); // $ExpectError
-}
-
-// The compiler throws an error if the function is provided a second argument which is not a number...
-{
-	cphase( 5, true ); // $ExpectError
-	cphase( 5, false ); // $ExpectError
-	cphase( 5, null ); // $ExpectError
-	cphase( 5, undefined ); // $ExpectError
-	cphase( 5, '5' ); // $ExpectError
-	cphase( 5, [] ); // $ExpectError
-	cphase( 5, {} ); // $ExpectError
-	cphase( 5, ( x: number ): number => x ); // $ExpectError
+	cphase( true ); // $ExpectError
+	cphase( false ); // $ExpectError
+	cphase( null ); // $ExpectError
+	cphase( undefined ); // $ExpectError
+	cphase( '5' ); // $ExpectError
+	cphase( [] ); // $ExpectError
+	cphase( {} ); // $ExpectError
+	cphase( ( x: number ): number => x ); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided insufficient arguments...

--- a/lib/node_modules/@stdlib/math/base/special/cphase/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/docs/types/test.ts
@@ -22,7 +22,7 @@ import cphase = require( './index' );
 
 // TESTS //
 
-// The function returns a number...
+// The function returns a double-precision complex floating-point number...
 {
 	cphase( new Complex128( 5.0, 3.0 ) ); // $ExpectType number
 }

--- a/lib/node_modules/@stdlib/math/base/special/cphase/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/docs/types/test.ts
@@ -22,7 +22,7 @@ import cphase = require( './index' );
 
 // TESTS //
 
-// The function returns a double-precision complex floating-point number...
+// The function returns a number...
 {
 	cphase( new Complex128( 5.0, 3.0 ) ); // $ExpectType number
 }

--- a/lib/node_modules/@stdlib/math/base/special/cphase/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2023 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/cphase/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/examples/c/example.c
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/cphase.h"
+#include "stdlib/complex/float64.h"
+#include "stdlib/complex/reim.h"
+#include <stdio.h>
+
+int main( void ) {
+	const stdlib_complex128_t x[] = {
+		stdlib_complex128( 3.14, 1.0 ),
+		stdlib_complex128( -3.14, -1.0 ),
+		stdlib_complex128( 0.0, 0.0 ),
+		stdlib_complex128( 0.0/0.0, 0.0/0.0 )
+	};
+
+	stdlib_complex128_t v;
+	double re;
+	double im;
+	double y;
+	int i;
+	for ( i = 0; i < 4; i++ ) {
+		v = x[ i ];
+		y = stdlib_base_cphase( v );
+		stdlib_reim( v, &re, &im );
+		printf( "fcphase(%lf + %lfi) = %lf\n", re, im, y );
+	}
+}

--- a/lib/node_modules/@stdlib/math/base/special/cphase/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/examples/index.js
@@ -19,18 +19,13 @@
 'use strict';
 
 var Complex128 = require( '@stdlib/complex/float64' );
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var cphase = require( './../lib' );
 
-var re;
-var im;
 var z;
 var i;
 
 for ( i = 0; i < 100; i++ ) {
-	re = round( randu()*100.0 ) - 50.0;
-	im = round( randu()*100.0 ) - 50.0;
-	z = new Complex128( re, im );
+	z = new Complex128( uniform( -500.0, 500.0 ), uniform( -500.0, 500.0 ) );
 	console.log( 'arg(%s) = %d', z.toString(), cphase( z ) );
 }

--- a/lib/node_modules/@stdlib/math/base/special/cphase/include.gypi
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2023 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/math/base/special/cphase/include/stdlib/math/base/special/cphase.h
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/include/stdlib/math/base/special/cphase.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2023 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -16,33 +16,25 @@
 * limitations under the License.
 */
 
-'use strict';
+#ifndef STDLIB_MATH_BASE_SPECIAL_CPHASE_H
+#define STDLIB_MATH_BASE_SPECIAL_CPHASE_H
 
-// MODULES //
+#include "stdlib/complex/float64.h"
 
-var atan2 = require( '@stdlib/math/base/special/atan2' );
-var real = require( '@stdlib/complex/real' );
-var imag = require( '@stdlib/complex/imag' );
-
-
-// MAIN //
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
 * Computes the argument of a complex number in radians.
-*
-* @param {Complex128} z - complex number
-* @returns {number} argument
-*
-* @example
-* var Complex128 = require( '@stdlib/complex/float64' );
-* var phi = cphase( new Complex128( 5.0, 3.0 ) );
-* // returns ~0.5404
 */
-function cphase( z ) {
-	return atan2( imag( z ), real( z ) );
+double stdlib_base_cphase( const stdlib_complex128_t z );
+
+#ifdef __cplusplus
 }
+#endif
 
-
-// EXPORTS //
-
-module.exports = cphase;
+#endif // !STDLIB_MATH_BASE_SPECIAL_CPHASE_H

--- a/lib/node_modules/@stdlib/math/base/special/cphase/include/stdlib/math/base/special/cphase.h
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/include/stdlib/math/base/special/cphase.h
@@ -29,7 +29,7 @@ extern "C" {
 #endif
 
 /**
-* Computes the argument of a complex number in radians.
+* Computes the argument of a double-precision complex floating-point number in radians.
 */
 double stdlib_base_cphase( const stdlib_complex128_t z );
 

--- a/lib/node_modules/@stdlib/math/base/special/cphase/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/lib/index.js
@@ -24,9 +24,10 @@
 * @module @stdlib/math/base/special/cphase
 *
 * @example
+* var Complex128 = require( '@stdlib/complex/float64' );
 * var cphase = require( '@stdlib/math/base/special/cphase' );
 *
-* var phi = cphase( 5.0, 3.0 );
+* var phi = cphase( new Complex128( 5.0, 3.0 ) );
 * // returns ~0.5404
 */
 

--- a/lib/node_modules/@stdlib/math/base/special/cphase/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Compute the argument of a complex number in radians.
+* Compute the argument of a double-precision complex floating-point number in radians.
 *
 * @module @stdlib/math/base/special/cphase
 *

--- a/lib/node_modules/@stdlib/math/base/special/cphase/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/lib/main.js
@@ -28,13 +28,14 @@ var imag = require( '@stdlib/complex/imag' );
 // MAIN //
 
 /**
-* Computes the argument of a complex number in radians.
+* Computes the argument of a double-precision complex floating-point number in radians.
 *
 * @param {Complex128} z - complex number
 * @returns {number} argument
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64' );
+*
 * var phi = cphase( new Complex128( 5.0, 3.0 ) );
 * // returns ~0.5404
 */

--- a/lib/node_modules/@stdlib/math/base/special/cphase/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/lib/native.js
@@ -26,7 +26,7 @@ var addon = require( './../src/addon.node' );
 // MAIN //
 
 /**
-* Computes the argument of a complex number in radians.
+* Computes the argument of a double-precision complex floating-point number in radians.
 *
 * @private
 * @param {Complex128} z - complex number

--- a/lib/node_modules/@stdlib/math/base/special/cphase/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/lib/native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2023 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -20,9 +20,7 @@
 
 // MODULES //
 
-var atan2 = require( '@stdlib/math/base/special/atan2' );
-var real = require( '@stdlib/complex/real' );
-var imag = require( '@stdlib/complex/imag' );
+var addon = require( './../src/addon.node' );
 
 
 // MAIN //
@@ -30,6 +28,7 @@ var imag = require( '@stdlib/complex/imag' );
 /**
 * Computes the argument of a complex number in radians.
 *
+* @private
 * @param {Complex128} z - complex number
 * @returns {number} argument
 *
@@ -39,7 +38,7 @@ var imag = require( '@stdlib/complex/imag' );
 * // returns ~0.5404
 */
 function cphase( z ) {
-	return atan2( imag( z ), real( z ) );
+	return addon( z );
 }
 
 

--- a/lib/node_modules/@stdlib/math/base/special/cphase/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/manifest.json
@@ -1,0 +1,76 @@
+{
+	"options": {
+		"task": "build"
+	},
+	"fields": [
+		{
+			"field": "src",
+			"resolve": true,
+			"relative": true
+		},
+		{
+			"field": "include",
+			"resolve": true,
+			"relative": true
+		},
+		{
+			"field": "libraries",
+			"resolve": false,
+			"relative": false
+		},
+		{
+			"field": "libpath",
+			"resolve": true,
+			"relative": false
+		}
+	],
+	"confs": [
+		{
+		  "task": "build",
+		  "src": [
+			"./src/main.c"
+		  ],
+		  "include": [
+			"./include"
+		  ],
+		  "libraries": [],
+		  "libpath": [],
+		  "dependencies": [
+			"@stdlib/math/base/napi/unary",
+			"@stdlib/complex/float64",
+			"@stdlib/complex/reim"
+		  ]
+		},
+		{
+		  "task": "benchmark",
+		  "src": [
+			"./src/main.c"
+		  ],
+		  "include": [
+			"./include"
+		  ],
+		  "libraries": [],
+		  "libpath": [],
+		  "dependencies": [
+			"@stdlib/complex/float64",
+			"@stdlib/complex/reim"
+		  ]
+		},
+		{
+		  "task": "examples",
+		  "src": [
+			"./src/main.c"
+		  ],
+		  "include": [
+			"./include"
+		  ],
+		  "libraries": [],
+		  "libpath": [],
+		  "dependencies": [
+			"@stdlib/complex/float64",
+			"@stdlib/complex/reim"
+		  ]
+		}
+	  ]
+}
+

--- a/lib/node_modules/@stdlib/math/base/special/cphase/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/manifest.json
@@ -1,76 +1,76 @@
 {
-	"options": {
-		"task": "build"
-	},
-	"fields": [
-		{
-			"field": "src",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "include",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "libraries",
-			"resolve": false,
-			"relative": false
-		},
-		{
-			"field": "libpath",
-			"resolve": true,
-			"relative": false
-		}
-	],
-	"confs": [
-		{
-		  "task": "build",
-		  "src": [
-			"./src/main.c"
-		  ],
-		  "include": [
-			"./include"
-		  ],
-		  "libraries": [],
-		  "libpath": [],
-		  "dependencies": [
-			"@stdlib/math/base/napi/unary",
-			"@stdlib/complex/float64",
-			"@stdlib/complex/reim"
-		  ]
-		},
-		{
-		  "task": "benchmark",
-		  "src": [
-			"./src/main.c"
-		  ],
-		  "include": [
-			"./include"
-		  ],
-		  "libraries": [],
-		  "libpath": [],
-		  "dependencies": [
-			"@stdlib/complex/float64",
-			"@stdlib/complex/reim"
-		  ]
-		},
-		{
-		  "task": "examples",
-		  "src": [
-			"./src/main.c"
-		  ],
-		  "include": [
-			"./include"
-		  ],
-		  "libraries": [],
-		  "libpath": [],
-		  "dependencies": [
-			"@stdlib/complex/float64",
-			"@stdlib/complex/reim"
-		  ]
-		}
-	  ]
+    "options": {
+        "task": "build"
+    },
+    "fields": [
+        {
+            "field": "src",
+            "resolve": true,
+            "relative": true
+        },
+        {
+            "field": "include",
+            "resolve": true,
+            "relative": true
+        },
+        {
+            "field": "libraries",
+            "resolve": false,
+            "relative": false
+        },
+        {
+            "field": "libpath",
+            "resolve": true,
+            "relative": false
+        }
+    ],
+    "confs": [
+        {
+          "task": "build",
+          "src": [
+            "./src/main.c"
+          ],
+          "include": [
+            "./include"
+          ],
+          "libraries": [],
+          "libpath": [],
+          "dependencies": [
+            "@stdlib/math/base/napi/unary",
+            "@stdlib/complex/float64",
+            "@stdlib/complex/reim"
+          ]
+        },
+        {
+          "task": "benchmark",
+          "src": [
+            "./src/main.c"
+          ],
+          "include": [
+            "./include"
+          ],
+          "libraries": [],
+          "libpath": [],
+          "dependencies": [
+            "@stdlib/complex/float64",
+            "@stdlib/complex/reim"
+          ]
+        },
+        {
+          "task": "examples",
+          "src": [
+            "./src/main.c"
+          ],
+          "include": [
+            "./include"
+          ],
+          "libraries": [],
+          "libpath": [],
+          "dependencies": [
+            "@stdlib/complex/float64",
+            "@stdlib/complex/reim"
+          ]
+        }
+      ]
 }
 

--- a/lib/node_modules/@stdlib/math/base/special/cphase/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/math/base/special/cphase",
   "version": "0.0.0",
-  "description": "Compute the argument of a complex number in radians.",
+  "description": "Compute the argument of a double-precision complex floating-point number in radians.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",
@@ -14,6 +14,7 @@
     }
   ],
   "main": "./lib",
+  "gypfile": true,
   "directories": {
     "benchmark": "./benchmark",
     "doc": "./docs",

--- a/lib/node_modules/@stdlib/math/base/special/cphase/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2023 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/cphase/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/src/addon.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2023 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -16,21 +16,8 @@
 * limitations under the License.
 */
 
-'use strict';
+#include "stdlib/math/base/special/cphase.h"
+#include "stdlib/math/base/napi/unary.h"
 
-var Complex128 = require( '@stdlib/complex/float64' );
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
-var cphase = require( './../lib' );
-
-var re;
-var im;
-var z;
-var i;
-
-for ( i = 0; i < 100; i++ ) {
-	re = round( randu()*100.0 ) - 50.0;
-	im = round( randu()*100.0 ) - 50.0;
-	z = new Complex128( re, im );
-	console.log( 'arg(%s) = %d', z.toString(), cphase( z ) );
-}
+// cppcheck-suppress shadowFunction
+STDLIB_MATH_BASE_NAPI_MODULE_Z_D( stdlib_base_cphase )

--- a/lib/node_modules/@stdlib/math/base/special/cphase/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/src/main.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2023 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -16,33 +16,30 @@
 * limitations under the License.
 */
 
-'use strict';
-
-// MODULES //
-
-var atan2 = require( '@stdlib/math/base/special/atan2' );
-var real = require( '@stdlib/complex/real' );
-var imag = require( '@stdlib/complex/imag' );
-
-
-// MAIN //
+#include "stdlib/math/base/special/cphase.h"
+#include "stdlib/complex/float64.h"
+#include "stdlib/complex/reim.h"
+#include <math.h>
 
 /**
 * Computes the argument of a complex number in radians.
 *
-* @param {Complex128} z - complex number
-* @returns {number} argument
+* @param z       input value
+* @return        argument
 *
 * @example
-* var Complex128 = require( '@stdlib/complex/float64' );
-* var phi = cphase( new Complex128( 5.0, 3.0 ) );
+* #include "stdlib/complex/float64.h"
+* #include "stdlib/complex/real.h"
+* #include "stdlib/complex/imag.h"
+*
+* stdlib_complex128_t z = stdlib_complex128( 5.0, 3.0 );
+* double out = stdlib_base_cphase( z );
 * // returns ~0.5404
 */
-function cphase( z ) {
-	return atan2( imag( z ), real( z ) );
+double stdlib_base_cphase( const stdlib_complex128_t z ) {
+	double re;
+	double im;
+
+	stdlib_reim( z, &re, &im );
+	return atan2( im, re );
 }
-
-
-// EXPORTS //
-
-module.exports = cphase;

--- a/lib/node_modules/@stdlib/math/base/special/cphase/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/src/main.c
@@ -22,7 +22,7 @@
 #include <math.h>
 
 /**
-* Computes the argument of a complex number in radians.
+* Computes the argument of a complex double-precision complex floating-point number in radians.
 *
 * @param z       input value
 * @return        argument
@@ -41,5 +41,5 @@ double stdlib_base_cphase( const stdlib_complex128_t z ) {
 	double im;
 
 	stdlib_reim( z, &re, &im );
-	return atan2( im, re );
+	return atan2( im, re ); // TODO: replace with stdlib function once available
 }

--- a/lib/node_modules/@stdlib/math/base/special/cphase/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/test/test.native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2023 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 
 // MODULES //
 
+var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
@@ -29,7 +30,15 @@ var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var PI = require( '@stdlib/constants/float64/pi' );
 var Complex128 = require( '@stdlib/complex/float64' );
-var cphase = require( './../lib' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var cphase = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( cphase instanceof Error )
+};
 
 
 // FIXTURES //
@@ -41,19 +50,19 @@ var negativeNegative = require( './fixtures/julia/negative_negative.json' );
 
 // TESTS //
 
-tape( 'main export is a function', function test( t ) {
+tape( 'main export is a function', opts, function test( t ) {
 	t.ok( true, __filename );
 	t.strictEqual( typeof cphase, 'function', 'main export is a function' );
 	t.end();
 });
 
-tape( 'the function returns `NaN` if provided `NaN` as either of the arguments', function test( t ) {
+tape( 'the function returns `NaN` if provided `NaN` as either of the arguments', opts, function test( t ) {
 	t.strictEqual( isnan( cphase( new Complex128( 2.0, NaN ) ) ), true, 'returns NaN' );
 	t.strictEqual( isnan( cphase( new Complex128( NaN, 3.0 ) ) ), true, 'returns NaN' );
 	t.end();
 });
 
-tape( 'the function returns `+0` if provided `im = +0.0` and `re >= 0`', function test( t ) {
+tape( 'the function returns `+0` if provided `im = +0.0` and `re >= 0`', opts, function test( t ) {
 	t.strictEqual( cphase( new Complex128( 0.0, +0.0) ), +0.0, 'returns +0' );
 	t.strictEqual( cphase( new Complex128( 2.0, +0.0) ), +0.0, 'returns +0' );
 	t.strictEqual( cphase( new Complex128( 4.0, +0.0) ), +0.0, 'returns +0' );
@@ -62,7 +71,7 @@ tape( 'the function returns `+0` if provided `im = +0.0` and `re >= 0`', functio
 	t.end();
 });
 
-tape( 'the function returns `-0` if provided `im = -0.0` and `re >= 0`', function test( t ) {
+tape( 'the function returns `-0` if provided `im = -0.0` and `re >= 0`', opts, function test( t ) {
 	t.strictEqual( isNegativeZero( cphase( new Complex128( 0.0, -0.0 ) ) ), true, 'returns -0' );
 	t.strictEqual( isNegativeZero( cphase( new Complex128( 2.0, -0.0 ) ) ), true, 'returns -0' );
 	t.strictEqual( isNegativeZero( cphase( new Complex128( 4.0, -0.0 ) ) ), true, 'returns -0' );
@@ -71,7 +80,7 @@ tape( 'the function returns `-0` if provided `im = -0.0` and `re >= 0`', functio
 	t.end();
 });
 
-tape( 'the function returns `PI` if provided `im = +0.0` and `re <= -0.0`', function test( t ) {
+tape( 'the function returns `PI` if provided `im = +0.0` and `re <= -0.0`', opts, function test( t ) {
 	t.strictEqual( cphase( new Complex128( -0.0, +0.0 ) ), +PI, 'returns +PI' );
 	t.strictEqual( cphase( new Complex128( -2.0, +0.0 ) ), +PI, 'returns +PI' );
 	t.strictEqual( cphase( new Complex128( -4.0, +0.0 ) ), +PI, 'returns +PI' );
@@ -80,7 +89,7 @@ tape( 'the function returns `PI` if provided `im = +0.0` and `re <= -0.0`', func
 	t.end();
 });
 
-tape( 'the function returns `-PI` if provided `im = -0.0` and `re <= -0.0`', function test( t ) {
+tape( 'the function returns `-PI` if provided `im = -0.0` and `re <= -0.0`', opts, function test( t ) {
 	t.strictEqual( cphase( new Complex128( -0.0, -0.0 ) ), -PI, 'returns -PI' );
 	t.strictEqual( cphase( new Complex128( -2.0, -0.0 ) ), -PI, 'returns -PI' );
 	t.strictEqual( cphase( new Complex128( -4.0, -0.0 ) ), -PI, 'returns -PI' );
@@ -89,76 +98,76 @@ tape( 'the function returns `-PI` if provided `im = -0.0` and `re <= -0.0`', fun
 	t.end();
 });
 
-tape( 'the function returns `+PI/4` if provided `re = im = +infinity`', function test( t ) {
+tape( 'the function returns `+PI/4` if provided `re = im = +infinity`', opts, function test( t ) {
 	t.strictEqual( cphase( new Complex128( PINF, PINF ) ), +PI/4.0, 'returns +PI/4' );
 	t.end();
 });
 
-tape( 'the function returns `-PI/4` if provided `re = -im = +infinity`', function test( t ) {
+tape( 'the function returns `-PI/4` if provided `re = -im = +infinity`', opts, function test( t ) {
 	t.strictEqual( cphase( new Complex128( PINF, NINF ) ), -PI/4.0, 'returns -PI/4' );
 	t.end();
 });
 
-tape( 'the function returns `*3*PI/4` if provided `-re = im = +infinity`', function test( t ) {
+tape( 'the function returns `*3*PI/4` if provided `-re = im = +infinity`', opts, function test( t ) {
 	t.strictEqual( cphase( new Complex128( NINF, PINF ) ), +3.0*PI/4.0, 'returns +3*PI/4' );
 	t.end();
 });
 
-tape( 'the function returns `-3*PI/4` if provided `re = im = -infinity`', function test( t ) {
+tape( 'the function returns `-3*PI/4` if provided `re = im = -infinity`', opts, function test( t ) {
 	t.strictEqual( cphase( new Complex128( NINF, NINF ) ), -3.0*PI/4.0, 'returns -3*PI/4' );
 	t.end();
 });
 
-tape( 'the function returns `0.0` when `re = +infinity`', function test( t ) {
+tape( 'the function returns `0.0` when `re = +infinity`', opts, function test( t ) {
 	t.strictEqual( cphase( new Complex128( PINF, -2.0 ) ), 0.0, 'returns 0.0' );
 	t.strictEqual( cphase( new Complex128( PINF, 0.0 ) ), 0.0, 'returns 0.0' );
 	t.strictEqual( cphase( new Complex128( PINF, 2.0 ) ), 0.0, 'returns 0.0' );
 	t.end();
 });
 
-tape( 'the function returns `+PI` when `im > 0` and `re = -infinity`', function test( t ) {
+tape( 'the function returns `+PI` when `im > 0` and `re = -infinity`', opts, function test( t ) {
 	t.strictEqual( cphase( new Complex128( NINF, 1.0 ) ), PI, 'returns PI' );
 	t.strictEqual( cphase( new Complex128( NINF, 2.0 ) ), PI, 'returns PI' );
 	t.strictEqual( cphase( new Complex128( NINF, 3.0 ) ), PI, 'returns PI' );
 	t.end();
 });
 
-tape( 'the function returns `-PI` when `im < 0` and `re = -infinity`', function test( t ) {
+tape( 'the function returns `-PI` when `im < 0` and `re = -infinity`', opts, function test( t ) {
 	t.strictEqual( cphase( new Complex128( NINF, -1.0 ) ), -PI, 'returns -PI' );
 	t.strictEqual( cphase( new Complex128( NINF, -2.0 ) ), -PI, 'returns -PI' );
 	t.strictEqual( cphase( new Complex128( NINF, -3.0 ) ), -PI, 'returns -PI' );
 	t.end();
 });
 
-tape( 'the function returns `+PI/2` when `im = +infinity`', function test( t ) {
+tape( 'the function returns `+PI/2` when `im = +infinity`', opts, function test( t ) {
 	t.strictEqual( cphase( new Complex128( -1.0, PINF ) ), PI/2.0, 'returns PI/2' );
 	t.strictEqual( cphase( new Complex128( 0.0, PINF ) ), PI/2.0, 'returns PI/2' );
 	t.strictEqual( cphase( new Complex128( 2.0, PINF ) ), PI/2.0, 'returns PI/2' );
 	t.end();
 });
 
-tape( 'the function returns `-PI/2` when `im = -infinity`', function test( t ) {
+tape( 'the function returns `-PI/2` when `im = -infinity`', opts, function test( t ) {
 	t.strictEqual( cphase( new Complex128( -1.0, NINF ) ), -PI/2.0, 'returns -PI/2' );
 	t.strictEqual( cphase( new Complex128( 0.0, NINF ) ), -PI/2.0, 'returns -PI/2' );
 	t.strictEqual( cphase( new Complex128( 2.0, NINF ) ), -PI/2.0, 'returns -PI/2' );
 	t.end();
 });
 
-tape( 'the function returns `PI/2` if provided a positive `im` and `re=0`', function test( t ) {
+tape( 'the function returns `PI/2` if provided a positive `im` and `re=0`', opts, function test( t ) {
 	t.strictEqual( cphase( new Complex128( 0.0, 2.0 ) ), PI/2.0, 'returns PI/2' );
 	t.strictEqual( cphase( new Complex128( 0.0, 1.0 ) ), PI/2.0, 'returns PI/2' );
 	t.strictEqual( cphase( new Complex128( 0.0, 0.5 ) ), PI/2.0, 'returns PI/2' );
 	t.end();
 });
 
-tape( 'the function returns `-PI/2` if provided a negative `im` and `re=0`', function test( t ) {
+tape( 'the function returns `-PI/2` if provided a negative `im` and `re=0`', opts, function test( t ) {
 	t.strictEqual( cphase( new Complex128( 0.0, -2.0 ) ), -PI/2.0, 'returns PI/2' );
 	t.strictEqual( cphase( new Complex128( 0.0, -1.0 ) ), -PI/2.0, 'returns PI/2' );
 	t.strictEqual( cphase( new Complex128( 0.0, -0.5 ) ), -PI/2.0, 'returns PI/2' );
 	t.end();
 });
 
-tape( 'the function computes the argument of a complex number (when `re` and `im` are positive)', function test( t ) {
+tape( 'the function computes the argument of a complex number (when `re` and `im` are positive)', opts, function test( t ) {
 	var expected;
 	var actual;
 	var delta;
@@ -179,7 +188,7 @@ tape( 'the function computes the argument of a complex number (when `re` and `im
 	t.end();
 });
 
-tape( 'the function computes the argument of a complex number (when `re` is negative and `im` is positive)', function test( t ) {
+tape( 'the function computes the argument of a complex number (when `re` is negative and `im` is positive)', opts, function test( t ) {
 	var expected;
 	var actual;
 	var delta;
@@ -200,7 +209,7 @@ tape( 'the function computes the argument of a complex number (when `re` is nega
 	t.end();
 });
 
-tape( 'the function computes the argument of a complex number (when `re` and `im` are negative)', function test( t ) {
+tape( 'the function computes the argument of a complex number (when `re` and `im` are negative)', opts, function test( t ) {
 	var expected;
 	var actual;
 	var delta;

--- a/lib/node_modules/@stdlib/math/base/special/cpolar/lib/cpolar.js
+++ b/lib/node_modules/@stdlib/math/base/special/cpolar/lib/cpolar.js
@@ -46,8 +46,11 @@ var Complex128 = require( '@stdlib/complex/float64' );
 * // returns true
 */
 function cpolar( out, re, im ) {
-	out[ 0 ] = cabs( new Complex128( re, im ) );
-	out[ 1 ] = cphase( new Complex128( re, im ) );
+	var z;
+
+	z = new Complex128( re, im );
+	out[ 0 ] = cabs( z );
+	out[ 1 ] = cphase( z );
 	return out;
 }
 

--- a/lib/node_modules/@stdlib/math/base/special/cpolar/lib/cpolar.js
+++ b/lib/node_modules/@stdlib/math/base/special/cpolar/lib/cpolar.js
@@ -47,7 +47,7 @@ var Complex128 = require( '@stdlib/complex/float64' );
 */
 function cpolar( out, re, im ) {
 	out[ 0 ] = cabs( new Complex128( re, im ) );
-	out[ 1 ] = cphase( re, im );
+	out[ 1 ] = cphase( new Complex128( re, im ) );
 	return out;
 }
 

--- a/lib/node_modules/@stdlib/math/base/special/cpolar/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/cpolar/test/test.js
@@ -42,7 +42,7 @@ tape( 'the function computes the absolute value and phase of a complex number', 
 	var v;
 
 	v = cpolar( 5.0, 3.0 );
-	expected = [ cabs( new Complex128( 5.0, 3.0 ) ), cphase( 5.0, 3.0 ) ];
+	expected = [ cabs( new Complex128( 5.0, 3.0 ) ), cphase( new Complex128( 5.0, 3.0 ) ) ];
 
 	t.deepEqual( v, expected, 'returns expected value' );
 
@@ -57,7 +57,7 @@ tape( 'the function computes the absolute value and phase of a complex number (o
 	out = new Array( 2 );
 	v = cpolar( out, 5.0, 3.0 );
 
-	expected = [ cabs( new Complex128( 5.0, 3.0 ) ), cphase( 5.0, 3.0 ) ];
+	expected = [ cabs( new Complex128( 5.0, 3.0 ) ), cphase( new Complex128( 5.0, 3.0 ) ) ];
 
 	t.deepEqual( v, expected, 'returns expected value' );
 	t.strictEqual( v, out, 'returns output value' );
@@ -75,7 +75,7 @@ tape( 'the function computes the absolute value and phase of a complex number (o
 	v = cpolar( out, 5.0, 3.0 );
 
 	abs = cabs( new Complex128( 5.0, 3.0 ) );
-	expected = new Float64Array( [ abs, cphase( 5.0, 3.0 ) ] );
+	expected = new Float64Array( [ abs, cphase( new Complex128( 5.0, 3.0 ) ) ] );
 
 	t.deepEqual( v, expected, 'returns expected value' );
 	t.strictEqual( v, out, 'returns output value' );
@@ -93,7 +93,7 @@ tape( 'the function computes the absolute value and phase of a complex number (o
 
 	expected = {
 		'0': cabs( new Complex128( 5.0, 3.0 ) ),
-		'1': cphase( 5.0, 3.0 )
+		'1': cphase( new Complex128( 5.0, 3.0 ) )
 	};
 
 	t.deepEqual( v, expected, 'returns expected value' );


### PR DESCRIPTION
Part of https://github.com/stdlib-js/todo/issues/1454

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds support for Complex128 dtype
-   Adds C implementation
-   Adds native addon with benchmark, tests, examples and readme update

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   Part of https://github.com/stdlib-js/todo/issues/1454

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
