### PR TITLE
feat: add `findIndex` method to `array/complex64`

### DIFF
--- a/lib/node_modules/@stdlib/array/complex64/README.md
+++ b/lib/node_modules/@stdlib/array/complex64/README.md
@@ -856,6 +856,66 @@ var count = context.count;
 // returns 3
 ```
 
+<a name="method-findIndex"></a>
+
+#### Complex64Array.prototype.findIndex( predicate\[, thisArg] )
+
+Returns the index of the first element in an array for which a predicate function returns a truthy value.
+
+```javascript
+var realf = require( '@stdlib/complex/realf' );
+var imagf = require( '@stdlib/complex/imagf' );
+
+function predicate( v ) {
+    return ( realf( v ) === imagf( v ) );
+}
+
+var arr = new Complex64Array( 3 );
+
+// Set the first three elements:
+arr.set( [ 1.0, -1.0 ], 0 );
+arr.set( [ 2.0, -2.0 ], 1 );
+arr.set( [ 3.0, 3.0 ], 2 );
+
+var idx = arr.findIndex( predicate );
+// returns 2
+```
+
+The `predicate` function is provided three arguments:
+
+-   **value**: current array element.
+-   **index**: current array element index.
+-   **arr**: the array on which this method was called.
+
+To set the function execution context, provide a `thisArg`.
+
+```javascript
+var realf = require( '@stdlib/complex/realf' );
+var imagf = require( '@stdlib/complex/imagf' );
+
+function predicate( v, i ) {
+    this.count += 1;
+    return ( i >= 0 && realf( v ) === imagf( v ) );
+}
+
+var arr = new Complex64Array( 3 );
+
+var context = {
+    'count': 0
+};
+
+// Set the first three elements:
+arr.set( [ 1.0, -1.0 ], 0 );
+arr.set( [ 2.0, -2.0 ], 1 );
+arr.set( [ 3.0, -3.0 ], 2 );
+
+var idx = arr.findIndex( predicate, context );
+// returns -1
+
+var count = context.count;
+// returns 3
+```
+
 <a name="method-get"></a>
 
 #### Complex64Array.prototype.get( i )

--- a/lib/node_modules/@stdlib/array/complex64/benchmark/benchmark.find_index.js
+++ b/lib/node_modules/@stdlib/array/complex64/benchmark/benchmark.find_index.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isComplex64 = require( '@stdlib/assert/is-complex64' );
-var isInteger = require('@stdlib/math/base/assert/is-integer');
+var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var pkg = require( './../package.json' ).name;
 var Complex64Array = require( './../lib' );
 

--- a/lib/node_modules/@stdlib/array/complex64/benchmark/benchmark.find_index.js
+++ b/lib/node_modules/@stdlib/array/complex64/benchmark/benchmark.find_index.js
@@ -1,0 +1,56 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isComplex64 = require( '@stdlib/assert/is-complex64' );
+var isInteger = require('@stdlib/math/base/assert/is-integer');
+var pkg = require( './../package.json' ).name;
+var Complex64Array = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg+':findIndex', function benchmark( b ) {
+	var arr;
+	var idx;
+	var i;
+
+	arr = new Complex64Array( [ 1, 2, 3, 4, 5, 6 ] );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		idx = arr.findIndex( predicate );
+		if ( typeof idx !== 'number' ) {
+			b.fail( 'should return an integer' );
+		}
+	}
+	b.toc();
+	if ( !isInteger( idx ) ) {
+		b.fail( 'should return an integer' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+
+	function predicate( v ) {
+		return isComplex64( v );
+	}
+});

--- a/lib/node_modules/@stdlib/array/complex64/benchmark/benchmark.find_index.length.js
+++ b/lib/node_modules/@stdlib/array/complex64/benchmark/benchmark.find_index.length.js
@@ -1,0 +1,119 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var Complex64 = require( '@stdlib/complex/float32' );
+var isInteger = require('@stdlib/math/base/assert/is-integer');
+var realf = require( '@stdlib/complex/realf' );
+var imagf = require( '@stdlib/complex/imagf' );
+var pkg = require( './../package.json' ).name;
+var Complex64Array = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Predicate function.
+*
+* @private
+* @param {Complex64} value - array element
+* @param {NonNegativeInteger} idx - array element index
+* @param {Complex64Array} arr - array instance
+* @returns {boolean} boolean indicating whether a value passes a test
+*/
+function predicate( value ) {
+	return ( realf( value ) === -imagf( value ) );
+}
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var arr;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < len-1; i++ ) {
+		arr.push( new Complex64( i, i ) );
+	}
+	arr.push( new Complex64( len-1, -( len-1 ) ) );
+	arr = new Complex64Array( arr );
+
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var idx;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			idx = arr.findIndex( predicate );
+			if ( typeof idx !== 'number' ) {
+				b.fail( 'should return an integer' );
+			}
+		}
+		b.toc();
+		if ( !isInteger( idx ) && typeof idx !== 'undefined' ) {
+			b.fail( 'should return an integer' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':find:len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/complex64/benchmark/benchmark.find_index.length.js
+++ b/lib/node_modules/@stdlib/array/complex64/benchmark/benchmark.find_index.length.js
@@ -23,7 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var Complex64 = require( '@stdlib/complex/float32' );
-var isInteger = require('@stdlib/math/base/assert/is-integer');
+var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var realf = require( '@stdlib/complex/realf' );
 var imagf = require( '@stdlib/complex/imagf' );
 var pkg = require( './../package.json' ).name;
@@ -83,7 +83,7 @@ function createBenchmark( len ) {
 			}
 		}
 		b.toc();
-		if ( !isInteger( idx ) && typeof idx !== 'undefined' ) {
+		if ( !isInteger( idx ) ) {
 			b.fail( 'should return an integer' );
 		}
 		b.pass( 'benchmark finished' );
@@ -112,7 +112,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':find:len='+len, f );
+		bench( pkg+':findIndex:len='+len, f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/complex64/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex64/docs/types/index.d.ts
@@ -344,6 +344,33 @@ declare class Complex64Array implements Complex64ArrayInterface {
 	every<U = unknown>( predicate: Predicate, thisArg?: ThisParameterType<Predicate<U>> ): boolean;
 
 	/**
+	* Returns the index of the first element in an array for which a predicate function returns a truthy value.
+	*
+	* @param predicate - test function
+	* @param thisArg - execution context
+	* @returns index or -1
+	*
+	* @example
+	* var Complex64 = require( '@stdlib/complex/float32' );
+	* var realf = require( '@stdlib/complex/realf' );
+	* var imagf = require( '@stdlib/complex/imagf' );
+	*
+	* function predicate( v ) {
+	*     return ( realf( v ) === imagf( v ) );
+	* }
+	*
+	* var arr = new Complex64Array( 3 );
+	*
+	* arr.set( [ 1.0, -1.0 ], 0 );
+	* arr.set( [ 2.0, -2.0 ], 1 );
+	* arr.set( [ 3.0, 3.0 ], 2 );
+	*
+	* var idx = arr.findIndex( predicate );
+	* // returns 2
+	*/
+	findIndex<U = unknown>( predicate: Predicate, thisArg?: ThisParameterType<Predicate<U>> ): number;
+
+	/**
 	* Returns an array element.
 	*
 	* @param i - element index

--- a/lib/node_modules/@stdlib/array/complex64/lib/main.js
+++ b/lib/node_modules/@stdlib/array/complex64/lib/main.js
@@ -920,6 +920,56 @@ setReadOnly( Complex64Array.prototype, 'every', function every( predicate, thisA
 });
 
 /**
+* Returns the index of the first element in an array for which a predicate function returns a truthy value.
+*
+* @name findIndex
+* @memberof Complex64Array.prototype
+* @type {Function}
+* @param {Function} predicate - test function
+* @param {*} [thisArg] - predicate function execution context
+* @throws {TypeError} `this` must be a complex number array
+* @throws {TypeError} first argument must be a function
+* @returns {integer} index or -1
+*
+* @example
+* var Complex64 = require( '@stdlib/complex/float32' );
+* var realf = require( '@stdlib/complex/realf' );
+* var imagf = require( '@stdlib/complex/imagf' );
+*
+* function predicate( v ) {
+*     return ( realf( v ) === imagf( v ) );
+* }
+*
+* var arr = new Complex64Array( 3 );
+*
+* arr.set( [ 1.0, -1.0 ], 0 );
+* arr.set( [ 2.0, -2.0 ], 1 );
+* arr.set( [ 3.0, 3.0 ], 2 );
+*
+* var idx = arr.findIndex( predicate );
+* // returns 2
+*/
+setReadOnly( Complex64Array.prototype, 'findIndex', function findIndex( predicate, thisArg ) {
+	var buf;
+	var i;
+	var z;
+	if ( !isComplexArray( this ) ) {
+		throw new TypeError( 'invalid invocation. `this` is not a complex number array.' );
+	}
+	if ( !isFunction( predicate ) ) {
+		throw new TypeError( format( 'invalid argument. First argument must be a function. Value: `%s`.', predicate ) );
+	}
+	buf = this._buffer;
+	for ( i = 0; i < this._length; i++ ) {
+		z = getComplex64( buf, i );
+		if ( predicate.call( thisArg, z, i, this ) ) {
+			return i;
+		}
+	}
+	return -1;
+});
+
+/**
 * Returns an array element.
 *
 * @name get

--- a/lib/node_modules/@stdlib/array/complex64/test/test.find_index.js
+++ b/lib/node_modules/@stdlib/array/complex64/test/test.find_index.js
@@ -1,0 +1,175 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var realf = require( '@stdlib/complex/realf' );
+var imagf = require( '@stdlib/complex/imagf' );
+var Complex64Array = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof Complex64Array, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the main export is a `findIndex` method for returning boolean indicating whether all elements pass a test', function test( t ) {
+	t.strictEqual( hasOwnProp( Complex64Array.prototype, 'findIndex' ), true, 'has property' );
+	t.strictEqual( isFunction( Complex64Array.prototype.findIndex ), true, 'has method' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a complex number array instance', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new Complex64Array( 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.findIndex.call( value, predicate );
+		};
+	}
+
+	function predicate( v ) {
+		return ( realf( v ) > 0 && imagf( v ) < 0 );
+	}
+});
+
+tape( 'the method throws an error if provided a first argument which is not a function', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new Complex64Array( 10 );
+
+	values = [
+		'5',
+		3.14,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[]
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.findIndex( value );
+		};
+	}
+});
+
+tape( 'the method returns `-1` if provided an empty complex number array', function test( t ) {
+	var arr;
+	var idx;
+
+	arr = new Complex64Array();
+	idx = arr.findIndex( predicate );
+
+	t.strictEqual( idx, -1, 'returns expected value' );
+	t.end();
+
+	function predicate() {
+		t.fail( 'should not be invoked' );
+	}
+});
+
+tape( 'the method returns index of first element which pass a test', function test( t ) {
+	var arr;
+	var idx;
+
+	arr = new Complex64Array( [ 1.0, 1.0, 2.0, -2.0 ] );
+	idx = arr.findIndex( predicate );
+
+	t.strictEqual( idx, 1, 'returns expected value' );
+	t.end();
+
+	function predicate( v ) {
+		return ( realf( v ) === -imagf( v ) );
+	}
+});
+
+tape( 'the method returns `-1` if all elements fail a test', function test( t ) {
+	var arr;
+	var idx;
+
+	arr = new Complex64Array( [ 1.0, -1.0, 2.0, -2.0, 3.0, -3.0 ] );
+	idx = arr.findIndex( predicate );
+
+	t.strictEqual( idx, -1, 'returns expected value' );
+	t.end();
+
+	function predicate( v ) {
+		return ( realf( v ) === imagf( v ) );
+	}
+});
+
+tape( 'the method supports providing an execution context', function test( t ) {
+	var ctx;
+	var arr;
+	var idx;
+
+	ctx = {
+		'count': 0
+	};
+	arr = new Complex64Array( [ 1.0, -1.0, 2.0, -2.0, 3.0, 3.0 ] );
+	idx = arr.findIndex( predicate, ctx );
+
+	t.strictEqual( idx, 2, 'returns expected value');
+	t.strictEqual( ctx.count, 3, 'returns expected value');
+
+	t.end();
+
+	function predicate( v ) {
+		this.count += 1; // eslint-disable-line no-invalid-this
+		return ( imagf( v ) === realf( v ) );
+	}
+});

--- a/lib/node_modules/@stdlib/array/complex64/test/test.find_index.js
+++ b/lib/node_modules/@stdlib/array/complex64/test/test.find_index.js
@@ -36,7 +36,7 @@ tape( 'main export is a function', function test( t ) {
 	t.end();
 });
 
-tape( 'attached to the prototype of the main export is a `findIndex` method for returning boolean indicating whether all elements pass a test', function test( t ) {
+tape( 'attached to the prototype of the main export is a `findIndex` method', function test( t ) {
 	t.strictEqual( hasOwnProp( Complex64Array.prototype, 'findIndex' ), true, 'has property' );
 	t.strictEqual( isFunction( Complex64Array.prototype.findIndex ), true, 'has method' );
 	t.end();
@@ -122,7 +122,7 @@ tape( 'the method returns `-1` if provided an empty complex number array', funct
 	}
 });
 
-tape( 'the method returns index of first element which pass a test', function test( t ) {
+tape( 'the method returns the index of the first element which passes a test', function test( t ) {
 	var arr;
 	var idx;
 
@@ -163,8 +163,8 @@ tape( 'the method supports providing an execution context', function test( t ) {
 	arr = new Complex64Array( [ 1.0, -1.0, 2.0, -2.0, 3.0, 3.0 ] );
 	idx = arr.findIndex( predicate, ctx );
 
-	t.strictEqual( idx, 2, 'returns expected value');
-	t.strictEqual( ctx.count, 3, 'returns expected value');
+	t.strictEqual( idx, 2, 'returns expected value' );
+	t.strictEqual( ctx.count, 3, 'returns expected value' );
 
 	t.end();
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Adds the typed array `findIndex` method to prototype of `Complex64Array`

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
