### PR TITLE
feat: add support for the typed array `at` method in `array/complex64`

### DIFF
--- a/lib/node_modules/@stdlib/array/complex64/README.md
+++ b/lib/node_modules/@stdlib/array/complex64/README.md
@@ -752,7 +752,7 @@ var bool = it.next().done;
 
 #### Complex64Array.prototype.get( i )
 
-Returns an array element located at non negative integer position (index) `i`.
+Returns an array element located at a nonnegative integer position (index) `i`.
 
 ```javascript
 var realf = require( '@stdlib/complex/realf' );
@@ -795,7 +795,7 @@ var imagf = require( '@stdlib/complex/imagf' );
 
 var arr = new Complex64Array( 10 );
 
-// Set the first, second and last element:
+// Set the first, second, and last elements:
 arr.set( [ 1.0, -1.0 ], 0 );
 arr.set( [ 2.0, -2.0 ], 1 );
 arr.set( [ 9.0, -9.0 ], 9 );
@@ -810,7 +810,7 @@ var re = realf( z );
 var im = imagf( z );
 // returns -1.0
 
-// Get the element at index -1:
+// Get the last element:
 z = arr.at( -1 );
 // returns <Complex64>
 

--- a/lib/node_modules/@stdlib/array/complex64/README.md
+++ b/lib/node_modules/@stdlib/array/complex64/README.md
@@ -787,7 +787,7 @@ var z = arr.get( 100 );
 
 #### Complex64Array.prototype.at( i )
 
-Returns an array element located at integer position (index) `i`.
+Returns an array element located at integer position (index) `i`, with support for both nonnegative and negative integer positions.
 
 ```javascript
 var realf = require( '@stdlib/complex/realf' );

--- a/lib/node_modules/@stdlib/array/complex64/README.md
+++ b/lib/node_modules/@stdlib/array/complex64/README.md
@@ -752,7 +752,7 @@ var bool = it.next().done;
 
 #### Complex64Array.prototype.get( i )
 
-Returns an array element located at position (index) `i`.
+Returns an array element located at non negative integer position (index) `i`.
 
 ```javascript
 var realf = require( '@stdlib/complex/realf' );
@@ -780,6 +780,56 @@ If provided an out-of-bounds index, the method returns `undefined`.
 var arr = new Complex64Array( 10 );
 
 var z = arr.get( 100 );
+// returns undefined
+```
+
+<a name="method-at"></a>
+
+#### Complex64Array.prototype.at( i )
+
+Returns an array element located at integer position (index) `i`.
+
+```javascript
+var realf = require( '@stdlib/complex/realf' );
+var imagf = require( '@stdlib/complex/imagf' );
+
+var arr = new Complex64Array( 10 );
+
+// Set the first, second and last element:
+arr.set( [ 1.0, -1.0 ], 0 );
+arr.set( [ 2.0, -2.0 ], 1 );
+arr.set( [ 9.0, -9.0 ], 9 );
+
+// Get the first element:
+var z = arr.at( 0 );
+// returns <Complex64>
+
+var re = realf( z );
+// returns 1.0
+
+var im = imagf( z );
+// returns -1.0
+
+// Get the element at index -1:
+z = arr.at( -1 );
+// returns <Complex64>
+
+re = realf( z );
+// returns 9.0
+
+im = imagf( z );
+// returns -9.0
+```
+
+If provided an out-of-bounds index, the method returns `undefined`.
+
+```javascript
+var arr = new Complex64Array( 10 );
+
+var z = arr.at( 100 );
+// returns undefined
+
+z = arr.at( -100 );
 // returns undefined
 ```
 

--- a/lib/node_modules/@stdlib/array/complex64/benchmark/benchmark.at.js
+++ b/lib/node_modules/@stdlib/array/complex64/benchmark/benchmark.at.js
@@ -1,0 +1,58 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var Complex64 = require( '@stdlib/complex/float32' );
+var isComplex64 = require( '@stdlib/assert/is-complex64' );
+var pkg = require( './../package.json' ).name;
+var Complex64Array = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg+':at', function benchmark( b ) {
+	var arr;
+	var N;
+	var z;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < 10; i++ ) {
+		arr.push( new Complex64( i, i ) );
+	}
+	arr = new Complex64Array( arr );
+	N = arr.length;
+
+	b.tic();
+	for ( i = -b.iterations; i < b.iterations; i++ ) {
+		z = arr.at( i%N );
+		if ( typeof z !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+	if ( !isComplex64( z ) ) {
+		b.fail( 'should return a complex number' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/array/complex64/benchmark/benchmark.at.js
+++ b/lib/node_modules/@stdlib/array/complex64/benchmark/benchmark.at.js
@@ -29,7 +29,7 @@ var Complex64Array = require( './../lib' );
 
 // MAIN //
 
-bench( pkg+':at', function benchmark( b ) {
+bench( pkg+'::nonnegative_indices:at', function benchmark( b ) {
 	var arr;
 	var N;
 	var z;
@@ -43,8 +43,36 @@ bench( pkg+':at', function benchmark( b ) {
 	N = arr.length;
 
 	b.tic();
-	for ( i = -b.iterations; i < b.iterations; i++ ) {
+	for ( i = 0; i < b.iterations; i++ ) {
 		z = arr.at( i%N );
+		if ( typeof z !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+	if ( !isComplex64( z ) ) {
+		b.fail( 'should return a complex number' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::negative_indices:at', function benchmark( b ) {
+	var arr;
+	var N;
+	var z;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < 10; i++ ) {
+		arr.push( new Complex64( i, i ) );
+	}
+	arr = new Complex64Array( arr );
+	N = arr.length;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		z = arr.at( -(i%N)-1 );
 		if ( typeof z !== 'object' ) {
 			b.fail( 'should return an object' );
 		}

--- a/lib/node_modules/@stdlib/array/complex64/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex64/docs/types/index.d.ts
@@ -234,6 +234,33 @@ declare class Complex64Array implements Complex64ArrayInterface {
 	get( i: number ): Complex64 | void;
 
 	/**
+	* Returns an array element at any integer index.
+	*
+	* @param i - element index
+	* @throws index argument must be a integer
+	* @returns array element
+	*
+	* @example
+	* var arr = new Complex64Array( 10 );
+	*
+	* var z = arr.at( 0 );
+	* // returns <Complex64>
+	*
+	* arr.set( [ 1.0, -1.0 ], 0 );
+	* arr.set( [ 9.0, -9.0 ], 9 );
+	*
+	* z = arr.get( -1 )
+	* // return <Complex64>
+	*
+	* z = arr.at( 100 );
+	* // returns undefined
+	*
+	* z = arr.at( -100 );
+	* // returns undefined
+	*/
+	at( i: number ): Complex64 | void;
+
+	/**
 	* Sets an array element.
 	*
 	* ## Notes

--- a/lib/node_modules/@stdlib/array/complex64/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex64/docs/types/index.d.ts
@@ -234,7 +234,7 @@ declare class Complex64Array implements Complex64ArrayInterface {
 	get( i: number ): Complex64 | void;
 
 	/**
-	* Returns an array element at any integer index.
+	* Returns an array element with support for both nonnegative and negative integer indices.
 	*
 	* @param i - element index
 	* @throws index argument must be a integer

--- a/lib/node_modules/@stdlib/array/complex64/lib/main.js
+++ b/lib/node_modules/@stdlib/array/complex64/lib/main.js
@@ -846,7 +846,7 @@ setReadOnly( Complex64Array.prototype, 'get', function get( idx ) {
 });
 
 /**
-* Returns an array element at any integer index.
+* Returns an array element with support for both nonnegative and negative integer indices.
 *
 * @name at
 * @memberof Complex64Array.prototype
@@ -906,13 +906,13 @@ setReadOnly( Complex64Array.prototype, 'at', function at( idx ) {
 	if ( !isInteger( idx ) ) {
 		throw new TypeError( format( 'invalid argument. Must provide a integer. Value: `%s`.', idx ) );
 	}
-	if ( idx < -this._length || idx >= this._length ) {
-		return;
-	}
-	buf = this._buffer;
 	if ( idx < 0 ) {
 		idx += this._length;
 	}
+	if ( idx < 0 || idx >= this._length ) {
+		return;
+	}
+	buf = this._buffer;
 	idx *= 2;
 	return new Complex64( buf[ idx ], buf[ idx+1 ] );
 });

--- a/lib/node_modules/@stdlib/array/complex64/lib/main.js
+++ b/lib/node_modules/@stdlib/array/complex64/lib/main.js
@@ -846,6 +846,78 @@ setReadOnly( Complex64Array.prototype, 'get', function get( idx ) {
 });
 
 /**
+* Returns an array element at any integer index.
+*
+* @name at
+* @memberof Complex64Array.prototype
+* @type {Function}
+* @param {integer} idx - element index
+* @throws {TypeError} `this` must be a complex number array
+* @throws {TypeError} must provide a integer
+* @returns {(Complex64|void)} array element
+*
+* @example
+* var arr = new Complex64Array( 10 );
+* var realf = require( '@stdlib/complex/realf' );
+* var imagf = require( '@stdlib/complex/imagf' );
+*
+* var z = arr.at( 0 );
+* // returns <Complex64>
+*
+* var re = realf( z );
+* // returns 0.0
+*
+* var im = imagf( z );
+* // returns 0.0
+*
+* arr.set( [ 1.0, -1.0 ], 0 );
+* arr.set( [ 2.0, -2.0 ], 1 );
+* arr.set( [ 9.0, -9.0 ], 9 );
+*
+* z = arr.at( 0 );
+* // returns <Complex64>
+*
+* re = realf( z );
+* // returns 1.0
+*
+* im = imagf( z );
+* // returns -1.0
+*
+* z = arr.at( -1 );
+* // returns <Complex64>
+*
+* re = realf( z );
+* // returns 9.0
+*
+* im = imagf( z );
+* // returns -9.0
+*
+* z = arr.at( 100 );
+* // returns undefined
+*
+* z = arr.at( -100 );
+* // returns undefined
+*/
+setReadOnly( Complex64Array.prototype, 'at', function at( idx ) {
+	var buf;
+	if ( !isComplexArray( this ) ) {
+		throw new TypeError( 'invalid invocation. `this` is not a complex number array.' );
+	}
+	if ( !isInteger( idx ) ) {
+		throw new TypeError( format( 'invalid argument. Must provide a integer. Value: `%s`.', idx ) );
+	}
+	if ( idx < -this._length || idx >= this._length ) {
+		return;
+	}
+	buf = this._buffer;
+	if ( idx < 0 ) {
+		idx += this._length;
+	}
+	idx *= 2;
+	return new Complex64( buf[ idx ], buf[ idx+1 ] );
+});
+
+/**
 * Number of array elements.
 *
 * @name length
@@ -885,7 +957,6 @@ setReadOnlyAccessor( Complex64Array.prototype, 'length', function get() {
 *     ```
 *
 *     by the time we begin copying into the overlapping region, we are copying from the end of `src`, a non-overlapping region, which means we don't run the risk of copying copied values, rather than the original `src` values as intended.
-*
 *
 * @name set
 * @memberof Complex64Array.prototype

--- a/lib/node_modules/@stdlib/array/complex64/test/test.at.js
+++ b/lib/node_modules/@stdlib/array/complex64/test/test.at.js
@@ -37,7 +37,7 @@ tape( 'main export is a function', function test( t ) {
 	t.end();
 });
 
-tape( 'attached to the prototype of the main export is a `at` method for returning an array element', function test( t ) {
+tape( 'attached to the prototype of the main export is an `at` method for returning an array element', function test( t ) {
 	t.strictEqual( hasOwnProp( Complex64Array.prototype, 'at' ), true, 'has property' );
 	t.strictEqual( isFunction( Complex64Array.prototype.at ), true, 'has method' );
 	t.end();
@@ -114,8 +114,7 @@ tape( 'the method returns `undefined` if provided an index which exceeds array d
 		if ( i < 0 ) {
 			v = arr.at( i-arr.length );
 			t.strictEqual( v, void 0, 'returns expected value for index '+(i-arr.length) );
-		}
-		else {
+		} else {
 			v = arr.at( arr.length+i );
 			t.strictEqual( v, void 0, 'returns expected value for index '+(arr.length+i) );
 		}

--- a/lib/node_modules/@stdlib/array/complex64/test/test.at.js
+++ b/lib/node_modules/@stdlib/array/complex64/test/test.at.js
@@ -1,0 +1,148 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var Complex64 = require( '@stdlib/complex/float32' );
+var realf = require( '@stdlib/complex/realf' );
+var imagf = require( '@stdlib/complex/imagf' );
+var Complex64Array = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof Complex64Array, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the main export is a `at` method for returning an array element', function test( t ) {
+	t.strictEqual( hasOwnProp( Complex64Array.prototype, 'at' ), true, 'has property' );
+	t.strictEqual( isFunction( Complex64Array.prototype.at ), true, 'has method' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a complex number array instance', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new Complex64Array( 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[]
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.at.call( value, 0 );
+		};
+	}
+});
+
+tape( 'the method throws an error if provided an index argument which is not a integer', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new Complex64Array( 10 );
+
+	values = [
+		'5',
+		3.14,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.at( value );
+		};
+	}
+});
+
+tape( 'the method returns `undefined` if provided an index which exceeds array dimensions', function test( t ) {
+	var arr;
+	var v;
+	var i;
+
+	arr = new Complex64Array( 10 );
+	for ( i = -arr.length; i < arr.length; i++ ) {
+		if ( i < 0 ) {
+			v = arr.at( i-arr.length );
+			t.strictEqual( v, void 0, 'returns expected value for index '+(i-arr.length) );
+		}
+		else {
+			v = arr.at( arr.length+i );
+			t.strictEqual( v, void 0, 'returns expected value for index '+(arr.length+i) );
+		}
+	}
+	t.end();
+});
+
+tape( 'the method returns an array element', function test( t ) {
+	var arr;
+	var v;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < 10; i++ ) {
+		arr.push( new Complex64( i, -i ) );
+	}
+	arr = new Complex64Array( arr );
+
+	for ( i = -arr.length; i < arr.length; i++ ) {
+		v = arr.at( i );
+		if ( i < 0 ) {
+			t.strictEqual( realf( v ), arr.length + i, 'returns expected real component for index '+i );
+			t.strictEqual( imagf( v ), -arr.length - i, 'returns expected imaginary component for index '+i );
+		} else {
+			t.strictEqual( realf( v ), i, 'returns expected real component for index '+i );
+			t.strictEqual( imagf( v ), -i, 'returns expected imaginary component for index '+i );
+		}
+	}
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Adds the typed array `at` method to prototype of `Complex64Array`.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
