### PR TITLE
feat: add truncate-middle-code-point string package

### DIFF
--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/README.md
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/README.md
@@ -30,19 +30,15 @@ limitations under the License.
 var truncateMiddleCodePoint = require( '@stdlib/string/base/truncate-middle-code-point' );
 ```
 
-#### truncateMiddleCodePoint( str, len\[, seq] )
+#### truncateMiddleCodePoint( str, len, seq )
 
 Truncates code points of string in the middle to a specified length.
 
 ```javascript
-var out = truncateMiddleCodePoint( 'beep boop', 7 );
+var out = truncateMiddleCodePoint( 'beep boop', 7, '...' );
 // returns 'be...op'
-```
 
-By default, the truncated string uses the replacement sequence `'...'`. To customize the replacement sequence, provide a `seq` argument:
-
-```javascript
-var out = truncateMiddleCodePoint( 'beep boop', 7, '!' );
+out = truncateMiddleCodePoint( 'beep boop', 7, '!' );
 // returns 'bee!oop'
 
 out = truncateMiddleCodePoint( 'beep boop', 7, '!!!' );
@@ -63,7 +59,7 @@ out = truncateMiddleCodePoint( 'beep boop', 7, '!!!' );
 var truncateMiddleCodePoint = require( '@stdlib/string/base/truncate-middle-code-point' );
 
 var str = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
-var out = truncateMiddleCodePoint( str, 15 );
+var out = truncateMiddleCodePoint( str, 15, '...' );
 // returns 'Lorem ... elit.'
 
 str = 'To be or not to be, that is the question';

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/README.md
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/README.md
@@ -1,0 +1,96 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2023 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# truncateMiddleCodePoint
+
+> Truncate code points of string in the middle to a specified length.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var truncateMiddleCodePoint = require( '@stdlib/string/base/truncate-middle-code-point' );
+```
+
+#### truncateMiddleCodePoint( str, len\[, seq] )
+
+Truncates code points of string in the middle to a specified length.
+
+```javascript
+var out = truncateMiddleCodePoint( 'beep boop', 7 );
+// returns 'be...op'
+```
+
+By default, the truncated string uses the replacement sequence `'...'`. To customize the replacement sequence, provide a `seq` argument:
+
+```javascript
+var out = truncateMiddleCodePoint( 'beep boop', 7, '!' );
+// returns 'bee!oop'
+
+out = truncateMiddleCodePoint( 'beep boop', 7, '!!!' );
+// returns 'be!!!op'
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var truncateMiddleCodePoint = require( '@stdlib/string/base/truncate-middle-code-point' );
+
+var str = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
+var out = truncateMiddleCodePoint( str, 15 );
+// returns 'Lorem ... elit.'
+
+str = 'To be or not to be, that is the question';
+out = truncateMiddleCodePoint( str, 19, '|' );
+// returns 'To be or | question'
+
+str = 'The quick fox jumps over the lazy dog.';
+out = truncateMiddleCodePoint( str, 28, '...' );
+// returns 'The quick fox...he lazy dog.'
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/README.md
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # truncateMiddleCodePoint
 
-> Truncate code points of string in the middle to a specified length.
+> Truncate code points in the middle of a string in order to return a string having a specified length.
 
 <section class="usage">
 
@@ -32,7 +32,7 @@ var truncateMiddleCodePoint = require( '@stdlib/string/base/truncate-middle-code
 
 #### truncateMiddleCodePoint( str, len, seq )
 
-Truncates code points of string in the middle to a specified length.
+Truncates code points in the middle of a string in order to return a string having a specified length.
 
 ```javascript
 var out = truncateMiddleCodePoint( 'beep boop', 7, '...' );

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/benchmark/benchmark.js
@@ -42,7 +42,7 @@ bench( pkg, function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		out = truncateMiddle( values[ i%values.length ], 1 );
+		out = truncateMiddle( values[ i%values.length ], 1, '...' );
 		if ( typeof out !== 'string' ) {
 			b.fail( 'should return a string' );
 		}

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/benchmark/benchmark.js
@@ -1,0 +1,56 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
+var pkg = require( './../package.json' ).name;
+var truncateMiddle = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var values;
+	var out;
+	var i;
+
+	values = [
+		'beep boop',
+		'foo bar',
+		'xyz abc',
+		'🐶🐮🐷🐰🐸'
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = truncateMiddle( values[ i%values.length ], 1 );
+		if ( typeof out !== 'string' ) {
+			b.fail( 'should return a string' );
+		}
+	}
+	b.toc();
+	if ( !isString( out ) ) {
+		b.fail( 'should return a string' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/docs/repl.txt
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/docs/repl.txt
@@ -1,5 +1,5 @@
 
-{{alias}}( str, len[, seq] )
+{{alias}}( str, len, seq )
     Truncates code points of string in the middle to a specified length.
 
     Parameters
@@ -10,8 +10,8 @@
     len: integer
         Output string length.
 
-    seq: string (optional)
-        Custom replacement sequence. Default: '...'.
+    seq: string
+        Custom replacement sequence.
 
     Returns
     -------
@@ -21,7 +21,7 @@
     Examples
     --------
     > var str = 'beep boop';
-    > var out = {{alias}}( str, 5 )
+    > var out = {{alias}}( str, 5, '...' )
     'b...p'
 
     > out = {{alias}}( str, 5, '|' )

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/docs/repl.txt
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/docs/repl.txt
@@ -1,0 +1,31 @@
+
+{{alias}}( str, len[, seq] )
+    Truncates code points of string in the middle to a specified length.
+
+    Parameters
+    ----------
+    str: string
+        Input string.
+
+    len: integer
+        Output string length.
+
+    seq: string (optional)
+        Custom replacement sequence. Default: '...'.
+
+    Returns
+    -------
+    out: string
+        Truncated string.
+
+    Examples
+    --------
+    > var str = 'beep boop';
+    > var out = {{alias}}( str, 5 )
+    'b...p'
+
+    > out = {{alias}}( str, 5, '|' )
+    'be|op'
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/docs/repl.txt
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/docs/repl.txt
@@ -1,6 +1,7 @@
 
 {{alias}}( str, len, seq )
-    Truncates code points of string in the middle to a specified length.
+    Truncates code points in the middle of a string in order to return a string
+    having a specified length.
 
     Parameters
     ----------

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/docs/types/index.d.ts
@@ -1,0 +1,59 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Truncates code points of string in the middle to a specified length.
+*
+* @param str - input string
+* @param len - output string length (including sequence)
+* @param seq - custom replacement sequence (default: `...`)
+* @returns truncated string
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 5 );
+* // returns 'b...p'
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 5, '>>>' );
+* // returns 'b>>>p'
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 10 );
+* // returns 'beep boop'
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 0 );
+* // returns ''
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 2 );
+* // returns '..'
+*/
+declare function truncateMiddle( str: string, len: number, seq?: string ): string; // tslint-disable-line max-line-length
+
+
+// EXPORTS //
+
+export = truncateMiddle;

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/docs/types/index.d.ts
@@ -23,12 +23,12 @@
 *
 * @param str - input string
 * @param len - output string length (including sequence)
-* @param seq - custom replacement sequence (default: `...`)
+* @param seq - custom replacement sequence
 * @returns truncated string
 *
 * @example
 * var str = 'beep boop';
-* var out = truncateMiddle( str, 5 );
+* var out = truncateMiddle( str, 5, '...' );
 * // returns 'b...p'
 *
 * @example
@@ -38,20 +38,20 @@
 *
 * @example
 * var str = 'beep boop';
-* var out = truncateMiddle( str, 10 );
+* var out = truncateMiddle( str, 10, '...' );
 * // returns 'beep boop'
 *
 * @example
 * var str = 'beep boop';
-* var out = truncateMiddle( str, 0 );
+* var out = truncateMiddle( str, 0, '...' );
 * // returns ''
 *
 * @example
 * var str = 'beep boop';
-* var out = truncateMiddle( str, 2 );
+* var out = truncateMiddle( str, 2, '...' );
 * // returns '..'
 */
-declare function truncateMiddle( str: string, len: number, seq?: string ): string; // tslint-disable-line max-line-length
+declare function truncateMiddle( str: string, len: number, seq: string ): string; // tslint-disable-line max-line-length
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/docs/types/index.d.ts
@@ -19,7 +19,7 @@
 // TypeScript Version: 4.1
 
 /**
-* Truncates code points of string in the middle to a specified length.
+* Truncates code points in the middle of a string in order to return a string having a specified length.
 *
 * @param str - input string
 * @param len - output string length (including sequence)

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/docs/types/test.ts
@@ -1,0 +1,64 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import truncateMiddle = require( './index' );
+
+
+// TESTS //
+
+// The function returns a string...
+{
+	truncateMiddle( 'abcdefghi', 3 ); // $ExpectType string
+	truncateMiddle( 'abcdefghi', 10, '|' ); // $ExpectType string
+}
+
+//  The compiler throws an error if the function is not provided a string as its first argument...
+{
+	truncateMiddle( true, 6 ); // $ExpectError
+	truncateMiddle( false, 6 ); // $ExpectError
+	truncateMiddle( 3, 6 ); // $ExpectError
+	truncateMiddle( [], 6 ); // $ExpectError
+	truncateMiddle( {}, 6 ); // $ExpectError
+	truncateMiddle( ( x: number ): number => x, 6 ); // $ExpectError
+}
+
+//  The compiler throws an error if the function is not provided a number as its second argument...
+{
+	truncateMiddle( 'abd', true ); // $ExpectError
+	truncateMiddle( 'abd', false ); // $ExpectError
+	truncateMiddle( 'abd', 'abc' ); // $ExpectError
+	truncateMiddle( 'abd', [], 0 ); // $ExpectError
+	truncateMiddle( 'abd', {}, 0 ); // $ExpectError
+	truncateMiddle( 'abd', ( x: number ): number => x, 0 ); // $ExpectError
+}
+
+//  The compiler throws an error if the function is not provided a string as its third argument...
+{
+	truncateMiddle( 'beep boop', 4, true ); // $ExpectError
+	truncateMiddle( 'beep boop', 4, false ); // $ExpectError
+	truncateMiddle( 'beep boop', 4, 123 ); // $ExpectError
+	truncateMiddle( 'beep boop', 4, [], 0 ); // $ExpectError
+	truncateMiddle( 'beep boop', 4, {}, 0 ); // $ExpectError
+	truncateMiddle( 'beep boop', 4, ( x: number ): number => x, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	truncateMiddle(); // $ExpectError
+	truncateMiddle( 'abc', 4, '|', true ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/docs/types/test.ts
@@ -23,28 +23,28 @@ import truncateMiddle = require( './index' );
 
 // The function returns a string...
 {
-	truncateMiddle( 'abcdefghi', 3 ); // $ExpectType string
+	truncateMiddle( 'abcdefghi', 3, '...' ); // $ExpectType string
 	truncateMiddle( 'abcdefghi', 10, '|' ); // $ExpectType string
 }
 
 //  The compiler throws an error if the function is not provided a string as its first argument...
 {
-	truncateMiddle( true, 6 ); // $ExpectError
-	truncateMiddle( false, 6 ); // $ExpectError
-	truncateMiddle( 3, 6 ); // $ExpectError
-	truncateMiddle( [], 6 ); // $ExpectError
-	truncateMiddle( {}, 6 ); // $ExpectError
-	truncateMiddle( ( x: number ): number => x, 6 ); // $ExpectError
+	truncateMiddle( true, 6, '...' ); // $ExpectError
+	truncateMiddle( false, 6, '...' ); // $ExpectError
+	truncateMiddle( 3, 6, '...' ); // $ExpectError
+	truncateMiddle( [], 6, '...' ); // $ExpectError
+	truncateMiddle( {}, 6, '...' ); // $ExpectError
+	truncateMiddle( ( x: number ): number => x, 6, '...' ); // $ExpectError
 }
 
 //  The compiler throws an error if the function is not provided a number as its second argument...
 {
-	truncateMiddle( 'abd', true ); // $ExpectError
-	truncateMiddle( 'abd', false ); // $ExpectError
-	truncateMiddle( 'abd', 'abc' ); // $ExpectError
-	truncateMiddle( 'abd', [], 0 ); // $ExpectError
-	truncateMiddle( 'abd', {}, 0 ); // $ExpectError
-	truncateMiddle( 'abd', ( x: number ): number => x, 0 ); // $ExpectError
+	truncateMiddle( 'abd', true, '...' ); // $ExpectError
+	truncateMiddle( 'abd', false, '...' ); // $ExpectError
+	truncateMiddle( 'abd', 'abc', '...' ); // $ExpectError
+	truncateMiddle( 'abd', [], '...' ); // $ExpectError
+	truncateMiddle( 'abd', {}, '...' ); // $ExpectError
+	truncateMiddle( 'abd', ( x: number ): number => x, '...' ); // $ExpectError
 }
 
 //  The compiler throws an error if the function is not provided a string as its third argument...

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/examples/index.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/examples/index.js
@@ -21,7 +21,7 @@
 var truncateMiddle = require( './../lib' );
 
 var str = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
-var out = truncateMiddle( str, 15 );
+var out = truncateMiddle( str, 15, '...' );
 console.log( out );
 // => 'Lorem ... elit.'
 

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/examples/index.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/examples/index.js
@@ -1,0 +1,41 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var truncateMiddle = require( './../lib' );
+
+var str = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
+var out = truncateMiddle( str, 15 );
+console.log( out );
+// => 'Lorem ... elit.'
+
+str = 'To be or not to be, that is the question';
+out = truncateMiddle( str, 19, '|' );
+console.log( out );
+// => 'To be or | question'
+
+str = 'The quick fox jumps over the lazy dog.';
+out = truncateMiddle( str, 28, '...' );
+console.log( out );
+// => 'The quick fox...he lazy dog.'
+
+str = 'अनुच्छेद';
+out = truncateMiddle( str, 6, '...' );
+console.log( out );
+// => 'अनुच्...छेद'

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/lib/index.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/lib/index.js
@@ -26,7 +26,7 @@
 * @example
 * var truncateMiddle = require( '@stdlib/string/base/truncate-middle-code-point' );
 *
-* var out = truncateMiddle( 'beep boop', 7 );
+* var out = truncateMiddle( 'beep boop', 7, '...' );
 * // returns 'be...op'
 *
 * out = truncateMiddle( 'beep boop', 7, '|' );

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/lib/index.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Truncate code points of string in the middle to a specified length.
+* Truncate code points in the middle of a string in order to return a string having a specified length.
 *
 * @module @stdlib/string/base/truncate-middle-code-point
 *

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/lib/index.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/lib/index.js
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Truncate code points of string in the middle to a specified length.
+*
+* @module @stdlib/string/base/truncate-middle-code-point
+*
+* @example
+* var truncateMiddle = require( '@stdlib/string/base/truncate-middle-code-point' );
+*
+* var out = truncateMiddle( 'beep boop', 7 );
+* // returns 'be...op'
+*
+* out = truncateMiddle( 'beep boop', 7, '|' );
+* // returns 'bee|oop'
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/lib/main.js
@@ -1,0 +1,110 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var round = require( '@stdlib/math/base/special/round' );
+var floor = require( '@stdlib/math/base/special/floor' );
+var numCodePoints = require( '@stdlib/string/num-code-points' );
+var nextCodePoint = require( '@stdlib/string/next-code-point' );
+
+
+// MAIN //
+
+/**
+* Truncates code points of string in the middle to a specified length.
+*
+* @param {string} str - input string
+* @param {integer} len - output string length (including sequence)
+* @param {string} [seq='...'] - custom replacement sequence
+* @returns {string} truncated string
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 5 );
+* // returns 'b...p'
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 5, '>>>' );
+* // returns 'b>>>p'
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 10 );
+* // returns 'beep boop'
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 0 );
+* // returns ''
+*
+* @example
+* var str = 'beep boop';
+* var out = truncateMiddle( str, 2 );
+* // returns '..'
+*/
+function truncateMiddle( str, len, seq ) {
+	var seqLength;
+	var strLength;
+	var seqStart;
+	var fromIdx;
+	var nVisual;
+	var seqEnd;
+	var idx1;
+	var idx2;
+
+	seq = seq || '...';
+	seqLength = numCodePoints( seq );
+	strLength = numCodePoints( str );
+	fromIdx = 0;
+	if ( len > strLength ) {
+		return str;
+	}
+	if ( len - seqLength < 0 ) {
+		return seq.slice( 0, len );
+	}
+	seqStart = round( ( len - seqLength ) / 2 );
+	seqEnd = strLength - floor( ( len - seqLength ) / 2 );
+	nVisual = 0;
+	while( nVisual < seqStart ) {
+		idx1 = nextCodePoint( str, fromIdx );
+		fromIdx = idx1;
+		nVisual += 1;
+	}
+	idx2 = idx1;
+	while( idx2 > 0 ) {
+		idx2 = nextCodePoint( str, fromIdx );
+		if ( idx2 >= seqEnd + fromIdx - nVisual ) {
+			break;
+		}
+		fromIdx = idx2;
+		nVisual += 1;
+	}
+	if ( idx2 === -1 ) {
+		idx2 = strLength - 1;
+	}
+	return str.substring( 0, idx1 ) + seq + str.substring( idx2 );
+}
+
+
+// EXPORTS //
+
+module.exports = truncateMiddle;

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/lib/main.js
@@ -29,7 +29,7 @@ var nextCodePoint = require( '@stdlib/string/next-code-point' );
 // MAIN //
 
 /**
-* Truncates code points of string in the middle to a specified length.
+* Truncates code points in the middle of a string in order to return a string having a specified length.
 *
 * @param {string} str - input string
 * @param {integer} len - output string length (including sequence)

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/lib/main.js
@@ -33,12 +33,12 @@ var nextCodePoint = require( '@stdlib/string/next-code-point' );
 *
 * @param {string} str - input string
 * @param {integer} len - output string length (including sequence)
-* @param {string} [seq='...'] - custom replacement sequence
+* @param {string} seq - custom replacement sequence
 * @returns {string} truncated string
 *
 * @example
 * var str = 'beep boop';
-* var out = truncateMiddle( str, 5 );
+* var out = truncateMiddle( str, 5, '...' );
 * // returns 'b...p'
 *
 * @example
@@ -48,17 +48,17 @@ var nextCodePoint = require( '@stdlib/string/next-code-point' );
 *
 * @example
 * var str = 'beep boop';
-* var out = truncateMiddle( str, 10 );
+* var out = truncateMiddle( str, 10, '...' );
 * // returns 'beep boop'
 *
 * @example
 * var str = 'beep boop';
-* var out = truncateMiddle( str, 0 );
+* var out = truncateMiddle( str, 0, '...' );
 * // returns ''
 *
 * @example
 * var str = 'beep boop';
-* var out = truncateMiddle( str, 2 );
+* var out = truncateMiddle( str, 2, '...' );
 * // returns '..'
 */
 function truncateMiddle( str, len, seq ) {
@@ -71,7 +71,6 @@ function truncateMiddle( str, len, seq ) {
 	var idx1;
 	var idx2;
 
-	seq = seq || '...';
 	seqLength = numCodePoints( seq );
 	strLength = numCodePoints( str );
 	fromIdx = 0;

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/package.json
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@stdlib/string/base/truncate-middle-code-point",
+  "version": "0.0.0",
+  "description": "Truncate code points of string in the middle to a specified length.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdstring",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "string",
+    "str",
+    "base",
+    "truncate",
+    "middle",
+    "character",
+    "char",
+    "codeunit",
+    "unicode"
+  ]
+}

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/package.json
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/string/base/truncate-middle-code-point",
   "version": "0.0.0",
-  "description": "Truncate code points of string in the middle to a specified length.",
+  "description": "Truncate code points in the middle of a string in order to return a string having a specified length.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/test/test.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/test/test.js
@@ -41,25 +41,25 @@ tape( 'the function truncates a string to the specified length', function test( 
 	str = 'beep boop';
 	len = 5;
 	expected = 'b...p';
-	actual = truncateMiddle( str, len );
+	actual = truncateMiddle( str, len, '...' );
 	t.strictEqual( actual, expected, 'returns expected value' );
 
 	str = 'beep boop';
 	len = 10;
 	expected = 'beep boop';
-	actual = truncateMiddle( str, len );
+	actual = truncateMiddle( str, len, '...' );
 	t.strictEqual( actual, expected, 'returns expected value' );
 
 	str = 'beep boop';
 	len = 0;
 	expected = '';
-	actual = truncateMiddle( str, len );
+	actual = truncateMiddle( str, len, '...' );
 	t.strictEqual( actual, expected, 'returns expected value' );
 
 	str = 'beep boop';
 	len = 1;
 	expected = '.';
-	actual = truncateMiddle( str, len );
+	actual = truncateMiddle( str, len, '...' );
 	t.strictEqual( actual, expected, 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/test/test.js
+++ b/lib/node_modules/@stdlib/string/base/truncate-middle-code-point/test/test.js
@@ -1,0 +1,93 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var truncateMiddle = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof truncateMiddle, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function truncates a string to the specified length', function test( t ) {
+	var expected;
+	var actual;
+	var str;
+	var len;
+
+	str = 'beep boop';
+	len = 5;
+	expected = 'b...p';
+	actual = truncateMiddle( str, len );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 10;
+	expected = 'beep boop';
+	actual = truncateMiddle( str, len );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 0;
+	expected = '';
+	actual = truncateMiddle( str, len );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 1;
+	expected = '.';
+	actual = truncateMiddle( str, len );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function truncates a string to the specified length (custom replacement sequence)', function test( t ) {
+	var expected;
+	var actual;
+	var str;
+	var len;
+
+	str = 'beep boop';
+	len = 5;
+	expected = 'be|op';
+	actual = truncateMiddle( str, len, '|' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 10;
+	expected = 'beep boop';
+	actual = truncateMiddle( str, len, '!' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	str = 'beep boop';
+	len = 3;
+	expected = 'b!p';
+	actual = truncateMiddle( str, len, '!' );
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	t.end();
+});


### PR DESCRIPTION
Part of https://github.com/stdlib-js/stdlib/issues/1062

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds `@stdlib/string/base/truncate-middle-code-point`

## Related Issues

> Does this pull request have any related issues?

This pull request:

- Part of https://github.com/stdlib-js/stdlib/issues/1062

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

This PR depends on the packages,

- `@stdlib/string/num-code-points` available in https://github.com/stdlib-js/stdlib/pull/1097
- `@stdlib/string/next-code-point` available in https://github.com/stdlib-js/stdlib/pull/1117

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
