### PR TITLE
feat: add `every` method to `array/complex128`

### DIFF
--- a/lib/node_modules/@stdlib/array/complex128/README.md
+++ b/lib/node_modules/@stdlib/array/complex128/README.md
@@ -820,7 +820,7 @@ arr.set( [ 2.0, 2.0 ], 1 );
 arr.set( [ 3.0, 3.0 ], 2 );
 
 // Check whether all elements pass a test:
-var z = arr.every( predicate );
+var bool = arr.every( predicate );
 // returns true
 ```
 
@@ -849,7 +849,7 @@ arr.set( [ 1.0, 1.0 ], 0 );
 arr.set( [ 2.0, 2.0 ], 1 );
 arr.set( [ 3.0, 3.0 ], 2 );
 
-var z = arr.every( predicate, context );
+var bool = arr.every( predicate, context );
 // returns true
 
 var count = context.count;

--- a/lib/node_modules/@stdlib/array/complex128/README.md
+++ b/lib/node_modules/@stdlib/array/complex128/README.md
@@ -798,6 +798,64 @@ var bool = it.next().done;
 // returns true
 ```
 
+<a name="method-every"></a>
+
+#### Complex128Array.prototype.every( predicate\[, thisArg] )
+
+Returns a boolean indicating whether all elements pass a test.
+
+```javascript
+var real = require( '@stdlib/complex/real' );
+var imag = require( '@stdlib/complex/imag' );
+
+function predicate( v ) {
+    return ( real( v ) === imag( v ) );
+}
+
+var arr = new Complex128Array( 3 );
+
+// Set the first three elements:
+arr.set( [ 1.0, 1.0 ], 0 );
+arr.set( [ 2.0, 2.0 ], 1 );
+arr.set( [ 3.0, 3.0 ], 2 );
+
+// Check whether all elements pass a test:
+var z = arr.every( predicate );
+// returns true
+```
+
+The `predicate` function is provided three arguments:
+
+-   **value**: current array element.
+-   **index**: current array element index.
+-   **arr**: the array on which this method was called.
+
+To set the function execution context, provide a `thisArg`.
+
+```javascript
+function predicate( v, i ) {
+    this.count += 1;
+    return ( i >= 0 );
+}
+
+var arr = new Complex128Array( 3 );
+
+var context = {
+    'count': 0
+};
+
+// Set the first three elements:
+arr.set( [ 1.0, 1.0 ], 0 );
+arr.set( [ 2.0, 2.0 ], 1 );
+arr.set( [ 3.0, 3.0 ], 2 );
+
+var z = arr.every( predicate, context );
+// returns true
+
+var count = context.count;
+// returns 3
+```
+
 <a name="method-get"></a>
 
 #### Complex128Array.prototype.get( i )

--- a/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.every.js
+++ b/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.every.js
@@ -1,0 +1,56 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isComplex128 = require( '@stdlib/assert/is-complex128' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var pkg = require( './../package.json' ).name;
+var Complex128Array = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg+':every', function benchmark( b ) {
+	var bool;
+	var arr;
+	var i;
+
+	arr = new Complex128Array( [ 1, 2, 3, 4 ] );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		bool = arr.every( predicate );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+
+	function predicate( v ) {
+		return isComplex128( v );
+	}
+});

--- a/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.every.length.js
+++ b/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.every.length.js
@@ -24,8 +24,8 @@ var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var pow = require( '@stdlib/math/base/special/pow' );
 var Complex128 = require( '@stdlib/complex/float64' );
-var real = require( '@stdlib/complex/realf' );
-var imag = require( '@stdlib/complex/imagf' );
+var real = require( '@stdlib/complex/real' );
+var imag = require( '@stdlib/complex/imag' );
 var pkg = require( './../package.json' ).name;
 var Complex128Array = require( './../lib' );
 
@@ -42,7 +42,7 @@ var Complex128Array = require( './../lib' );
 * @returns {boolean} boolean indicating whether a value passes a test
 */
 function predicate( value ) {
-	return ( realf( value ) === imagf( value ) );
+	return ( real( value ) === imag( value ) );
 }
 
 /**

--- a/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.every.length.js
+++ b/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.every.length.js
@@ -1,0 +1,118 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var pow = require( '@stdlib/math/base/special/pow' );
+var Complex128 = require( '@stdlib/complex/float64' );
+var real = require( '@stdlib/complex/realf' );
+var imag = require( '@stdlib/complex/imagf' );
+var pkg = require( './../package.json' ).name;
+var Complex128Array = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Predicate function.
+*
+* @private
+* @param {Complex128} value - array element
+* @param {NonNegativeInteger} idx - array element index
+* @param {Complex128Array} arr - array instance
+* @returns {boolean} boolean indicating whether a value passes a test
+*/
+function predicate( value ) {
+	return ( realf( value ) === imagf( value ) );
+}
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var arr;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < len; i++ ) {
+		arr.push( new Complex128( i, i ) );
+	}
+	arr = new Complex128Array( arr );
+
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var bool;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			bool = arr.every( predicate );
+			if ( typeof bool !== 'boolean' ) {
+				b.fail( 'should return a boolean' );
+			}
+		}
+		b.toc();
+		if ( !isBoolean( bool ) ) {
+			b.fail( 'should return a boolean' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':every:len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
@@ -29,6 +29,50 @@ import ArrayBuffer = require( '@stdlib/array/buffer' );
 type Iterator = Iter | IterableIterator;
 
 /**
+* Checks whether an element in an array passes a test.
+*
+* @returns boolean indicating whether an element in an array passes a test
+*/
+type NullaryPredicate<U> = ( this: U ) => boolean;
+
+/**
+* Checks whether an element in an array passes a test.
+*
+* @param value - current array element
+* @returns boolean indicating whether an element in an array passes a test
+*/
+type UnaryPredicate<U> = ( this: U, value: Complex64 ) => boolean;
+
+/**
+* Checks whether an element in an array passes a test.
+*
+* @param value - current array element
+* @param index - current array element index
+* @returns boolean indicating whether an element in an array passes a test
+*/
+type BinaryPredicate<U> = ( this: U, value: Complex64, index: number ) => boolean;
+
+/**
+* Checks whether an element in an array passes a test.
+*
+* @param value - current array element
+* @param index - current array element index
+* @param arr - array on which the method was called
+* @returns boolean indicating whether an element in an array passes a test
+*/
+type TernaryPredicate<U> = ( this: U, value: Complex64, index: number, arr: Complex64Array ) => boolean;
+
+/**
+* Checks whether an element in an array passes a test.
+*
+* @param value - current array element
+* @param index - current array element index
+* @param arr - array on which the method was called
+* @returns boolean indicating whether an element in an array passes a test
+*/
+type Predicate<U> = NullaryPredicate<U> | UnaryPredicate<U> | BinaryPredicate<U> | TernaryPredicate<U>;
+
+/**
 * Class for creating a 128-bit complex number array.
 */
 declare class Complex128Array implements Complex128ArrayInterface {
@@ -239,6 +283,32 @@ declare class Complex128Array implements Complex128ArrayInterface {
 	* // returns true
 	*/
 	entries(): Iterator;
+
+	/**
+	* Tests whether all elements in an array pass a test implemented by a predicate function.
+	*
+	* @param predicate - test function
+	* @param thisArg - execution context
+	* @returns boolean indicating whether all elements pass a test
+	*
+	* @example
+	* var real = require( '@stdlib/complex/real' );
+	* var imag = require( '@stdlib/complex/imag' );
+	*
+	* function predicate( v ) {
+	*     return ( real( v ) === imag( v ) );
+	* }
+	*
+	* var arr = new Complex128Array( 3 );
+	*
+	* arr.set( [ 1.0 , 1.0 ], 0 );
+	* arr.set( [ 2.0 , 2.0 ], 1 );
+	* arr.set( [ 3.0 , 3.0 ], 2 );
+	*
+	* var bool = arr.every( predicate );
+	* // returns true
+	*/
+	every<U = unknown>( predicate: Predicate, thisArg?: ThisParameterType<Predicate<U>> ): boolean;
 
 	/**
 	* Returns an array element.

--- a/lib/node_modules/@stdlib/array/complex128/lib/main.js
+++ b/lib/node_modules/@stdlib/array/complex128/lib/main.js
@@ -874,6 +874,53 @@ setReadOnly( Complex128Array.prototype, 'entries', function entries() {
 });
 
 /**
+* Tests whether all elements in an array pass a test implemented by a predicate function.
+*
+* @name every
+* @memberof Complex128Array.prototype
+* @type {Function}
+* @param {Function} predicate - test function
+* @param {*} [thisArg] - predicate function execution context
+* @throws {TypeError} `this` must be a complex number array
+* @throws {TypeError} first argument must be a function
+* @returns {boolean} boolean indicating whether all elements pass a test
+*
+* @example
+* var real = require( '@stdlib/complex/real' );
+* var imag = require( '@stdlib/complex/imag' );
+*
+* function predicate( v ) {
+*     return ( real( v ) === imag( v ) );
+* }
+*
+* var arr = new Complex128Array( 3 );
+*
+* arr.set( [ 1.0, 1.0 ], 0 );
+* arr.set( [ 2.0, 2.0 ], 1 );
+* arr.set( [ 3.0, 3.0 ], 2 );
+*
+* var bool = arr.every( predicate );
+* // returns true
+*/
+setReadOnly( Complex128Array.prototype, 'every', function every( predicate, thisArg ) {
+	var buf;
+	var i;
+	if ( !isComplexArray( this ) ) {
+		throw new TypeError( 'invalid invocation. `this` is not a complex number array.' );
+	}
+	if ( !isFunction( predicate ) ) {
+		throw new TypeError( format( 'invalid argument. First argument must be a function. Value: `%s`.', predicate ) );
+	}
+	buf = this._buffer;
+	for ( i = 0; i < this._length; i++ ) {
+		if ( !predicate.call( thisArg, getComplex128( buf, i ), i, this ) ) {
+			return false;
+		}
+	}
+	return true;
+});
+
+/**
 * Returns an array element.
 *
 * @name get

--- a/lib/node_modules/@stdlib/array/complex128/test/test.every.js
+++ b/lib/node_modules/@stdlib/array/complex128/test/test.every.js
@@ -1,0 +1,175 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var real = require( '@stdlib/complex/real' );
+var imag = require( '@stdlib/complex/imag' );
+var Complex128Array = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof Complex128Array, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the main export is an `every` method for returning boolean indicating whether all elements pass a test', function test( t ) {
+	t.strictEqual( hasOwnProp( Complex128Array.prototype, 'every' ), true, 'has property' );
+	t.strictEqual( isFunction( Complex128Array.prototype.every ), true, 'has method' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a complex number array instance', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new Complex128Array( 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.every.call( value, predicate );
+		};
+	}
+
+	function predicate( v ) {
+		return ( real( v ) > 0 && imag( v ) < 0 );
+	}
+});
+
+tape( 'the method throws an error if provided a first argument which is not a function', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new Complex128Array( 10 );
+
+	values = [
+		'5',
+		3.14,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[]
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.every( value );
+		};
+	}
+});
+
+tape( 'the method returns `true` if provided an empty complex number array', function test( t ) {
+	var bool;
+	var arr;
+
+	arr = new Complex128Array();
+	bool = arr.every( predicate );
+
+	t.strictEqual( bool, true, 'returns expected value' );
+	t.end();
+
+	function predicate() {
+		t.fail( 'should not be invoked' );
+	}
+});
+
+tape( 'the method returns `true` if all elements pass a test', function test( t ) {
+	var bool;
+	var arr;
+
+	arr = new Complex128Array( [ 1.0, 1.0, 1.0, 1.0 ] );
+	bool = arr.every( predicate );
+
+	t.strictEqual( bool, true, 'returns expected value' );
+	t.end();
+
+	function predicate( v ) {
+		return ( real( v ) === imag( v ) );
+	}
+});
+
+tape( 'the method returns `false` if one or more elements fail a test', function test( t ) {
+	var bool;
+	var arr;
+
+	arr = new Complex128Array( [ 1.0, -1.0, 2.0, -2.0, 3.0, -3.0 ] );
+	bool = arr.every( predicate );
+
+	t.strictEqual( bool, false, 'returns expected value' );
+	t.end();
+
+	function predicate( v ) {
+		return ( real( v ) === imag( v ) );
+	}
+});
+
+tape( 'the method supports providing an execution context', function test( t ) {
+	var bool;
+	var ctx;
+	var arr;
+
+	ctx = {
+		'count': 0
+	};
+	arr = new Complex128Array( [ 1.0, 1.0, 2.0, 2.0, 3.0, 3.0 ] );
+	bool = arr.every( predicate, ctx );
+
+	t.strictEqual( bool, true, 'returns expected value' );
+	t.strictEqual( ctx.count, 3, 'returns expected value');
+
+	t.end();
+
+	function predicate( v ) {
+		this.count += 1; // eslint-disable-line no-invalid-this
+		return ( imag( v ) === real( v ) );
+	}
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Adds the typed array `every` method to prototype of `Complex128Array`

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
