### PR TITLE
feat: refactor string package `remove-first`

### DIFF
--- a/lib/node_modules/@stdlib/string/base/remove-first-code-point/README.md
+++ b/lib/node_modules/@stdlib/string/base/remove-first-code-point/README.md
@@ -1,0 +1,95 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2023 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# removeFirstCodePoint
+
+> Remove the first `n` Unicode code points of a string.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var removeFirstCodePoint = require( '@stdlib/string/base/remove-first-code-point' );
+```
+
+#### removeFirstCodePoint( str, n )
+
+Removes the first `n` Unicode code points of a string.
+
+```javascript
+var out = removeFirstCodePoint( 'last man standing', 1 );
+// returns 'ast man standing'
+
+out = removeFirstCodePoint( 'Hidden Treasures', 1 );
+// returns 'idden Treasures'
+
+out = removeFirstCodePoint( 'foo bar', 5 );
+// returns 'ar'
+
+out = removeFirstCodePoint( 'foo bar', 10 );
+// returns ''
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var removeFirstCodePoint = require( '@stdlib/string/base/remove-first-code-point' );
+
+var str = removeFirstCodePoint( 'presidential election', 1 );
+// returns 'residential election'
+
+str = removeFirstCodePoint( 'JavaScript', 1 );
+// returns 'avaScript'
+
+str = removeFirstCodePoint( 'The Last of the Mohicans', 5 );
+// returns 'ast of the Mohicans'
+
+str = removeFirstCodePoint( 'अनुच्छेद', 1 );
+// returns 'नुच्छेद'
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/string/base/remove-first-code-point/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/string/base/remove-first-code-point/benchmark/benchmark.js
@@ -1,0 +1,56 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
+var pkg = require( './../package.json' ).name;
+var removeFirst = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var values;
+	var out;
+	var i;
+
+	values = [
+		'beep boop',
+		'foo bar',
+		'xyz abc',
+		'🐶🐮🐷🐰🐸'
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = removeFirst( values[ i%values.length ], 1 );
+		if ( typeof out !== 'string' ) {
+			b.fail( 'should return a string' );
+		}
+	}
+	b.toc();
+	if ( !isString( out ) ) {
+		b.fail( 'should return a string' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/string/base/remove-first-code-point/docs/repl.txt
+++ b/lib/node_modules/@stdlib/string/base/remove-first-code-point/docs/repl.txt
@@ -1,0 +1,29 @@
+
+{{alias}}( str, n )
+    Removes the first `n` Unicode code points of a string.
+
+    Parameters
+    ----------
+    str: string
+        Input string.
+
+    n: integer
+        Number of Unicode code points to remove.
+
+    Returns
+    -------
+    out: string
+        Output string.
+
+    Examples
+    --------
+    > var out = {{alias}}( 'beep', 1 )
+    'eep'
+    > out = {{alias}}( 'Boop', 1 )
+    'oop'
+    > out = {{alias}}( 'foo bar', 5 )
+    'ar'
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/string/base/remove-first-code-point/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/base/remove-first-code-point/docs/types/index.d.ts
@@ -1,0 +1,53 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 2.0
+
+/**
+* Removes the first `n` Unicode code points of a string.
+*
+* @param str - input string
+* @param n - number of code points to remove
+* @returns output string
+*
+* @example
+* var out = removeFirst( 'last man standing', 1 );
+* // returns 'ast man standing'
+*
+* @example
+* var out = removeFirst( 'presidential election', 1 );
+* // returns 'residential election'
+*
+* @example
+* var out = removeFirst( 'JavaScript', 1 );
+* // returns 'avaScript'
+*
+* @example
+* var out = removeFirst( 'Hidden Treasures', 1 );
+* // returns 'idden Treasures'
+*
+* @example
+* var out = removeFirst( 'foo bar', 5 );
+* // returns 'ar'
+*/
+declare function removeFirst( str: string, n: number ): string;
+
+
+// EXPORTS //
+
+export = removeFirst;

--- a/lib/node_modules/@stdlib/string/base/remove-first-code-point/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/string/base/remove-first-code-point/docs/types/test.ts
@@ -1,0 +1,57 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import first = require( './index' );
+
+
+// TESTS //
+
+// The function returns a string...
+{
+	first( 'abc', 1 ); // $ExpectType string
+}
+
+// The compiler throws an error if the function is provided a value other than a string...
+{
+	first( true, 1 ); // $ExpectError
+	first( false, 1 ); // $ExpectError
+	first( null, 1 ); // $ExpectError
+	first( undefined, 1 ); // $ExpectError
+	first( 5, 1 ); // $ExpectError
+	first( [], 1 ); // $ExpectError
+	first( {}, 1 ); // $ExpectError
+	first( ( x: number ): number => x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument that is not a number...
+{
+	first( 'abc', true ); // $ExpectError
+	first( 'abc', false ); // $ExpectError
+	first( 'abc', null ); // $ExpectError
+	first( 'abc', 'abc' ); // $ExpectError
+	first( 'abc', [] ); // $ExpectError
+	first( 'abc', {} ); // $ExpectError
+	first( 'abc', ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	first(); // $ExpectError
+	first( 'abc' ); // $ExpectError
+	first( 'abc', 1, 2 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/string/base/remove-first-code-point/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/string/base/remove-first-code-point/docs/types/test.ts
@@ -16,42 +16,42 @@
 * limitations under the License.
 */
 
-import first = require( './index' );
+import removeFirst = require( './index' );
 
 
 // TESTS //
 
 // The function returns a string...
 {
-	first( 'abc', 1 ); // $ExpectType string
+	removeFirst( 'abc', 1 ); // $ExpectType string
 }
 
 // The compiler throws an error if the function is provided a value other than a string...
 {
-	first( true, 1 ); // $ExpectError
-	first( false, 1 ); // $ExpectError
-	first( null, 1 ); // $ExpectError
-	first( undefined, 1 ); // $ExpectError
-	first( 5, 1 ); // $ExpectError
-	first( [], 1 ); // $ExpectError
-	first( {}, 1 ); // $ExpectError
-	first( ( x: number ): number => x, 1 ); // $ExpectError
+	removeFirst( true, 1 ); // $ExpectError
+	removeFirst( false, 1 ); // $ExpectError
+	removeFirst( null, 1 ); // $ExpectError
+	removeFirst( undefined, 1 ); // $ExpectError
+	removeFirst( 5, 1 ); // $ExpectError
+	removeFirst( [], 1 ); // $ExpectError
+	removeFirst( {}, 1 ); // $ExpectError
+	removeFirst( ( x: number ): number => x, 1 ); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided a second argument that is not a number...
 {
-	first( 'abc', true ); // $ExpectError
-	first( 'abc', false ); // $ExpectError
-	first( 'abc', null ); // $ExpectError
-	first( 'abc', 'abc' ); // $ExpectError
-	first( 'abc', [] ); // $ExpectError
-	first( 'abc', {} ); // $ExpectError
-	first( 'abc', ( x: number ): number => x ); // $ExpectError
+	removeFirst( 'abc', true ); // $ExpectError
+	removeFirst( 'abc', false ); // $ExpectError
+	removeFirst( 'abc', null ); // $ExpectError
+	removeFirst( 'abc', 'abc' ); // $ExpectError
+	removeFirst( 'abc', [] ); // $ExpectError
+	removeFirst( 'abc', {} ); // $ExpectError
+	removeFirst( 'abc', ( x: number ): number => x ); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided an unsupported number of arguments...
 {
-	first(); // $ExpectError
-	first( 'abc' ); // $ExpectError
-	first( 'abc', 1, 2 ); // $ExpectError
+	removeFirst(); // $ExpectError
+	removeFirst( 'abc' ); // $ExpectError
+	removeFirst( 'abc', 1, 2 ); // $ExpectError
 }

--- a/lib/node_modules/@stdlib/string/base/remove-first-code-point/examples/index.js
+++ b/lib/node_modules/@stdlib/string/base/remove-first-code-point/examples/index.js
@@ -1,0 +1,33 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var removeFirstCodePoint = require( './../lib' );
+
+console.log( removeFirstCodePoint( 'presidential election', 1 ) );
+// => 'residential election'
+
+console.log( removeFirstCodePoint( 'JavaScript', 1 ) );
+// => 'avaScript'
+
+console.log( removeFirstCodePoint( 'The Last of the Mohicans', 5 ) );
+// => 'ast of the Mohicans'
+
+console.log( removeFirstCodePoint( 'अनुच्छेद', 1 ) );
+// => 'नुच्छेद'

--- a/lib/node_modules/@stdlib/string/base/remove-first-code-point/lib/index.js
+++ b/lib/node_modules/@stdlib/string/base/remove-first-code-point/lib/index.js
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Remove the first `n` Unicode code points of a string.
+*
+* @module @stdlib/string/base/remove-first-code-point
+*
+* @example
+* var removeFirst = require( '@stdlib/string/base/remove-first-code-point' );
+*
+* var out = removeFirst( 'last man standing', 1 );
+* // returns 'ast man standing'
+*
+* out = removeFirst( 'Hidden Treasures', 1 );
+* // returns 'idden Treasures';
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/string/base/remove-first-code-point/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/remove-first-code-point/lib/main.js
@@ -1,0 +1,94 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// VARIABLES //
+
+var RE_UTF16_LOW_SURROGATE = /[\uDC00-\uDFFF]/; // TODO: replace with stdlib pkg
+var RE_UTF16_HIGH_SURROGATE = /[\uD800-\uDBFF]/; // TODO: replace with stdlib pkg
+
+
+// MAIN //
+
+/**
+* Removes the first `n` Unicode code points of a string.
+*
+* @param {string} str - input string
+* @param {NonNegativeInteger} n - number of Unicode code points to remove
+* @returns {string} output string
+*
+* @example
+* var out = removeFirst( 'last man standing', 1 );
+* // returns 'ast man standing'
+*
+* @example
+* var out = removeFirst( 'presidential election', 1 );
+* // returns 'residential election'
+*
+* @example
+* var out = removeFirst( 'JavaScript', 1 );
+* // returns 'avaScript'
+*
+* @example
+* var out = removeFirst( 'Hidden Treasures', 1 );
+* // returns 'idden Treasures'
+*/
+function removeFirst( str, n ) {
+	var len;
+	var ch1;
+	var ch2;
+	var cnt;
+	var i;
+	if ( n === 0 ) {
+		return str;
+	}
+	len = str.length;
+	cnt = 0;
+
+	// Process the string one Unicode code unit at a time and count UTF-16 surrogate pairs as a single Unicode code point...
+	for ( i = 0; i < len; i++ ) {
+		ch1 = str[ i ];
+		cnt += 1;
+
+		// Check for a high UTF-16 surrogate...
+		if ( RE_UTF16_HIGH_SURROGATE.test( ch1 ) ) {
+			// Check for an unpaired surrogate at the end of the input string...
+			if ( i === len-1 ) {
+				// We found an unpaired surrogate...
+				break;
+			}
+			// Check whether the high surrogate is paired with a low surrogate...
+			ch2 = str[ i+1 ];
+			if ( RE_UTF16_LOW_SURROGATE.test( ch2 ) ) {
+				// We found a surrogate pair:
+				i += 1; // bump the index to process the next code unit
+			}
+		}
+		// Check whether we've found the desired number of code points...
+		if ( cnt === n ) {
+			break;
+		}
+	}
+	return str.substring( cnt, str.length );
+}
+
+
+// EXPORTS //
+
+module.exports = removeFirst;

--- a/lib/node_modules/@stdlib/string/base/remove-first-code-point/package.json
+++ b/lib/node_modules/@stdlib/string/base/remove-first-code-point/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/string/base/first-code-point",
   "version": "0.0.0",
-  "description": "Removes the first `n` Unicode code points of a string.",
+  "description": "Remove the first Unicode code point of a string.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/string/base/remove-first-code-point/package.json
+++ b/lib/node_modules/@stdlib/string/base/remove-first-code-point/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@stdlib/string/base/first-code-point",
+  "version": "0.0.0",
+  "description": "Removes the first `n` Unicode code points of a string.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdstring",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "string",
+    "str",
+    "base",
+    "first",
+    "character",
+    "char",
+    "codepoint",
+    "unicode"
+  ]
+}

--- a/lib/node_modules/@stdlib/string/base/remove-first-code-point/test/test.js
+++ b/lib/node_modules/@stdlib/string/base/remove-first-code-point/test/test.js
@@ -1,0 +1,96 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var first = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof first, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns an empty string if provided an empty string', function test( t ) {
+	t.strictEqual( first( '', 1 ), '', 'returns expected value' );
+	t.strictEqual( first( '', 2 ), '', 'returns expected value' );
+	t.strictEqual( first( '', 3 ), '', 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns the input string if provided zero as the second argument', function test( t ) {
+	t.strictEqual( first( 'hello world', 0 ), 'hello world', 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function removes the first Unicode code point of a provided string (ascii)', function test( t ) {
+	var out;
+
+	out = first( 'hello world', 1 );
+	t.strictEqual( out, 'ello world', 'returns expected value' );
+
+	out = first( '!!!', 1 );
+	t.strictEqual( out, '!!', 'returns expected value' );
+
+	out = first( 'Hello World', 1 );
+	t.strictEqual( out, 'ello World', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function removes the first Unicode code point of a provided string (Unicode)', function test( t ) {
+	var out;
+
+	out = first( 'अनुच्छेद', 1 );
+	t.strictEqual( out, 'नुच्छेद', 'returns expected value' );
+
+	out = first( '六书/六書', 1 );
+	t.strictEqual( out, '书/六書', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports removing the first `n` Unicode code points of a provided string', function test( t ) {
+	var out;
+
+	out = first( 'hello world', 1 );
+	t.strictEqual( out, 'ello world', 'returns expected value' );
+
+	out = first( 'hello world', 7 );
+	t.strictEqual( out, 'orld', 'returns expected value' );
+
+	out = first( '!!!', 1 );
+	t.strictEqual( out, '!!', 'returns expected value' );
+
+	out = first( '!!!', 2 );
+	t.strictEqual( out, '!', 'returns expected value' );
+
+	out = first( 'अनुच्छेद', 1 );
+	t.strictEqual( out, 'नुच्छेद', 'returns expected value' );
+
+	out = first( '六书/六書', 3 );
+	t.strictEqual( out, '六書', 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/string/base/remove-first-code-point/test/test.js
+++ b/lib/node_modules/@stdlib/string/base/remove-first-code-point/test/test.js
@@ -21,39 +21,39 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var first = require( './../lib' );
+var removeFirst = require( './../lib' );
 
 
 // TESTS //
 
 tape( 'main export is a function', function test( t ) {
 	t.ok( true, __filename );
-	t.strictEqual( typeof first, 'function', 'main export is a function' );
+	t.strictEqual( typeof removeFirst, 'function', 'main export is a function' );
 	t.end();
 });
 
 tape( 'the function returns an empty string if provided an empty string', function test( t ) {
-	t.strictEqual( first( '', 1 ), '', 'returns expected value' );
-	t.strictEqual( first( '', 2 ), '', 'returns expected value' );
-	t.strictEqual( first( '', 3 ), '', 'returns expected value' );
+	t.strictEqual( removeFirst( '', 1 ), '', 'returns expected value' );
+	t.strictEqual( removeFirst( '', 2 ), '', 'returns expected value' );
+	t.strictEqual( removeFirst( '', 3 ), '', 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns the input string if provided zero as the second argument', function test( t ) {
-	t.strictEqual( first( 'hello world', 0 ), 'hello world', 'returns expected value' );
+	t.strictEqual( removeFirst( 'hello world', 0 ), 'hello world', 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function removes the first Unicode code point of a provided string (ascii)', function test( t ) {
 	var out;
 
-	out = first( 'hello world', 1 );
+	out = removeFirst( 'hello world', 1 );
 	t.strictEqual( out, 'ello world', 'returns expected value' );
 
-	out = first( '!!!', 1 );
+	out = removeFirst( '!!!', 1 );
 	t.strictEqual( out, '!!', 'returns expected value' );
 
-	out = first( 'Hello World', 1 );
+	out = removeFirst( 'Hello World', 1 );
 	t.strictEqual( out, 'ello World', 'returns expected value' );
 
 	t.end();
@@ -62,10 +62,10 @@ tape( 'the function removes the first Unicode code point of a provided string (a
 tape( 'the function removes the first Unicode code point of a provided string (Unicode)', function test( t ) {
 	var out;
 
-	out = first( 'अनुच्छेद', 1 );
+	out = removeFirst( 'अनुच्छेद', 1 );
 	t.strictEqual( out, 'नुच्छेद', 'returns expected value' );
 
-	out = first( '六书/六書', 1 );
+	out = removeFirst( '六书/六書', 1 );
 	t.strictEqual( out, '书/六書', 'returns expected value' );
 
 	t.end();
@@ -74,22 +74,22 @@ tape( 'the function removes the first Unicode code point of a provided string (U
 tape( 'the function supports removing the first `n` Unicode code points of a provided string', function test( t ) {
 	var out;
 
-	out = first( 'hello world', 1 );
+	out = removeFirst( 'hello world', 1 );
 	t.strictEqual( out, 'ello world', 'returns expected value' );
 
-	out = first( 'hello world', 7 );
+	out = removeFirst( 'hello world', 7 );
 	t.strictEqual( out, 'orld', 'returns expected value' );
 
-	out = first( '!!!', 1 );
+	out = removeFirst( '!!!', 1 );
 	t.strictEqual( out, '!!', 'returns expected value' );
 
-	out = first( '!!!', 2 );
+	out = removeFirst( '!!!', 2 );
 	t.strictEqual( out, '!', 'returns expected value' );
 
-	out = first( 'अनुच्छेद', 1 );
+	out = removeFirst( 'अनुच्छेद', 1 );
 	t.strictEqual( out, 'नुच्छेद', 'returns expected value' );
 
-	out = first( '六书/六書', 3 );
+	out = removeFirst( '六书/六書', 3 );
 	t.strictEqual( out, '六書', 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/README.md
+++ b/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/README.md
@@ -26,6 +26,8 @@ limitations under the License.
 
 ## Usage
 
+<!-- eslint-disable id-length -->
+
 ```javascript
 var removeFirstGraphemeCluster = require( '@stdlib/string/base/remove-first-grapheme-cluster' );
 ```
@@ -33,6 +35,8 @@ var removeFirstGraphemeCluster = require( '@stdlib/string/base/remove-first-grap
 #### removeFirstGraphemeCluster( str, n )
 
 Removes the first `n` grapheme clusters (i.e., user-perceived characters) of a string.
+
+<!-- eslint-disable id-length -->
 
 ```javascript
 var out = removeFirstGraphemeCluster( 'last man standing', 1 );
@@ -57,6 +61,8 @@ out = removeFirstGraphemeCluster( 'foo bar', 10 );
 ## Examples
 
 <!-- eslint no-undef: "error" -->
+
+<!-- eslint-disable id-length -->
 
 ```javascript
 var removeFirstGraphemeCluster = require( '@stdlib/string/base/remove-first-grapheme-cluster' );

--- a/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/README.md
+++ b/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/README.md
@@ -1,0 +1,98 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2023 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# removeFirstGraphemeCluster
+
+> Remove the first `n` grapheme clusters (i.e., user-perceived characters) of a string.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var removeFirstGrapheme = require( '@stdlib/string/base/remove-first-grapheme-cluster' );
+```
+
+#### removeFirstGrapheme( str, n )
+
+Removes the first `n` grapheme clusters (i.e., user-perceived characters) of a string.
+
+```javascript
+var out = removeFirstGrapheme( 'last man standing', 1 );
+// returns 'ast man standing'
+
+out = removeFirstGrapheme( 'Hidden Treasures', 1 );
+// returns 'idden Treasures'
+
+out = removeFirstGrapheme( 'foo bar', 5 );
+// returns 'ar'
+
+out = removeFirstGrapheme( 'foo bar', 10 );
+// returns ''
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var removeFirstGrapheme = require( '@stdlib/string/base/remove-first-grapheme-cluster' );
+
+var str = removeFirstGrapheme( 'presidential election', 1 );
+// returns 'residential election'
+
+str = removeFirstGrapheme( 'JavaScript', 1 );
+// returns 'avaScript'
+
+str = removeFirstGrapheme( 'The Last of the Mohicans', 5 );
+// returns 'ast of the Mohicans'
+
+str = removeFirstGrapheme( '🐶🐮🐷🐰🐸', 2 );
+// returns '🐷🐰🐸'
+
+str = removeFirstGrapheme( '🐶🐮🐷🐰🐸', 10 );
+// returns ''
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/README.md
+++ b/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/README.md
@@ -27,24 +27,24 @@ limitations under the License.
 ## Usage
 
 ```javascript
-var removeFirstGrapheme = require( '@stdlib/string/base/remove-first-grapheme-cluster' );
+var removeFirstGraphemeCluster = require( '@stdlib/string/base/remove-first-grapheme-cluster' );
 ```
 
-#### removeFirstGrapheme( str, n )
+#### removeFirstGraphemeCluster( str, n )
 
 Removes the first `n` grapheme clusters (i.e., user-perceived characters) of a string.
 
 ```javascript
-var out = removeFirstGrapheme( 'last man standing', 1 );
+var out = removeFirstGraphemeCluster( 'last man standing', 1 );
 // returns 'ast man standing'
 
-out = removeFirstGrapheme( 'Hidden Treasures', 1 );
+out = removeFirstGraphemeCluster( 'Hidden Treasures', 1 );
 // returns 'idden Treasures'
 
-out = removeFirstGrapheme( 'foo bar', 5 );
+out = removeFirstGraphemeCluster( 'foo bar', 5 );
 // returns 'ar'
 
-out = removeFirstGrapheme( 'foo bar', 10 );
+out = removeFirstGraphemeCluster( 'foo bar', 10 );
 // returns ''
 ```
 
@@ -59,21 +59,21 @@ out = removeFirstGrapheme( 'foo bar', 10 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var removeFirstGrapheme = require( '@stdlib/string/base/remove-first-grapheme-cluster' );
+var removeFirstGraphemeCluster = require( '@stdlib/string/base/remove-first-grapheme-cluster' );
 
-var str = removeFirstGrapheme( 'presidential election', 1 );
+var str = removeFirstGraphemeCluster( 'presidential election', 1 );
 // returns 'residential election'
 
-str = removeFirstGrapheme( 'JavaScript', 1 );
+str = removeFirstGraphemeCluster( 'JavaScript', 1 );
 // returns 'avaScript'
 
-str = removeFirstGrapheme( 'The Last of the Mohicans', 5 );
+str = removeFirstGraphemeCluster( 'The Last of the Mohicans', 5 );
 // returns 'ast of the Mohicans'
 
-str = removeFirstGrapheme( '🐶🐮🐷🐰🐸', 2 );
+str = removeFirstGraphemeCluster( '🐶🐮🐷🐰🐸', 2 );
 // returns '🐷🐰🐸'
 
-str = removeFirstGrapheme( '🐶🐮🐷🐰🐸', 10 );
+str = removeFirstGraphemeCluster( '🐶🐮🐷🐰🐸', 10 );
 // returns ''
 ```
 

--- a/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/benchmark/benchmark.js
@@ -1,0 +1,56 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
+var pkg = require( './../package.json' ).name;
+var removeFirst = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var values;
+	var out;
+	var i;
+
+	values = [
+		'beep boop',
+		'foo bar',
+		'xyz abc',
+		'🐶🐮🐷🐰🐸'
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = removeFirst( values[ i%values.length ], 1 );
+		if ( typeof out !== 'string' ) {
+			b.fail( 'should return a string' );
+		}
+	}
+	b.toc();
+	if ( !isString( out ) ) {
+		b.fail( 'should return a string' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/docs/repl.txt
+++ b/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/docs/repl.txt
@@ -1,0 +1,30 @@
+
+{{alias}}( str, n )
+    Removes the first `n` grapheme clusters (i.e., user-perceived characters)
+    of a string.
+
+    Parameters
+    ----------
+    str: string
+        Input string.
+
+    n: integer
+        Number of grapheme clusters to remove.
+
+    Returns
+    -------
+    out: string
+        Output string.
+
+    Examples
+    --------
+    > var out = {{alias}}( 'beep', 1 )
+    'eep'
+    > out = {{alias}}( 'Boop', 1 )
+    'oop'
+    > out = {{alias}}( 'foo bar', 5 )
+    'ar'
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/docs/types/index.d.ts
@@ -1,0 +1,57 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 2.0
+
+/**
+* Removes the first `n` grapheme clusters (i.e., user-perceived characters) of a string.
+*
+* @param str - input string
+* @param n - number of grapheme clusters to remove
+* @returns output string
+*
+* @example
+* var out = removeFirst( 'last man standing', 1 );
+* // returns 'ast man standing'
+*
+* @example
+* var out = removeFirst( 'presidential election', 1 );
+* // returns 'residential election'
+*
+* @example
+* var out = removeFirst( 'JavaScript', 1 );
+* // returns 'avaScript'
+*
+* @example
+* var out = removeFirst( 'Hidden Treasures', 1 );
+* // returns 'idden Treasures'
+*
+* @example
+* var out = removeFirst( '🐶🐮🐷🐰🐸', 2 );
+* // returns '🐷🐰🐸'
+*
+* @example
+* var out = removeFirst( 'foo bar', 5 );
+* // returns 'ar'
+*/
+declare function removeFirst( str: string, n: number ): string;
+
+
+// EXPORTS //
+
+export = removeFirst;

--- a/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/docs/types/test.ts
@@ -1,0 +1,57 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import removeFirst = require( './index' );
+
+
+// TESTS //
+
+// The function returns a string...
+{
+	removeFirst( 'abc', 1 ); // $ExpectType string
+}
+
+// The compiler throws an error if the function is provided a value other than a string...
+{
+	removeFirst( true, 1 ); // $ExpectError
+	removeFirst( false, 1 ); // $ExpectError
+	removeFirst( null, 1 ); // $ExpectError
+	removeFirst( undefined, 1 ); // $ExpectError
+	removeFirst( 5, 1 ); // $ExpectError
+	removeFirst( [], 1 ); // $ExpectError
+	removeFirst( {}, 1 ); // $ExpectError
+	removeFirst( ( x: number ): number => x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument that is not a number...
+{
+	removeFirst( 'abc', true ); // $ExpectError
+	removeFirst( 'abc', false ); // $ExpectError
+	removeFirst( 'abc', null ); // $ExpectError
+	removeFirst( 'abc', 'abc' ); // $ExpectError
+	removeFirst( 'abc', [] ); // $ExpectError
+	removeFirst( 'abc', {} ); // $ExpectError
+	removeFirst( 'abc', ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	removeFirst(); // $ExpectError
+	removeFirst( 'abc' ); // $ExpectError
+	removeFirst( 'abc', 1, 2 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/examples/index.js
+++ b/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/examples/index.js
@@ -18,7 +18,7 @@
 
 'use strict';
 
-var removeFirstGraphemeCluster = require( './../lib' );
+var removeFirstGraphemeCluster = require( './../lib' ); // eslint-disable-line id-length
 
 console.log( removeFirstGraphemeCluster( 'presidential election', 1 ) );
 // => 'residential election'

--- a/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/examples/index.js
+++ b/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/examples/index.js
@@ -1,0 +1,36 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var removeFirstGraphemeCluster = require( './../lib' );
+
+console.log( removeFirstGraphemeCluster( 'presidential election', 1 ) );
+// => 'residential election'
+
+console.log( removeFirstGraphemeCluster( 'JavaScript', 1 ) );
+// => 'avaScript'
+
+console.log( removeFirstGraphemeCluster( 'The Last of the Mohicans', 5 ) );
+// => 'ast of the Mohicans'
+
+console.log( removeFirstGraphemeCluster( '🐶🐮🐷🐰🐸', 2 ) );
+// => '🐷🐰🐸'
+
+console.log( removeFirstGraphemeCluster( '🐶🐮🐷🐰🐸', 10 ) );
+// => ''

--- a/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/lib/index.js
+++ b/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/lib/index.js
@@ -1,0 +1,46 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Remove the first `n` grapheme clusters (i.e., user-perceived characters) of a string.
+*
+* @module @stdlib/string/base/remove-first-grapheme-cluster
+*
+* @example
+* var first = require( '@stdlib/string/base/remove-first-grapheme-cluster' );
+*
+* var out = first( 'last man standing', 1 );
+* // returns 'ast man standing'
+*
+* out = first( 'Hidden Treasures', 1 );
+* // returns 'idden Treasures';
+*
+* out = first( '🐮🐷🐸🐵', 2 );
+* // returns '🐸🐵'
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/lib/index.js
+++ b/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/lib/index.js
@@ -24,15 +24,15 @@
 * @module @stdlib/string/base/remove-first-grapheme-cluster
 *
 * @example
-* var first = require( '@stdlib/string/base/remove-first-grapheme-cluster' );
+* var removeFirst = require( '@stdlib/string/base/remove-first-grapheme-cluster' );
 *
-* var out = first( 'last man standing', 1 );
+* var out = removeFirst( 'last man standing', 1 );
 * // returns 'ast man standing'
 *
-* out = first( 'Hidden Treasures', 1 );
+* out = removeFirst( 'Hidden Treasures', 1 );
 * // returns 'idden Treasures';
 *
-* out = first( '🐮🐷🐸🐵', 2 );
+* out = removeFirst( '🐮🐷🐸🐵', 2 );
 * // returns '🐸🐵'
 */
 

--- a/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/lib/main.js
@@ -1,0 +1,75 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var nextGraphemeClusterBreak = require( '@stdlib/string/next-grapheme-cluster-break' );
+
+
+// MAIN //
+
+/**
+* Removes the first `n` grapheme clusters (i.e., user-perceived characters) of a string.
+*
+* @param {string} str - input string
+* @param {NonNegativeInteger} n - number of grapheme clusters to remove
+* @returns {string} output string
+*
+* @example
+* var out = removeFirst( 'last man standing', 1 );
+* // returns 'ast man standing'
+*
+* @example
+* var out = removeFirst( 'presidential election', 1 );
+* // returns 'residential election'
+*
+* @example
+* var out = removeFirst( 'JavaScript', 1 );
+* // returns 'avaScript'
+*
+* @example
+* var out = removeFirst( 'Hidden Treasures', 1 );
+* // returns 'idden Treasures'
+*
+* @example
+* var out = removeFirst( '🐶🐮🐷🐰🐸', 2 );
+* // returns '🐷🐰🐸'
+*
+* @example
+* var out = removeFirst( 'foo bar', 5 );
+* // returns 'ar'
+*/
+function removeFirst( str, n ) {
+	var i = 0;
+	while ( n > 0 ) {
+		i = nextGraphemeClusterBreak( str, i );
+		n -= 1;
+	}
+	// Value of `i` will be -1 if and only if `str` is an empty string or `str` has only 1 extended grapheme cluster...
+	if ( str === '' || i === -1 ) {
+		return '';
+	}
+	return str.substring( i, str.length );
+}
+
+
+// EXPORTS //
+
+module.exports = removeFirst;

--- a/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/package.json
+++ b/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/string/base/first-grapheme-cluster",
   "version": "0.0.0",
-  "description": "Remove the first grapheme cluster (i.e., user-perceived characters) of a string.",
+  "description": "Remove the first grapheme cluster (i.e., user-perceived character) of a string.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/package.json
+++ b/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@stdlib/string/base/first-grapheme-cluster",
+  "version": "0.0.0",
+  "description": "Removes the first `n` grapheme clusters (i.e., user-perceived characters) of a string.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdstring",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "string",
+    "str",
+    "base",
+    "first",
+    "character",
+    "char",
+    "grapheme",
+    "cluster",
+    "unicode"
+  ]
+}

--- a/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/package.json
+++ b/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/string/base/first-grapheme-cluster",
   "version": "0.0.0",
-  "description": "Removes the first `n` grapheme clusters (i.e., user-perceived characters) of a string.",
+  "description": "Remove the first grapheme cluster (i.e., user-perceived characters) of a string.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/test/test.js
+++ b/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/test/test.js
@@ -1,0 +1,111 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var removeFirst = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof removeFirst, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns an empty string if provided an empty string', function test( t ) {
+	t.strictEqual( removeFirst( '', 1 ), '', 'returns expected value' );
+	t.strictEqual( removeFirst( '', 2 ), '', 'returns expected value' );
+	t.strictEqual( removeFirst( '', 3 ), '', 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns the input string if provided zero as the second argument', function test( t ) {
+	t.strictEqual( removeFirst( 'hello world', 0 ), 'hello world', 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function removes the first grapheme cluster of a provided string (ascii)', function test( t ) {
+	var out;
+
+	out = removeFirst( 'hello world', 1 );
+	t.strictEqual( out, 'ello world', 'returns expected value' );
+
+	out = removeFirst( '!!!', 1 );
+	t.strictEqual( out, '!!', 'returns expected value' );
+
+	out = removeFirst( 'Hello World', 1 );
+	t.strictEqual( out, 'ello World', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns the removeFirst grapheme cluster of a provided string (Unicode)', function test( t ) {
+	var out;
+
+	out = removeFirst( 'अनुच्छेद', 1 );
+	t.strictEqual( out, 'नुच्छेद', 'returns expected value' );
+
+	out = removeFirst( '六书/六書', 1 );
+	t.strictEqual( out, '书/六書', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns the removeFirst grapheme cluster of a provided string (emoji)', function test( t ) {
+	var out;
+
+	out = removeFirst( '🌷', 1 );
+	t.strictEqual( out, '', 'returns expected value' );
+
+	out = removeFirst( '🏝️🌷', 1 );
+	t.strictEqual( out, '🌷', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports returning the removeFirst `n` grapheme clusters of a provided string', function test( t ) {
+	var out;
+
+	out = removeFirst( 'hello world', 1 );
+	t.strictEqual( out, 'ello world', 'returns expected value' );
+
+	out = removeFirst( 'hello world', 7 );
+	t.strictEqual( out, 'orld', 'returns expected value' );
+
+	out = removeFirst( '!!!', 1 );
+	t.strictEqual( out, '!!', 'returns expected value' );
+
+	out = removeFirst( '!!!', 2 );
+	t.strictEqual( out, '!', 'returns expected value' );
+
+	out = removeFirst( 'अनुच्छेद', 1 );
+	t.strictEqual( out, 'नुच्छेद', 'returns expected value' );
+
+	out = removeFirst( '六书/六書', 1 );
+	t.strictEqual( out, '书/六書', 'returns expected value' );
+
+	out = removeFirst( '🌷🌷🌷🌷🌷', 2 );
+	t.strictEqual( out, '🌷🌷🌷', 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/test/test.js
+++ b/lib/node_modules/@stdlib/string/base/remove-first-grapheme-cluster/test/test.js
@@ -59,7 +59,7 @@ tape( 'the function removes the first grapheme cluster of a provided string (asc
 	t.end();
 });
 
-tape( 'the function returns the removeFirst grapheme cluster of a provided string (Unicode)', function test( t ) {
+tape( 'the function removes the first grapheme cluster of a provided string (Unicode)', function test( t ) {
 	var out;
 
 	out = removeFirst( 'अनुच्छेद', 1 );
@@ -71,7 +71,7 @@ tape( 'the function returns the removeFirst grapheme cluster of a provided strin
 	t.end();
 });
 
-tape( 'the function returns the removeFirst grapheme cluster of a provided string (emoji)', function test( t ) {
+tape( 'the function removes the first grapheme cluster of a provided string (emoji)', function test( t ) {
 	var out;
 
 	out = removeFirst( '🌷', 1 );
@@ -83,7 +83,7 @@ tape( 'the function returns the removeFirst grapheme cluster of a provided strin
 	t.end();
 });
 
-tape( 'the function supports returning the removeFirst `n` grapheme clusters of a provided string', function test( t ) {
+tape( 'the function supports removing the first `n` grapheme clusters of a provided string', function test( t ) {
 	var out;
 
 	out = removeFirst( 'hello world', 1 );

--- a/lib/node_modules/@stdlib/string/base/remove-first/README.md
+++ b/lib/node_modules/@stdlib/string/base/remove-first/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # removeFirst
 
-> remove the first `n` UTF-16 code units of a string.
+> Remove the first `n` UTF-16 code units of a string.
 
 <section class="usage">
 

--- a/lib/node_modules/@stdlib/string/base/remove-first/README.md
+++ b/lib/node_modules/@stdlib/string/base/remove-first/README.md
@@ -1,0 +1,92 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2023 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# removeFirst
+
+> remove the first `n` UTF-16 code units of a string.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var removeFirst = require( '@stdlib/string/base/remove-first' );
+```
+
+#### removeFirst( str, n )
+
+Removes the first `n` UTF-16 code units of a string.
+
+```javascript
+var out = removeFirst( 'last man standing', 1 );
+// returns 'ast man standing'
+
+out = removeFirst( 'Hidden Treasures', 1 );
+// returns 'idden Treasures'
+
+out = removeFirst( 'foo bar', 5 );
+// returns 'ar'
+
+out = removeFirst( 'foo bar', 10 );
+// returns ''
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var removeFirst = require( '@stdlib/string/base/remove-first' );
+
+var str = removeFirst( 'presidential election', 1 );
+// returns 'residential election'
+
+str = removeFirst( 'JavaScript', 1 );
+// returns 'avaScript'
+
+str = removeFirst( 'The Last of the Mohicans', 5 );
+// returns 'ast of the Mohicans'
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/string/base/remove-first/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/string/base/remove-first/benchmark/benchmark.js
@@ -1,0 +1,56 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
+var pkg = require( './../package.json' ).name;
+var removeFirst = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var values;
+	var out;
+	var i;
+
+	values = [
+		'beep boop',
+		'foo bar',
+		'xyz abc',
+		'🐶🐮🐷🐰🐸'
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = removeFirst( values[ i%values.length ], 1 );
+		if ( typeof out !== 'string' ) {
+			b.fail( 'should return a string' );
+		}
+	}
+	b.toc();
+	if ( !isString( out ) ) {
+		b.fail( 'should return a string' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/string/base/remove-first/docs/repl.txt
+++ b/lib/node_modules/@stdlib/string/base/remove-first/docs/repl.txt
@@ -1,0 +1,29 @@
+
+{{alias}}( str, n )
+    Removes the first `n` UTF-16 code units of a string.
+
+    Parameters
+    ----------
+    str: string
+        Input string.
+
+    n: integer
+        Number of UTF-16 code units to return.
+
+    Returns
+    -------
+    out: string
+        Output string.
+
+    Examples
+    --------
+    > var out = {{alias}}( 'beep', 1 )
+    'eep'
+    > out = {{alias}}( 'Boop', 1 )
+    'oop'
+    > out = {{alias}}( 'foo bar', 5 )
+    'ar'
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/string/base/remove-first/docs/repl.txt
+++ b/lib/node_modules/@stdlib/string/base/remove-first/docs/repl.txt
@@ -8,7 +8,7 @@
         Input string.
 
     n: integer
-        Number of UTF-16 code units to return.
+        Number of UTF-16 code units to remove.
 
     Returns
     -------

--- a/lib/node_modules/@stdlib/string/base/remove-first/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/base/remove-first/docs/types/index.d.ts
@@ -1,0 +1,53 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 2.0
+
+/**
+* Removes the first `n` UTF-16 code units of a string.
+*
+* @param str - input string
+* @param n - number of code units to remove
+* @returns output string
+*
+* @example
+* var out = removeFirst( 'last man standing', 1 );
+* // returns 'ast man standing'
+*
+* @example
+* var out = removeFirst( 'presidential election', 1 );
+* // returns 'residential election'
+*
+* @example
+* var out = removeFirst( 'JavaScript', 1 );
+* // returns 'avaScript'
+*
+* @example
+* var out = removeFirst( 'Hidden Treasures', 1 );
+* // returns 'idden Treasures'
+*
+* @example
+* var out = removeFirst( 'foo bar', 5 );
+* // returns 'ar'
+*/
+declare function removeFirst( str: string, n: number ): string;
+
+
+// EXPORTS //
+
+export = removeFirst;

--- a/lib/node_modules/@stdlib/string/base/remove-first/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/string/base/remove-first/docs/types/test.ts
@@ -1,0 +1,57 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import removeFirst = require( './index' );
+
+
+// TESTS //
+
+// The function returns a string...
+{
+	removeFirst( 'abc', 1 ); // $ExpectType string
+}
+
+// The compiler throws an error if the function is provided a value other than a string...
+{
+	removeFirst( true, 1 ); // $ExpectError
+	removeFirst( false, 1 ); // $ExpectError
+	removeFirst( null, 1 ); // $ExpectError
+	removeFirst( undefined, 1 ); // $ExpectError
+	removeFirst( 5, 1 ); // $ExpectError
+	removeFirst( [], 1 ); // $ExpectError
+	removeFirst( {}, 1 ); // $ExpectError
+	removeFirst( ( x: number ): number => x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument that is not a number...
+{
+	removeFirst( 'abc', true ); // $ExpectError
+	removeFirst( 'abc', false ); // $ExpectError
+	removeFirst( 'abc', null ); // $ExpectError
+	removeFirst( 'abc', 'abc' ); // $ExpectError
+	removeFirst( 'abc', [] ); // $ExpectError
+	removeFirst( 'abc', {} ); // $ExpectError
+	removeFirst( 'abc', ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	removeFirst(); // $ExpectError
+	removeFirst( 'abc' ); // $ExpectError
+	removeFirst( 'abc', 1, 2 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/string/base/remove-first/examples/index.js
+++ b/lib/node_modules/@stdlib/string/base/remove-first/examples/index.js
@@ -1,0 +1,30 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var first = require( './../lib' );
+
+console.log( first( 'presidential election', 1 ) );
+// => 'residential election'
+
+console.log( first( 'JavaScript', 1 ) );
+// => 'avaScript'
+
+console.log( first( 'The Last of the Mohicans', 5 ) );
+// => 'ast of the Mohicans'

--- a/lib/node_modules/@stdlib/string/base/remove-first/examples/index.js
+++ b/lib/node_modules/@stdlib/string/base/remove-first/examples/index.js
@@ -18,13 +18,13 @@
 
 'use strict';
 
-var first = require( './../lib' );
+var removeFirst = require( './../lib' );
 
-console.log( first( 'presidential election', 1 ) );
+console.log( removeFirst( 'presidential election', 1 ) );
 // => 'residential election'
 
-console.log( first( 'JavaScript', 1 ) );
+console.log( removeFirst( 'JavaScript', 1 ) );
 // => 'avaScript'
 
-console.log( first( 'The Last of the Mohicans', 5 ) );
+console.log( removeFirst( 'The Last of the Mohicans', 5 ) );
 // => 'ast of the Mohicans'

--- a/lib/node_modules/@stdlib/string/base/remove-first/lib/index.js
+++ b/lib/node_modules/@stdlib/string/base/remove-first/lib/index.js
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Remove the first `n` UTF-16 code units of a string.
+*
+* @module @stdlib/string/base/remove-first
+*
+* @example
+* var removeFirst = require( '@stdlib/string/base/remove-first' );
+*
+* var out = removeFirst( 'last man standing', 1 );
+* // returns 'ast man standing'
+*
+* out = removeFirst( 'Hidden Treasures', 1 );
+* // returns 'idden Treasures';
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/string/base/remove-first/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/remove-first/lib/main.js
@@ -1,0 +1,53 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MAIN //
+
+/**
+* Removes the first `n` UTF-16 code units of a string.
+*
+* @param {string} str - input string
+* @param {NonNegativeInteger} n - number of UTF-16 code units to remove
+* @returns {string} output string
+*
+* @example
+* var out = removeFirst( 'last man standing', 1 );
+* // returns 'ast man standing'
+*
+* @example
+* var out = removeFirst( 'presidential election', 1 );
+* // returns 'residential election'
+*
+* @example
+* var out = removeFirst( 'JavaScript', 1 );
+* // returns 'avaScript'
+*
+* @example
+* var out = removeFirst( 'Hidden Treasures', 1 );
+* // returns 'idden Treasures'
+*/
+function removeFirst( str, n ) {
+	return str.substring( n, str.length );
+}
+
+
+// EXPORTS //
+
+module.exports = removeFirst;

--- a/lib/node_modules/@stdlib/string/base/remove-first/package.json
+++ b/lib/node_modules/@stdlib/string/base/remove-first/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@stdlib/string/base/first",
+  "version": "0.0.0",
+  "description": "Remove the first `n` UTF-16 code units of a string.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdstring",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "string",
+    "str",
+    "base",
+    "first",
+    "character",
+    "char",
+    "codeunit",
+    "unicode"
+  ]
+}

--- a/lib/node_modules/@stdlib/string/base/remove-first/package.json
+++ b/lib/node_modules/@stdlib/string/base/remove-first/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/string/base/first",
   "version": "0.0.0",
-  "description": "Remove the first `n` UTF-16 code units of a string.",
+  "description": "Remove the first UTF-16 code unit of a string.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/string/base/remove-first/test/test.js
+++ b/lib/node_modules/@stdlib/string/base/remove-first/test/test.js
@@ -21,39 +21,39 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var first = require( './../lib' );
+var removeFirst = require( './../lib' );
 
 
 // TESTS //
 
 tape( 'main export is a function', function test( t ) {
 	t.ok( true, __filename );
-	t.strictEqual( typeof first, 'function', 'main export is a function' );
+	t.strictEqual( typeof removeFirst, 'function', 'main export is a function' );
 	t.end();
 });
 
 tape( 'the function returns an empty string if provided an empty string', function test( t ) {
-	t.strictEqual( first( '', 1 ), '', 'returns expected value' );
-	t.strictEqual( first( '', 2 ), '', 'returns expected value' );
-	t.strictEqual( first( '', 3 ), '', 'returns expected value' );
+	t.strictEqual( removeFirst( '', 1 ), '', 'returns expected value' );
+	t.strictEqual( removeFirst( '', 2 ), '', 'returns expected value' );
+	t.strictEqual( removeFirst( '', 3 ), '', 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns the input string if provided zero as the second argument', function test( t ) {
-	t.strictEqual( first( 'hello world', 0 ), 'hello world', 'returns expected value' );
+	t.strictEqual( removeFirst( 'hello world', 0 ), 'hello world', 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns the string without the first UTF-16 code unit', function test( t ) {
 	var out;
 
-	out = first( 'hello world', 1 );
+	out = removeFirst( 'hello world', 1 );
 	t.strictEqual( out, 'ello world', 'returns expected value' );
 
-	out = first( '!!!', 1 );
+	out = removeFirst( '!!!', 1 );
 	t.strictEqual( out, '!!', 'returns expected value' );
 
-	out = first( 'Hello World', 1 );
+	out = removeFirst( 'Hello World', 1 );
 	t.strictEqual( out, 'ello World', 'returns expected value' );
 
 	t.end();
@@ -62,16 +62,16 @@ tape( 'the function returns the string without the first UTF-16 code unit', func
 tape( 'the function supports removing the first `n` UTF-16 code units of a provided string', function test( t ) {
 	var out;
 
-	out = first( 'hello world', 1 );
+	out = removeFirst( 'hello world', 1 );
 	t.strictEqual( out, 'ello world', 'returns expected value' );
 
-	out = first( 'hello world', 7 );
+	out = removeFirst( 'hello world', 7 );
 	t.strictEqual( out, 'orld', 'returns expected value' );
 
-	out = first( '!!!', 1 );
+	out = removeFirst( '!!!', 1 );
 	t.strictEqual( out, '!!', 'returns expected value' );
 
-	out = first( '!!!', 2 );
+	out = removeFirst( '!!!', 2 );
 	t.strictEqual( out, '!', 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/string/base/remove-first/test/test.js
+++ b/lib/node_modules/@stdlib/string/base/remove-first/test/test.js
@@ -1,0 +1,78 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var first = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof first, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns an empty string if provided an empty string', function test( t ) {
+	t.strictEqual( first( '', 1 ), '', 'returns expected value' );
+	t.strictEqual( first( '', 2 ), '', 'returns expected value' );
+	t.strictEqual( first( '', 3 ), '', 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns the input string if provided zero as the second argument', function test( t ) {
+	t.strictEqual( first( 'hello world', 0 ), 'hello world', 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns the string without the first UTF-16 code unit', function test( t ) {
+	var out;
+
+	out = first( 'hello world', 1 );
+	t.strictEqual( out, 'ello world', 'returns expected value' );
+
+	out = first( '!!!', 1 );
+	t.strictEqual( out, '!!', 'returns expected value' );
+
+	out = first( 'Hello World', 1 );
+	t.strictEqual( out, 'ello World', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports removing the first `n` UTF-16 code units of a provided string', function test( t ) {
+	var out;
+
+	out = first( 'hello world', 1 );
+	t.strictEqual( out, 'ello world', 'returns expected value' );
+
+	out = first( 'hello world', 7 );
+	t.strictEqual( out, 'orld', 'returns expected value' );
+
+	out = first( '!!!', 1 );
+	t.strictEqual( out, '!!', 'returns expected value' );
+
+	out = first( '!!!', 2 );
+	t.strictEqual( out, '!', 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/string/remove-first/README.md
+++ b/lib/node_modules/@stdlib/string/remove-first/README.md
@@ -30,9 +30,9 @@ limitations under the License.
 var removeFirst = require( '@stdlib/string/remove-first' );
 ```
 
-#### removeFirst( str\[, n] )
+#### removeFirst( str\[, n]\[, options] )
 
-Removes the first character of a `string`.
+Removes the first character(s) of a `string`.
 
 ```javascript
 var out = removeFirst( 'last man standing' );
@@ -42,7 +42,17 @@ out = removeFirst( 'Hidden Treasures' );
 // returns 'idden Treasures'
 ```
 
-If provided a second argument, the function removes the first `n` characters.
+The function supports the following options:
+
+-   **mode**: type of characters to return. Must be one of the following:
+
+    -   `'grapheme'`: grapheme clusters. Appropriate for strings containing visual characters which can span multiple Unicode code points (e.g., emoji).
+    -   `'code_point'`: Unicode code points. Appropriate for strings containing visual characters which are comprised of more than one Unicode code unit (e.g., ideographic symbols and punctuation and mathematical alphanumerics).
+    -   `'code_unit'`: UTF-16 code units. Appropriate for strings containing visual characters drawn from the basic multilingual plane (BMP) (e.g., common characters, such as those from the Latin, Greek, and Cyrillic alphabets).
+
+    Default: `'grapheme'`.
+
+By default, the function returns the first character. To return the first `n` characters, provide a second argument specifying the number of characters to return.
 
 ```javascript
 var out = removeFirst( 'foo bar', 4 );
@@ -55,6 +65,18 @@ out = removeFirst( 'foo bar', 10 );
 </section>
 
 <!-- /.usage -->
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+## Notes
+
+-   By default, the function assumes the general case in which an input string may contain an arbitrary number of grapheme clusters. This assumption comes with a performance cost. Accordingly, if an input string is known to only contain visual characters of a particular type (e.g., only alphanumeric), one can achieve better performance by specifying the appropriate `mode` option.
+
+</section>
+
+<!-- /.notes -->
 
 <section class="examples">
 
@@ -110,6 +132,7 @@ Options:
   -V,    --version             Print the package version.
          --n                   Number of characters to remove. Default: 1.
          --split sep           Delimiter for stdin data. Default: '/\\r?\\n/'.
+         --mode mode           Type of character to return. Default: 'grapheme'.
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/string/remove-first/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/string/remove-first/benchmark/benchmark.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2023 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@
 
 var bench = require( '@stdlib/bench' );
 var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
-var fromCodePoint = require( '@stdlib/string/from-code-point' );
 var pkg = require( './../package.json' ).name;
 var removeFirst = require( './../lib' );
 
@@ -30,16 +29,111 @@ var removeFirst = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
-	var str;
+	var values;
 	var out;
 	var i;
 
+	values = [
+		'beep boop',
+		'foo bar',
+		'xyz abc'
+	];
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		str = fromCodePoint( i%126 ) + 'eep boop';
-		out = removeFirst( str );
-		if ( out !== 'eep boop' ) {
-			b.fail( 'should return a shorter string' );
+		out = removeFirst( values[ i%values.length ] );
+		if ( typeof out !== 'string' ) {
+			b.fail( 'should return a string' );
+		}
+	}
+	b.toc();
+	if ( !isString( out ) ) {
+		b.fail( 'should return a string' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+':mode=grapheme', function benchmark( b ) {
+	var values;
+	var opts;
+	var out;
+	var i;
+
+	values = [
+		'beep boop',
+		'foo bar',
+		'xyz abc'
+	];
+	opts = {
+		'mode': 'grapheme'
+	};
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = removeFirst( values[ i%values.length ], opts );
+		if ( typeof out !== 'string' ) {
+			b.fail( 'should return a string' );
+		}
+	}
+	b.toc();
+	if ( !isString( out ) ) {
+		b.fail( 'should return a string' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+':mode=code_point', function benchmark( b ) {
+	var values;
+	var opts;
+	var out;
+	var i;
+
+	values = [
+		'beep boop',
+		'foo bar',
+		'xyz abc'
+	];
+	opts = {
+		'mode': 'code_point'
+	};
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = removeFirst( values[ i%values.length ], opts );
+		if ( typeof out !== 'string' ) {
+			b.fail( 'should return a string' );
+		}
+	}
+	b.toc();
+	if ( !isString( out ) ) {
+		b.fail( 'should return a string' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+':mode=code_unit', function benchmark( b ) {
+	var values;
+	var opts;
+	var out;
+	var i;
+
+	values = [
+		'beep boop',
+		'foo bar',
+		'xyz abc'
+	];
+	opts = {
+		'mode': 'code_unit'
+	};
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = removeFirst( values[ i%values.length ], opts );
+		if ( typeof out !== 'string' ) {
+			b.fail( 'should return a string' );
 		}
 	}
 	b.toc();

--- a/lib/node_modules/@stdlib/string/remove-first/bin/cli
+++ b/lib/node_modules/@stdlib/string/remove-first/bin/cli
@@ -45,6 +45,7 @@ function main() {
 	var split;
 	var flags;
 	var args;
+	var opts;
 	var cli;
 	var n;
 
@@ -64,6 +65,12 @@ function main() {
 	}
 	if ( flags.n ) {
 		n = parseInt( flags.n, 10 );
+	} else {
+		n = 1;
+	}
+	opts = {};
+	if ( flags.mode ) {
+		opts.mode = flags.mode;
 	}
 
 	// Get any provided command-line arguments:
@@ -81,10 +88,10 @@ function main() {
 		}
 		return stdin( onRead );
 	}
-	if ( n ) {
-		console.log( removeFirst( args[ 0 ], n ) ); // eslint-disable-line no-console
-	} else {
-		console.log( removeFirst( args[ 0 ] ) ); // eslint-disable-line no-console
+	try {
+		console.log( removeFirst( args[ 0 ], n, opts ) ); // eslint-disable-line no-console
+	} catch ( error ) {
+		return cli.error( error );
 	}
 
 	/**
@@ -107,13 +114,14 @@ function main() {
 		if ( lines[ lines.length-1 ] === '' ) {
 			lines.pop();
 		}
-		if ( n ) {
-			for ( i = 0; i < lines.length; i++ ) {
-				console.log( removeFirst( lines[ i ], n ) ); // eslint-disable-line no-console
+		if ( lines.length ) {
+			try {
+				console.log( removeFirst( lines[ 0 ], n, opts ) ); // eslint-disable-line no-console
+			} catch ( error ) {
+				return cli.error( error );
 			}
-		} else {
-			for ( i = 0; i < lines.length; i++ ) {
-				console.log( removeFirst( lines[ i ] ) ); // eslint-disable-line no-console
+			for ( i = 1; i < lines.length; i++ ) {
+				console.log( removeFirst( lines[ i ], n, opts ) ); // eslint-disable-line no-console
 			}
 		}
 	}

--- a/lib/node_modules/@stdlib/string/remove-first/docs/repl.txt
+++ b/lib/node_modules/@stdlib/string/remove-first/docs/repl.txt
@@ -1,5 +1,5 @@
 
-{{alias}}( str[, n] )
+{{alias}}( str[, n][, options] )
     Removes the first character(s) of a `string`.
 
     Parameters
@@ -9,6 +9,25 @@
 
     n: integer (optional)
         Number of characters to remove. Default: 1.
+
+    options: Object (optional)
+        Options.
+
+    options.mode: string (optional)
+        Type of characters to return. The following modes are supported:
+
+        - grapheme: grapheme clusters. Appropriate for strings containing visual
+          characters which can span multiple Unicode code points (e.g., emoji).
+        - code_point: Unicode code points. Appropriate for strings containing
+          visual characters which are comprised of more than one Unicode code
+          unit (e.g., ideographic symbols and punctuation and mathematical
+          alphanumerics).
+        - code_unit': UTF-16 code units. Appropriate for strings containing
+          visual characters drawn from the basic multilingual plane (BMP) (e.g.,
+          common characters, such as those from the Latin, Greek, and Cyrillic
+          alphabets).
+
+        Default: 'grapheme'.
 
     Returns
     -------

--- a/lib/node_modules/@stdlib/string/remove-first/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/remove-first/docs/types/index.d.ts
@@ -114,6 +114,7 @@ declare function removeFirst( str: string, options?: Options ): string;
 */
 declare function removeFirst( str: string, n?: number ): string;
 
+
 // EXPORTS //
 
 export = removeFirst;

--- a/lib/node_modules/@stdlib/string/remove-first/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/remove-first/docs/types/index.d.ts
@@ -18,6 +18,69 @@
 
 // TypeScript Version: 2.0
 
+// tslint:disable:unified-signatures
+
+/**
+* Interface describing function options.
+*/
+interface Options {
+	/**
+	* Specifies the type of characters to return (default: 'grapheme').
+	*
+	* ## Notes
+	*
+	* -   The following option values are supported:
+	*
+	*     -   `'grapheme'`: grapheme clusters. Appropriate for strings containing visual characters which can span multiple Unicode code points (e.g., emoji).
+	*     -   `'code_point'`: Unicode code points. Appropriate for strings containing visual characters which are comprised of more than one Unicode code unit (e.g., ideographic symbols and punctuation and mathematical alphanumerics).
+	*     -   `'code_unit'`: UTF-16 code units. Appropriate for strings containing visual characters drawn from the basic multilingual plane (BMP) (e.g., common characters, such as those from the Latin, Greek, and Cyrillic alphabets).
+	*/
+	mode?: 'grapheme' | 'code_point' | 'code_unit';
+}
+
+/**
+* Removes the first character(s) of a string.
+*
+* @param str - input string
+* @param n - number of characters to remove (default: 1)
+* @param options - options
+* @returns updated string
+*
+* @example
+* var out = removeFirst( 'last man standing', 1, {
+*     'mode': 'code_unit'
+* });
+* // returns 'ast man standing'
+*
+* @example
+* var out = removeFirst( '🐶🐮🐷🐰🐸', 2, {
+*     'mode': 'grapheme'
+* });
+* // returns '🐷🐰🐸'
+*/
+declare function removeFirst( str: string, n: number, options?: Options ): string;
+
+/**
+* Removes the first character of a string.
+*
+* @param str - input string
+* @param options - options
+* @returns updated string
+*
+* @example
+* var out = removeFirst( 'last man standing', {
+*     'mode': 'code_unit'
+* });
+* // returns 'ast man standing'
+*
+* @example
+* var out = removeFirst( '🐶🐮🐷🐰🐸', 2, {
+*     'mode': 'grapheme'
+* });
+* // returns '🐷🐰🐸'
+*/
+declare function removeFirst( str: string, options?: Options ): string;
+
 /**
 * Removes the first character(s) of a string.
 *
@@ -50,7 +113,6 @@
 * // returns 'bar'
 */
 declare function removeFirst( str: string, n?: number ): string;
-
 
 // EXPORTS //
 

--- a/lib/node_modules/@stdlib/string/remove-first/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/string/remove-first/docs/types/test.ts
@@ -24,6 +24,9 @@ import removeFirst = require( './index' );
 // The function returns a string...
 {
 	removeFirst( 'abc' ); // $ExpectType string
+	removeFirst( 'abc', 1 ); // $ExpectType string
+	removeFirst( 'abc', {} ); // $ExpectType string
+	removeFirst( 'abc', 1, {} ); // $ExpectType string
 }
 
 // The compiler throws an error if the function is provided a value other than a string...
@@ -36,6 +39,33 @@ import removeFirst = require( './index' );
 	removeFirst( [] ); // $ExpectError
 	removeFirst( {} ); // $ExpectError
 	removeFirst( ( x: number ): number => x ); // $ExpectError
+
+	removeFirst( true, 1 ); // $ExpectError
+	removeFirst( false, 1 ); // $ExpectError
+	removeFirst( null, 1 ); // $ExpectError
+	removeFirst( undefined, 1 ); // $ExpectError
+	removeFirst( 5, 1 ); // $ExpectError
+	removeFirst( [], 1 ); // $ExpectError
+	removeFirst( {}, 1 ); // $ExpectError
+	removeFirst( ( x: number ): number => x, 1 ); // $ExpectError
+
+	removeFirst( true, {} ); // $ExpectError
+	removeFirst( false, {} ); // $ExpectError
+	removeFirst( null, {} ); // $ExpectError
+	removeFirst( undefined, {} ); // $ExpectError
+	removeFirst( 5, {} ); // $ExpectError
+	removeFirst( [], {} ); // $ExpectError
+	removeFirst( {}, {} ); // $ExpectError
+	removeFirst( ( x: number ): number => x, {} ); // $ExpectError
+
+	removeFirst( true, 1, {} ); // $ExpectError
+	removeFirst( false, 1, {} ); // $ExpectError
+	removeFirst( null, 1, {} ); // $ExpectError
+	removeFirst( undefined, 1, {} ); // $ExpectError
+	removeFirst( 5, 1, {} ); // $ExpectError
+	removeFirst( [], 1, {} ); // $ExpectError
+	removeFirst( {}, 1, {} ); // $ExpectError
+	removeFirst( ( x: number ): number => x, 1, {} ); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided a second argument that is not a number...
@@ -45,8 +75,33 @@ import removeFirst = require( './index' );
 	removeFirst( 'abc', null ); // $ExpectError
 	removeFirst( 'abc', 'abc' ); // $ExpectError
 	removeFirst( 'abc', [] ); // $ExpectError
-	removeFirst( 'abc', {} ); // $ExpectError
 	removeFirst( 'abc', ( x: number ): number => x ); // $ExpectError
+
+	removeFirst( 'abc', true, {} ); // $ExpectError
+	removeFirst( 'abc', false, {} ); // $ExpectError
+	removeFirst( 'abc', null, {} ); // $ExpectError
+	removeFirst( 'abc', '', {} ); // $ExpectError
+	removeFirst( 'abc', [], {} ); // $ExpectError
+	removeFirst( 'abc', {}, {} ); // $ExpectError
+	removeFirst( 'abc', ( x: number ): number => x, {} ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an invalid `mode` option...
+{
+	removeFirst( 'abc', { 'mode': true } ); // $ExpectError
+	removeFirst( 'abc', { 'mode': false } ); // $ExpectError
+	removeFirst( 'abc', { 'mode': null } ); // $ExpectError
+	removeFirst( 'abc', { 'mode': '' } ); // $ExpectError
+	removeFirst( 'abc', { 'mode': [] } ); // $ExpectError
+	removeFirst( 'abc', { 'mode': ( x: number ): number => x } ); // $ExpectError
+
+	removeFirst( 'abc', 1, { 'mode': true } ); // $ExpectError
+	removeFirst( 'abc', 1, { 'mode': false } ); // $ExpectError
+	removeFirst( 'abc', 1, { 'mode': null } ); // $ExpectError
+	removeFirst( 'abc', 1, { 'mode': '' } ); // $ExpectError
+	removeFirst( 'abc', 1, { 'mode': [] } ); // $ExpectError
+	removeFirst( 'abc', 1, { 'mode': {} } ); // $ExpectError
+	removeFirst( 'abc', 1, { 'mode': ( x: number ): number => x } ); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided insufficient arguments...

--- a/lib/node_modules/@stdlib/string/remove-first/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/string/remove-first/docs/types/test.ts
@@ -68,7 +68,7 @@ import removeFirst = require( './index' );
 	removeFirst( ( x: number ): number => x, 1, {} ); // $ExpectError
 }
 
-// The compiler throws an error if the function is provided a second argument that is not a number...
+// The compiler throws an error if the function is provided an invalid second argument...
 {
 	removeFirst( 'abc', true ); // $ExpectError
 	removeFirst( 'abc', false ); // $ExpectError

--- a/lib/node_modules/@stdlib/string/remove-first/docs/usage.txt
+++ b/lib/node_modules/@stdlib/string/remove-first/docs/usage.txt
@@ -7,3 +7,4 @@ Options:
   -V,    --version             Print the package version.
          --n                   Number of characters to remove. Default: 1.
          --split sep           Delimiter for stdin data. Default: '/\\r?\\n/'.
+         --mode mode           Type of character to return. Default: 'grapheme'.

--- a/lib/node_modules/@stdlib/string/remove-first/etc/cli_opts.json
+++ b/lib/node_modules/@stdlib/string/remove-first/etc/cli_opts.json
@@ -5,7 +5,8 @@
 	],
 	"string": [
 		"n",
-		"split"
+		"split",
+		"mode"
 	],
 	"alias": {
 		"help": [

--- a/lib/node_modules/@stdlib/string/remove-first/lib/main.js
+++ b/lib/node_modules/@stdlib/string/remove-first/lib/main.js
@@ -27,7 +27,7 @@ var contains = require( '@stdlib/array/base/assert/contains' ).factory;
 var isNonNegativeInteger = require( '@stdlib/assert/is-nonnegative-integer' ).isPrimitive;
 var removeFirstCodeUnit = require( '@stdlib/string/base/remove-first' );
 var removeFirstCodePoint = require( '@stdlib/string/base/remove-first-code-point' );
-var removeFirstGraphemeCluster = require( '@stdlib/string/base/remove-first-grapheme-cluster' );
+var removeFirstGraphemeCluster = require( '@stdlib/string/base/remove-first-grapheme-cluster' ); // eslint-disable-line id-length
 var format = require( '@stdlib/string/format' );
 
 

--- a/lib/node_modules/@stdlib/string/remove-first/lib/main.js
+++ b/lib/node_modules/@stdlib/string/remove-first/lib/main.js
@@ -21,9 +21,25 @@
 // MODULES //
 
 var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
+var isPlainObject = require( '@stdlib/assert/is-plain-object' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var contains = require( '@stdlib/array/base/assert/contains' ).factory;
 var isNonNegativeInteger = require( '@stdlib/assert/is-nonnegative-integer' ).isPrimitive;
-var nextGraphemeClusterBreak = require( '@stdlib/string/next-grapheme-cluster-break' );
+var removeFirstCodeUnit = require( '@stdlib/string/base/remove-first' );
+var removeFirstCodePoint = require( '@stdlib/string/base/remove-first-code-point' );
+var removeFirstGraphemeCluster = require( '@stdlib/string/base/remove-first-grapheme-cluster' );
 var format = require( '@stdlib/string/format' );
+
+
+// VARIABLES //
+
+var MODES = [ 'grapheme', 'code_point', 'code_unit' ];
+var FCNS = {
+	'grapheme': removeFirstGraphemeCluster,
+	'code_point': removeFirstCodePoint,
+	'code_unit': removeFirstCodeUnit
+};
+var isMode = contains( MODES );
 
 
 // MAIN //
@@ -33,8 +49,12 @@ var format = require( '@stdlib/string/format' );
 *
 * @param {string} str - input string
 * @param {NonNegativeInteger} [n=1] - number of characters to remove
+* @param {Options} [options] - options
+* @param {string} [options.mode="grapheme"] - type of "character" to return (must be either `grapheme`, `code_point`, or `code_unit`)
 * @throws {TypeError} must provide a string primitive
 * @throws {TypeError} second argument must be a nonnegative integer
+* @throws {TypeError} options argument must be an object
+* @throws {TypeError} must provide valid options
 * @returns {string} updated string
 *
 * @example
@@ -61,28 +81,48 @@ var format = require( '@stdlib/string/format' );
 * var out = removeFirst( 'foo bar', 4 );
 * // returns 'bar'
 */
-function removeFirst( str, n ) {
-	var nextBreak;
+function removeFirst( str ) {
+	var options;
+	var nargs;
+	var opts;
+	var n;
+
 	if ( !isString( str ) ) {
 		throw new TypeError( format( 'invalid argument. First argument must be a string. Value: `%s`.', str ) );
 	}
-	if ( arguments.length > 1 ) {
+	opts = {
+		'mode': 'grapheme'
+	};
+	nargs = arguments.length;
+	if ( nargs === 1 ) {
+		n = 1;
+	} else if ( nargs === 2 ) {
+		n = arguments[ 1 ];
+		if ( isPlainObject( n ) ) {
+			options = n;
+			n = 1;
+		} else if ( !isNonNegativeInteger( n ) ) {
+			throw new TypeError( format( 'invalid argument. Second argument must be a nonnegative integer. Value: `%s`.', n ) );
+		}
+	} else { // nargs > 2
+		n = arguments[ 1 ];
 		if ( !isNonNegativeInteger( n ) ) {
 			throw new TypeError( format( 'invalid argument. Second argument must be a nonnegative integer. Value: `%s`.', n ) );
 		}
-		nextBreak = 0;
-		while ( n > 0 ) {
-			nextBreak = nextGraphemeClusterBreak( str, nextBreak );
-			n -= 1;
+		options = arguments[ 2 ];
+		if ( !isPlainObject( options ) ) {
+			throw new TypeError( format( 'invalid argument. Options argument must be an object. Value: `%s`.', options ) );
 		}
-	} else {
-		nextBreak = nextGraphemeClusterBreak( str );
 	}
-	// Value of `nextBreak` will be -1 if and only if `str` is an empty string or `str` has only 1 extended grapheme cluster...
-	if ( str === '' || nextBreak === -1 ) {
-		return '';
+	if ( options ) {
+		if ( hasOwnProp( options, 'mode' ) ) {
+			opts.mode = options.mode;
+			if ( !isMode( opts.mode ) ) {
+				throw new TypeError( format( 'invalid option. `%s` option must be one of the following: "%s". Value: `%s`.', 'mode', MODES.join( '", "' ), opts.mode ) );
+			}
+		}
 	}
-	return str.substring( nextBreak );
+	return FCNS[ opts.mode ]( str, n );
 }
 
 

--- a/lib/node_modules/@stdlib/string/remove-first/test/test.cli.js
+++ b/lib/node_modules/@stdlib/string/remove-first/test/test.cli.js
@@ -182,6 +182,46 @@ tape( 'the command-line interface removes the first `n` characters of a string a
 	}
 });
 
+tape( 'the command-line interface supports specifying the type of characters to return', opts, function test( t ) {
+	var cmd = [
+		EXEC_PATH,
+		'-e',
+		'"process.stdin.isTTY = true; process.argv[ 2 ] = \'beep\';  process.argv[ 3 ] = \'--mode=code_point\'; require( \''+fpath+'\' );"'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), 'eep\n', 'expected value' );
+			t.strictEqual( stderr.toString(), '', 'does not print to `stderr`' );
+		}
+		t.end();
+	}
+});
+
+tape( 'if provided an invalid option, the command-line interface prints an error and sets a non-zero exit code', opts, function test( t ) {
+	var cmd = [
+		EXEC_PATH,
+		'-e',
+		'"process.stdin.isTTY = true; process.argv[ 2 ] = \'beep\';  process.argv[ 3 ] = \'--mode=foo\'; require( \''+fpath+'\' );"'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.pass( error.message );
+			t.strictEqual( error.code, 1, 'expected exit code' );
+		}
+		t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+		t.strictEqual( stderr.toString().length > 0, true, 'expected value' );
+		t.end();
+	}
+});
+
 tape( 'the command-line interface supports use as a standard stream', opts, function test( t ) {
 	var cmd = [
 		'printf "beep\nboop"',
@@ -247,6 +287,28 @@ tape( 'the command-line interface supports specifying a custom delimiter when us
 	}
 });
 
+tape( 'the command-line interface supports specifying the type of characters to return when used as a standard stream', opts, function test( t ) {
+	var cmd = [
+		'printf \'foo\nbar\nbaz\'',
+		'|',
+		EXEC_PATH,
+		fpath,
+		'--mode code_point'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), 'oo\nar\naz\n', 'expected value' );
+			t.strictEqual( stderr.toString(), '', 'does not print to `stderr`' );
+		}
+		t.end();
+	}
+});
+
 tape( 'the command-line interface supports specifying a custom delimiter when used as a standard stream (regexp)', opts, function test( t ) {
 	var cmd = [
 		'printf \'foo\tbar\tbaz\'',
@@ -265,6 +327,28 @@ tape( 'the command-line interface supports specifying a custom delimiter when us
 			t.strictEqual( stdout.toString(), 'oo\nar\naz\n', 'expected value' );
 			t.strictEqual( stderr.toString(), '', 'does not print to `stderr`' );
 		}
+		t.end();
+	}
+});
+
+tape( 'when used as a standard stream, if provided an invalid option, the command-line interface prints an error and sets a non-zero exit code', opts, function test( t ) {
+	var cmd = [
+		'printf \'foo\tbar\tbaz\'',
+		'|',
+		EXEC_PATH,
+		fpath,
+		'--mode=foo'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.pass( error.message );
+			t.strictEqual( error.code, 1, 'expected exit code' );
+		}
+		t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+		t.strictEqual( stderr.toString().length > 0, true, 'expected value' );
 		t.end();
 	}
 });

--- a/lib/node_modules/@stdlib/string/remove-first/test/test.js
+++ b/lib/node_modules/@stdlib/string/remove-first/test/test.js
@@ -59,7 +59,61 @@ tape( 'the function throws an error if not provided a string', function test( t 
 	}
 });
 
+tape( 'the function throws an error if not provided a string (options)', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		5,
+		null,
+		true,
+		void 0,
+		NaN,
+		[],
+		{},
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			removeFirst( value, {} );
+		};
+	}
+});
+
 tape( 'the function throws an error if provided a second argument which is not a nonnegative integer', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'abc',
+		3.14,
+		null,
+		true,
+		void 0,
+		NaN,
+		[],
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			removeFirst( 'beep', value );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a second argument which is not a nonnegative integer (options)', function test( t ) {
 	var values;
 	var i;
 
@@ -82,13 +136,101 @@ tape( 'the function throws an error if provided a second argument which is not a
 
 	function badValue( value ) {
 		return function badValue() {
-			removeFirst( 'beep', value );
+			removeFirst( 'beep', value, {} );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an options argument which is not an object', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'abc',
+		3,
+		null,
+		true,
+		void 0,
+		NaN,
+		[],
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			removeFirst( 'beep', 1, value );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a `mode` option which is not a supported mode (second argument)', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'abc',
+		3,
+		null,
+		true,
+		void 0,
+		NaN,
+		[],
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			removeFirst( 'beep', {
+				'mode': value
+			});
+		};
+	}
+});
+
+tape( 'the function throws an error if provided a `mode` option which is not a supported mode (third argument)', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'abc',
+		3,
+		null,
+		true,
+		void 0,
+		NaN,
+		[],
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			removeFirst( 'beep', 1, {
+				'mode': value
+			});
 		};
 	}
 });
 
 tape( 'the function returns an empty string if provided an empty string', function test( t ) {
 	t.strictEqual( removeFirst( '' ), '', 'returns empty string' );
+	t.strictEqual( removeFirst( '', 1 ), '', 'returns expected value' );
+	t.strictEqual( removeFirst( '', {} ), '', 'returns expected value' );
+	t.strictEqual( removeFirst( '', 1, {} ), '', 'returns expected value' );
 	t.end();
 });
 
@@ -122,10 +264,13 @@ tape( 'the function returns the original string if provided zero as the second a
 	out = removeFirst( 'hello world', 0 );
 	t.strictEqual( out, 'hello world', 'returns original string' );
 
+	out = removeFirst( 'hello world', 0, {} );
+	t.strictEqual( out, 'hello world', 'returns expected value' );
+
 	t.end();
 });
 
-tape( 'the function removes the first `n` characters of a given string if provided a second argument', function test( t ) {
+tape( 'the function removes the first `n` characters of a given string (default)', function test( t ) {
 	var out;
 
 	out = removeFirst( 'hello world', 1 );
@@ -149,5 +294,102 @@ tape( 'the function removes the first `n` characters of a given string if provid
 	out = removeFirst( '🌷', 1 );
 	t.strictEqual( out, '', 'returns expected value' );
 
+	t.end();
+});
+
+tape( 'the function supports returning the first `n` characters of a provided string (mode=grapheme)', function test( t ) {
+	var opts;
+	var out;
+
+	opts = {
+		'mode': 'grapheme'
+	};
+
+	out = removeFirst( 'hello world', 1, opts );
+	t.strictEqual( out, 'ello world', 'returns expected value' );
+
+	out = removeFirst( 'hello world', 7, opts );
+	t.strictEqual( out, 'orld', 'returns expected value' );
+
+	out = removeFirst( '!!!', 1, opts );
+	t.strictEqual( out, '!!', 'returns expected value' );
+
+	out = removeFirst( '!!!', 2, opts );
+	t.strictEqual( out, '!', 'returns expected value' );
+
+	out = removeFirst( 'अनुच्छेद', 1, opts );
+	t.strictEqual( out, 'नुच्छेद', 'returns expected value' );
+
+	out = removeFirst( '六书/六書', 1, opts );
+	t.strictEqual( out, '书/六書', 'returns expected value' );
+
+	out = removeFirst( '🌷', 1, opts );
+	t.strictEqual( out, '', 'returns expected value' );
+
+	out = removeFirst( '👉🏿', 1, opts );
+	t.strictEqual( out, '', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports returning the first `n` characters of a provided string (mode=code_point)', function test( t ) {
+	var opts;
+	var out;
+
+	opts = {
+		'mode': 'code_point'
+	};
+
+	out = removeFirst( 'hello world', 1, opts );
+	t.strictEqual( out, 'ello world', 'returns expected value' );
+
+	out = removeFirst( 'hello world', 7, opts );
+	t.strictEqual( out, 'orld', 'returns expected value' );
+
+	out = removeFirst( '!!!', 1, opts );
+	t.strictEqual( out, '!!', 'returns expected value' );
+
+	out = removeFirst( '!!!', 2, opts );
+	t.strictEqual( out, '!', 'returns expected value' );
+
+	out = removeFirst( 'अनुच्छेद', 1, opts );
+	t.strictEqual( out, 'नुच्छेद', 'returns expected value' );
+
+	out = removeFirst( '六书/六書', 1, opts );
+	t.strictEqual( out, '书/六書', 'returns expected value' );
+
+	out = removeFirst( '🌷', 1, opts );
+	t.strictEqual( out, '\udf37', 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports returning the first `n` characters of a provided string (mode=code_unit)', function test( t ) {
+	var opts;
+	var out;
+
+	opts = {
+		'mode': 'code_unit'
+	};
+
+	out = removeFirst( 'hello world', 1, opts );
+	t.strictEqual( out, 'ello world', 'returns expected value' );
+
+	out = removeFirst( 'hello world', 7, opts );
+	t.strictEqual( out, 'orld', 'returns expected value' );
+
+	out = removeFirst( '!!!', 1, opts );
+	t.strictEqual( out, '!!', 'returns expected value' );
+
+	out = removeFirst( '!!!', 2, opts );
+	t.strictEqual( out, '!', 'returns expected value' );
+
+	out = removeFirst( 'अनुच्छेद', 1, opts );
+	t.strictEqual( out, 'नुच्छेद', 'returns expected value' );
+
+	out = removeFirst( '六书/六書', 1, opts );
+	t.strictEqual( out, '书/六書', 'returns expected value' );
+
+	out = removeFirst( '🌷', 1, opts );
+	t.strictEqual( out, '\udf37', 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/string/remove-first/test/test.js
+++ b/lib/node_modules/@stdlib/string/remove-first/test/test.js
@@ -297,7 +297,7 @@ tape( 'the function removes the first `n` characters of a given string (default)
 	t.end();
 });
 
-tape( 'the function supports returning the first `n` characters of a provided string (mode=grapheme)', function test( t ) {
+tape( 'the function supports removing the first `n` characters of a provided string (mode=grapheme)', function test( t ) {
 	var opts;
 	var out;
 
@@ -332,7 +332,7 @@ tape( 'the function supports returning the first `n` characters of a provided st
 	t.end();
 });
 
-tape( 'the function supports returning the first `n` characters of a provided string (mode=code_point)', function test( t ) {
+tape( 'the function supports removing the first `n` characters of a provided string (mode=code_point)', function test( t ) {
 	var opts;
 	var out;
 
@@ -363,7 +363,7 @@ tape( 'the function supports returning the first `n` characters of a provided st
 	t.end();
 });
 
-tape( 'the function supports returning the first `n` characters of a provided string (mode=code_unit)', function test( t ) {
+tape( 'the function supports removing the first `n` characters of a provided string (mode=code_unit)', function test( t ) {
 	var opts;
 	var out;
 


### PR DESCRIPTION
Part of https://github.com/stdlib-js/stdlib/issues/1062

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors the string package `@stdlib/string/remove-first`
-   Adds `@stdlib/string/base/remove-first`
-   Adds `@stdlib/string/base/remove-first-code-point`
-   Adds `@stdlib/string/base/remove-first-grapheme-cluster`

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   Is part of https://github.com/stdlib-js/stdlib/issues/1062

## Questions

> Any questions for reviewers of this pull request?

- The linter doesn't like the identifier name `removeFirstGraphemeCluster` because it exceeds 25 characters, should we supress this rule, or there's a shorter name we want to adopt for that package?

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
