### PR TITLE
fix: add support for negative indices in method `indexOf` and `lastIndexOf`

### DIFF
--- a/lib/node_modules/@stdlib/array/complex64/README.md
+++ b/lib/node_modules/@stdlib/array/complex64/README.md
@@ -900,7 +900,7 @@ Returns the first index at which a given element can be found.
 ```javascript
 var Complex64 = require( '@stdlib/complex/float32' );
 
-var arr = new Complex64Array( 10 );
+var arr = new Complex64Array( 5 );
 
 arr.set( [ 1.0, -1.0 ], 0 );
 arr.set( [ 2.0, -2.0 ], 1 );
@@ -913,6 +913,9 @@ var idx = arr.indexOf( new Complex64( 3.0, -3.0 ) );
 
 idx = arr.indexOf( new Complex64( 2.0, -2.0 ), 2 );
 // returns 4
+
+idx = arr.indexOf( new Complex64( 4.0, -4.0 ), -3 );
+// returns 3
 ```
 
 If `searchElement` is not present in the array, the method returns `-1`.
@@ -941,7 +944,7 @@ Returns the last index at which a given element can be found.
 ```javascript
 var Complex64 = require( '@stdlib/complex/float32' );
 
-var arr = new Complex64Array( 10 );
+var arr = new Complex64Array( 5 );
 
 arr.set( [ 1.0, -1.0 ], 0 );
 arr.set( [ 2.0, -2.0 ], 1 );
@@ -954,6 +957,9 @@ var idx = arr.lastIndexOf( new Complex64( 3.0, -3.0 ) );
 
 idx = arr.lastIndexOf( new Complex64( 2.0, -2.0 ), 2 );
 // returns 1
+
+idx = arr.lastIndexOf( new Complex64( 4.0, -4.0 ), -1 );
+// returns 3
 ```
 
 If `searchElement` is not present in the array, the method returns `-1`.

--- a/lib/node_modules/@stdlib/array/complex64/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex64/docs/types/index.d.ts
@@ -371,17 +371,21 @@ declare class Complex64Array implements Complex64ArrayInterface {
 	* @returns index or -1
 	*
 	* @example
-	* var arr = new Complex64Array( 10 );
+	* var arr = new Complex64Array( 5 );
 	*
 	* arr.set( [ 1.0, 1.0 ], 0 );
 	* arr.set( [ 2.0, 2.0 ], 1 );
 	* arr.set( [ 3.0, 3.0 ], 2 );
 	* arr.set( [ 2.0, 2.0 ], 3 );
+	* arr.set( [ 5.0, 5.0 ], 4 );
 	*
 	* var idx = arr.indexOf( new Complex64( [ 2.0, 2.0 ] ) );
 	* // returns 1
 	*
 	* idx = arr.indexOf( new Complex64( [ 2.0, 2.0 ] ), 2 );
+	* // returns 3
+	*
+	* idx = arr.indexOf( new Complex64( [ 2.0, 2.0 ] ), -3 );
 	* // returns 3
 	*/
 	indexOf( searchElement: ComplexLike, fromIndex?: number ): number;
@@ -410,8 +414,8 @@ declare class Complex64Array implements Complex64ArrayInterface {
 	* idx = arr.lastIndexOf( new Complex64( 3.0, -3.0 ), 3 );
 	* // returns 2
 	*
-	* idx = arr.lastIndexOf( new Complex64( 5.0, -5.0 ), 3 );
-	* // returns -1
+	* idx = arr.lastIndexOf( new Complex64( 2.0, -2.0 ), -3 );
+	* // returns 1
 	*/
 	lastIndexOf( searchElement: ComplexLike, fromIndex?: number ): number;
 

--- a/lib/node_modules/@stdlib/array/complex64/lib/main.js
+++ b/lib/node_modules/@stdlib/array/complex64/lib/main.js
@@ -1019,7 +1019,8 @@ setReadOnly( Complex64Array.prototype, 'indexOf', function indexOf( searchElemen
 	if ( arguments.length > 1 ) {
 		if ( !isInteger( fromIndex ) ) {
 			throw new TypeError( format( 'invalid argument. Second argument must be an integer. Value: `%s`.', fromIndex ) );
-		} else if ( fromIndex < 0 ) {
+		}
+		if ( fromIndex < 0 ) {
 			fromIndex += this._length;
 			if ( fromIndex < 0 ) {
 				fromIndex = 0;

--- a/lib/node_modules/@stdlib/array/complex64/lib/main.js
+++ b/lib/node_modules/@stdlib/array/complex64/lib/main.js
@@ -981,7 +981,7 @@ setReadOnly( Complex64Array.prototype, 'get', function get( idx ) {
 * @param {integer} [fromIndex=0] - starting index (inclusive)
 * @throws {TypeError} `this` must be a complex number array
 * @throws {TypeError} first argument must be a complex number
-* @throws {TypeError} second argument must be an nonnegative integer
+* @throws {TypeError} second argument must be an integer
 * @returns {integer} index or -1
 *
 * @example
@@ -1000,6 +1000,9 @@ setReadOnly( Complex64Array.prototype, 'get', function get( idx ) {
 *
 * idx = arr.indexOf( new Complex64( 3.0, -3.0 ), 3 );
 * // returns -1
+*
+* idx = arr.indexOf( new Complex64( 4.0, -4.0 ), -3 );
+* // returns -1
 */
 setReadOnly( Complex64Array.prototype, 'indexOf', function indexOf( searchElement, fromIndex ) {
 	var buf;
@@ -1014,8 +1017,13 @@ setReadOnly( Complex64Array.prototype, 'indexOf', function indexOf( searchElemen
 		throw new TypeError( format( 'invalid argument. First argument must be a complex number. Value: `%s`.', searchElement ) );
 	}
 	if ( arguments.length > 1 ) {
-		if ( !isNonNegativeInteger( fromIndex ) ) {
-			throw new TypeError( format( 'invalid argument. Second argument must be a nonnegative integer. Value: `%s`.', fromIndex ) );
+		if ( !isInteger( fromIndex ) ) {
+			throw new TypeError( format( 'invalid argument. Second argument must be an integer. Value: `%s`.', fromIndex ) );
+		} else if ( fromIndex < 0 ) {
+			fromIndex += this._length;
+			if ( fromIndex < 0 ) {
+				fromIndex = 0;
+			}
 		}
 	} else {
 		fromIndex = 0;
@@ -1042,7 +1050,7 @@ setReadOnly( Complex64Array.prototype, 'indexOf', function indexOf( searchElemen
 * @param {integer} [fromIndex] - index at which to start searching backward (inclusive)
 * @throws {TypeError} `this` must be a complex number array
 * @throws {TypeError} first argument must be a complex number
-* @throws {TypeError} second argument must be an nonnegative integer
+* @throws {TypeError} second argument must be an integer
 * @returns {integer} index or -1
 *
 * @example
@@ -1064,6 +1072,9 @@ setReadOnly( Complex64Array.prototype, 'indexOf', function indexOf( searchElemen
 *
 * idx = arr.lastIndexOf( new Complex64( 5.0, -5.0 ), 3 );
 * // returns -1
+*
+* idx = arr.lastIndexOf( new Complex64( 2.0, -2.0 ), -3 );
+* // returns 1
 */
 setReadOnly( Complex64Array.prototype, 'lastIndexOf', function lastIndexOf( searchElement, fromIndex ) {
 	var buf;
@@ -1078,11 +1089,13 @@ setReadOnly( Complex64Array.prototype, 'lastIndexOf', function lastIndexOf( sear
 		throw new TypeError( format( 'invalid argument. First argument must be a complex number. Value: `%s`.', searchElement ) );
 	}
 	if ( arguments.length > 1 ) {
-		if ( !isNonNegativeInteger( fromIndex ) ) {
-			throw new TypeError( format( 'invalid argument. Second argument must be a nonnegative integer. Value: `%s`.', fromIndex ) );
+		if ( !isInteger( fromIndex ) ) {
+			throw new TypeError( format( 'invalid argument. Second argument must be an integer. Value: `%s`.', fromIndex ) );
 		}
 		if ( fromIndex >= this._length ) {
 			fromIndex = this._length - 1;
+		} else if ( fromIndex < 0 ) {
+			fromIndex += this._length;
 		}
 	} else {
 		fromIndex = this._length - 1;

--- a/lib/node_modules/@stdlib/array/complex64/test/test.index_of.js
+++ b/lib/node_modules/@stdlib/array/complex64/test/test.index_of.js
@@ -222,7 +222,7 @@ tape( 'the method supports specifying a starting search index (negative)', funct
 	t.end();
 });
 
-tape( 'when provided a starting index which resolves to an index which is less than zero , the method searches from the first array element', function test( t ) {
+tape( 'when provided a starting index which resolves to an index which is less than zero, the method searches from the first array element', function test( t ) {
 	var idx;
 	var arr;
 

--- a/lib/node_modules/@stdlib/array/complex64/test/test.index_of.js
+++ b/lib/node_modules/@stdlib/array/complex64/test/test.index_of.js
@@ -222,7 +222,7 @@ tape( 'the method supports specifying a starting search index (negative)', funct
 	t.end();
 });
 
-tape( 'the method supports specifying a starting index less than `0` whose absolute value exceeds array length, the method start searching from the first array element', function test( t ) {
+tape( 'when provided a starting index which resolves to an index which is less than zero , the method searches from the first array element', function test( t ) {
 	var idx;
 	var arr;
 

--- a/lib/node_modules/@stdlib/array/complex64/test/test.index_of.js
+++ b/lib/node_modules/@stdlib/array/complex64/test/test.index_of.js
@@ -103,7 +103,7 @@ tape( 'the method throws an error if provided a first argument which is not a co
 	}
 });
 
-tape( 'the method throws an error if provided a second argument which is not a nonnegative integer', function test( t ) {
+tape( 'the method throws an error if provided a second argument which is not an integer', function test( t ) {
 	var values;
 	var arr;
 	var i;
@@ -112,7 +112,6 @@ tape( 'the method throws an error if provided a second argument which is not a n
 
 	values = [
 		'5',
-		-5,
 		3.14,
 		NaN,
 		true,
@@ -200,6 +199,44 @@ tape( 'the method supports specifying a starting search index', function test( t
 	t.strictEqual( idx, 3, 'returns expected value' );
 
 	idx = arr.indexOf( new Complex64( 3.0, 3.0 ), 3 );
+	t.strictEqual( idx, -1, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method supports specifying a starting search index (negative)', function test( t ) {
+	var idx;
+	var arr;
+
+	arr = new Complex64Array( 5 );
+	arr.set( [ 1.0, 1.0 ], 0 );
+	arr.set( [ 2.0, 2.0 ], 1 );
+	arr.set( [ 3.0, 3.0 ], 2 );
+	arr.set( [ 2.0, 2.0 ], 3 );
+	arr.set( [ 2.0, 2.0 ], 4 );
+
+	idx = arr.indexOf( new Complex64( 2.0, 2.0 ), -5 );
+	t.strictEqual( idx, 1, 'returns expected value' );
+
+	idx = arr.indexOf( new Complex64( 4.0, 4.0 ), -2 );
+	t.strictEqual( idx, -1, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method supports specifying a starting index less than `0` whose absolute value exceeds array length, the method start searching from the first array element', function test( t ) {
+	var idx;
+	var arr;
+
+	arr = new Complex64Array( 5 );
+	arr.set( [ 1.0, 1.0 ], 0 );
+	arr.set( [ 2.0, 2.0 ], 1 );
+	arr.set( [ 3.0, 3.0 ], 2 );
+	arr.set( [ 2.0, 2.0 ], 3 );
+	arr.set( [ 2.0, 2.0 ], 4 );
+
+	idx = arr.indexOf( new Complex64( 2.0, 2.0 ), -10 );
+	t.strictEqual( idx, 1, 'returns expected value' );
+
+	idx = arr.indexOf( new Complex64( 4.0, 4.0 ), -10 );
 	t.strictEqual( idx, -1, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/array/complex64/test/test.last_index_of.js
+++ b/lib/node_modules/@stdlib/array/complex64/test/test.last_index_of.js
@@ -103,7 +103,7 @@ tape( 'the method throws an error if provided a first argument which is not a co
 	}
 });
 
-tape( 'the method throws an error if provided a second argument which is not a nonnegative integer', function test( t ) {
+tape( 'the method throws an error if provided a second argument which is not an integer', function test( t ) {
 	var values;
 	var arr;
 	var i;
@@ -112,7 +112,6 @@ tape( 'the method throws an error if provided a second argument which is not a n
 
 	values = [
 		'5',
-		-5,
 		3.14,
 		NaN,
 		true,
@@ -190,6 +189,44 @@ tape( 'the method supports specifying a starting search index', function test( t
 	t.strictEqual( idx, 1, 'returns expected value' );
 
 	idx = arr.lastIndexOf( new Complex64( 3.0, 3.0 ), 1 );
+	t.strictEqual( idx, -1, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method supports specifying a starting search index (negative)', function test( t ) {
+	var idx;
+	var arr;
+
+	arr = new Complex64Array( 5 );
+	arr.set( [ 1.0, 1.0 ], 0 );
+	arr.set( [ 2.0, 2.0 ], 1 );
+	arr.set( [ 3.0, 3.0 ], 2 );
+	arr.set( [ 2.0, 2.0 ], 3 );
+	arr.set( [ 2.0, 2.0 ], 4 );
+
+	idx = arr.lastIndexOf( new Complex64( 2.0, 2.0 ), -3 );
+	t.strictEqual( idx, 1, 'returns expected value' );
+
+	idx = arr.lastIndexOf( new Complex64( 3.0, 3.0 ), -1 );
+	t.strictEqual( idx, 2, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method supports specifying a starting index greater than `0` whose value exceeds array length, the method start searching from the last array element', function test( t ) {
+	var idx;
+	var arr;
+
+	arr = new Complex64Array( 5 );
+	arr.set( [ 1.0, 1.0 ], 0 );
+	arr.set( [ 2.0, 2.0 ], 1 );
+	arr.set( [ 3.0, 3.0 ], 2 );
+	arr.set( [ 2.0, 2.0 ], 3 );
+	arr.set( [ 2.0, 2.0 ], 4 );
+
+	idx = arr.lastIndexOf( new Complex64( 2.0, 2.0 ), 10 );
+	t.strictEqual( idx, 4, 'returns expected value' );
+
+	idx = arr.lastIndexOf( new Complex64( 4.0, 4.0 ), 10 );
 	t.strictEqual( idx, -1, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/array/complex64/test/test.last_index_of.js
+++ b/lib/node_modules/@stdlib/array/complex64/test/test.last_index_of.js
@@ -212,7 +212,7 @@ tape( 'the method supports specifying a starting search index (negative)', funct
 	t.end();
 });
 
-tape( 'the method supports specifying a starting index greater than `0` whose value exceeds array length, the method start searching from the last array element', function test( t ) {
+tape( 'when the method is provided a starting index when exceeds the maximum array index, the method searches from the last array element', function test( t ) {
 	var idx;
 	var arr;
 

--- a/lib/node_modules/@stdlib/array/complex64/test/test.last_index_of.js
+++ b/lib/node_modules/@stdlib/array/complex64/test/test.last_index_of.js
@@ -212,7 +212,7 @@ tape( 'the method supports specifying a starting search index (negative)', funct
 	t.end();
 });
 
-tape( 'when the method is provided a starting index which exceeds the maximum array index, the method searches from the last array element', function test( t ) {
+tape( 'when the method is provided a starting index which resolves to an index which exceeds the maximum array index, the method searches from the last array element', function test( t ) {
 	var idx;
 	var arr;
 

--- a/lib/node_modules/@stdlib/array/complex64/test/test.last_index_of.js
+++ b/lib/node_modules/@stdlib/array/complex64/test/test.last_index_of.js
@@ -212,7 +212,7 @@ tape( 'the method supports specifying a starting search index (negative)', funct
 	t.end();
 });
 
-tape( 'when the method is provided a starting index when exceeds the maximum array index, the method searches from the last array element', function test( t ) {
+tape( 'when the method is provided a starting index which exceeds the maximum array index, the method searches from the last array element', function test( t ) {
 	var idx;
 	var arr;
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Adds support for negative indices in method `indexOf` and `lastIndexOf`.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
