### PR TITLE
fix: resolves issue with `constantcase` returning incorrect result for strings with hyphens

### DIFF
--- a/lib/node_modules/@stdlib/string/base/constantcase/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/constantcase/lib/main.js
@@ -28,7 +28,7 @@ var trim = require( '@stdlib/string/base/trim' );
 // VARIABLES //
 
 var RE_WHITESPACE = /\s+/g;
-var RE_SPECIAL = /[!"'(),–.:;<>?`{}|~\/\\\[\]_#$*&^@%]+/g; // eslint-disable-line no-useless-escape
+var RE_SPECIAL = /[\-!"'(),–.:;<>?`{}|~\/\\\[\]_#$*&^@%]+/g; // eslint-disable-line no-useless-escape
 var RE_CAMEL = /([a-z0-9])([A-Z])/g;
 
 

--- a/lib/node_modules/@stdlib/string/base/constantcase/test/test.js
+++ b/lib/node_modules/@stdlib/string/base/constantcase/test/test.js
@@ -81,7 +81,10 @@ tape( 'the function converts a string with Unicode characters to constant case',
 		'Я маленькая лошадка',
 		'Большие проблемы',
 		'Быстрый коричневый фонд',
-		'Café esuna bella'
+		'Café esuna bella',
+		'fóoBár',
+		'😀😀-😀',
+		'신규 서비스'
 	];
 
 	expected = [
@@ -89,11 +92,80 @@ tape( 'the function converts a string with Unicode characters to constant case',
 		'Я_МАЛЕНЬКАЯ_ЛОШАДКА',
 		'БОЛЬШИЕ_ПРОБЛЕМЫ',
 		'БЫСТРЫЙ_КОРИЧНЕВЫЙ_ФОНД',
-		'CAFÉ_ESUNA_BELLA'
+		'CAFÉ_ESUNA_BELLA',
+		'FÓO_BÁR',
+		'😀😀_😀',
+		'신규_서비스'
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
 		t.strictEqual( constantcase( values[i] ), expected[i], 'returns expected value.' );
+	}
+	t.end();
+});
+
+tape( 'the function converts a string with special characters to constant case', function test( t ) {
+	var expected;
+	var values;
+	var i;
+
+	values = [
+		'foo-bar',
+		'foo!bar',
+		'foo@bar',
+		'foo#bar',
+		'foo$bar',
+		'foo%bar',
+		'foo^bar',
+		'foo&bar',
+		'foo*bar',
+		'foo(bar',
+		'foo)bar',
+		'foo[bar',
+		'foo]bar',
+		'foo{bar',
+		'foo}bar',
+		'foo|bar',
+		'foo~bar',
+		'foo:"bar',
+		'foo\'bar',
+		'foo<bar',
+		'foo\\bar',
+		'foo>bar',
+		'foo?bar',
+		'foo/bar'
+	];
+
+	expected = [
+		'FOO_BAR',
+		'FOO_BAR',
+		'FOO_BAR',
+		'FOO_BAR',
+		'FOO_BAR',
+		'FOO_BAR',
+		'FOO_BAR',
+		'FOO_BAR',
+		'FOO_BAR',
+		'FOO_BAR',
+		'FOO_BAR',
+		'FOO_BAR',
+		'FOO_BAR',
+		'FOO_BAR',
+		'FOO_BAR',
+		'FOO_BAR',
+		'FOO_BAR',
+		'FOO_BAR',
+		'FOO_BAR',
+		'FOO_BAR',
+		'FOO_BAR',
+		'FOO_BAR',
+		'FOO_BAR',
+		'FOO_BAR',
+		'FOO_BAR'
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.strictEqual( constantcase( values[i] ), expected[i], 'returns '+expected[i] );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves #1017.

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds a fix to `@stdlib/string/base/constantcase` returning an incorrect result for strings with hyphens.
-   Adds test cases

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   fixes #1017 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
