### PR TITLE
feat: add `at` method to `array/complex128`

### DIFF
--- a/lib/node_modules/@stdlib/array/complex128/README.md
+++ b/lib/node_modules/@stdlib/array/complex128/README.md
@@ -514,6 +514,56 @@ len = arr.length;
 // returns 2
 ```
 
+<a name="method-at"></a>
+
+#### Complex128Array.prototype.at( i )
+
+Returns an array element located at integer position (index) `i`, with support for both nonnegative and negative integer positions.
+
+```javascript
+var realf = require( '@stdlib/complex/realf' );
+var imagf = require( '@stdlib/complex/imagf' );
+
+var arr = new Complex128Array( 10 );
+
+// Set the first, second, and last elements:
+arr.set( [ 1.0, -1.0 ], 0 );
+arr.set( [ 2.0, -2.0 ], 1 );
+arr.set( [ 9.0, -9.0 ], 9 );
+
+// Get the first element:
+var z = arr.at( 0 );
+// returns <Complex128>
+
+var re = realf( z );
+// returns 1.0
+
+var im = imagf( z );
+// returns -1.0
+
+// Get the last element:
+z = arr.at( -1 );
+// returns <Complex128>
+
+re = realf( z );
+// returns 9.0
+
+im = imagf( z );
+// returns -9.0
+```
+
+If provided an out-of-bounds index, the method returns `undefined`.
+
+```javascript
+var arr = new Complex128Array( 10 );
+
+var z = arr.at( 100 );
+// returns undefined
+
+z = arr.at( -100 );
+// returns undefined
+```
+
 <a name="method-copy-within"></a>
 
 #### Complex128Array.prototype.copyWithin( target, start\[, end] )

--- a/lib/node_modules/@stdlib/array/complex128/README.md
+++ b/lib/node_modules/@stdlib/array/complex128/README.md
@@ -521,8 +521,8 @@ len = arr.length;
 Returns an array element located at integer position (index) `i`, with support for both nonnegative and negative integer positions.
 
 ```javascript
-var realf = require( '@stdlib/complex/realf' );
-var imagf = require( '@stdlib/complex/imagf' );
+var real = require( '@stdlib/complex/real' );
+var imag = require( '@stdlib/complex/imag' );
 
 var arr = new Complex128Array( 10 );
 
@@ -535,20 +535,20 @@ arr.set( [ 9.0, -9.0 ], 9 );
 var z = arr.at( 0 );
 // returns <Complex128>
 
-var re = realf( z );
+var re = real( z );
 // returns 1.0
 
-var im = imagf( z );
+var im = imag( z );
 // returns -1.0
 
 // Get the last element:
 z = arr.at( -1 );
 // returns <Complex128>
 
-re = realf( z );
+re = real( z );
 // returns 9.0
 
-im = imagf( z );
+im = imag( z );
 // returns -9.0
 ```
 

--- a/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.at.js
+++ b/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.at.js
@@ -1,0 +1,86 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var Complex128 = require( '@stdlib/complex/float64' );
+var isComplex128 = require( '@stdlib/assert/is-complex128' );
+var pkg = require( './../package.json' ).name;
+var Complex128Array = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg+'::nonnegative_indices:at', function benchmark( b ) {
+	var arr;
+	var N;
+	var z;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < 10; i++ ) {
+		arr.push( new Complex128( i, i ) );
+	}
+	arr = new Complex128Array( arr );
+	N = arr.length;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		z = arr.at( i%N );
+		if ( typeof z !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+	if ( !isComplex128( z ) ) {
+		b.fail( 'should return a complex number' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::negative_indices:at', function benchmark( b ) {
+	var arr;
+	var N;
+	var z;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < 10; i++ ) {
+		arr.push( new Complex128( i, i ) );
+	}
+	arr = new Complex128Array( arr );
+	N = arr.length;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		z = arr.at( -(i%N)-1 );
+		if ( typeof z !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+	if ( !isComplex128( z ) ) {
+		b.fail( 'should return a complex number' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
@@ -102,6 +102,33 @@ declare class Complex128Array implements Complex128ArrayInterface {
 	constructor( arg?: number | RealOrComplexTypedArray | ArrayLike<number | ComplexLike> | ArrayBuffer | Iterable<number | ComplexLike>, byteOffset?: number, length?: number );
 
 	/**
+	* Returns an array element with support for both nonnegative and negative integer indices.
+	*
+	* @param i - element index
+	* @throws index argument must be a integer
+	* @returns array element
+	*
+	* @example
+	* var arr = new Complex128Array( 10 );
+	*
+	* var z = arr.at( 0 );
+	* // returns <Complex128>
+	*
+	* arr.set( [ 1.0, -1.0 ], 0 );
+	* arr.set( [ 9.0, -9.0 ], 9 );
+	*
+	* z = arr.get( -1 )
+	* // return <Complex128>
+	*
+	* z = arr.at( 100 );
+	* // returns undefined
+	*
+	* z = arr.at( -100 );
+	* // returns undefined
+	*/
+	at( i: number ): Complex128 | void;
+
+	/**
 	* Length (in bytes) of the array.
 	*
 	* @example

--- a/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
@@ -105,7 +105,7 @@ declare class Complex128Array implements Complex128ArrayInterface {
 	* Returns an array element with support for both nonnegative and negative integer indices.
 	*
 	* @param i - element index
-	* @throws index argument must be a integer
+	* @throws index argument must be an integer
 	* @returns array element
 	*
 	* @example

--- a/lib/node_modules/@stdlib/array/complex128/lib/main.js
+++ b/lib/node_modules/@stdlib/array/complex128/lib/main.js
@@ -131,6 +131,19 @@ function isComplex128Array( value ) {
 	);
 }
 
+/**
+* Retrieves a complex number from a complex number array buffer.
+*
+* @private
+* @param {Float64Array} buf - array buffer
+* @param {NonNegativeInteger} idx - element index
+* @returns {Complex128} complex number
+*/
+function getComplex128( buf, idx ) {
+	idx *= 2;
+	return new Complex128( buf[ idx ], buf[ idx+1 ] );
+}
+
 
 // MAIN //
 
@@ -553,6 +566,75 @@ setReadOnly( Complex128Array, 'of', function of() {
 });
 
 /**
+* Returns an array element with support for both nonnegative and negative integer indices.
+*
+* @name at
+* @memberof Complex128Array.prototype
+* @type {Function}
+* @param {integer} idx - element index
+* @throws {TypeError} `this` must be a complex number array
+* @throws {TypeError} must provide an integer
+* @returns {(Complex128|void)} array element
+*
+* @example
+* var arr = new Complex128Array( 10 );
+* var realf = require( '@stdlib/complex/realf' );
+* var imagf = require( '@stdlib/complex/imagf' );
+*
+* var z = arr.at( 0 );
+* // returns <Complex128>
+*
+* var re = realf( z );
+* // returns 0.0
+*
+* var im = imagf( z );
+* // returns 0.0
+*
+* arr.set( [ 1.0, -1.0 ], 0 );
+* arr.set( [ 2.0, -2.0 ], 1 );
+* arr.set( [ 9.0, -9.0 ], 9 );
+*
+* z = arr.at( 0 );
+* // returns <Complex128>
+*
+* re = realf( z );
+* // returns 1.0
+*
+* im = imagf( z );
+* // returns -1.0
+*
+* z = arr.at( -1 );
+* // returns <Complex128>
+*
+* re = realf( z );
+* // returns 9.0
+*
+* im = imagf( z );
+* // returns -9.0
+*
+* z = arr.at( 100 );
+* // returns undefined
+*
+* z = arr.at( -100 );
+* // returns undefined
+*/
+setReadOnly( Complex128Array.prototype, 'at', function at( idx ) {
+	if ( !isComplexArray( this ) ) {
+		throw new TypeError( 'invalid invocation. `this` is not a complex number array.' );
+	}
+	if ( !isInteger( idx ) ) {
+		throw new TypeError( format( 'invalid argument. Must provide an integer. Value: `%s`.', idx ) );
+	}
+	if ( idx < 0 ) {
+		idx += this._length;
+	}
+	if ( idx < 0 || idx >= this._length ) {
+		return;
+	}
+	return getComplex128( this._buffer, idx );
+});
+
+/**
 * Pointer to the underlying data buffer.
 *
 * @name buffer
@@ -830,7 +912,6 @@ setReadOnly( Complex128Array.prototype, 'entries', function entries() {
 * // returns undefined
 */
 setReadOnly( Complex128Array.prototype, 'get', function get( idx ) {
-	var buf;
 	if ( !isComplexArray( this ) ) {
 		throw new TypeError( 'invalid invocation. `this` is not a complex number array.' );
 	}
@@ -840,9 +921,7 @@ setReadOnly( Complex128Array.prototype, 'get', function get( idx ) {
 	if ( idx >= this._length ) {
 		return;
 	}
-	buf = this._buffer;
-	idx *= 2;
-	return new Complex128( buf[ idx ], buf[ idx+1 ] );
+	return getComplex128( this._buffer, idx );
 });
 
 /**
@@ -885,7 +964,6 @@ setReadOnlyAccessor( Complex128Array.prototype, 'length', function get() {
 *     ```
 *
 *     by the time we begin copying into the overlapping region, we are copying from the end of `src`, a non-overlapping region, which means we don't run the risk of copying copied values, rather than the original `src` values as intended.
-*
 *
 * @name set
 * @memberof Complex128Array.prototype

--- a/lib/node_modules/@stdlib/array/complex128/lib/main.js
+++ b/lib/node_modules/@stdlib/array/complex128/lib/main.js
@@ -577,17 +577,18 @@ setReadOnly( Complex128Array, 'of', function of() {
 * @returns {(Complex128|void)} array element
 *
 * @example
+* var real = require( '@stdlib/complex/real' );
+* var imag = require( '@stdlib/complex/imag' );
+*
 * var arr = new Complex128Array( 10 );
-* var realf = require( '@stdlib/complex/realf' );
-* var imagf = require( '@stdlib/complex/imagf' );
 *
 * var z = arr.at( 0 );
 * // returns <Complex128>
 *
-* var re = realf( z );
+* var re = real( z );
 * // returns 0.0
 *
-* var im = imagf( z );
+* var im = imag( z );
 * // returns 0.0
 *
 * arr.set( [ 1.0, -1.0 ], 0 );
@@ -597,19 +598,19 @@ setReadOnly( Complex128Array, 'of', function of() {
 * z = arr.at( 0 );
 * // returns <Complex128>
 *
-* re = realf( z );
+* re = real( z );
 * // returns 1.0
 *
-* im = imagf( z );
+* im = imag( z );
 * // returns -1.0
 *
 * z = arr.at( -1 );
 * // returns <Complex128>
 *
-* re = realf( z );
+* re = real( z );
 * // returns 9.0
 *
-* im = imagf( z );
+* im = imag( z );
 * // returns -9.0
 *
 * z = arr.at( 100 );

--- a/lib/node_modules/@stdlib/array/complex128/test/test.at.js
+++ b/lib/node_modules/@stdlib/array/complex128/test/test.at.js
@@ -24,8 +24,8 @@ var tape = require( 'tape' );
 var hasOwnProp = require( '@stdlib/assert/has-own-property' );
 var isFunction = require( '@stdlib/assert/is-function' );
 var Complex128 = require( '@stdlib/complex/float64' );
-var realf = require( '@stdlib/complex/realf' );
-var imagf = require( '@stdlib/complex/imagf' );
+var real = require( '@stdlib/complex/real' );
+var imag = require( '@stdlib/complex/imag' );
 var Complex128Array = require( './../lib' );
 
 
@@ -136,11 +136,11 @@ tape( 'the method returns an array element', function test( t ) {
 	for ( i = -arr.length; i < arr.length; i++ ) {
 		v = arr.at( i );
 		if ( i < 0 ) {
-			t.strictEqual( realf( v ), arr.length + i, 'returns expected real component for index '+i );
-			t.strictEqual( imagf( v ), -arr.length - i, 'returns expected imaginary component for index '+i );
+			t.strictEqual( real( v ), arr.length + i, 'returns expected real component for index '+i );
+			t.strictEqual( imag( v ), -arr.length - i, 'returns expected imaginary component for index '+i );
 		} else {
-			t.strictEqual( realf( v ), i, 'returns expected real component for index '+i );
-			t.strictEqual( imagf( v ), -i, 'returns expected imaginary component for index '+i );
+			t.strictEqual( real( v ), i, 'returns expected real component for index '+i );
+			t.strictEqual( imag( v ), -i, 'returns expected imaginary component for index '+i );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/array/complex128/test/test.at.js
+++ b/lib/node_modules/@stdlib/array/complex128/test/test.at.js
@@ -1,0 +1,147 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var Complex128 = require( '@stdlib/complex/float64' );
+var realf = require( '@stdlib/complex/realf' );
+var imagf = require( '@stdlib/complex/imagf' );
+var Complex128Array = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof Complex128Array, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the main export is an `at` method for returning an array element', function test( t ) {
+	t.strictEqual( hasOwnProp( Complex128Array.prototype, 'at' ), true, 'has property' );
+	t.strictEqual( isFunction( Complex128Array.prototype.at ), true, 'has method' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a complex number array instance', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new Complex128Array( 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[]
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.at.call( value, 0 );
+		};
+	}
+});
+
+tape( 'the method throws an error if provided an index argument which is not an integer', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new Complex128Array( 10 );
+
+	values = [
+		'5',
+		3.14,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.at( value );
+		};
+	}
+});
+
+tape( 'the method returns `undefined` if provided an index which exceeds array dimensions', function test( t ) {
+	var arr;
+	var v;
+	var i;
+
+	arr = new Complex128Array( 10 );
+	for ( i = -arr.length; i < arr.length; i++ ) {
+		if ( i < 0 ) {
+			v = arr.at( i-arr.length );
+			t.strictEqual( v, void 0, 'returns expected value for index '+(i-arr.length) );
+		} else {
+			v = arr.at( arr.length+i );
+			t.strictEqual( v, void 0, 'returns expected value for index '+(arr.length+i) );
+		}
+	}
+	t.end();
+});
+
+tape( 'the method returns an array element', function test( t ) {
+	var arr;
+	var v;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < 10; i++ ) {
+		arr.push( new Complex128( i, -i ) );
+	}
+	arr = new Complex128Array( arr );
+
+	for ( i = -arr.length; i < arr.length; i++ ) {
+		v = arr.at( i );
+		if ( i < 0 ) {
+			t.strictEqual( realf( v ), arr.length + i, 'returns expected real component for index '+i );
+			t.strictEqual( imagf( v ), -arr.length - i, 'returns expected imaginary component for index '+i );
+		} else {
+			t.strictEqual( realf( v ), i, 'returns expected real component for index '+i );
+			t.strictEqual( imagf( v ), -i, 'returns expected imaginary component for index '+i );
+		}
+	}
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Adds the typed array `at` method to prototype of `Complex128Array`
-   Changes in `get` method according to `Complex64Array` using `getComplex128` 

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
