### PR TITLE
feat: add support for the typed array `some` method in `array/complex64`

### DIFF
--- a/lib/node_modules/@stdlib/array/complex64/README.md
+++ b/lib/node_modules/@stdlib/array/complex64/README.md
@@ -1027,7 +1027,7 @@ A few notes:
 
 #### Complex64Array.prototype.some( predicate\[, thisArg] )
 
-Returns a boolean indicating whether atleast one element pass a test.
+Returns a boolean indicating whether at least one element passes a test.
 
 ```javascript
 var realf = require( '@stdlib/complex/realf' );
@@ -1044,12 +1044,12 @@ arr.set( [ 1.0, -1.0 ], 0 );
 arr.set( [ 2.0, 2.0 ], 1 );
 arr.set( [ 3.0, -3.0 ], 2 );
 
-// Check whether all elements pass a test:
+// Check whether at least one element passes a test:
 var z = arr.some( predicate );
 // returns true
 ```
 
-The `predicate` function is provided four arguments:
+The `predicate` function is provided three arguments:
 
 -   **value**: current array element.
 -   **index**: current array element index.

--- a/lib/node_modules/@stdlib/array/complex64/README.md
+++ b/lib/node_modules/@stdlib/array/complex64/README.md
@@ -1023,6 +1023,67 @@ A few notes:
 -   If a target array cannot accommodate all values (i.e., the length of source array plus `i` exceeds the target array length), the method throws an error.
 -   If provided a [typed array][@stdlib/array/typed] which shares an [`ArrayBuffer`][@stdlib/array/buffer] with the target array, the method will intelligently copy the source range to the destination range.
 
+<a name="method-some"></a>
+
+#### Complex64Array.prototype.some( predicate\[, thisArg] )
+
+Returns a boolean indicating whether atleast one element pass a test.
+
+```javascript
+var realf = require( '@stdlib/complex/realf' );
+var imagf = require( '@stdlib/complex/imagf' );
+
+function predicate( v ) {
+    return ( realf( v ) === imagf( v ) );
+}
+
+var arr = new Complex64Array( 3 );
+
+// Set the first three elements:
+arr.set( [ 1.0, -1.0 ], 0 );
+arr.set( [ 2.0, 2.0 ], 1 );
+arr.set( [ 3.0, -3.0 ], 2 );
+
+// Check whether all elements pass a test:
+var z = arr.some( predicate );
+// returns true
+```
+
+The `predicate` function is provided four arguments:
+
+-   **value**: current array element.
+-   **index**: current array element index.
+-   **arr**: the array on which this method was called.
+
+To set the function execution context, provide a `thisArg`.
+
+```javascript
+var realf = require( '@stdlib/complex/realf' );
+var imagf = require( '@stdlib/complex/imagf' );
+
+function predicate( v, i ) {
+    this.count += 1;
+    return ( imagf( v ) === realf( v ) );
+}
+
+var arr = new Complex64Array( 3 );
+
+var context = {
+    'count': 0
+};
+
+// Set the first three elements:
+arr.set( [ 1.0, -1.0 ], 0 );
+arr.set( [ 2.0, 2.0 ], 1 );
+arr.set( [ 3.0, -3.0 ], 2 );
+
+var z = arr.some( predicate, context );
+// returns true
+
+var count = context.count;
+// returns 2
+```
+
 </section>
 
 <!-- /.usage -->

--- a/lib/node_modules/@stdlib/array/complex64/benchmark/benchmark.some.js
+++ b/lib/node_modules/@stdlib/array/complex64/benchmark/benchmark.some.js
@@ -1,0 +1,56 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isComplex64 = require( '@stdlib/assert/is-complex64' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var pkg = require( './../package.json' ).name;
+var Complex64Array = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg+':some', function benchmark( b ) {
+	var bool;
+	var arr;
+	var i;
+
+	arr = new Complex64Array( [ 1, 3, 4, 5 ] );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		bool = arr.some( predicate );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+
+	function predicate( v ) {
+		return isComplex64( v );
+	}
+});

--- a/lib/node_modules/@stdlib/array/complex64/benchmark/benchmark.some.length.js
+++ b/lib/node_modules/@stdlib/array/complex64/benchmark/benchmark.some.length.js
@@ -1,0 +1,118 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var pow = require( '@stdlib/math/base/special/pow' );
+var Complex64 = require( '@stdlib/complex/float32' );
+var realf = require( '@stdlib/complex/realf' );
+var imagf = require( '@stdlib/complex/imagf' );
+var pkg = require( './../package.json' ).name;
+var Complex64Array = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Predicate function.
+*
+* @private
+* @param {Complex64} value - array element
+* @param {NonNegativeInteger} idx - array element index
+* @param {Complex64Array} arr - array instance
+* @returns {boolean} boolean indicating whether a value passes a test
+*/
+function predicate( value ) {
+	return ( realf( value ) === imagf( value ) );
+}
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var arr;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < len; i++ ) {
+		arr.push( new Complex64( i, i ) );
+	}
+	arr = new Complex64Array( arr );
+
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var bool;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			bool = arr.some( predicate );
+			if ( typeof bool !== 'boolean' ) {
+				b.fail( 'should return a boolean' );
+			}
+		}
+		b.toc();
+		if ( !isBoolean( bool ) ) {
+			b.fail( 'should return a boolean' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':some:len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/complex64/benchmark/benchmark.some.length.js
+++ b/lib/node_modules/@stdlib/array/complex64/benchmark/benchmark.some.length.js
@@ -57,9 +57,10 @@ function createBenchmark( len ) {
 	var i;
 
 	arr = [];
-	for ( i = 0; i < len; i++ ) {
-		arr.push( new Complex64( i, i ) );
+	for ( i = 0; i < len-1; i++ ) {
+		arr.push( new Complex64( i, -i ) );
 	}
+	arr.push( new Complex64( i, i ) );
 	arr = new Complex64Array( arr );
 
 	return benchmark;

--- a/lib/node_modules/@stdlib/array/complex64/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex64/docs/types/index.d.ts
@@ -427,7 +427,7 @@ declare class Complex64Array implements Complex64ArrayInterface {
 	*
 	* @param predicate - test function
 	* @param thisArg - execution context
-	* @returns boolean indicating whether atleast one element pass a test
+	* @returns boolean indicating whether at least one element passes a test
 	*
 	* @example
 	* var realf = require( '@stdlib/complex/realf' );
@@ -439,9 +439,9 @@ declare class Complex64Array implements Complex64ArrayInterface {
 	*
 	* var arr = new Complex64Array( 3 );
 	*
-	* arr.set( [ 1.0 , 1.0 ], 0 );
+	* arr.set( [ 1.0 , -1.0 ], 0 );
 	* arr.set( [ 2.0 , 2.0 ], 1 );
-	* arr.set( [ 3.0 , 3.0 ], 2 );
+	* arr.set( [ 3.0 , -3.0 ], 2 );
 	*
 	* var bool = arr.some( predicate );
 	* // returns true

--- a/lib/node_modules/@stdlib/array/complex64/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex64/docs/types/index.d.ts
@@ -423,7 +423,7 @@ declare class Complex64Array implements Complex64ArrayInterface {
 	set( value: ArrayLike<number | ComplexLike> | RealOrComplexTypedArray | ComplexLike, i?: number ): void;
 
 	/**
-	* Tests whether atleast one element in an array pass a test implemented by a predicate function.
+	* Tests whether at least one element in an array passes a test implemented by a predicate function.
 	*
 	* @param predicate - test function
 	* @param thisArg - execution context

--- a/lib/node_modules/@stdlib/array/complex64/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex64/docs/types/index.d.ts
@@ -421,6 +421,32 @@ declare class Complex64Array implements Complex64ArrayInterface {
 	* // returns -1.0
 	*/
 	set( value: ArrayLike<number | ComplexLike> | RealOrComplexTypedArray | ComplexLike, i?: number ): void;
+
+	/**
+	* Tests whether atleast one element in an array pass a test implemented by a predicate function.
+	*
+	* @param predicate - test function
+	* @param thisArg - execution context
+	* @returns boolean indicating whether atleast one element pass a test
+	*
+	* @example
+	* var realf = require( '@stdlib/complex/realf' );
+	* var imagf = require( '@stdlib/complex/imagf' );
+	*
+	* function predicate( v ) {
+	*     return ( realf( v ) === imagf( v ) );
+	* }
+	*
+	* var arr = new Complex64Array( 3 );
+	*
+	* arr.set( [ 1.0 , 1.0 ], 0 );
+	* arr.set( [ 2.0 , 2.0 ], 1 );
+	* arr.set( [ 3.0 , 3.0 ], 2 );
+	*
+	* var bool = arr.some( predicate );
+	* // returns true
+	*/
+	some<U = unknown>( predicate: Predicate, thisArg?: ThisParameterType<Predicate<U>> ): boolean;
 }
 
 /**

--- a/lib/node_modules/@stdlib/array/complex64/lib/main.js
+++ b/lib/node_modules/@stdlib/array/complex64/lib/main.js
@@ -1181,7 +1181,7 @@ setReadOnly( Complex64Array.prototype, 'set', function set( value ) {
 });
 
 /**
-* Tests whether atleast one element in an array pass a test implemented by a predicate function.
+* Tests whether at least one element in an array passes a test implemented by a predicate function.
 *
 * @name some
 * @memberof Complex64Array.prototype
@@ -1190,7 +1190,7 @@ setReadOnly( Complex64Array.prototype, 'set', function set( value ) {
 * @param {*} [thisArg] - predicate function execution context
 * @throws {TypeError} `this` must be a complex number array
 * @throws {TypeError} first argument must be a function
-* @returns {boolean} boolean indicating whether atleast one element pass a test
+* @returns {boolean} boolean indicating whether at least one element passes a test
 *
 * @example
 * var realf = require( '@stdlib/complex/realf' );

--- a/lib/node_modules/@stdlib/array/complex64/lib/main.js
+++ b/lib/node_modules/@stdlib/array/complex64/lib/main.js
@@ -1180,6 +1180,53 @@ setReadOnly( Complex64Array.prototype, 'set', function set( value ) {
 	/* eslint-enable no-underscore-dangle */
 });
 
+/**
+* Tests whether atleast one element in an array pass a test implemented by a predicate function.
+*
+* @name some
+* @memberof Complex64Array.prototype
+* @type {Function}
+* @param {Function} predicate - test function
+* @param {*} [thisArg] - predicate function execution context
+* @throws {TypeError} `this` must be a complex number array
+* @throws {TypeError} first argument must be a function
+* @returns {boolean} boolean indicating whether atleast one element pass a test
+*
+* @example
+* var realf = require( '@stdlib/complex/realf' );
+* var imagf = require( '@stdlib/complex/imagf' );
+*
+* function predicate( v ) {
+*     return ( realf( v ) === imagf( v ) );
+* }
+*
+* var arr = new Complex64Array( 3 );
+*
+* arr.set( [ 1.0, -1.0 ], 0 );
+* arr.set( [ 2.0, 2.0 ], 1 );
+* arr.set( [ 3.0, -3.0 ], 2 );
+*
+* var bool = arr.some( predicate );
+* // returns true
+*/
+setReadOnly( Complex64Array.prototype, 'some', function some( predicate, thisArg ) {
+	var buf;
+	var i;
+	if ( !isComplexArray( this ) ) {
+		throw new TypeError( 'invalid invocation. `this` is not a complex number array.' );
+	}
+	if ( !isFunction( predicate ) ) {
+		throw new TypeError( format( 'invalid argument. First argument must be a function. Value: `%s`.', predicate ) );
+	}
+	buf = this._buffer;
+	for ( i = 0; i < this._length; i++ ) {
+		if ( predicate.call( thisArg, getComplex64( buf, i ), i, this ) ) {
+			return true;
+		}
+	}
+	return false;
+});
+
 
 // EXPORTS //
 

--- a/lib/node_modules/@stdlib/array/complex64/test/test.some.js
+++ b/lib/node_modules/@stdlib/array/complex64/test/test.some.js
@@ -77,7 +77,7 @@ tape( 'the method throws an error if invoked with a `this` context which is not 
 	}
 });
 
-tape( 'the method throws an error if provided an first argument which is not a function', function test( t ) {
+tape( 'the method throws an error if provided a first argument which is not a function', function test( t ) {
 	var values;
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/array/complex64/test/test.some.js
+++ b/lib/node_modules/@stdlib/array/complex64/test/test.some.js
@@ -1,0 +1,197 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var realf = require( '@stdlib/complex/realf' );
+var imagf = require( '@stdlib/complex/imagf' );
+var Complex64Array = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof Complex64Array, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the main export is an `some` method for returning boolean indicating whether atleast one element pass a test', function test( t ) {
+	t.strictEqual( hasOwnProp( Complex64Array.prototype, 'some' ), true, 'has property' );
+	t.strictEqual( isFunction( Complex64Array.prototype.some ), true, 'has method' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a complex number array instance', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new Complex64Array( 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.some.call( value, predicate );
+		};
+	}
+
+	function predicate( v ) {
+		return ( realf( v ) > 0 && imagf( v ) < 0 );
+	}
+});
+
+tape( 'the method throws an error if provided an first argument which is not a function', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new Complex64Array( 10 );
+
+	values = [
+		'5',
+		3.14,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[]
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.some( value );
+		};
+	}
+});
+
+tape( 'the method returns `false` if provided an empty complex number array', function test( t ) {
+	var bool;
+	var arr;
+
+	arr = new Complex64Array();
+	bool = arr.some( predicate );
+
+	t.strictEqual( bool, false, 'returns expected value' );
+	t.end();
+
+	function predicate() {
+		t.fail( 'should not be invoked' );
+	}
+});
+
+tape( 'the method returns `true` if atleast one element pass a test', function test( t ) {
+	var bool;
+	var arr;
+
+	arr = new Complex64Array( [ 1.0, 1.0, 1.0, 2.0 ] );
+	bool = arr.some( predicate );
+
+	t.strictEqual( bool, true, 'returns expected value' );
+	t.end();
+
+	function predicate( v ) {
+		return ( realf( v ) === imagf( v ) );
+	}
+});
+
+tape( 'the method returns `false` if all elements fail a test', function test( t ) {
+	var bool;
+	var arr;
+
+	arr = new Complex64Array( [ 1.0, -1.0, 2.0, -2.0, 3.0, -3.0 ] );
+	bool = arr.some( predicate );
+
+	t.strictEqual( bool, false, 'returns expected value' );
+	t.end();
+
+	function predicate( v ) {
+		return ( realf( v ) === imagf( v ) );
+	}
+});
+
+tape( 'the method supports providing an execution context', function test( t ) {
+	var bool;
+	var ctx;
+	var arr;
+
+	ctx = {
+		'count': 0
+	};
+	arr = new Complex64Array( [ 1.0, -1.0, 2.0, -2.0, 3.0, 3.0 ] );
+	bool = arr.some( predicate, ctx );
+
+	t.strictEqual( bool, true, 'returns expected value' );
+	t.strictEqual( ctx.count, 3, 'returns expected value');
+
+	t.end();
+
+	function predicate( v ) {
+		this.count += 1; // eslint-disable-line no-invalid-this
+		return ( imagf( v ) === realf( v ) );
+	}
+});
+
+tape( 'the method stop executing when any element pass a test', function test( t ) {
+	var bool;
+	var ctx;
+	var arr;
+
+	ctx = {
+		'count': 0
+	};
+	arr = new Complex64Array( [ 1.0, 1.0, 2.0, 2.0, 3.0, 3.0 ] );
+	bool = arr.some( predicate, ctx );
+
+	t.strictEqual( bool, true, 'returns expected value' );
+	t.strictEqual( ctx.count, 1, 'returns expected value');
+
+	t.end();
+
+	function predicate( v ) {
+		this.count += 1; // eslint-disable-line no-invalid-this
+		return ( imagf( v ) === realf( v ) );
+	}
+});

--- a/lib/node_modules/@stdlib/array/complex64/test/test.some.js
+++ b/lib/node_modules/@stdlib/array/complex64/test/test.some.js
@@ -36,7 +36,7 @@ tape( 'main export is a function', function test( t ) {
 	t.end();
 });
 
-tape( 'attached to the prototype of the main export is an `some` method for returning boolean indicating whether atleast one element pass a test', function test( t ) {
+tape( 'attached to the prototype of the main export is a `some` method for returning boolean indicating whether at least one element passes a test', function test( t ) {
 	t.strictEqual( hasOwnProp( Complex64Array.prototype, 'some' ), true, 'has property' );
 	t.strictEqual( isFunction( Complex64Array.prototype.some ), true, 'has method' );
 	t.end();
@@ -122,7 +122,7 @@ tape( 'the method returns `false` if provided an empty complex number array', fu
 	}
 });
 
-tape( 'the method returns `true` if atleast one element pass a test', function test( t ) {
+tape( 'the method returns `true` if at least one element passes a test', function test( t ) {
 	var bool;
 	var arr;
 
@@ -174,7 +174,7 @@ tape( 'the method supports providing an execution context', function test( t ) {
 	}
 });
 
-tape( 'the method stop executing when any element pass a test', function test( t ) {
+tape( 'the method stops executing upon encountering the first element which passes a test', function test( t ) {
 	var bool;
 	var ctx;
 	var arr;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Adds the typed array `some` method to prototype of `Complex64Array`

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
