### PR TITLE
feat: add strided interface for Weibull distribution

### DIFF
--- a/lib/node_modules/@stdlib/random/strided/weibull/README.md
+++ b/lib/node_modules/@stdlib/random/strided/weibull/README.md
@@ -74,8 +74,8 @@ var k0 = new Float64Array( [ 0.0, 0.0, 0.0, 2.0, 2.0, 2.0 ] );
 var lambda0 = new Float64Array( [ 5.0, 5.0, 5.0, 5.0, 5.0, 5.0 ] );
 
 // Create offset views...
-var k1 = new Float64Array( alpha0.buffer, alpha0.BYTES_PER_ELEMENT*1 ); // start at 2nd element
-var lambda1 = new Float64Array( beta0.buffer, beta0.BYTES_PER_ELEMENT*3 ); // start at 4th element
+var k1 = new Float64Array( k0.buffer, k0.BYTES_PER_ELEMENT*1 ); // start at 2nd element
+var lambda1 = new Float64Array( lambda0.buffer, lambda0.BYTES_PER_ELEMENT*3 ); // start at 4th element
 
 // Create an output array:
 var out = new Float64Array( 3 );

--- a/lib/node_modules/@stdlib/random/strided/weibull/README.md
+++ b/lib/node_modules/@stdlib/random/strided/weibull/README.md
@@ -135,7 +135,7 @@ weibull.ndarray( out.length, [ 2.0 ], 0, 0, [ 5.0 ], 0, 0, out, 1, 0 );
 The function has the following additional parameters:
 
 -   **ok**: starting index for `k`.
--   **ol*: starting index for `lambda`.
+-   **ol**: starting index for `lambda`.
 -   **oo**: starting index for `out`.
 
 While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying `buffer`, the offset parameters support indexing semantics based on starting indices. For example, to access every other value in `out` starting from the second value,

--- a/lib/node_modules/@stdlib/random/strided/weibull/README.md
+++ b/lib/node_modules/@stdlib/random/strided/weibull/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Weibull Random Numbers
 
-> Fill a strided array with pseudorandom numbers drawn from a [weibull][@stdlib/random/base/weibull] distribution.
+> Fill a strided array with pseudorandom numbers drawn from a [Weibull][@stdlib/random/base/weibull] distribution.
 
 <section class="usage">
 
@@ -30,9 +30,9 @@ limitations under the License.
 var weibull = require( '@stdlib/random/strided/weibull' );
 ```
 
-#### beta( N, k, sa, lambda, sb, out, so\[, options] )
+#### weibull( N, k, sk, lambda, sl, out, so\[, options] )
 
-Fills a strided array with pseudorandom numbers drawn from a [weibull][@stdlib/random/base/weibull] distribution.
+Fills a strided array with pseudorandom numbers drawn from a [Weibull][@stdlib/random/base/weibull] distribution.
 
 ```javascript
 var Float64Array = require( '@stdlib/array/float64' );
@@ -48,9 +48,9 @@ The function has the following parameters:
 
 -   **N**: number of indexed elements.
 -   **k**: scale parameter.
--   **sa**: index increment for `alpha`.
+-   **sk**: index increment for `k`.
 -   **lambda**:shape parameter.
--   **sb**: index increment for `beta`.
+-   **sl**: index increment for `lambda`.
 -   **out**: output array.
 -   **so**: index increment for `out`.
 
@@ -118,9 +118,9 @@ var out = new Float64Array( 10 );
 weibull( out.length, [ 2.0 ], 0, [ 5.0 ], 0, out, 1, opts );
 ```
 
-#### weibull.ndarray( N, k, sa, oa, lambda, sb, ob, out, so, oo\[, options] )
+#### weibull.ndarray( N, k, sk, ok, lambda, sl, ol, out, so, oo\[, options] )
 
-Fills a strided array with pseudorandom numbers drawn from a [weibull][@stdlib/random/base/weibull] distribution using alternative indexing semantics.
+Fills a strided array with pseudorandom numbers drawn from a [Weibull][@stdlib/random/base/weibull] distribution using alternative indexing semantics.
 
 ```javascript
 var Float64Array = require( '@stdlib/array/float64' );
@@ -134,8 +134,8 @@ weibull.ndarray( out.length, [ 2.0 ], 0, 0, [ 5.0 ], 0, 0, out, 1, 0 );
 
 The function has the following additional parameters:
 
--   **oa**: starting index for `k`.
--   **ob**: starting index for `alpha`.
+-   **ok**: starting index for `k`.
+-   **ol*: starting index for `lambda`.
 -   **oo**: starting index for `out`.
 
 While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying `buffer`, the offset parameters support indexing semantics based on starting indices. For example, to access every other value in `out` starting from the second value,

--- a/lib/node_modules/@stdlib/random/strided/weibull/README.md
+++ b/lib/node_modules/@stdlib/random/strided/weibull/README.md
@@ -1,0 +1,226 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2023 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# Weibull Random Numbers
+
+> Fill a strided array with pseudorandom numbers drawn from a [weibull][@stdlib/random/base/weibull] distribution.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var weibull = require( '@stdlib/random/strided/weibull' );
+```
+
+#### beta( N, k, sa, lambda, sb, out, so\[, options] )
+
+Fills a strided array with pseudorandom numbers drawn from a [weibull][@stdlib/random/base/weibull] distribution.
+
+```javascript
+var Float64Array = require( '@stdlib/array/float64' );
+
+// Create an array:
+var out = new Float64Array( 10 );
+
+// Fill the array with pseudorandom numbers:
+weibull( out.length, [ 2.0 ], 0, [ 5.0 ], 0, out, 1 );
+```
+
+The function has the following parameters:
+
+-   **N**: number of indexed elements.
+-   **k**: scale parameter.
+-   **sa**: index increment for `alpha`.
+-   **lambda**:shape parameter.
+-   **sb**: index increment for `beta`.
+-   **out**: output array.
+-   **so**: index increment for `out`.
+
+The `N` and stride parameters determine which strided array elements are accessed at runtime. For example, to access every other value in `out`,
+
+```javascript
+var out = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
+
+weibull( 3, [ 2.0 ], 0, [ 5.0 ], 0, out, 2 );
+```
+
+Note that indexing is relative to the first index. To introduce an offset, use [`typed array`][mdn-typed-array] views.
+
+<!-- eslint-disable stdlib/capitalized-comments -->
+
+```javascript
+var Float64Array = require( '@stdlib/array/float64' );
+
+// Initial arrays...
+var k0 = new Float64Array( [ 0.0, 0.0, 0.0, 2.0, 2.0, 2.0 ] );
+var lambda0 = new Float64Array( [ 5.0, 5.0, 5.0, 5.0, 5.0, 5.0 ] );
+
+// Create offset views...
+var k1 = new Float64Array( alpha0.buffer, alpha0.BYTES_PER_ELEMENT*1 ); // start at 2nd element
+var lambda1 = new Float64Array( beta0.buffer, beta0.BYTES_PER_ELEMENT*3 ); // start at 4th element
+
+// Create an output array:
+var out = new Float64Array( 3 );
+
+// Fill the output array:
+weibull( out.length, k1, -2, lambda1, 1, out, 1 );
+```
+
+The function accepts the following `options`:
+
+-   **prng**: pseudorandom number generator for generating uniformly distributed pseudorandom numbers on the interval `[0,1)`. If provided, the function **ignores** both the `state` and `seed` options. In order to seed the underlying pseudorandom number generator, one must seed the provided `prng` (assuming the provided `prng` is seedable).
+-   **seed**: pseudorandom number generator seed.
+-   **state**: a [`Uint32Array`][@stdlib/array/uint32] containing pseudorandom number generator state. If provided, the function ignores the `seed` option.
+-   **copy**: `boolean` indicating whether to copy a provided pseudorandom number generator state. Setting this option to `false` allows sharing state between two or more pseudorandom number generators. Setting this option to `true` ensures that an underlying generator has exclusive control over its internal state. Default: `true`.
+
+To use a custom PRNG as the underlying source of uniformly distributed pseudorandom numbers, set the `prng` option.
+
+```javascript
+var Float64Array = require( '@stdlib/array/float64' );
+var minstd = require( '@stdlib/random/base/minstd' );
+
+var opts = {
+    'prng': minstd.normalized
+};
+
+var out = new Float64Array( 10 );
+weibull( out.length, [ 2.0 ], 0, [ 5.0 ], 0, out, 1, opts );
+```
+
+To seed the underlying pseudorandom number generator, set the `seed` option.
+
+```javascript
+var Float64Array = require( '@stdlib/array/float64' );
+
+var opts = {
+    'seed': 12345
+};
+
+var out = new Float64Array( 10 );
+weibull( out.length, [ 2.0 ], 0, [ 5.0 ], 0, out, 1, opts );
+```
+
+#### weibull.ndarray( N, k, sa, oa, lambda, sb, ob, out, so, oo\[, options] )
+
+Fills a strided array with pseudorandom numbers drawn from a [weibull][@stdlib/random/base/weibull] distribution using alternative indexing semantics.
+
+```javascript
+var Float64Array = require( '@stdlib/array/float64' );
+
+// Create an array:
+var out = new Float64Array( 10 );
+
+// Fill the array with pseudorandom numbers:
+weibull.ndarray( out.length, [ 2.0 ], 0, 0, [ 5.0 ], 0, 0, out, 1, 0 );
+```
+
+The function has the following additional parameters:
+
+-   **oa**: starting index for `k`.
+-   **ob**: starting index for `alpha`.
+-   **oo**: starting index for `out`.
+
+While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying `buffer`, the offset parameters support indexing semantics based on starting indices. For example, to access every other value in `out` starting from the second value,
+
+```javascript
+var out = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
+
+weibull.ndarray( 3, [ 2.0 ], 0, 0, [ 5.0 ], 0, 0, out, 2, 1 );
+```
+
+The function accepts the same `options` as documented above for `weibull()`.
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   If `N <= 0`, both functions leave the output array unchanged.
+-   Both functions support array-like objects having getter and setter accessors for array element access.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var zeros = require( '@stdlib/array/zeros' );
+var zeroTo = require( '@stdlib/array/base/zero-to' );
+var logEach = require( '@stdlib/console/log-each' );
+var beta = require( '@stdlib/random/strided/beta' );
+
+// Specify a PRNG seed:
+var opts = {
+    'seed': 1234
+};
+
+// Create an array:
+var x1 = zeros( 10, 'float64' );
+
+// Create a list of indices:
+var idx = zeroTo( x1.length );
+
+// Fill the array with pseudorandom numbers:
+weibull( x1.length, [ 2.0 ], 0, [ 5.0 ], 0, x1, 1, opts );
+
+// Create a second array:
+var x2 = zeros( 10, 'generic' );
+
+// Fill the array with the same pseudorandom numbers:
+weibull( x2.length, [ 2.0 ], 0, [ 5.0 ], 0, x2, 1, opts );
+
+// Print the array contents:
+logEach( 'x1[%d] = %.2f; x2[%d] = %.2f', idx, x1, idx, x2 );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
+
+[@stdlib/random/base/weibull]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/random/base/weibull
+
+[@stdlib/array/uint32]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/uint32
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/random/strided/weibull/README.md
+++ b/lib/node_modules/@stdlib/random/strided/weibull/README.md
@@ -173,7 +173,7 @@ The function accepts the same `options` as documented above for `weibull()`.
 var zeros = require( '@stdlib/array/zeros' );
 var zeroTo = require( '@stdlib/array/base/zero-to' );
 var logEach = require( '@stdlib/console/log-each' );
-var beta = require( '@stdlib/random/strided/beta' );
+var weibull = require( '@stdlib/random/strided/weibull' );
 
 // Specify a PRNG seed:
 var opts = {

--- a/lib/node_modules/@stdlib/random/strided/weibull/benchmark/benchmark.float32.broadcast.js
+++ b/lib/node_modules/@stdlib/random/strided/weibull/benchmark/benchmark.float32.broadcast.js
@@ -1,0 +1,102 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var filledarray = require( '@stdlib/array/filled' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var pkg = require( './../package.json' ).name;
+var beta = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var out;
+	var x;
+	var y;
+
+	x = filledarray( 2.0, 1, 'float32' );
+	y = filledarray( 5.0, 1, 'float32' );
+	out = filledarray( 0.0, len, 'float32' );
+
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var o;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			o = beta( len, x, 0, y, 0, out, 1 );
+			if ( isnanf( o[ i%len ] ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnanf( o[ i%len ] ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+'::broadcast:dtype=float32,len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/random/strided/weibull/benchmark/benchmark.float32.js
+++ b/lib/node_modules/@stdlib/random/strided/weibull/benchmark/benchmark.float32.js
@@ -1,0 +1,102 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var filledarray = require( '@stdlib/array/filled' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var pkg = require( './../package.json' ).name;
+var beta = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var out;
+	var x;
+	var y;
+
+	x = filledarray( 2.0, len, 'float32' );
+	y = filledarray( 5.0, len, 'float32' );
+	out = filledarray( 0.0, len, 'float32' );
+
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var o;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			o = beta( len, x, 1, y, 1, out, 1 );
+			if ( isnanf( o[ i%len ] ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnanf( o[ i%len ] ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':dtype=float32,len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/random/strided/weibull/benchmark/benchmark.float64.broadcast.js
+++ b/lib/node_modules/@stdlib/random/strided/weibull/benchmark/benchmark.float64.broadcast.js
@@ -1,0 +1,102 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var filledarray = require( '@stdlib/array/filled' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var pkg = require( './../package.json' ).name;
+var beta = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var out;
+	var x;
+	var y;
+
+	x = filledarray( 2.0, 1, 'float64' );
+	y = filledarray( 5.0, 1, 'float64' );
+	out = filledarray( 0.0, len, 'float64' );
+
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var o;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			o = beta( len, x, 0, y, 0, out, 1 );
+			if ( isnan( o[ i%len ] ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnan( o[ i%len ] ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+'::broadcast:dtype=float64,len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/random/strided/weibull/benchmark/benchmark.float64.broadcast.options.js
+++ b/lib/node_modules/@stdlib/random/strided/weibull/benchmark/benchmark.float64.broadcast.options.js
@@ -1,0 +1,109 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var filledarray = require( '@stdlib/array/filled' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var pkg = require( './../package.json' ).name;
+var beta = require( './../lib' );
+
+
+// VARIABLES //
+
+var OPTS = {
+	'seed': 1234
+};
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var out;
+	var x;
+	var y;
+
+	x = filledarray( 2.0, 1, 'float64' );
+	y = filledarray( 5.0, 1, 'float64' );
+	out = filledarray( 0.0, len, 'float64' );
+
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var o;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			o = beta( len, x, 0, y, 0, out, 1, OPTS );
+			if ( isnan( o[ i%len ] ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnan( o[ i%len ] ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+'::broadcast,options:dtype=float64,len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/random/strided/weibull/benchmark/benchmark.float64.js
+++ b/lib/node_modules/@stdlib/random/strided/weibull/benchmark/benchmark.float64.js
@@ -1,0 +1,102 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var filledarray = require( '@stdlib/array/filled' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var pkg = require( './../package.json' ).name;
+var beta = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var out;
+	var x;
+	var y;
+
+	x = filledarray( 2.0, len, 'float64' );
+	y = filledarray( 5.0, len, 'float64' );
+	out = filledarray( 0.0, len, 'float64' );
+
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var o;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			o = beta( len, x, 1, y, 1, out, 1 );
+			if ( isnan( o[ i%len ] ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnan( o[ i%len ] ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':dtype=float64,len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/random/strided/weibull/benchmark/benchmark.float64.options.js
+++ b/lib/node_modules/@stdlib/random/strided/weibull/benchmark/benchmark.float64.options.js
@@ -1,0 +1,109 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var filledarray = require( '@stdlib/array/filled' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var pkg = require( './../package.json' ).name;
+var beta = require( './../lib' );
+
+
+// VARIABLES //
+
+var OPTS = {
+	'seed': 1234
+};
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var out;
+	var x;
+	var y;
+
+	x = filledarray( 2.0, len, 'float64' );
+	y = filledarray( 5.0, len, 'float64' );
+	out = filledarray( 0.0, len, 'float64' );
+
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var o;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			o = beta( len, x, 1, y, 1, out, 1, OPTS );
+			if ( isnan( o[ i%len ] ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnan( o[ i%len ] ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+'::options:dtype=float64,len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/random/strided/weibull/benchmark/benchmark.generic.broadcast.js
+++ b/lib/node_modules/@stdlib/random/strided/weibull/benchmark/benchmark.generic.broadcast.js
@@ -1,0 +1,102 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var filledarray = require( '@stdlib/array/filled' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var pkg = require( './../package.json' ).name;
+var beta = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var out;
+	var x;
+	var y;
+
+	x = filledarray( 2.0, 1, 'generic' );
+	y = filledarray( 5.0, 1, 'generic' );
+	out = filledarray( 0.0, len, 'generic' );
+
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var o;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			o = beta( len, x, 0, y, 0, out, 1 );
+			if ( isnan( o[ i%len ] ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnan( o[ i%len ] ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+'::broadcast:dtype=generic,len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/random/strided/weibull/benchmark/benchmark.generic.js
+++ b/lib/node_modules/@stdlib/random/strided/weibull/benchmark/benchmark.generic.js
@@ -1,0 +1,102 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var filledarray = require( '@stdlib/array/filled' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var pkg = require( './../package.json' ).name;
+var beta = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var out;
+	var x;
+	var y;
+
+	x = filledarray( 2.0, len, 'generic' );
+	y = filledarray( 5.0, len, 'generic' );
+	out = filledarray( 0.0, len, 'generic' );
+
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var o;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			o = beta( len, x, 1, y, 1, out, 1 );
+			if ( isnan( o[ i%len ] ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnan( o[ i%len ] ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':dtype=generic,len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/random/strided/weibull/docs/repl.txt
+++ b/lib/node_modules/@stdlib/random/strided/weibull/docs/repl.txt
@@ -1,0 +1,175 @@
+
+{{alias}}( N, alpha, sa, beta, sb, out, so[, options] )
+    Fills a strided array with pseudorandom numbers drawn from a beta
+    distribution.
+
+    The `N` and stride parameters determine which elements in the provided
+    strided arrays are accessed at runtime.
+
+    Indexing is relative to the first index. To introduce an offset, use typed
+    array views.
+
+    If `N` is less than or equal to `0`, the output strided array is left
+    unchanged.
+
+    Parameters
+    ----------
+    N: integer
+        Number of indexed elements.
+
+    alpha: ArrayLikeObject
+        First shape parameter.
+
+    sa: integer
+        Index increment for `alpha`.
+
+    beta: ArrayLikeObject
+        Second shape parameter.
+
+    sb: integer
+        Index increment for `beta`.
+
+    out: ArrayLikeObject
+        Output array.
+
+    so: integer
+        Index increment for `out`.
+
+    options: Object (optional)
+        Options.
+
+    options.prng: Function (optional)
+        Pseudorandom number generator (PRNG) for generating uniformly
+        distributed pseudorandom numbers on the interval `[0,1)`. If provided,
+        the `state` and `seed` options are ignored. In order to seed the
+        underlying pseudorandom number generator, one must seed the provided
+        `prng` (assuming the provided `prng` is seedable).
+
+    options.seed: integer|ArrayLikeObject<integer> (optional)
+        Pseudorandom number generator seed. The seed may be either a positive
+        unsigned 32-bit integer or, for arbitrary length seeds, an array-like
+        object containing unsigned 32-bit integers.
+
+    options.state: Uint32Array (optional)
+        Pseudorandom number generator state. If provided, the `seed` option is
+        ignored.
+
+    options.copy: boolean (optional)
+        Boolean indicating whether to copy a provided pseudorandom number
+        generator state. Setting this option to `false` allows sharing state
+        between two or more pseudorandom number generators. Setting this option
+        to `true` ensures that the underlying generator has exclusive control
+        over its internal state. Default: true.
+
+    Returns
+    -------
+    out: ArrayLikeObject
+        Output array.
+
+    Examples
+    --------
+    // Standard usage:
+    > var a = {{alias:@stdlib/array/linspace}}( 1.0, 5.0, 5 );
+    > var b = {{alias:@stdlib/array/linspace}}( 1.0, 5.0, 5 );
+    > var out = {{alias:@stdlib/array/zeros}}( 5, 'generic' );
+    > {{alias}}( out.length, a, 1, b, 1, out, 1 )
+    [...]
+
+    // Advanced indexing:
+    > a = {{alias:@stdlib/array/linspace}}( 1.0, 5.0, 6 );
+    > b = {{alias:@stdlib/array/linspace}}( 1.0, 5.0, 6 );
+    > out = {{alias:@stdlib/array/zeros}}( 6, 'generic' );
+    > {{alias}}( 3, a, -2, b, 1, out, 1 )
+    [...]
+
+
+{{alias}}.ndarray( N, alpha, sa, oa, beta, sb, ob, out, so, oo[, options] )
+    Fills a strided array with pseudorandom numbers drawn from a beta
+    distribution using alternative indexing semantics.
+
+    While typed array views mandate a view offset based on the underlying
+    buffer, the offset parameters support indexing semantics based on starting
+    indices.
+
+    Parameters
+    ----------
+    N: integer
+        Number of indexed elements.
+
+    alpha: ArrayLikeObject
+        First shape parameter.
+
+    sa: integer
+        Index increment for `alpha`.
+
+    oa: integer
+        Starting index for `alpha`.
+
+    beta: ArrayLikeObject
+        Second shape parameter.
+
+    sb: integer
+        Index increment for `beta`.
+
+    ob: integer
+        Starting index for `beta`.
+
+    out: ArrayLikeObject
+        Output array.
+
+    so: integer
+        Index increment for `out`.
+
+    oo: integer
+        Starting index for `out`.
+
+    options: Object (optional)
+        Options.
+
+    options.prng: Function (optional)
+        Pseudorandom number generator (PRNG) for generating uniformly
+        distributed pseudorandom numbers on the interval `[0,1)`. If provided,
+        the `state` and `seed` options are ignored. In order to seed the
+        underlying pseudorandom number generator, one must seed the provided
+        `prng` (assuming the provided `prng` is seedable).
+
+    options.seed: integer|ArrayLikeObject<integer> (optional)
+        Pseudorandom number generator seed. The seed may be either a positive
+        unsigned 32-bit integer or, for arbitrary length seeds, an array-like
+        object containing unsigned 32-bit integers.
+
+    options.state: Uint32Array (optional)
+        Pseudorandom number generator state. If provided, the `seed` option is
+        ignored.
+
+    options.copy: boolean (optional)
+        Boolean indicating whether to copy a provided pseudorandom number
+        generator state. Setting this option to `false` allows sharing state
+        between two or more pseudorandom number generators. Setting this option
+        to `true` ensures that the underlying generator has exclusive control
+        over its internal state. Default: true.
+
+    Returns
+    -------
+    out: ArrayLikeObject
+        Output array.
+
+    Examples
+    --------
+    // Standard usage:
+    > var a = {{alias:@stdlib/array/linspace}}( 1.0, 5.0, 5 );
+    > var b = {{alias:@stdlib/array/linspace}}( 1.0, 5.0, 5 );
+    > var out = {{alias:@stdlib/array/zeros}}( 5, 'generic' );
+    > {{alias}}.ndarray( out.length, a, 1, 0, b, 1, 0, out, 1, 0 )
+    [...]
+
+    // Advanced indexing:
+    > a = {{alias:@stdlib/array/linspace}}( 1.0, 5.0, 6 );
+    > b = {{alias:@stdlib/array/linspace}}( 1.0, 5.0, 6 );
+    > out = {{alias:@stdlib/array/zeros}}( 6, 'generic' );
+    > {{alias}}.ndarray( 3, a, 2, 1, b, -1, b.length-1, out, 1, 0 )
+    [...]
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/random/strided/weibull/docs/repl.txt
+++ b/lib/node_modules/@stdlib/random/strided/weibull/docs/repl.txt
@@ -1,6 +1,6 @@
 
-{{alias}}( N, k, sa, lambda, sb, out, so[, options] )
-    Fills a strided array with pseudorandom numbers drawn from a weibull
+{{alias}}( N, k, sk, lambda, sl, out, so[, options] )
+    Fills a strided array with pseudorandom numbers drawn from a Weibull
     distribution.
 
     The `N` and stride parameters determine which elements in the provided
@@ -18,16 +18,16 @@
         Number of indexed elements.
 
     k: ArrayLikeObject
-        scale parameter.
+        Scale parameter.
 
-    sa: integer
-        Index increment for `alpha`.
+    sk: integer
+        Index increment for `k`.
 
     lambda: ArrayLikeObject
-        shape parameter.
+        Shape parameter.
 
-    sb: integer
-        Index increment for `beta`.
+    sl: integer
+        Index increment for `lambda`.
 
     out: ArrayLikeObject
         Output array.
@@ -83,7 +83,7 @@
     [...]
 
 
-{{alias}}.ndarray( N, k, sa, oa, lambda, sb, ob, out, so, oo[, options] )
+{{alias}}.ndarray( N, k, sk, ok, lambda, sl, ol, out, so, oo[, options] )
     Fills a strided array with pseudorandom numbers drawn from a weibull
     distribution using alternative indexing semantics.
 
@@ -99,20 +99,19 @@
     k: ArrayLikeObject
         scale parameter.
 
-    sa: integer
-        Index increment for `alpha`.
+    sk: integer
+        Index increment for `k`.
 
-    oa: integer
-        Starting index for `alpha`.
+    ok: integer
+        Starting index for `k`.
 
     lambda: ArrayLikeObject
         shape parameter.
+    sl: integer
+        Index increment for `lambda`.
 
-    sb: integer
-        Index increment for `beta`.
-
-    ob: integer
-        Starting index for `beta`.
+    ol: integer
+        Starting index for `lambda`.
 
     out: ArrayLikeObject
         Output array.

--- a/lib/node_modules/@stdlib/random/strided/weibull/docs/repl.txt
+++ b/lib/node_modules/@stdlib/random/strided/weibull/docs/repl.txt
@@ -97,7 +97,7 @@
         Number of indexed elements.
 
     k: ArrayLikeObject
-        scale parameter.
+        Scale parameter.
 
     sk: integer
         Index increment for `k`.
@@ -106,7 +106,8 @@
         Starting index for `k`.
 
     lambda: ArrayLikeObject
-        shape parameter.
+        Shape parameter.
+
     sl: integer
         Index increment for `lambda`.
 

--- a/lib/node_modules/@stdlib/random/strided/weibull/docs/repl.txt
+++ b/lib/node_modules/@stdlib/random/strided/weibull/docs/repl.txt
@@ -1,6 +1,6 @@
 
-{{alias}}( N, alpha, sa, beta, sb, out, so[, options] )
-    Fills a strided array with pseudorandom numbers drawn from a beta
+{{alias}}( N, k, sa, lambda, sb, out, so[, options] )
+    Fills a strided array with pseudorandom numbers drawn from a weibull
     distribution.
 
     The `N` and stride parameters determine which elements in the provided
@@ -17,14 +17,14 @@
     N: integer
         Number of indexed elements.
 
-    alpha: ArrayLikeObject
-        First shape parameter.
+    k: ArrayLikeObject
+        scale parameter.
 
     sa: integer
         Index increment for `alpha`.
 
-    beta: ArrayLikeObject
-        Second shape parameter.
+    lambda: ArrayLikeObject
+        shape parameter.
 
     sb: integer
         Index increment for `beta`.
@@ -83,8 +83,8 @@
     [...]
 
 
-{{alias}}.ndarray( N, alpha, sa, oa, beta, sb, ob, out, so, oo[, options] )
-    Fills a strided array with pseudorandom numbers drawn from a beta
+{{alias}}.ndarray( N, k, sa, oa, lambda, sb, ob, out, so, oo[, options] )
+    Fills a strided array with pseudorandom numbers drawn from a weibull
     distribution using alternative indexing semantics.
 
     While typed array views mandate a view offset based on the underlying
@@ -96,8 +96,8 @@
     N: integer
         Number of indexed elements.
 
-    alpha: ArrayLikeObject
-        First shape parameter.
+    k: ArrayLikeObject
+        scale parameter.
 
     sa: integer
         Index increment for `alpha`.
@@ -105,8 +105,8 @@
     oa: integer
         Starting index for `alpha`.
 
-    beta: ArrayLikeObject
-        Second shape parameter.
+    lambda: ArrayLikeObject
+        shape parameter.
 
     sb: integer
         Index increment for `beta`.

--- a/lib/node_modules/@stdlib/random/strided/weibull/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/strided/weibull/docs/types/index.d.ts
@@ -49,17 +49,17 @@ interface Options {
 }
 
 /**
-* Interface describing `beta`.
+* Interface describing `weibull`.
 */
 interface Routine {
 	/**
-	* Fills a strided array with pseudorandom numbers drawn from a beta distribution.
+	* Fills a strided array with pseudorandom numbers drawn from a weibull distribution.
 	*
 	* @param N - number of indexed elements
-	* @param alpha - first shape parameter
+	* @param k - scale parameter
 	* @param sa - `alpha` stride length
-	* @param beta - second shape parameter
-	* @param sb - `beta` stride length
+	* @param lambda - shape parameter
+	* @param sb - `weibull` stride length
 	* @param out - output array
 	* @param so - `out` stride length
 	* @param options - function options
@@ -75,20 +75,20 @@ interface Routine {
 	* var out = new Float64Array( 10 );
 	*
 	* // Fill the array with pseudorandom numbers:
-	* beta( out.length, [ 2.0 ], 0, [ 5.0 ], 0, out, 1 );
+	* weibull( out.length, [ 2.0 ], 0, [ 5.0 ], 0, out, 1 );
 	*/
-	( N: number, alpha: Collection, sa: number, beta: Collection, sb: number, out: Collection, so: number, options?: Options ): Collection; // tslint:disable-line:max-line-length
+	( N: number, k: Collection, sa: number, lambda: Collection, sb: number, out: Collection, so: number, options?: Options ): Collection; // tslint:disable-line:max-line-length
 
 	/**
-	* Fills a strided array with pseudorandom numbers drawn from a beta distribution using alternative indexing semantics.
+	* Fills a strided array with pseudorandom numbers drawn from a weibull distribution using alternative indexing semantics.
 	*
 	* @param N - number of indexed elements
-	* @param alpha - first shape parameter
-	* @param sa - `alpha` stride length
-	* @param oa - starting index for `alpha`
-	* @param beta - second shape parameter
-	* @param sb - `beta` stride length
-	* @param ob - starting index for `beta`
+	* @param k - scale parameter
+	* @param sa - `k` stride length
+	* @param oa - starting index for `k`
+	* @param lambda - shape parameter
+	* @param sb - `lambda` stride length
+	* @param ob - starting index for `lambda`
 	* @param out - output array
 	* @param so - `out` stride length
 	* @param oo - starting index for `out`
@@ -105,19 +105,19 @@ interface Routine {
 	* var out = new Float64Array( 10 );
 	*
 	* // Fill the array with pseudorandom numbers:
-	* beta.ndarray( out.length, [ 2.0 ], 0, 0, [ 5.0 ], 0, 0, out, 1, 0 );
+	* weibull.ndarray( out.length, [ 2.0 ], 0, 0, [ 5.0 ], 0, 0, out, 1, 0 );
 	*/
-	ndarray( N: number, alpha: Collection, sa: number, oa: number, beta: Collection, sb: number, ob: number, out: Collection, so: number, oo: number, options?: Options ): Collection; // tslint:disable-line:max-line-length
+	ndarray( N: number, k: Collection, sa: number, oa: number, lambda: Collection, sb: number, ob: number, out: Collection, so: number, oo: number, options?: Options ): Collection; // tslint:disable-line:max-line-length
 }
 
 /**
-* Fills a strided array with pseudorandom numbers drawn from a beta distribution.
+* Fills a strided array with pseudorandom numbers drawn from a weibull distribution.
 *
 * @param N - number of indexed elements
-* @param alpha - first shape parameter
-* @param sa - `alpha` stride length
-* @param beta - second shape parameter
-* @param sb - `beta` stride length
+* @param k - scale parameter
+* @param sa - `k` stride length
+* @param lambda -  shape parameter
+* @param sb - `lambda` stride length
 * @param out - output array
 * @param so - `out` stride length
 * @param options - function options
@@ -133,7 +133,7 @@ interface Routine {
 * var out = new Float64Array( 10 );
 *
 * // Fill the array with pseudorandom numbers:
-* beta( out.length, [ 2.0 ], 0, [ 5.0 ], 0, out, 1 );
+* weibull( out.length, [ 2.0 ], 0, [ 5.0 ], 0, out, 1 );
 *
 * @example
 * var Float64Array = require( `@stdlib/array/float64` );
@@ -142,7 +142,7 @@ interface Routine {
 * var out = new Float64Array( 10 );
 *
 * // Fill the array with pseudorandom numbers:
-* beta.ndarray( out.length, [ 2.0 ], 0, 0, [ 5.0 ], 0, 0, out, 1, 0 );
+* weibull.ndarray( out.length, [ 2.0 ], 0, 0, [ 5.0 ], 0, 0, out, 1, 0 );
 */
 declare var weibull: Routine;
 

--- a/lib/node_modules/@stdlib/random/strided/weibull/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/strided/weibull/docs/types/index.d.ts
@@ -53,13 +53,13 @@ interface Options {
 */
 interface Routine {
 	/**
-	* Fills a strided array with pseudorandom numbers drawn from a weibull distribution.
+	* Fills a strided array with pseudorandom numbers drawn from a Weibull distribution.
 	*
 	* @param N - number of indexed elements
 	* @param k - scale parameter
-	* @param sa - `alpha` stride length
+	* @param sk - `k` stride length
 	* @param lambda - shape parameter
-	* @param sb - `weibull` stride length
+	* @param sl - `lambda` stride length
 	* @param out - output array
 	* @param so - `out` stride length
 	* @param options - function options
@@ -77,18 +77,18 @@ interface Routine {
 	* // Fill the array with pseudorandom numbers:
 	* weibull( out.length, [ 2.0 ], 0, [ 5.0 ], 0, out, 1 );
 	*/
-	( N: number, k: Collection, sa: number, lambda: Collection, sb: number, out: Collection, so: number, options?: Options ): Collection; // tslint:disable-line:max-line-length
+	( N: number, k: Collection, sk: number, lambda: Collection, sl: number, out: Collection, so: number, options?: Options ): Collection; // tslint:disable-line:max-line-length
 
 	/**
-	* Fills a strided array with pseudorandom numbers drawn from a weibull distribution using alternative indexing semantics.
+	* Fills a strided array with pseudorandom numbers drawn from a Weibull distribution using alternative indexing semantics.
 	*
 	* @param N - number of indexed elements
 	* @param k - scale parameter
-	* @param sa - `k` stride length
-	* @param oa - starting index for `k`
+	* @param sk - `k` stride length
+	* @param ok - starting index for `k`
 	* @param lambda - shape parameter
-	* @param sb - `lambda` stride length
-	* @param ob - starting index for `lambda`
+	* @param sl - `lambda` stride length
+	* @param ol - starting index for `lambda`
 	* @param out - output array
 	* @param so - `out` stride length
 	* @param oo - starting index for `out`
@@ -107,17 +107,17 @@ interface Routine {
 	* // Fill the array with pseudorandom numbers:
 	* weibull.ndarray( out.length, [ 2.0 ], 0, 0, [ 5.0 ], 0, 0, out, 1, 0 );
 	*/
-	ndarray( N: number, k: Collection, sa: number, oa: number, lambda: Collection, sb: number, ob: number, out: Collection, so: number, oo: number, options?: Options ): Collection; // tslint:disable-line:max-line-length
+	ndarray( N: number, k: Collection, sk: number, ok: number, lambda: Collection, sl: number, ol: number, out: Collection, so: number, oo: number, options?: Options ): Collection; // tslint:disable-line:max-line-length
 }
 
 /**
-* Fills a strided array with pseudorandom numbers drawn from a weibull distribution.
+* Fills a strided array with pseudorandom numbers drawn from a Weibull distribution.
 *
 * @param N - number of indexed elements
 * @param k - scale parameter
-* @param sa - `k` stride length
+* @param sk - `k` stride length
 * @param lambda -  shape parameter
-* @param sb - `lambda` stride length
+* @param sl - `lambda` stride length
 * @param out - output array
 * @param so - `out` stride length
 * @param options - function options

--- a/lib/node_modules/@stdlib/random/strided/weibull/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/random/strided/weibull/docs/types/index.d.ts
@@ -1,0 +1,152 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 2.0
+
+/// <reference types="@stdlib/types"/>
+
+import * as random from '@stdlib/types/random';
+import { Collection } from '@stdlib/types/object';
+
+/**
+* Interface defining function options.
+*/
+interface Options {
+	/**
+	* Pseudorandom number generator which generates uniformly distributed pseudorandom numbers.
+	*/
+	prng?: random.PRNG;
+
+	/**
+	* Pseudorandom number generator seed.
+	*/
+	seed?: random.PRNGSeedMT19937;
+
+	/**
+	* Pseudorandom number generator state.
+	*/
+	state?: random.PRNGStateMT19937;
+
+	/**
+	* Specifies whether to copy a provided pseudorandom number generator state (default: `true`).
+	*/
+	copy?: boolean;
+}
+
+/**
+* Interface describing `beta`.
+*/
+interface Routine {
+	/**
+	* Fills a strided array with pseudorandom numbers drawn from a beta distribution.
+	*
+	* @param N - number of indexed elements
+	* @param alpha - first shape parameter
+	* @param sa - `alpha` stride length
+	* @param beta - second shape parameter
+	* @param sb - `beta` stride length
+	* @param out - output array
+	* @param so - `out` stride length
+	* @param options - function options
+	* @throws must provide valid distribution parameters
+	* @throws must provide valid options
+	* @throws must provide a valid state
+	* @returns output array
+	*
+	* @example
+	* var Float64Array = require( `@stdlib/array/float64` );
+	*
+	* // Create an array:
+	* var out = new Float64Array( 10 );
+	*
+	* // Fill the array with pseudorandom numbers:
+	* beta( out.length, [ 2.0 ], 0, [ 5.0 ], 0, out, 1 );
+	*/
+	( N: number, alpha: Collection, sa: number, beta: Collection, sb: number, out: Collection, so: number, options?: Options ): Collection; // tslint:disable-line:max-line-length
+
+	/**
+	* Fills a strided array with pseudorandom numbers drawn from a beta distribution using alternative indexing semantics.
+	*
+	* @param N - number of indexed elements
+	* @param alpha - first shape parameter
+	* @param sa - `alpha` stride length
+	* @param oa - starting index for `alpha`
+	* @param beta - second shape parameter
+	* @param sb - `beta` stride length
+	* @param ob - starting index for `beta`
+	* @param out - output array
+	* @param so - `out` stride length
+	* @param oo - starting index for `out`
+	* @param options - function options
+	* @throws must provide valid distribution parameters
+	* @throws must provide valid options
+	* @throws must provide a valid state
+	* @returns output array
+	*
+	* @example
+	* var Float64Array = require( `@stdlib/array/float64` );
+	*
+	* // Create an array:
+	* var out = new Float64Array( 10 );
+	*
+	* // Fill the array with pseudorandom numbers:
+	* beta.ndarray( out.length, [ 2.0 ], 0, 0, [ 5.0 ], 0, 0, out, 1, 0 );
+	*/
+	ndarray( N: number, alpha: Collection, sa: number, oa: number, beta: Collection, sb: number, ob: number, out: Collection, so: number, oo: number, options?: Options ): Collection; // tslint:disable-line:max-line-length
+}
+
+/**
+* Fills a strided array with pseudorandom numbers drawn from a beta distribution.
+*
+* @param N - number of indexed elements
+* @param alpha - first shape parameter
+* @param sa - `alpha` stride length
+* @param beta - second shape parameter
+* @param sb - `beta` stride length
+* @param out - output array
+* @param so - `out` stride length
+* @param options - function options
+* @throws must provide valid distribution parameters
+* @throws must provide valid options
+* @throws must provide a valid state
+* @returns output array
+*
+* @example
+* var Float64Array = require( `@stdlib/array/float64` );
+*
+* // Create an array:
+* var out = new Float64Array( 10 );
+*
+* // Fill the array with pseudorandom numbers:
+* beta( out.length, [ 2.0 ], 0, [ 5.0 ], 0, out, 1 );
+*
+* @example
+* var Float64Array = require( `@stdlib/array/float64` );
+*
+* // Create an array:
+* var out = new Float64Array( 10 );
+*
+* // Fill the array with pseudorandom numbers:
+* beta.ndarray( out.length, [ 2.0 ], 0, 0, [ 5.0 ], 0, 0, out, 1, 0 );
+*/
+declare var weibull: Routine;
+
+
+// EXPORTS //
+
+export = weibull;

--- a/lib/node_modules/@stdlib/random/strided/weibull/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/strided/weibull/docs/types/test.ts
@@ -1,0 +1,498 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import random = require( './index' );
+
+
+// TESTS //
+
+// The function returns a collection...
+{
+	const x1 = new Float64Array( 10 );
+	const x2 = new Float64Array( 10 );
+	const out = new Float64Array( 10 );
+
+	random( x1.length, x1, 1, x2, 1, out, 1 ); // $ExpectType Collection
+	random( x1.length, x1, 1, x2, 1, out, 1, {} ); // $ExpectType Collection
+}
+
+// The compiler throws an error if the function is provided a first argument which is not a number...
+{
+	const x1 = new Float64Array( 10 );
+	const x2 = new Float64Array( 10 );
+	const out = new Float64Array( 10 );
+
+	random( '10', x1, 1, x2, 1, out, 1 ); // $ExpectError
+	random( true, x1, 1, x2, 1, out, 1 ); // $ExpectError
+	random( false, x1, 1, x2, 1, out, 1 ); // $ExpectError
+	random( null, x1, 1, x2, 1, out, 1 ); // $ExpectError
+	random( undefined, x1, 1, x2, 1, out, 1 ); // $ExpectError
+	random( [], x1, 1, x2, 1, out, 1 ); // $ExpectError
+	random( {}, x1, 1, x2, 1, out, 1 ); // $ExpectError
+	random( ( x: number ): number => x, x1, 1, x2, 1, out, 1 ); // $ExpectError
+
+	random( '10', x1, 1, x2, 1, out, 1, {} ); // $ExpectError
+	random( true, x1, 1, x2, 1, out, 1, {} ); // $ExpectError
+	random( false, x1, 1, x2, 1, out, 1, {} ); // $ExpectError
+	random( null, x1, 1, x2, 1, out, 1, {} ); // $ExpectError
+	random( undefined, x1, 1, x2, 1, out, 1, {} ); // $ExpectError
+	random( [], x1, 1, x2, 1, out, 1, {} ); // $ExpectError
+	random( {}, x1, 1, x2, 1, out, 1, {} ); // $ExpectError
+	random( ( x: number ): number => x, x1, 1, x2, 1, out, 1, {} ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument which is not a collection...
+{
+	const x1 = new Float64Array( 10 );
+	const x2 = new Float64Array( 10 );
+	const out = new Float64Array( 10 );
+
+	random( x1.length, 10, 1, x2, 1, out, 1 ); // $ExpectError
+	random( x1.length, true, 1, x2, 1, out, 1 ); // $ExpectError
+	random( x1.length, false, 1, x2, 1, out, 1 ); // $ExpectError
+	random( x1.length, null, 1, x2, 1, out, 1 ); // $ExpectError
+	random( x1.length, undefined, 1, x2, 1, out, 1 ); // $ExpectError
+	random( x1.length, {}, 1, x2, 1, out, 1 ); // $ExpectError
+
+	random( x1.length, 10, 1, x2, 1, out, 1, {} ); // $ExpectError
+	random( x1.length, true, 1, x2, 1, out, 1, {} ); // $ExpectError
+	random( x1.length, false, 1, x2, 1, out, 1, {} ); // $ExpectError
+	random( x1.length, null, 1, x2, 1, out, 1, {} ); // $ExpectError
+	random( x1.length, undefined, 1, x2, 1, out, 1, {} ); // $ExpectError
+	random( x1.length, {}, 1, x2, 1, out, 1, {} ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a third argument which is not a number...
+{
+	const x1 = new Float64Array( 10 );
+	const x2 = new Float64Array( 10 );
+	const out = new Float64Array( 10 );
+
+	random( x1.length, x1, '10', x2, 1, out, 1 ); // $ExpectError
+	random( x1.length, x1, true, x2, 1, out, 1 ); // $ExpectError
+	random( x1.length, x1, false, x2, 1, out, 1 ); // $ExpectError
+	random( x1.length, x1, null, x2, 1, out, 1 ); // $ExpectError
+	random( x1.length, x1, undefined, x2, 1, out, 1 ); // $ExpectError
+	random( x1.length, x1, [], x2, 1, out, 1 ); // $ExpectError
+	random( x1.length, x1, {}, x2, 1, out, 1 ); // $ExpectError
+	random( x1.length, x1, ( x: number ): number => x, x2, 1, out, 1 ); // $ExpectError
+
+	random( x1.length, x1, '10', x2, 1, out, 1, {} ); // $ExpectError
+	random( x1.length, x1, true, x2, 1, out, 1, {} ); // $ExpectError
+	random( x1.length, x1, false, x2, 1, out, 1, {} ); // $ExpectError
+	random( x1.length, x1, null, x2, 1, out, 1, {} ); // $ExpectError
+	random( x1.length, x1, undefined, x2, 1, out, 1, {} ); // $ExpectError
+	random( x1.length, x1, [], x2, 1, out, 1, {} ); // $ExpectError
+	random( x1.length, x1, {}, x2, 1, out, 1, {} ); // $ExpectError
+	random( x1.length, x1, ( x: number ): number => x, x2, 1, out, 1, {} ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a fourth argument which is not a collection...
+{
+	const x1 = new Float64Array( 10 );
+	const out = new Float64Array( 10 );
+
+	random( x1.length, x1, 1, 10, 1, out, 1 ); // $ExpectError
+	random( x1.length, x1, 1, true, 1, out, 1 ); // $ExpectError
+	random( x1.length, x1, 1, false, 1, out, 1 ); // $ExpectError
+	random( x1.length, x1, 1, null, 1, out, 1 ); // $ExpectError
+	random( x1.length, x1, 1, undefined, 1, out, 1 ); // $ExpectError
+	random( x1.length, x1, 1, {}, 1, out, 1 ); // $ExpectError
+
+	random( x1.length, x1, 1, 10, 1, out, 1, {} ); // $ExpectError
+	random( x1.length, x1, 1, true, 1, out, 1, {} ); // $ExpectError
+	random( x1.length, x1, 1, false, 1, out, 1, {} ); // $ExpectError
+	random( x1.length, x1, 1, null, 1, out, 1, {} ); // $ExpectError
+	random( x1.length, x1, 1, undefined, 1, out, 1, {} ); // $ExpectError
+	random( x1.length, x1, 1, {}, 1, out, 1, {} ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a fifth argument which is not a number...
+{
+	const x1 = new Float64Array( 10 );
+	const x2 = new Float64Array( 10 );
+	const out = new Float64Array( 10 );
+
+	random( x1.length, x1, 1, x2, '10', out, 1 ); // $ExpectError
+	random( x1.length, x1, 1, x2, true, out, 1 ); // $ExpectError
+	random( x1.length, x1, 1, x2, false, out, 1 ); // $ExpectError
+	random( x1.length, x1, 1, x2, null, out, 1 ); // $ExpectError
+	random( x1.length, x1, 1, x2, undefined, out, 1 ); // $ExpectError
+	random( x1.length, x1, 1, x2, [], out, 1 ); // $ExpectError
+	random( x1.length, x1, 1, x2, {}, out, 1 ); // $ExpectError
+	random( x1.length, x1, 1, x2, ( x: number ): number => x, out, 1 ); // $ExpectError
+
+	random( x1.length, x1, 1, x2, '10', out, 1, {} ); // $ExpectError
+	random( x1.length, x1, 1, x2, true, out, 1, {} ); // $ExpectError
+	random( x1.length, x1, 1, x2, false, out, 1, {} ); // $ExpectError
+	random( x1.length, x1, 1, x2, null, out, 1, {} ); // $ExpectError
+	random( x1.length, x1, 1, x2, undefined, out, 1, {} ); // $ExpectError
+	random( x1.length, x1, 1, x2, [], out, 1, {} ); // $ExpectError
+	random( x1.length, x1, 1, x2, {}, out, 1, {} ); // $ExpectError
+	random( x1.length, x1, 1, x2, ( x: number ): number => x, out, 1, {} ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a sixth argument which is not a collection...
+{
+	const x1 = new Float64Array( 10 );
+	const x2 = new Float64Array( 10 );
+
+	random( x1.length, x1, 1, x2, 1, 10, 1 ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, true, 1 ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, false, 1 ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, null, 1 ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, undefined, 1 ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, {}, 1 ); // $ExpectError
+
+	random( x1.length, x1, 1, x2, 1, 10, 1, {} ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, true, 1, {} ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, false, 1, {} ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, null, 1, {} ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, undefined, 1, {} ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, {}, 1, {} ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a seventh argument which is not a number...
+{
+	const x1 = new Float64Array( 10 );
+	const x2 = new Float64Array( 10 );
+	const out = new Float64Array( 10 );
+
+	random( x1.length, x1, 1, x2, 1, out, '10' ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, out, true ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, out, false ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, out, null ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, out, undefined ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, out, [] ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, out, {} ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, out, ( x: number ): number => x ); // $ExpectError
+
+	random( x1.length, x1, 1, x2, 1, out, '10', {} ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, out, true, {} ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, out, false, {} ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, out, null, {} ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, out, undefined, {} ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, out, [], {} ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, out, {}, {} ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, out, ( x: number ): number => x, {} ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an invalid option...
+{
+	const x1 = new Float64Array( 10 );
+	const x2 = new Float64Array( 10 );
+	const out = new Float64Array( 10 );
+
+	random( x1.length, x1, 1, x2, 1, out, 1, { 'copy': '10' } ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, out, 1, { 'copy': null } ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, out, 1, { 'copy': [] } ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, out, 1, { 'copy': {} } ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, out, 1, { 'copy': ( x: number ): number => x } ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	const x1 = new Float64Array( 10 );
+	const x2 = new Float64Array( 10 );
+	const out = new Float64Array( 10 );
+
+	random(); // $ExpectError
+	random( x1.length ); // $ExpectError
+	random( x1.length, x1 ); // $ExpectError
+	random( x1.length, x1, 1 ); // $ExpectError
+	random( x1.length, x1, 1, x2 ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1 ); // $ExpectError
+	random( x1.length, x1, 1, x2, 1, out ); // $ExpectError
+}
+
+// Attached to main export is an `ndarray` method which returns a collection...
+{
+	const x1 = new Float64Array( 10 );
+	const x2 = new Float64Array( 10 );
+	const out = new Float64Array( 10 );
+
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, 1, 0 ); // $ExpectType Collection
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, 1, 0, {} ); // $ExpectType Collection
+}
+
+// The compiler throws an error if the `ndarray` method is provided a first argument which is not a number...
+{
+	const x1 = new Float64Array( 10 );
+	const x2 = new Float64Array( 10 );
+	const out = new Float64Array( 10 );
+
+	random.ndarray( '10', x1, 1, 0, x2, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( true, x1, 1, 0, x2, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( false, x1, 1, 0, x2, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( null, x1, 1, 0, x2, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( undefined, x1, 1, 0, x2, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( [], x1, 1, 0, x2, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( {}, x1, 1, 0, x2, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( ( x: number ): number => x, x1, 1, 0, x2, 1, 0, out, 1, 0 ); // $ExpectError
+
+	random.ndarray( '10', x1, 1, 0, x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( true, x1, 1, 0, x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( false, x1, 1, 0, x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( null, x1, 1, 0, x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( undefined, x1, 1, 0, x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( [], x1, 1, 0, x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( {}, x1, 1, 0, x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( ( x: number ): number => x, x1, 1, 0, x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a second argument which is not a collection...
+{
+	const x1 = new Float64Array( 10 );
+	const x2 = new Float64Array( 10 );
+	const out = new Float64Array( 10 );
+
+	random.ndarray( x1.length, 10, 1, 0, x2, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, true, 1, 0, x2, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, false, 1, 0, x2, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, null, 1, 0, x2, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, undefined, 1, 0, x2, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, {}, 1, 0, x2, 1, 0, out, 1, 0 ); // $ExpectError
+
+	random.ndarray( x1.length, 10, 1, 0, x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, true, 1, 0, x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, false, 1, 0, x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, null, 1, 0, x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, undefined, 1, 0, x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, {}, 1, 0, x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a third argument which is not a number...
+{
+	const x1 = new Float64Array( 10 );
+	const x2 = new Float64Array( 10 );
+	const out = new Float64Array( 10 );
+
+	random.ndarray( x1.length, x1, '10', 0, x2, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, true, 0, x2, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, false, 0, x2, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, null, 0, x2, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, undefined, 0, x2, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, [], 0, x2, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, {}, 0, x2, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, ( x: number ): number => x, 0, x2, 1, 0, out, 1, 0 ); // $ExpectError
+
+	random.ndarray( x1.length, x1, '10', 0, x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, true, 0, x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, false, 0, x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, null, 0, x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, undefined, 0, x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, [], 0, x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, {}, 0, x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, ( x: number ): number => x, 0, x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a fourth argument which is not a number...
+{
+	const x1 = new Float64Array( 10 );
+	const x2 = new Float64Array( 10 );
+	const out = new Float64Array( 10 );
+
+	random.ndarray( x1.length, x1, 1, '10', x2, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, true, x2, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, false, x2, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, null, x2, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, undefined, x2, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, [], x2, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, {}, x2, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, ( x: number ): number => x, x2, 1, 0, out, 1, 0 ); // $ExpectError
+
+	random.ndarray( x1.length, x1, 1, '10', x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, true, x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, false, x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, null, x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, undefined, x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, [], x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, {}, x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, ( x: number ): number => x, x2, 1, 0, out, 1, 0, {} ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a fifth argument which is not a collection...
+{
+	const x1 = new Float64Array( 10 );
+	const out = new Float64Array( 10 );
+
+	random.ndarray( x1.length, x1, 1, 0, 10, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, true, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, false, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, null, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, undefined, 1, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, {}, 1, 0, out, 1, 0 ); // $ExpectError
+
+	random.ndarray( x1.length, x1, 1, 0, 10, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, true, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, false, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, null, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, undefined, 1, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, {}, 1, 0, out, 1, 0, {} ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a sixth argument which is not a number...
+{
+	const x1 = new Float64Array( 10 );
+	const x2 = new Float64Array( 10 );
+	const out = new Float64Array( 10 );
+
+	random.ndarray( x1.length, x1, 1, 0, x2, '10', 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, true, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, false, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, null, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, undefined, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, [], 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, {}, 0, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, ( x: number ): number => x, 0, out, 1, 0 ); // $ExpectError
+
+	random.ndarray( x1.length, x1, 1, 0, x2, '10', 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, true, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, false, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, null, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, undefined, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, [], 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, {}, 0, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, ( x: number ): number => x, 0, out, 1, 0, {} ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a seventh argument which is not a number...
+{
+	const x1 = new Float64Array( 10 );
+	const x2 = new Float64Array( 10 );
+	const out = new Float64Array( 10 );
+
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, '10', out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, true, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, false, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, null, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, undefined, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, [], out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, {}, out, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, ( x: number ): number => x, out, 1, 0 ); // $ExpectError
+
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, '10', out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, true, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, false, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, null, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, undefined, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, [], out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, {}, out, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, ( x: number ): number => x, out, 1, 0, {} ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided an eighth argument which is not a collection...
+{
+	const x1 = new Float64Array( 10 );
+	const x2 = new Float64Array( 10 );
+
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, 10, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, true, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, false, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, null, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, undefined, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, {}, 1, 0 ); // $ExpectError
+
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, 10, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, true, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, false, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, null, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, undefined, 1, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, {}, 1, 0, {} ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a ninth argument which is not a number...
+{
+	const x1 = new Float64Array( 10 );
+	const x2 = new Float64Array( 10 );
+	const out = new Float64Array( 10 );
+
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, '10', 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, true, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, false, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, null, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, undefined, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, [], 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, {}, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, ( x: number ): number => x, 0 ); // $ExpectError
+
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, '10', 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, true, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, false, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, null, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, undefined, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, [], 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, {}, 0, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, ( x: number ): number => x, 0, {} ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a tenth argument which is not a number...
+{
+	const x1 = new Float64Array( 10 );
+	const x2 = new Float64Array( 10 );
+	const out = new Float64Array( 10 );
+
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, 1, '10' ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, 1, true ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, 1, false ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, 1, null ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, 1, undefined ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, 1, [] ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, 1, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, 1, ( x: number ): number => x ); // $ExpectError
+
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, 1, '10', {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, 1, true, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, 1, false, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, 1, null, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, 1, undefined, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, 1, [], {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, 1, {}, {} ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, 1, ( x: number ): number => x, {} ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided an invalid option...
+{
+	const x1 = new Float64Array( 10 );
+	const x2 = new Float64Array( 10 );
+	const out = new Float64Array( 10 );
+
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, 1, 0, { 'copy': '10' } ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, 1, 0, { 'copy': null } ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, 1, 0, { 'copy': [] } ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, 1, 0, { 'copy': {} } ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, 1, 0, { 'copy': ( x: number ): number => x } ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided an unsupported number of arguments...
+{
+	const x1 = new Float64Array( 10 );
+	const x2 = new Float64Array( 10 );
+	const out = new Float64Array( 10 );
+
+	random.ndarray(); // $ExpectError
+	random.ndarray( x1.length ); // $ExpectError
+	random.ndarray( x1.length, x1 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0 ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out ); // $ExpectError
+	random.ndarray( x1.length, x1, 1, 0, x2, 1, 0, out, 1 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/random/strided/weibull/examples/index.js
+++ b/lib/node_modules/@stdlib/random/strided/weibull/examples/index.js
@@ -1,0 +1,47 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var zeros = require( '@stdlib/array/zeros' );
+var zeroTo = require( '@stdlib/array/base/zero-to' );
+var logEach = require( '@stdlib/console/log-each' );
+var weibull = require( './../lib' );
+
+// Specify a PRNG seed:
+var opts = {
+	'seed': 1234
+};
+
+// Create an array:
+var x1 = zeros( 10, 'float64' );
+
+// Create a list of indices:
+var idx = zeroTo( x1.length );
+
+// Fill the array with pseudorandom numbers:
+weibull( x1.length, [ 2.0 ], 0, [ 5.0 ], 0, x1, 1, opts );
+
+// Create a second array:
+var x2 = zeros( 10, 'generic' );
+
+// Fill the array with the same pseudorandom numbers:
+weibull( x2.length, [ 2.0 ], 0, [ 5.0 ], 0, x2, 1, opts );
+
+// Print the array contents:
+logEach( 'x1[%d] = %.2f; x2[%d] = %.2f', idx, x1, idx, x2 );

--- a/lib/node_modules/@stdlib/random/strided/weibull/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/weibull/lib/index.js
@@ -1,0 +1,63 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Fill a strided array with pseudorandom numbers drawn from a weibull distribution.
+*
+* @module @stdlib/random/strided/weibull
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+* var weibull = require( '@stdlib/random/strided/weibull' );
+*
+* // Create an array:
+* var out = new Float64Array( 10 );
+*
+* // Fill the array with pseudorandom numbers:
+* weibull( out.length, [ 2.0 ], 0, [ 5.0 ], 0, out, 1 );
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+* var weibull = require( '@stdlib/random/strided/weibull' );
+*
+* // Create an array:
+* var out = new Float64Array( 10 );
+*
+* // Fill the array with pseudorandom numbers:
+* weibull.factory( out.length, [ 2.0 ], 0, 0, [ 5.0 ], 0, 0, out, 1, 0 );
+*/
+
+// MODULES //
+
+var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
+var main = require( './main.js' );
+var ndarray = require( './ndarray.js' );
+
+
+// MAIN //
+
+setReadOnly( main, 'ndarray', ndarray );
+
+
+// EXPORTS //
+
+module.exports = main;
+
+// exports: { "ndarray": "main.ndarray" }

--- a/lib/node_modules/@stdlib/random/strided/weibull/lib/index.js
+++ b/lib/node_modules/@stdlib/random/strided/weibull/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Fill a strided array with pseudorandom numbers drawn from a weibull distribution.
+* Fill a strided array with pseudorandom numbers drawn from a Weibull distribution.
 *
 * @module @stdlib/random/strided/weibull
 *

--- a/lib/node_modules/@stdlib/random/strided/weibull/lib/main.js
+++ b/lib/node_modules/@stdlib/random/strided/weibull/lib/main.js
@@ -34,7 +34,7 @@ var prng = require( './prng.js' );
 * @param {Collection} k - scale parameter
 * @param {integer} sk - `k` stride length
 * @param {Collection} lambda - shape parameter
-* @param {integer} sk - `lambda` stride length
+* @param {integer} sl - `lambda` stride length
 * @param {Collection} out - output array
 * @param {integer} so - `out` stride length
 * @param {Options} [options] - function options

--- a/lib/node_modules/@stdlib/random/strided/weibull/lib/main.js
+++ b/lib/node_modules/@stdlib/random/strided/weibull/lib/main.js
@@ -28,13 +28,13 @@ var prng = require( './prng.js' );
 // MAIN //
 
 /**
-* Fills a strided array with pseudorandom numbers drawn from a beta distribution.
+* Fills a strided array with pseudorandom numbers drawn from a Weibull distribution.
 *
 * @param {NonNegativeInteger} N - number of indexed elements
 * @param {Collection} k - scale parameter
-* @param {integer} sa - `k` stride length
+* @param {integer} sk - `k` stride length
 * @param {Collection} lambda - shape parameter
-* @param {integer} sb - `lambda` stride length
+* @param {integer} sk - `lambda` stride length
 * @param {Collection} out - output array
 * @param {integer} so - `out` stride length
 * @param {Options} [options] - function options
@@ -56,13 +56,13 @@ var prng = require( './prng.js' );
 * // Fill the array with pseudorandom numbers:
 * weibull( out.length, [ 2.0 ], 0, [ 5.0 ], 0, out, 1 );
 */
-function weibull( N, k, sa, lambda, sb, out, so, options ) {
-	var rand = prng( k, sa, 0, lambda, sb, 0, arguments.length > 7, options );
+function weibull( N, k, sk, lambda, sl, out, so, options ) {
+	var rand = prng( k, sk, 0, lambda, sl, 0, arguments.length > 7, options );
 	if ( rand.arity === 0 ) {
 		nullary( [ out ], [ N ], [ so ], rand.fcn );
 		return out;
 	}
-	binary( [ k, lambda, out ], [ N ], [ sa, sb, so ], rand.fcn );
+	binary( [ k, lambda, out ], [ N ], [ sk, sl, so ], rand.fcn );
 	return out;
 }
 

--- a/lib/node_modules/@stdlib/random/strided/weibull/lib/main.js
+++ b/lib/node_modules/@stdlib/random/strided/weibull/lib/main.js
@@ -1,0 +1,72 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var nullary = require( '@stdlib/strided/base/nullary' );
+var binary = require( '@stdlib/strided/base/binary' );
+var prng = require( './prng.js' );
+
+
+// MAIN //
+
+/**
+* Fills a strided array with pseudorandom numbers drawn from a beta distribution.
+*
+* @param {NonNegativeInteger} N - number of indexed elements
+* @param {Collection} k - scale parameter
+* @param {integer} sa - `k` stride length
+* @param {Collection} lambda - shape parameter
+* @param {integer} sb - `lambda` stride length
+* @param {Collection} out - output array
+* @param {integer} so - `out` stride length
+* @param {Options} [options] - function options
+* @param {PRNG} [options.prng] - pseudorandom number generator which generates uniformly distributed pseudorandom numbers
+* @param {PRNGSeedMT19937} [options.seed] - pseudorandom number generator seed
+* @param {PRNGStateMT19937} [options.state] - pseudorandom number generator state
+* @param {boolean} [options.copy=true] - boolean indicating whether to copy a provided pseudorandom number generator state
+* @throws {Error} must provide valid distribution parameters
+* @throws {Error} must provide valid options
+* @throws {Error} must provide a valid state
+* @returns {Collection} output array
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+*
+* // Create an array:
+* var out = new Float64Array( 10 );
+*
+* // Fill the array with pseudorandom numbers:
+* weibull( out.length, [ 2.0 ], 0, [ 5.0 ], 0, out, 1 );
+*/
+function weibull( N, k, sa, lambda, sb, out, so, options ) {
+	var rand = prng( k, sa, 0, lambda, sb, 0, arguments.length > 7, options );
+	if ( rand.arity === 0 ) {
+		nullary( [ out ], [ N ], [ so ], rand.fcn );
+		return out;
+	}
+	binary( [ k, lambda, out ], [ N ], [ sa, sb, so ], rand.fcn );
+	return out;
+}
+
+
+// EXPORTS //
+
+module.exports = weibull;

--- a/lib/node_modules/@stdlib/random/strided/weibull/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/random/strided/weibull/lib/ndarray.js
@@ -1,0 +1,75 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var nullary = require( '@stdlib/strided/base/nullary' ).ndarray;
+var binary = require( '@stdlib/strided/base/binary' ).ndarray;
+var prng = require( './prng.js' );
+
+
+// MAIN //
+
+/**
+* Fills a strided array with pseudorandom numbers drawn from a weibull distribution.
+*
+* @param {NonNegativeInteger} N - number of indexed elements
+* @param {Collection} k - scale parameter
+* @param {integer} sa - `k` stride length
+* @param {NonNegativeInteger} oa - starting `k` index
+* @param {Collection} lambda - shape parameter
+* @param {integer} sb - `lambda` stride length
+* @param {NonNegativeInteger} ob - starting `lambda` index
+* @param {Collection} out - output array
+* @param {integer} so - `out` stride length
+* @param {NonNegativeInteger} oo - starting `out` index
+* @param {Options} [options] - function options
+* @param {PRNG} [options.prng] - pseudorandom number generator which generates uniformly distributed pseudorandom numbers
+* @param {PRNGSeedMT19937} [options.seed] - pseudorandom number generator seed
+* @param {PRNGStateMT19937} [options.state] - pseudorandom number generator state
+* @param {boolean} [options.copy=true] - boolean indicating whether to copy a provided pseudorandom number generator state
+* @throws {Error} must provide valid distribution parameters
+* @throws {Error} must provide valid options
+* @throws {Error} must provide a valid state
+* @returns {Collection} output array
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+*
+* // Create an array:
+* var out = new Float64Array( 10 );
+*
+* // Fill the array with pseudorandom numbers:
+* weibull( out.length, [ 2.0 ], 0, 0, [ 5.0 ], 0, 0, out, 1, 0 );
+*/
+function weibull( N, k, sa, oa, lambda, sb, ob, out, so, oo, options ) { // eslint-disable-line max-params
+	var rand = prng( k, sa, oa, lambda, sb, ob, arguments.length > 10, options ); // eslint-disable-line max-len
+	if ( rand.arity === 0 ) {
+		nullary( [ out ], [ N ], [ so ], [ oo ], rand.fcn );
+		return out;
+	}
+	binary( [ k, lambda, out ], [ N ], [ sa, sb, so ], [ oa, ob, oo ], rand.fcn ); // eslint-disable-line max-len
+	return out;
+}
+
+
+// EXPORTS //
+
+module.exports = weibull;

--- a/lib/node_modules/@stdlib/random/strided/weibull/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/random/strided/weibull/lib/ndarray.js
@@ -28,15 +28,15 @@ var prng = require( './prng.js' );
 // MAIN //
 
 /**
-* Fills a strided array with pseudorandom numbers drawn from a weibull distribution.
+* Fills a strided array with pseudorandom numbers drawn from a Weibull distribution.
 *
 * @param {NonNegativeInteger} N - number of indexed elements
 * @param {Collection} k - scale parameter
-* @param {integer} sa - `k` stride length
-* @param {NonNegativeInteger} oa - starting `k` index
+* @param {integer} sk - `k` stride length
+* @param {NonNegativeInteger} ok - starting `k` index
 * @param {Collection} lambda - shape parameter
-* @param {integer} sb - `lambda` stride length
-* @param {NonNegativeInteger} ob - starting `lambda` index
+* @param {integer} sl - `lambda` stride length
+* @param {NonNegativeInteger} ol - starting `lambda` index
 * @param {Collection} out - output array
 * @param {integer} so - `out` stride length
 * @param {NonNegativeInteger} oo - starting `out` index
@@ -59,13 +59,13 @@ var prng = require( './prng.js' );
 * // Fill the array with pseudorandom numbers:
 * weibull( out.length, [ 2.0 ], 0, 0, [ 5.0 ], 0, 0, out, 1, 0 );
 */
-function weibull( N, k, sa, oa, lambda, sb, ob, out, so, oo, options ) { // eslint-disable-line max-params
-	var rand = prng( k, sa, oa, lambda, sb, ob, arguments.length > 10, options ); // eslint-disable-line max-len
+function weibull( N, k, sk, ok, lambda, sl, ol, out, so, oo, options ) { // eslint-disable-line max-params
+	var rand = prng( k, sk, ok, lambda, sl, ol, arguments.length > 10, options ); // eslint-disable-line max-len
 	if ( rand.arity === 0 ) {
 		nullary( [ out ], [ N ], [ so ], [ oo ], rand.fcn );
 		return out;
 	}
-	binary( [ k, lambda, out ], [ N ], [ sa, sb, so ], [ oa, ob, oo ], rand.fcn ); // eslint-disable-line max-len
+	binary( [ k, lambda, out ], [ N ], [ sk, sl, so ], [ ok, ol, oo ], rand.fcn ); // eslint-disable-line max-len
 	return out;
 }
 

--- a/lib/node_modules/@stdlib/random/strided/weibull/lib/prng.js
+++ b/lib/node_modules/@stdlib/random/strided/weibull/lib/prng.js
@@ -1,0 +1,85 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isAccessorArray = require( '@stdlib/array/base/assert/is-accessor-array' );
+var random = require( '@stdlib/random/base/weibull' );
+
+
+// MAIN //
+
+/**
+* Returns a function for generating pseudorandom numbers.
+*
+* ## Notes
+*
+* -   The returned object has the following properties:
+*
+*     -   **arity**: number of function parameters.
+*     -   **fcn**: function for generating pseudorandom numbers.
+*
+* @private
+* @param {Collection} x - first parameter
+* @param {integer} sx - `x` stride length
+* @param {NonNegativeInteger} ox - starting `x` index
+* @param {Collection} y - second parameter
+* @param {integer} sy - `y` stride length
+* @param {NonNegativeInteger} oy - starting `y` index
+* @param {boolean} hasOptions - boolean indicating whether to process an options argument
+* @param {(void|Options)} options - function options
+* @returns {Object} function object
+*/
+function clbk( x, sx, ox, y, sy, oy, hasOptions, options ) {
+	var out;
+	var v1;
+	var v2;
+
+	out = {
+		'arity': 0,
+		'fcn': null
+	};
+	if ( hasOptions ) {
+		if ( sx === 0 && sy === 0 ) {
+			if ( isAccessorArray( x ) ) {
+				v1 = x.get( ox );
+			} else {
+				v1 = x[ ox ];
+			}
+			if ( isAccessorArray( y ) ) {
+				v2 = y.get( oy );
+			} else {
+				v2 = y[ oy ];
+			}
+			out.fcn = random.factory( v1, v2, options );
+			return out;
+		}
+		out.fcn = random.factory( options );
+	} else {
+		out.fcn = random;
+	}
+	out.arity += 2;
+	return out;
+}
+
+
+// EXPORTS //
+
+module.exports = clbk;

--- a/lib/node_modules/@stdlib/random/strided/weibull/package.json
+++ b/lib/node_modules/@stdlib/random/strided/weibull/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@stdlib/random/strided/weibull",
+  "version": "0.0.0",
+  "description": "Fill a strided array with pseudorandom numbers drawn from a weibull distribution.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
+    "statistics",
+    "stats",
+    "prng",
+    "rng",
+    "pseudorandom",
+    "random",
+    "rand",
+    "weibull",
+    "continuous",
+    "generator",
+    "seed",
+    "seedable",
+    "strided",
+    "array",
+    "vector",
+    "ndarray"
+  ]
+}

--- a/lib/node_modules/@stdlib/random/strided/weibull/package.json
+++ b/lib/node_modules/@stdlib/random/strided/weibull/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/random/strided/weibull",
   "version": "0.0.0",
-  "description": "Fill a strided array with pseudorandom numbers drawn from a weibull distribution.",
+  "description": "Fill a strided array with pseudorandom numbers drawn from a Weibull distribution.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/random/strided/weibull/test/test.js
+++ b/lib/node_modules/@stdlib/random/strided/weibull/test/test.js
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var random = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof random, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the main export is a method providing an ndarray interface', function test( t ) {
+	t.strictEqual( typeof random.ndarray, 'function', 'method is a function' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/random/strided/weibull/test/test.main.js
+++ b/lib/node_modules/@stdlib/random/strided/weibull/test/test.main.js
@@ -1,0 +1,819 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var Float64Array = require( '@stdlib/array/float64' );
+var zeros = require( '@stdlib/array/zeros' );
+var filledarrayBy = require( '@stdlib/array/filled-by' );
+var toAccessorArray = require( '@stdlib/array/base/to-accessor-array' );
+var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/base/uniform' ).factory;
+var prng = require( '@stdlib/random/base/weibull' );
+var random = require( './../lib/main.js' );
+
+
+// VARIABLES //
+
+// Valid values for PRNG parameters:
+var PARAM1 = linspace( 1.0, 5.0, 10 );
+var PARAM2 = linspace( 1.0, 5.0, 10 );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof random, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function fills a strided array with pseudorandom numbers', function test( t ) {
+	var out;
+	var x1;
+	var x2;
+	var N;
+	var i;
+
+	N = 10;
+
+	x1 = [ PARAM1[ 0 ] ];
+	x2 = [ PARAM2[ 0 ] ];
+	out = zeros( N, 'generic' );
+
+	random( N, x1, 0, x2, 0, out, 1 );
+	for ( i = 0; i < N; i++ ) {
+		t.strictEqual( typeof out[ i ], 'number', 'returns a number' );
+	}
+
+	x1 = filledarrayBy( N, 'generic', uniform( PARAM1[ 0 ], PARAM1[ 9 ] ) );
+	x2 = filledarrayBy( N, 'generic', uniform( PARAM2[ 0 ], PARAM2[ 9 ] ) );
+	out = zeros( N, 'generic' );
+
+	random( N, x1, 1, x2, 1, out, 1 );
+	for ( i = 0; i < N; i++ ) {
+		t.strictEqual( typeof out[ i ], 'number', 'returns a number' );
+	}
+	t.end();
+});
+
+tape( 'the function fills a strided array with pseudorandom numbers (accessors)', function test( t ) {
+	var out;
+	var x1;
+	var x2;
+	var N;
+	var i;
+
+	N = 10;
+
+	x1 = toAccessorArray( [ PARAM1[ 0 ] ] );
+	x2 = toAccessorArray( [ PARAM2[ 0 ] ] );
+	out = zeros( N, 'generic' );
+
+	random( N, x1, 0, x2, 0, out, 1 );
+	for ( i = 0; i < N; i++ ) {
+		t.strictEqual( typeof out[ i ], 'number', 'returns a number' );
+	}
+
+	x1 = toAccessorArray( filledarrayBy( N, 'generic', uniform( PARAM1[ 0 ], PARAM1[ 9 ] ) ) );
+	x2 = toAccessorArray( filledarrayBy( N, 'generic', uniform( PARAM2[ 0 ], PARAM2[ 9 ] ) ) );
+	out = zeros( N, 'generic' );
+
+	random( N, x1, 1, x2, 1, out, 1 );
+	for ( i = 0; i < N; i++ ) {
+		t.strictEqual( typeof out[ i ], 'number', 'returns a number' );
+	}
+	t.end();
+});
+
+tape( 'the function fills a strided array with pseudorandom numbers (seeded)', function test( t ) {
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+	var i;
+
+	opts = {
+		'seed': prng.seed
+	};
+
+	N = 10;
+
+	x1 = [ PARAM1[ 0 ] ];
+	x2 = [ PARAM2[ 0 ] ];
+	out = zeros( N, 'generic' );
+
+	random( N, x1, 0, x2, 0, out, 1, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	for ( i = 0; i < N; i++ ) {
+		t.strictEqual( out[ i ], rand( x1[ 0 ], x2[ 0 ] ), 'returns expected value' );
+	}
+
+	x1 = filledarrayBy( N, 'generic', uniform( PARAM1[ 0 ], PARAM1[ 9 ] ) );
+	x2 = filledarrayBy( N, 'generic', uniform( PARAM2[ 0 ], PARAM2[ 9 ] ) );
+	out = zeros( N, 'generic' );
+
+	random( N, x1, 1, x2, 1, out, 1, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	for ( i = 0; i < N; i++ ) {
+		t.strictEqual( out[ i ], rand( x1[ i ], x2[ i ] ), 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function fills a strided array with pseudorandom numbers (accessors; seeded)', function test( t ) {
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+	var i;
+
+	opts = {
+		'seed': prng.seed
+	};
+
+	N = 10;
+
+	x1 = toAccessorArray( [ PARAM1[ 0 ] ] );
+	x2 = toAccessorArray( [ PARAM2[ 0 ] ] );
+	out = zeros( N, 'generic' );
+
+	random( N, x1, 0, x2, 0, out, 1, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	for ( i = 0; i < N; i++ ) {
+		t.strictEqual( out[ i ], rand( x1.get( 0 ), x2.get( 0 ) ), 'returns expected value' );
+	}
+
+	x1 = toAccessorArray( filledarrayBy( N, 'generic', uniform( PARAM1[ 0 ], PARAM1[ 9 ] ) ) );
+	x2 = toAccessorArray( filledarrayBy( N, 'generic', uniform( PARAM2[ 0 ], PARAM2[ 9 ] ) ) );
+	out = zeros( N, 'generic' );
+
+	random( N, x1, 1, x2, 1, out, 1, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	for ( i = 0; i < N; i++ ) {
+		t.strictEqual( out[ i ], rand( x1.get( i ), x2.get( i ) ), 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function supports a stride for the first strided array', function test( t ) {
+	var expected;
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+
+	N = 3;
+	x1 = [
+		PARAM1[ 0 ], // 0
+		PARAM1[ 1 ],
+		PARAM1[ 2 ], // 1
+		PARAM1[ 3 ],
+		PARAM1[ 4 ]  // 2
+	];
+	x2 = [
+		PARAM2[ 0 ], // 0
+		PARAM2[ 1 ], // 1
+		PARAM2[ 2 ], // 2
+		PARAM2[ 3 ],
+		PARAM2[ 4 ]
+	];
+	out = [
+		0.0, // 0
+		0.0, // 1
+		0.0, // 2
+		0.0,
+		0.0
+	];
+
+	opts = {
+		'seed': prng.seed
+	};
+	random( N, x1, 2, x2, 1, out, 1, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	expected = [
+		rand( x1[ 0 ], x2[ 0 ] ),
+		rand( x1[ 2 ], x2[ 1 ] ),
+		rand( x1[ 4 ], x2[ 2 ] ),
+		0.0,
+		0.0
+	];
+
+	t.deepEqual( out, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports a stride for the first strided array (accessors)', function test( t ) {
+	var expected;
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+
+	N = 3;
+	x1 = toAccessorArray([
+		PARAM1[ 0 ], // 0
+		PARAM1[ 1 ],
+		PARAM1[ 2 ], // 1
+		PARAM1[ 3 ],
+		PARAM1[ 4 ]  // 2
+	]);
+	x2 = toAccessorArray([
+		PARAM2[ 0 ], // 0
+		PARAM2[ 1 ], // 1
+		PARAM2[ 2 ], // 2
+		PARAM2[ 3 ],
+		PARAM2[ 4 ]
+	]);
+	out = [
+		0.0, // 0
+		0.0, // 1
+		0.0, // 2
+		0.0,
+		0.0
+	];
+
+	opts = {
+		'seed': prng.seed
+	};
+	random( N, x1, 2, x2, 1, toAccessorArray( out ), 1, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	expected = [
+		rand( x1.get( 0 ), x2.get( 0 ) ),
+		rand( x1.get( 2 ), x2.get( 1 ) ),
+		rand( x1.get( 4 ), x2.get( 2 ) ),
+		0.0,
+		0.0
+	];
+
+	t.deepEqual( out, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports a stride for the second strided array', function test( t ) {
+	var expected;
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+
+	N = 3;
+	x1 = [
+		PARAM1[ 0 ], // 0
+		PARAM1[ 1 ], // 1
+		PARAM1[ 2 ], // 2
+		PARAM1[ 3 ],
+		PARAM1[ 4 ]
+	];
+	x2 = [
+		PARAM2[ 0 ], // 0
+		PARAM2[ 1 ],
+		PARAM2[ 2 ], // 1
+		PARAM2[ 3 ],
+		PARAM2[ 4 ]  // 2
+	];
+	out = [
+		0.0, // 0
+		0.0, // 1
+		0.0, // 2
+		0.0,
+		0.0
+	];
+
+	opts = {
+		'seed': prng.seed
+	};
+	random( N, x1, 1, x2, 2, out, 1, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	expected = [
+		rand( x1[ 0 ], x2[ 0 ] ),
+		rand( x1[ 1 ], x2[ 2 ] ),
+		rand( x1[ 2 ], x2[ 4 ] ),
+		0.0,
+		0.0
+	];
+
+	t.deepEqual( out, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports a stride for the second strided array (accessors)', function test( t ) {
+	var expected;
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+
+	N = 3;
+	x1 = toAccessorArray([
+		PARAM1[ 0 ], // 0
+		PARAM1[ 1 ], // 1
+		PARAM1[ 2 ], // 2
+		PARAM1[ 3 ],
+		PARAM1[ 4 ]
+	]);
+	x2 = toAccessorArray([
+		PARAM2[ 0 ], // 0
+		PARAM2[ 1 ],
+		PARAM2[ 2 ], // 1
+		PARAM2[ 3 ],
+		PARAM2[ 4 ]  // 2
+	]);
+	out = [
+		0.0, // 0
+		0.0, // 1
+		0.0, // 2
+		0.0,
+		0.0
+	];
+
+	opts = {
+		'seed': prng.seed
+	};
+	random( N, x1, 1, x2, 2, toAccessorArray( out ), 1, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	expected = [
+		rand( x1.get( 0 ), x2.get( 0 ) ),
+		rand( x1.get( 1 ), x2.get( 2 ) ),
+		rand( x1.get( 2 ), x2.get( 4 ) ),
+		0.0,
+		0.0
+	];
+
+	t.deepEqual( out, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports a stride for the output strided array', function test( t ) {
+	var expected;
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+
+	N = 3;
+	x1 = [
+		PARAM1[ 0 ], // 0
+		PARAM1[ 1 ], // 1
+		PARAM1[ 2 ], // 2
+		PARAM1[ 3 ],
+		PARAM1[ 4 ]
+	];
+	x2 = [
+		PARAM2[ 0 ], // 0
+		PARAM2[ 1 ], // 1
+		PARAM2[ 2 ], // 2
+		PARAM2[ 3 ],
+		PARAM2[ 4 ]
+	];
+	out = [
+		0.0, // 0
+		0.0,
+		0.0, // 1
+		0.0,
+		0.0  // 2
+	];
+
+	opts = {
+		'seed': prng.seed
+	};
+	random( N, x1, 1, x2, 1, out, 2, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	expected = [
+		rand( x1[ 0 ], x2[ 0 ] ),
+		0.0,
+		rand( x1[ 1 ], x2[ 1 ] ),
+		0.0,
+		rand( x1[ 2 ], x2[ 2 ] )
+	];
+
+	t.deepEqual( out, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports a stride for the output strided array (accessors)', function test( t ) {
+	var expected;
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+
+	N = 3;
+	x1 = toAccessorArray([
+		PARAM1[ 0 ], // 0
+		PARAM1[ 1 ], // 1
+		PARAM1[ 2 ], // 2
+		PARAM1[ 3 ],
+		PARAM1[ 4 ]
+	]);
+	x2 = toAccessorArray([
+		PARAM2[ 0 ], // 0
+		PARAM2[ 1 ], // 1
+		PARAM2[ 2 ], // 2
+		PARAM2[ 3 ],
+		PARAM2[ 4 ]
+	]);
+	out = [
+		0.0, // 0
+		0.0,
+		0.0, // 1
+		0.0,
+		0.0  // 2
+	];
+
+	opts = {
+		'seed': prng.seed
+	};
+	random( N, x1, 1, x2, 1, toAccessorArray( out ), 2, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	expected = [
+		rand( x1.get( 0 ), x2.get( 0 ) ),
+		0.0,
+		rand( x1.get( 1 ), x2.get( 1 ) ),
+		0.0,
+		rand( x1.get( 2 ), x2.get( 2 ) )
+	];
+
+	t.deepEqual( out, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns a reference to the output array', function test( t ) {
+	var actual;
+	var out;
+	var x1;
+	var x2;
+
+	x1 = [ PARAM1[ 0 ] ];
+	x2 = [ PARAM2[ 0 ] ];
+	out = zeros( 10, 'generic' );
+
+	actual = random( out.length, x1, 1, x2, 1, out, 1 );
+	t.strictEqual( actual, out, 'same reference' );
+
+	x1 = [ PARAM1[ 0 ], PARAM1[ 1 ], PARAM1[ 2 ] ];
+	x2 = [ PARAM2[ 0 ], PARAM2[ 1 ], PARAM2[ 2 ] ];
+	out = zeros( 3, 'generic' );
+
+	actual = random( out.length, x1, 1, x2, 1, out, 1 );
+	t.strictEqual( actual, out, 'same reference' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter less than or equal to `0`, the function leaves the output array unchanged', function test( t ) {
+	var expected;
+	var out;
+	var x1;
+	var x2;
+
+	x1 = [ PARAM1[ 0 ] ];
+	x2 = [ PARAM2[ 0 ] ];
+	out = zeros( 10, 'generic' );
+	expected = zeros( 10, 'generic' );
+
+	random( -1, x1, 1, x2, 1, out, 1 );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	random( 0, x1, 1, x2, 1, out, 1 );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	x1 = [ PARAM1[ 0 ], PARAM1[ 1 ], PARAM1[ 2 ] ];
+	x2 = [ PARAM2[ 0 ], PARAM2[ 1 ], PARAM2[ 2 ] ];
+	out = zeros( x1.length, 'generic' );
+	expected = zeros( x1.length, 'generic' );
+
+	random( -1, x1, 1, x2, 1, out, 1 );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	random( 0, x1, 1, x2, 1, out, 1 );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter less than or equal to `0`, the function leaves the output array unchanged (accessors)', function test( t ) {
+	var expected;
+	var out;
+	var x1;
+	var x2;
+
+	x1 = toAccessorArray( [ PARAM1[ 0 ] ] );
+	x2 = toAccessorArray( [ PARAM2[ 0 ] ] );
+	out = zeros( 10, 'generic' );
+	expected = zeros( 10, 'generic' );
+
+	random( -1, x1, 1, x2, 1, toAccessorArray( out ), 1 );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	random( 0, x1, 1, x2, 1, toAccessorArray( out ), 1 );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	x1 = toAccessorArray( [ PARAM1[ 0 ], PARAM1[ 1 ], PARAM1[ 2 ] ] );
+	x2 = toAccessorArray( [ PARAM2[ 0 ], PARAM2[ 1 ], PARAM2[ 2 ] ] );
+	out = zeros( x1.length, 'generic' );
+	expected = zeros( x1.length, 'generic' );
+
+	random( -1, x1, 1, x2, 1, toAccessorArray( out ), 1 );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	random( 0, x1, 1, x2, 1, toAccessorArray( out ), 1 );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports negative strides', function test( t ) {
+	var expected;
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+
+	N = 3;
+	x1 = [
+		PARAM1[ 0 ], // 2
+		PARAM1[ 1 ],
+		PARAM1[ 2 ], // 1
+		PARAM1[ 3 ],
+		PARAM1[ 4 ]  // 0
+	];
+	x2 = [
+		PARAM2[ 0 ], // 2
+		PARAM2[ 1 ], // 1
+		PARAM2[ 2 ], // 0
+		PARAM2[ 3 ],
+		PARAM2[ 4 ]
+	];
+	out = [
+		0.0, // 0
+		0.0,
+		0.0, // 1
+		0.0,
+		0.0  // 2
+	];
+
+	opts = {
+		'seed': prng.seed
+	};
+	random( N, x1, -2, x2, -1, out, 2, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	expected = [
+		rand( x1[ 4 ], x2[ 2 ] ),
+		0.0,
+		rand( x1[ 2 ], x2[ 1 ] ),
+		0.0,
+		rand( x1[ 0 ], x2[ 0 ] )
+	];
+
+	t.deepEqual( out, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports negative strides (accessors)', function test( t ) {
+	var expected;
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+
+	N = 3;
+	x1 = toAccessorArray([
+		PARAM1[ 0 ], // 2
+		PARAM1[ 1 ],
+		PARAM1[ 2 ], // 1
+		PARAM1[ 3 ],
+		PARAM1[ 4 ]  // 0
+	]);
+	x2 = toAccessorArray([
+		PARAM2[ 0 ], // 2
+		PARAM2[ 1 ], // 1
+		PARAM2[ 2 ], // 0
+		PARAM2[ 3 ],
+		PARAM2[ 4 ]
+	]);
+	out = [
+		0.0, // 0
+		0.0,
+		0.0, // 1
+		0.0,
+		0.0  // 2
+	];
+
+	opts = {
+		'seed': prng.seed
+	};
+	random( N, x1, -2, x2, -1, toAccessorArray( out ), 2, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	expected = [
+		rand( x1.get( 4 ), x2.get( 2 ) ),
+		0.0,
+		rand( x1.get( 2 ), x2.get( 1 ) ),
+		0.0,
+		rand( x1.get( 0 ), x2.get( 0 ) )
+	];
+
+	t.deepEqual( out, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports complex access patterns', function test( t ) {
+	var expected;
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+
+	N = 3;
+	x1 = [
+		PARAM1[ 0 ], // 0
+		PARAM1[ 1 ],
+		PARAM1[ 2 ], // 1
+		PARAM1[ 3 ],
+		PARAM1[ 4 ], // 2
+		PARAM1[ 5 ]
+	];
+	x2 = [
+		PARAM2[ 0 ],  // 2
+		PARAM2[ 1 ],  // 1
+		PARAM2[ 2 ],  // 0
+		PARAM2[ 3 ],
+		PARAM2[ 4 ],
+		PARAM2[ 5 ]
+	];
+	out = [
+		0.0, // 2
+		0.0,
+		0.0, // 1
+		0.0,
+		0.0  // 0
+	];
+
+	opts = {
+		'seed': prng.seed
+	};
+	random( N, x1, 2, x2, -1, out, -2, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+
+	// The order in which `rand` is invoked matters as the order in which pseudorandom numbers are generated is fixed...
+	expected = [
+		rand( x1[ 0 ], x2[ 2 ] ),
+		rand( x1[ 2 ], x2[ 1 ] ),
+		rand( x1[ 4 ], x2[ 0 ] )
+	];
+	expected = [
+		expected[ 2 ],
+		0.0,
+		expected[ 1 ],
+		0.0,
+		expected[ 0 ]
+	];
+
+	t.deepEqual( out, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports view offsets', function test( t ) {
+	var expected;
+	var viewOut;
+	var viewX1;
+	var viewX2;
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+
+	N = 3;
+
+	// Initial arrays...
+	x1 = new Float64Array([
+		PARAM1[ 0 ],
+		PARAM1[ 1 ], // 2
+		PARAM1[ 2 ],
+		PARAM1[ 3 ], // 1
+		PARAM1[ 4 ],
+		PARAM1[ 5 ]  // 0
+	]);
+	x2 = new Float64Array([
+		PARAM2[ 0 ],
+		PARAM2[ 1 ],
+		PARAM2[ 2 ],
+		PARAM2[ 3 ], // 0
+		PARAM2[ 4 ], // 1
+		PARAM2[ 5 ]  // 2
+	]);
+	out = new Float64Array([
+		0.0,
+		0.0,
+		0.0, // 0
+		0.0, // 1
+		0.0, // 2
+		0.0
+	]);
+
+	// Create offset views...
+	viewX1 = new Float64Array( x1.buffer, x1.BYTES_PER_ELEMENT*1 ); // begin at the 2nd element
+	viewX2 = new Float64Array( x2.buffer, x2.BYTES_PER_ELEMENT*3 ); // begin at the 4th element
+	viewOut = new Float64Array( out.buffer, out.BYTES_PER_ELEMENT*2 ); // begin at the 3rd element
+
+	opts = {
+		'seed': prng.seed
+	};
+	random( N, viewX1, -2, viewX2, 1, viewOut, 1, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	expected = new Float64Array([
+		0.0,
+		0.0,
+		rand( x1[ 5 ], x2[ 3 ] ),
+		rand( x1[ 3 ], x2[ 4 ] ),
+		rand( x1[ 1 ], x2[ 5 ] ),
+		0.0
+	]);
+
+	t.deepEqual( expected, out, 'returns expected value' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/random/strided/weibull/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/random/strided/weibull/test/test.ndarray.js
@@ -1,0 +1,1064 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var zeros = require( '@stdlib/array/zeros' );
+var filledarrayBy = require( '@stdlib/array/filled-by' );
+var toAccessorArray = require( '@stdlib/array/base/to-accessor-array' );
+var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/base/uniform' ).factory;
+var prng = require( '@stdlib/random/base/weibull' );
+var random = require( './../lib/ndarray.js' );
+
+
+// VARIABLES //
+
+// Valid values for PRNG parameters:
+var PARAM1 = linspace( 1.0, 5.0, 10 );
+var PARAM2 = linspace( 1.0, 5.0, 10 );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof random, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function fills a strided array with pseudorandom numbers', function test( t ) {
+	var out;
+	var x1;
+	var x2;
+	var N;
+	var i;
+
+	N = 10;
+
+	x1 = [ PARAM1[ 0 ] ];
+	x2 = [ PARAM2[ 0 ] ];
+	out = zeros( N, 'generic' );
+
+	random( N, x1, 0, 0, x2, 0, 0, out, 1, 0 );
+	for ( i = 0; i < N; i++ ) {
+		t.strictEqual( typeof out[ i ], 'number', 'returns a number' );
+	}
+
+	x1 = filledarrayBy( N, 'generic', uniform( PARAM1[ 0 ], PARAM1[ 9 ] ) );
+	x2 = filledarrayBy( N, 'generic', uniform( PARAM2[ 0 ], PARAM2[ 9 ] ) );
+	out = zeros( N, 'generic' );
+
+	random( N, x1, 1, 0, x2, 1, 0, out, 1, 0 );
+	for ( i = 0; i < N; i++ ) {
+		t.strictEqual( typeof out[ i ], 'number', 'returns a number' );
+	}
+	t.end();
+});
+
+tape( 'the function fills a strided array with pseudorandom numbers (accessors)', function test( t ) {
+	var out;
+	var x1;
+	var x2;
+	var N;
+	var i;
+
+	N = 10;
+
+	x1 = toAccessorArray( [ PARAM1[ 0 ] ] );
+	x2 = toAccessorArray( [ PARAM2[ 0 ] ] );
+	out = zeros( N, 'generic' );
+
+	random( N, x1, 0, 0, x2, 0, 0, out, 1, 0 );
+	for ( i = 0; i < N; i++ ) {
+		t.strictEqual( typeof out[ i ], 'number', 'returns a number' );
+	}
+
+	x1 = toAccessorArray( filledarrayBy( N, 'generic', uniform( PARAM1[ 0 ], PARAM1[ 9 ] ) ) );
+	x2 = toAccessorArray( filledarrayBy( N, 'generic', uniform( PARAM2[ 0 ], PARAM2[ 9 ] ) ) );
+	out = zeros( N, 'generic' );
+
+	random( N, x1, 1, 0, x2, 1, 0, out, 1, 0 );
+	for ( i = 0; i < N; i++ ) {
+		t.strictEqual( typeof out[ i ], 'number', 'returns a number' );
+	}
+	t.end();
+});
+
+tape( 'the function fills a strided array with pseudorandom numbers (seeded)', function test( t ) {
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+	var i;
+
+	opts = {
+		'seed': prng.seed
+	};
+
+	N = 10;
+
+	x1 = [ PARAM1[ 0 ] ];
+	x2 = [ PARAM2[ 0 ] ];
+	out = zeros( N, 'generic' );
+
+	random( N, x1, 0, 0, x2, 0, 0, out, 1, 0, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	for ( i = 0; i < N; i++ ) {
+		t.strictEqual( out[ i ], rand( x1[ 0 ], x2[ 0 ] ), 'returns expected value' );
+	}
+
+	x1 = filledarrayBy( N, 'generic', uniform( PARAM1[ 0 ], PARAM1[ 9 ] ) );
+	x2 = filledarrayBy( N, 'generic', uniform( PARAM2[ 0 ], PARAM2[ 9 ] ) );
+	out = zeros( N, 'generic' );
+
+	random( N, x1, 1, 0, x2, 1, 0, out, 1, 0, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	for ( i = 0; i < N; i++ ) {
+		t.strictEqual( out[ i ], rand( x1[ i ], x2[ i ] ), 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function fills a strided array with pseudorandom numbers (accessors; seeded)', function test( t ) {
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+	var i;
+
+	opts = {
+		'seed': prng.seed
+	};
+
+	N = 10;
+
+	x1 = toAccessorArray( [ PARAM1[ 0 ] ] );
+	x2 = toAccessorArray( [ PARAM2[ 0 ] ] );
+	out = zeros( N, 'generic' );
+
+	random( N, x1, 0, 0, x2, 0, 0, out, 1, 0, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	for ( i = 0; i < N; i++ ) {
+		t.strictEqual( out[ i ], rand( x1.get( 0 ), x2.get( 0 ) ), 'returns expected value' );
+	}
+
+	x1 = toAccessorArray( filledarrayBy( N, 'generic', uniform( PARAM1[ 0 ], PARAM1[ 9 ] ) ) );
+	x2 = toAccessorArray( filledarrayBy( N, 'generic', uniform( PARAM2[ 0 ], PARAM2[ 9 ] ) ) );
+	out = zeros( N, 'generic' );
+
+	random( N, x1, 1, 0, x2, 1, 0, out, 1, 0, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	for ( i = 0; i < N; i++ ) {
+		t.strictEqual( out[ i ], rand( x1.get( i ), x2.get( i ) ), 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function supports a stride for the first strided array', function test( t ) {
+	var expected;
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+
+	N = 3;
+	x1 = [
+		PARAM1[ 0 ], // 0
+		PARAM1[ 1 ],
+		PARAM1[ 2 ], // 1
+		PARAM1[ 3 ],
+		PARAM1[ 4 ]  // 2
+	];
+	x2 = [
+		PARAM2[ 0 ], // 0
+		PARAM2[ 1 ], // 1
+		PARAM2[ 2 ], // 2
+		PARAM2[ 3 ],
+		PARAM2[ 4 ]
+	];
+	out = [
+		0.0, // 0
+		0.0, // 1
+		0.0, // 2
+		0.0,
+		0.0
+	];
+
+	opts = {
+		'seed': prng.seed
+	};
+	random( N, x1, 2, 0, x2, 1, 0, out, 1, 0, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	expected = [
+		rand( x1[ 0 ], x2[ 0 ] ),
+		rand( x1[ 2 ], x2[ 1 ] ),
+		rand( x1[ 4 ], x2[ 2 ] ),
+		0.0,
+		0.0
+	];
+
+	t.deepEqual( out, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports a stride for the first strided array (accessors)', function test( t ) {
+	var expected;
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+
+	N = 3;
+	x1 = toAccessorArray([
+		PARAM1[ 0 ], // 0
+		PARAM1[ 1 ],
+		PARAM1[ 2 ], // 1
+		PARAM1[ 3 ],
+		PARAM1[ 4 ]  // 2
+	]);
+	x2 = toAccessorArray([
+		PARAM2[ 0 ], // 0
+		PARAM2[ 1 ], // 1
+		PARAM2[ 2 ], // 2
+		PARAM2[ 3 ],
+		PARAM2[ 4 ]
+	]);
+	out = [
+		0.0, // 0
+		0.0, // 1
+		0.0, // 2
+		0.0,
+		0.0
+	];
+
+	opts = {
+		'seed': prng.seed
+	};
+	random( N, x1, 2, 0, x2, 1, 0, toAccessorArray( out ), 1, 0, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	expected = [
+		rand( x1.get( 0 ), x2.get( 0 ) ),
+		rand( x1.get( 2 ), x2.get( 1 ) ),
+		rand( x1.get( 4 ), x2.get( 2 ) ),
+		0.0,
+		0.0
+	];
+
+	t.deepEqual( out, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports an offset for the first strided array', function test( t ) {
+	var expected;
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+
+	N = 3;
+	x1 = [
+		PARAM1[ 0 ],
+		PARAM1[ 1 ],
+		PARAM1[ 2 ], // 0
+		PARAM1[ 3 ], // 1
+		PARAM1[ 4 ]  // 2
+	];
+	x2 = [
+		PARAM2[ 0 ], // 0
+		PARAM2[ 1 ], // 1
+		PARAM2[ 2 ], // 2
+		PARAM2[ 3 ],
+		PARAM2[ 4 ]
+	];
+	out = [
+		0.0, // 0
+		0.0, // 1
+		0.0, // 2
+		0.0,
+		0.0
+	];
+
+	opts = {
+		'seed': prng.seed
+	};
+	random( N, x1, 1, 2, x2, 1, 0, out, 1, 0, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	expected = [
+		rand( x1[ 2 ], x2[ 0 ] ),
+		rand( x1[ 3 ], x2[ 1 ] ),
+		rand( x1[ 4 ], x2[ 2 ] ),
+		0.0,
+		0.0
+	];
+
+	t.deepEqual( out, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports an offset for the first strided array (accessors)', function test( t ) {
+	var expected;
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+
+	N = 3;
+	x1 = toAccessorArray([
+		PARAM1[ 0 ],
+		PARAM1[ 1 ],
+		PARAM1[ 2 ], // 0
+		PARAM1[ 3 ], // 1
+		PARAM1[ 4 ]  // 2
+	]);
+	x2 = toAccessorArray([
+		PARAM2[ 0 ], // 0
+		PARAM2[ 1 ], // 1
+		PARAM2[ 2 ], // 2
+		PARAM2[ 3 ],
+		PARAM2[ 4 ]
+	]);
+	out = [
+		0.0, // 0
+		0.0, // 1
+		0.0, // 2
+		0.0,
+		0.0
+	];
+
+	opts = {
+		'seed': prng.seed
+	};
+	random( N, x1, 1, 2, x2, 1, 0, toAccessorArray( out ), 1, 0, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	expected = [
+		rand( x1.get( 2 ), x2.get( 0 ) ),
+		rand( x1.get( 3 ), x2.get( 1 ) ),
+		rand( x1.get( 4 ), x2.get( 2 ) ),
+		0.0,
+		0.0
+	];
+
+	t.deepEqual( out, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports a stride for the second strided array', function test( t ) {
+	var expected;
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+
+	N = 3;
+	x1 = [
+		PARAM1[ 0 ], // 0
+		PARAM1[ 1 ], // 1
+		PARAM1[ 2 ], // 2
+		PARAM1[ 3 ],
+		PARAM1[ 4 ]
+	];
+	x2 = [
+		PARAM2[ 0 ], // 0
+		PARAM2[ 1 ],
+		PARAM2[ 2 ], // 1
+		PARAM2[ 3 ],
+		PARAM2[ 4 ]  // 2
+	];
+	out = [
+		0.0, // 0
+		0.0, // 1
+		0.0, // 2
+		0.0,
+		0.0
+	];
+
+	opts = {
+		'seed': prng.seed
+	};
+	random( N, x1, 1, 0, x2, 2, 0, out, 1, 0, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	expected = [
+		rand( x1[ 0 ], x2[ 0 ] ),
+		rand( x1[ 1 ], x2[ 2 ] ),
+		rand( x1[ 2 ], x2[ 4 ] ),
+		0.0,
+		0.0
+	];
+
+	t.deepEqual( out, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports a stride for the second strided array (accessors)', function test( t ) {
+	var expected;
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+
+	N = 3;
+	x1 = toAccessorArray([
+		PARAM1[ 0 ], // 0
+		PARAM1[ 1 ], // 1
+		PARAM1[ 2 ], // 2
+		PARAM1[ 3 ],
+		PARAM1[ 4 ]
+	]);
+	x2 = toAccessorArray([
+		PARAM2[ 0 ], // 0
+		PARAM2[ 1 ],
+		PARAM2[ 2 ], // 1
+		PARAM2[ 3 ],
+		PARAM2[ 4 ]  // 2
+	]);
+	out = [
+		0.0, // 0
+		0.0, // 1
+		0.0, // 2
+		0.0,
+		0.0
+	];
+
+	opts = {
+		'seed': prng.seed
+	};
+	random( N, x1, 1, 0, x2, 2, 0, toAccessorArray( out ), 1, 0, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	expected = [
+		rand( x1.get( 0 ), x2.get( 0 ) ),
+		rand( x1.get( 1 ), x2.get( 2 ) ),
+		rand( x1.get( 2 ), x2.get( 4 ) ),
+		0.0,
+		0.0
+	];
+
+	t.deepEqual( out, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports an offset for the second strided array', function test( t ) {
+	var expected;
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+
+	N = 3;
+	x1 = [
+		PARAM1[ 0 ], // 0
+		PARAM1[ 1 ], // 1
+		PARAM1[ 2 ], // 2
+		PARAM1[ 3 ],
+		PARAM1[ 4 ]
+	];
+	x2 = [
+		PARAM2[ 0 ],
+		PARAM2[ 1 ],
+		PARAM2[ 2 ], // 0
+		PARAM2[ 3 ], // 1
+		PARAM2[ 4 ]  // 2
+	];
+	out = [
+		0.0, // 0
+		0.0, // 1
+		0.0, // 2
+		0.0,
+		0.0
+	];
+
+	opts = {
+		'seed': prng.seed
+	};
+	random( N, x1, 1, 0, x2, 1, 2, out, 1, 0, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	expected = [
+		rand( x1[ 0 ], x2[ 2 ] ),
+		rand( x1[ 1 ], x2[ 3 ] ),
+		rand( x1[ 2 ], x2[ 4 ] ),
+		0.0,
+		0.0
+	];
+
+	t.deepEqual( out, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports an offset for the second strided array (accessors)', function test( t ) {
+	var expected;
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+
+	N = 3;
+	x1 = toAccessorArray([
+		PARAM1[ 0 ], // 0
+		PARAM1[ 1 ], // 1
+		PARAM1[ 2 ], // 2
+		PARAM1[ 3 ],
+		PARAM1[ 4 ]
+	]);
+	x2 = toAccessorArray([
+		PARAM2[ 0 ],
+		PARAM2[ 1 ],
+		PARAM2[ 2 ], // 0
+		PARAM2[ 3 ], // 1
+		PARAM2[ 4 ]  // 2
+	]);
+	out = [
+		0.0, // 0
+		0.0, // 1
+		0.0, // 2
+		0.0,
+		0.0
+	];
+
+	opts = {
+		'seed': prng.seed
+	};
+	random( N, x1, 1, 0, x2, 1, 2, toAccessorArray( out ), 1, 0, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	expected = [
+		rand( x1.get( 0 ), x2.get( 2 ) ),
+		rand( x1.get( 1 ), x2.get( 3 ) ),
+		rand( x1.get( 2 ), x2.get( 4 ) ),
+		0.0,
+		0.0
+	];
+
+	t.deepEqual( out, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports a stride for the output strided array', function test( t ) {
+	var expected;
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+
+	N = 3;
+	x1 = [
+		PARAM1[ 0 ], // 0
+		PARAM1[ 1 ], // 1
+		PARAM1[ 2 ], // 2
+		PARAM1[ 3 ],
+		PARAM1[ 4 ]
+	];
+	x2 = [
+		PARAM2[ 0 ], // 0
+		PARAM2[ 1 ], // 1
+		PARAM2[ 2 ], // 2
+		PARAM2[ 3 ],
+		PARAM2[ 4 ]
+	];
+	out = [
+		0.0, // 0
+		0.0,
+		0.0, // 1
+		0.0,
+		0.0  // 2
+	];
+
+	opts = {
+		'seed': prng.seed
+	};
+	random( N, x1, 1, 0, x2, 1, 0, out, 2, 0, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	expected = [
+		rand( x1[ 0 ], x2[ 0 ] ),
+		0.0,
+		rand( x1[ 1 ], x2[ 1 ] ),
+		0.0,
+		rand( x1[ 2 ], x2[ 2 ] )
+	];
+
+	t.deepEqual( out, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports a stride for the output strided array (accessors)', function test( t ) {
+	var expected;
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+
+	N = 3;
+	x1 = toAccessorArray([
+		PARAM1[ 0 ], // 0
+		PARAM1[ 1 ], // 1
+		PARAM1[ 2 ], // 2
+		PARAM1[ 3 ],
+		PARAM1[ 4 ]
+	]);
+	x2 = toAccessorArray([
+		PARAM2[ 0 ], // 0
+		PARAM2[ 1 ], // 1
+		PARAM2[ 2 ], // 2
+		PARAM2[ 3 ],
+		PARAM2[ 4 ]
+	]);
+	out = [
+		0.0, // 0
+		0.0,
+		0.0, // 1
+		0.0,
+		0.0  // 2
+	];
+
+	opts = {
+		'seed': prng.seed
+	};
+	random( N, x1, 1, 0, x2, 1, 0, toAccessorArray( out ), 2, 0, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	expected = [
+		rand( x1.get( 0 ), x2.get( 0 ) ),
+		0.0,
+		rand( x1.get( 1 ), x2.get( 1 ) ),
+		0.0,
+		rand( x1.get( 2 ), x2.get( 2 ) )
+	];
+
+	t.deepEqual( out, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports an offset for the output strided array', function test( t ) {
+	var expected;
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+
+	N = 3;
+	x1 = [
+		PARAM1[ 0 ], // 0
+		PARAM1[ 1 ], // 1
+		PARAM1[ 2 ], // 2
+		PARAM1[ 3 ],
+		PARAM1[ 4 ]
+	];
+	x2 = [
+		PARAM2[ 0 ], // 0
+		PARAM2[ 1 ], // 1
+		PARAM2[ 2 ], // 2
+		PARAM2[ 3 ],
+		PARAM2[ 4 ]
+	];
+	out = [
+		0.0,
+		0.0,
+		0.0, // 0
+		0.0, // 1
+		0.0  // 2
+	];
+
+	opts = {
+		'seed': prng.seed
+	};
+	random( N, x1, 1, 0, x2, 1, 0, out, 1, 2, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	expected = [
+		0.0,
+		0.0,
+		rand( x1[ 0 ], x2[ 0 ] ),
+		rand( x1[ 1 ], x2[ 1 ] ),
+		rand( x1[ 2 ], x2[ 2 ] )
+	];
+
+	t.deepEqual( out, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports an offset for the output strided array (accessors)', function test( t ) {
+	var expected;
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+
+	N = 3;
+	x1 = toAccessorArray([
+		PARAM1[ 0 ], // 0
+		PARAM1[ 1 ], // 1
+		PARAM1[ 2 ], // 2
+		PARAM1[ 3 ],
+		PARAM1[ 4 ]
+	]);
+	x2 = toAccessorArray([
+		PARAM2[ 0 ], // 0
+		PARAM2[ 1 ], // 1
+		PARAM2[ 2 ], // 2
+		PARAM2[ 3 ],
+		PARAM2[ 4 ]
+	]);
+	out = [
+		0.0,
+		0.0,
+		0.0, // 0
+		0.0, // 1
+		0.0  // 2
+	];
+
+	opts = {
+		'seed': prng.seed
+	};
+	random( N, x1, 1, 0, x2, 1, 0, toAccessorArray( out ), 1, 2, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	expected = [
+		0.0,
+		0.0,
+		rand( x1.get( 0 ), x2.get( 0 ) ),
+		rand( x1.get( 1 ), x2.get( 1 ) ),
+		rand( x1.get( 2 ), x2.get( 2 ) )
+	];
+
+	t.deepEqual( out, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns a reference to the output array', function test( t ) {
+	var actual;
+	var out;
+	var x1;
+	var x2;
+
+	x1 = [ PARAM1[ 0 ] ];
+	x2 = [ PARAM2[ 0 ] ];
+	out = zeros( 10, 'generic' );
+
+	actual = random( out.length, x1, 1, 0, x2, 1, 0, out, 1, 0 );
+	t.strictEqual( actual, out, 'same reference' );
+
+	x1 = [ PARAM1[ 0 ], PARAM1[ 1 ], PARAM1[ 2 ] ];
+	x2 = [ PARAM2[ 0 ], PARAM2[ 1 ], PARAM2[ 2 ] ];
+	out = zeros( 3, 'generic' );
+
+	actual = random( out.length, x1, 1, 0, x2, 1, 0, out, 1, 0 );
+	t.strictEqual( actual, out, 'same reference' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter less than or equal to `0`, the function leaves the output array unchanged', function test( t ) {
+	var expected;
+	var out;
+	var x1;
+	var x2;
+
+	x1 = [ PARAM1[ 0 ] ];
+	x2 = [ PARAM2[ 0 ] ];
+	out = zeros( 10, 'generic' );
+	expected = zeros( 10, 'generic' );
+
+	random( -1, x1, 1, 0, x2, 1, 0, out, 1, 0 );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	random( 0, x1, 1, 0, x2, 1, 0, out, 1, 0 );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	x1 = [ PARAM1[ 0 ], PARAM1[ 1 ], PARAM1[ 2 ] ];
+	x2 = [ PARAM2[ 0 ], PARAM2[ 1 ], PARAM2[ 2 ] ];
+	out = zeros( x1.length, 'generic' );
+	expected = zeros( x1.length, 'generic' );
+
+	random( -1, x1, 1, 0, x2, 1, 0, out, 1, 0 );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	random( 0, x1, 1, 0, x2, 1, 0, out, 1, 0 );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided an `N` parameter less than or equal to `0`, the function leaves the output array unchanged (accessors)', function test( t ) {
+	var expected;
+	var out;
+	var x1;
+	var x2;
+
+	x1 = toAccessorArray( [ PARAM1[ 0 ] ] );
+	x2 = toAccessorArray( [ PARAM2[ 0 ] ] );
+	out = zeros( 10, 'generic' );
+	expected = zeros( 10, 'generic' );
+
+	random( -1, x1, 1, 0, x2, 1, 0, toAccessorArray( out ), 1, 0 );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	random( 0, x1, 1, 0, x2, 1, 0, toAccessorArray( out ), 1, 0 );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	x1 = toAccessorArray( [ PARAM1[ 0 ], PARAM1[ 1 ], PARAM1[ 2 ] ] );
+	x2 = toAccessorArray( [ PARAM2[ 0 ], PARAM2[ 1 ], PARAM2[ 2 ] ] );
+	out = zeros( x1.length, 'generic' );
+	expected = zeros( x1.length, 'generic' );
+
+	random( -1, x1, 1, 0, x2, 1, 0, toAccessorArray( out ), 1, 0 );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	random( 0, x1, 1, 0, x2, 1, 0, toAccessorArray( out ), 1, 0 );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports negative strides', function test( t ) {
+	var expected;
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+
+	N = 3;
+	x1 = [
+		PARAM1[ 0 ], // 2
+		PARAM1[ 1 ],
+		PARAM1[ 2 ], // 1
+		PARAM1[ 3 ],
+		PARAM1[ 4 ]  // 0
+	];
+	x2 = [
+		PARAM2[ 0 ], // 2
+		PARAM2[ 1 ], // 1
+		PARAM2[ 2 ], // 0
+		PARAM2[ 3 ],
+		PARAM2[ 4 ]
+	];
+	out = [
+		0.0, // 0
+		0.0,
+		0.0, // 1
+		0.0,
+		0.0  // 2
+	];
+
+	opts = {
+		'seed': prng.seed
+	};
+	random( N, x1, -2, 4, x2, -1, 2, out, 2, 0, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	expected = [
+		rand( x1[ 4 ], x2[ 2 ] ),
+		0.0,
+		rand( x1[ 2 ], x2[ 1 ] ),
+		0.0,
+		rand( x1[ 0 ], x2[ 0 ] )
+	];
+
+	t.deepEqual( out, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports negative strides (accessors)', function test( t ) {
+	var expected;
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+
+	N = 3;
+	x1 = toAccessorArray([
+		PARAM1[ 0 ], // 2
+		PARAM1[ 1 ],
+		PARAM1[ 2 ], // 1
+		PARAM1[ 3 ],
+		PARAM1[ 4 ]  // 0
+	]);
+	x2 = toAccessorArray([
+		PARAM2[ 0 ], // 2
+		PARAM2[ 1 ], // 1
+		PARAM2[ 2 ], // 0
+		PARAM2[ 3 ],
+		PARAM2[ 4 ]
+	]);
+	out = [
+		0.0, // 0
+		0.0,
+		0.0, // 1
+		0.0,
+		0.0  // 2
+	];
+
+	opts = {
+		'seed': prng.seed
+	};
+	random( N, x1, -2, 4, x2, -1, 2, toAccessorArray( out ), 2, 0, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+	expected = [
+		rand( x1.get( 4 ), x2.get( 2 ) ),
+		0.0,
+		rand( x1.get( 2 ), x2.get( 1 ) ),
+		0.0,
+		rand( x1.get( 0 ), x2.get( 0 ) )
+	];
+
+	t.deepEqual( out, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports complex access patterns', function test( t ) {
+	var expected;
+	var rand;
+	var opts;
+	var out;
+	var x1;
+	var x2;
+	var N;
+
+	N = 3;
+	x1 = [
+		PARAM1[ 0 ],
+		PARAM1[ 1 ], // 0
+		PARAM1[ 2 ],
+		PARAM1[ 3 ], // 1
+		PARAM1[ 4 ],
+		PARAM1[ 5 ]  // 2
+	];
+	x2 = [
+		PARAM2[ 0 ],
+		PARAM2[ 1 ], // 2
+		PARAM2[ 2 ], // 1
+		PARAM2[ 3 ], // 0
+		PARAM2[ 4 ],
+		PARAM2[ 5 ]
+	];
+	out = [
+		0.0, // 2
+		0.0,
+		0.0, // 1
+		0.0,
+		0.0  // 0
+	];
+
+	opts = {
+		'seed': prng.seed
+	};
+	random( N, x1, 2, 1, x2, -1, 3, out, -2, 4, opts );
+
+	rand = prng.factory({
+		'seed': opts.seed
+	});
+
+	// The order in which `rand` is invoked matters as the order in which pseudorandom numbers are generated is fixed...
+	expected = [
+		rand( x1[ 1 ], x2[ 3 ] ),
+		rand( x1[ 3 ], x2[ 2 ] ),
+		rand( x1[ 5 ], x2[ 1 ] )
+	];
+	expected = [
+		expected[ 2 ],
+		0.0,
+		expected[ 1 ],
+		0.0,
+		expected[ 0 ]
+	];
+
+	t.deepEqual( out, expected, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
Resolves #946 

## Adding support for filling a strided array with pseudorandom numbers drawn from a Weibull distribution. This is the strided interface analog of @stdlib/random/base/weibull.

## Related Issues
None

This pull request:

-   resolves #946 

## Questions

> Any questions for reviewers of this pull request?

Do lemme know if i interpreted wrong implementation

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
