### PR TITLE
feat: add `findIndex` method to `array/complex128`

### DIFF
--- a/lib/node_modules/@stdlib/array/complex128/README.md
+++ b/lib/node_modules/@stdlib/array/complex128/README.md
@@ -928,9 +928,69 @@ var count = context.count;
 // returns 2
 ```
 
+<a name="method-find-index"></a>
+
+#### Complex128Array.prototype.findIndex( predicate\[, thisArg] )
+
+Returns the index of the first element in an array for which a predicate function returns a truthy value.
+
+```javascript
+var real = require( '@stdlib/complex/real' );
+var imag = require( '@stdlib/complex/imag' );
+
+function predicate( v ) {
+    return ( real( v ) === imag( v ) );
+}
+
+var arr = new Complex128Array( 3 );
+
+// Set the first three elements:
+arr.set( [ 1.0, -1.0 ], 0 );
+arr.set( [ 2.0, -2.0 ], 1 );
+arr.set( [ 3.0, 3.0 ], 2 );
+
+var idx = arr.findIndex( predicate );
+// returns 2
+```
+
+The `predicate` function is provided three arguments:
+
+-   **value**: current array element.
+-   **index**: current array element index.
+-   **arr**: the array on which this method was called.
+
+To set the function execution context, provide a `thisArg`.
+
+```javascript
+var real = require( '@stdlib/complex/real' );
+var imag = require( '@stdlib/complex/imag' );
+
+function predicate( v, i ) {
+    this.count += 1;
+    return ( i >= 0 && real( v ) === imag( v ) );
+}
+
+var arr = new Complex128Array( 3 );
+
+var context = {
+    'count': 0
+};
+
+// Set the first three elements:
+arr.set( [ 1.0, -1.0 ], 0 );
+arr.set( [ 2.0, -2.0 ], 1 );
+arr.set( [ 3.0, -3.0 ], 2 );
+
+var idx = arr.findIndex( predicate, context );
+// returns -1
+
+var count = context.count;
+// returns 3
+```
+
 <a name="method-find-last"></a>
 
-#### Complex64Array.prototype.findLast( predicate\[, thisArg] )
+#### Complex128Array.prototype.findLast( predicate\[, thisArg] )
 
 Returns the last element in an array for which a predicate function returns a truthy value.
 

--- a/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.find_index.js
+++ b/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.find_index.js
@@ -1,0 +1,56 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isComplex128 = require( '@stdlib/assert/is-complex128' );
+var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
+var pkg = require( './../package.json' ).name;
+var Complex128Array = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg+':findIndex', function benchmark( b ) {
+	var arr;
+	var idx;
+	var i;
+
+	arr = new Complex128Array( [ 1, 2, 3, 4, 5, 6 ] );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		idx = arr.findIndex( predicate );
+		if ( typeof idx !== 'number' ) {
+			b.fail( 'should return an integer' );
+		}
+	}
+	b.toc();
+	if ( !isInteger( idx ) ) {
+		b.fail( 'should return an integer' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+
+	function predicate( v ) {
+		return isComplex128( v );
+	}
+});

--- a/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.find_index.length.js
+++ b/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.find_index.length.js
@@ -1,0 +1,119 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var Complex128 = require( '@stdlib/complex/float64' );
+var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
+var real = require( '@stdlib/complex/real' );
+var imag = require( '@stdlib/complex/imag' );
+var pkg = require( './../package.json' ).name;
+var Complex128Array = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Predicate function.
+*
+* @private
+* @param {Complex128} value - array element
+* @param {NonNegativeInteger} idx - array element index
+* @param {Complex128Array} arr - array instance
+* @returns {boolean} boolean indicating whether a value passes a test
+*/
+function predicate( value ) {
+	return ( real( value ) === -imag( value ) );
+}
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var arr;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < len-1; i++ ) {
+		arr.push( new Complex128( i, i ) );
+	}
+	arr.push( new Complex128( len-1, -( len-1 ) ) );
+	arr = new Complex128Array( arr );
+
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var idx;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			idx = arr.findIndex( predicate );
+			if ( typeof idx !== 'number' ) {
+				b.fail( 'should return an integer' );
+			}
+		}
+		b.toc();
+		if ( !isInteger( idx ) ) {
+			b.fail( 'should return an integer' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':findIndex:len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
@@ -366,7 +366,7 @@ declare class Complex128Array implements Complex128ArrayInterface {
 	* var idx = arr.findIndex( predicate );
 	* // returns 2
 	*/
-	findIndex<U = unknown>( predicate: Predicate, thisArg?: ThisParameterType<Predicate<U>> ): number;
+	findIndex<U = unknown>( predicate: Predicate<U>, thisArg?: ThisParameterType<Predicate<U>> ): number;
 
 	/**
 	* Returns the last element in an array for which a predicate function returns a truthy value.

--- a/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
@@ -41,7 +41,7 @@ type NullaryPredicate<U> = ( this: U ) => boolean;
 * @param value - current array element
 * @returns boolean indicating whether an element in an array passes a test
 */
-type UnaryPredicate<U> = ( this: U, value: Complex64 ) => boolean;
+type UnaryPredicate<U> = ( this: U, value: Complex128 ) => boolean;
 
 /**
 * Checks whether an element in an array passes a test.
@@ -50,17 +50,17 @@ type UnaryPredicate<U> = ( this: U, value: Complex64 ) => boolean;
 * @param index - current array element index
 * @returns boolean indicating whether an element in an array passes a test
 */
-type BinaryPredicate<U> = ( this: U, value: Complex64, index: number ) => boolean;
+type BinaryPredicate<U> = ( this: U, value: Complex128, index: number ) => boolean;
 
 /**
-* Checks whether an element in an array passes a test.
+* Checks whether an element in an array passes a test.Complex128Array
 *
 * @param value - current array element
 * @param index - current array element index
 * @param arr - array on which the method was called
 * @returns boolean indicating whether an element in an array passes a test
 */
-type TernaryPredicate<U> = ( this: U, value: Complex64, index: number, arr: Complex128Array ) => boolean;
+type TernaryPredicate<U> = ( this: U, value: Complex128, index: number, arr: Complex128Array ) => boolean;
 
 /**
 * Checks whether an element in an array passes a test.
@@ -308,7 +308,7 @@ declare class Complex128Array implements Complex128ArrayInterface {
 	* var bool = arr.every( predicate );
 	* // returns true
 	*/
-	every<U = unknown>( predicate: Predicate, thisArg?: ThisParameterType<Predicate<U>> ): boolean;
+	every<U = unknown>( predicate: Predicate<U>, thisArg?: ThisParameterType<Predicate<U>> ): boolean;
 
 	/**
 	* Returns the first element in an array for which a predicate function returns a truthy value.

--- a/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
@@ -60,7 +60,7 @@ type BinaryPredicate<U> = ( this: U, value: Complex64, index: number ) => boolea
 * @param arr - array on which the method was called
 * @returns boolean indicating whether an element in an array passes a test
 */
-type TernaryPredicate<U> = ( this: U, value: Complex64, index: number, arr: Complex64Array ) => boolean;
+type TernaryPredicate<U> = ( this: U, value: Complex64, index: number, arr: Complex128Array ) => boolean;
 
 /**
 * Checks whether an element in an array passes a test.
@@ -341,6 +341,32 @@ declare class Complex128Array implements Complex128ArrayInterface {
 	* // returns 1.0
 	*/
 	find<U = unknown>( predicate: Predicate, thisArg?: ThisParameterType<Predicate<U>> ): Complex128 | void;
+
+	/**
+	* Returns the index of the first element in an array for which a predicate function returns a truthy value.
+	*
+	* @param predicate - test function
+	* @param thisArg - execution context
+	* @returns index or -1
+	*
+	* @example
+	* var real = require( '@stdlib/complex/real' );
+	* var imag = require( '@stdlib/complex/imag' );
+	*
+	* function predicate( v ) {
+	*     return ( real( v ) === imag( v ) );
+	* }
+	*
+	* var arr = new Complex128Array( 3 );
+	*
+	* arr.set( [ 1.0, -1.0 ], 0 );
+	* arr.set( [ 2.0, -2.0 ], 1 );
+	* arr.set( [ 3.0, 3.0 ], 2 );
+	*
+	* var idx = arr.findIndex( predicate );
+	* // returns 2
+	*/
+	findIndex<U = unknown>( predicate: Predicate, thisArg?: ThisParameterType<Predicate<U>> ): number;
 
 	/**
 	* Returns the last element in an array for which a predicate function returns a truthy value.

--- a/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
@@ -53,7 +53,7 @@ type UnaryPredicate<U> = ( this: U, value: Complex128 ) => boolean;
 type BinaryPredicate<U> = ( this: U, value: Complex128, index: number ) => boolean;
 
 /**
-* Checks whether an element in an array passes a test.Complex128Array
+* Checks whether an element in an array passes a test.
 *
 * @param value - current array element
 * @param index - current array element index

--- a/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
@@ -308,7 +308,7 @@ declare class Complex128Array implements Complex128ArrayInterface {
 	* var bool = arr.every( predicate );
 	* // returns true
 	*/
-	every<U = unknown>( predicate: Predicate<U>, thisArg?: ThisParameterType<Predicate<U>> ): boolean;
+	every<U = unknown>( predicate: Predicate, thisArg?: ThisParameterType<Predicate<U>> ): boolean;
 
 	/**
 	* Returns the first element in an array for which a predicate function returns a truthy value.

--- a/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
@@ -60,7 +60,7 @@ type BinaryPredicate<U> = ( this: U, value: Complex64, index: number ) => boolea
 * @param arr - array on which the method was called
 * @returns boolean indicating whether an element in an array passes a test
 */
-type TernaryPredicate<U> = ( this: U, value: Complex64, index: number, arr: Complex128Array ) => boolean;
+type TernaryPredicate<U> = ( this: U, value: Complex128, index: number, arr: Complex128Array ) => boolean;
 
 /**
 * Checks whether an element in an array passes a test.

--- a/lib/node_modules/@stdlib/array/complex128/lib/main.js
+++ b/lib/node_modules/@stdlib/array/complex128/lib/main.js
@@ -975,6 +975,55 @@ setReadOnly( Complex128Array.prototype, 'find', function find( predicate, thisAr
 });
 
 /**
+* Returns the index of the first element in an array for which a predicate function returns a truthy value.
+*
+* @name findIndex
+* @memberof Complex128Array.prototype
+* @type {Function}
+* @param {Function} predicate - test function
+* @param {*} [thisArg] - predicate function execution context
+* @throws {TypeError} `this` must be a complex number array
+* @throws {TypeError} first argument must be a function
+* @returns {integer} index or -1
+*
+* @example
+* var real = require( '@stdlib/complex/real' );
+* var imag = require( '@stdlib/complex/imag' );
+*
+* function predicate( v ) {
+*     return ( real( v ) === imag( v ) );
+* }
+*
+* var arr = new Complex128Array( 3 );
+*
+* arr.set( [ 1.0, -1.0 ], 0 );
+* arr.set( [ 2.0, -2.0 ], 1 );
+* arr.set( [ 3.0, 3.0 ], 2 );
+*
+* var idx = arr.findIndex( predicate );
+* // returns 2
+*/
+setReadOnly( Complex128Array.prototype, 'findIndex', function findIndex( predicate, thisArg ) {
+	var buf;
+	var i;
+	var z;
+	if ( !isComplexArray( this ) ) {
+		throw new TypeError( 'invalid invocation. `this` is not a complex number array.' );
+	}
+	if ( !isFunction( predicate ) ) {
+		throw new TypeError( format( 'invalid argument. First argument must be a function. Value: `%s`.', predicate ) );
+	}
+	buf = this._buffer;
+	for ( i = 0; i < this._length; i++ ) {
+		z = getComplex128( buf, i );
+		if ( predicate.call( thisArg, z, i, this ) ) {
+			return i;
+		}
+	}
+	return -1;
+});
+
+/**
 * Returns the last element in an array for which a predicate function returns a truthy value.
 *
 * @name findLast

--- a/lib/node_modules/@stdlib/array/complex128/test/test.find_index.js
+++ b/lib/node_modules/@stdlib/array/complex128/test/test.find_index.js
@@ -77,7 +77,7 @@ tape( 'the method throws an error if invoked with a `this` context which is not 
 	}
 });
 
-tape( 'the method throws an error if operating with a first argument which is not a function', function test( t ) {
+tape( 'the method throws an error if provided a first argument which is not a function', function test( t ) {
 	var values;
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/array/complex128/test/test.find_index.js
+++ b/lib/node_modules/@stdlib/array/complex128/test/test.find_index.js
@@ -107,7 +107,7 @@ tape( 'the method throws an error if operating with a first argument which is no
 	}
 });
 
-tape( 'the method returns `-1` if operating with an empty complex number array', function test( t ) {
+tape( 'the method returns `-1` if operating on an empty complex number array', function test( t ) {
 	var arr;
 	var idx;
 

--- a/lib/node_modules/@stdlib/array/complex128/test/test.find_index.js
+++ b/lib/node_modules/@stdlib/array/complex128/test/test.find_index.js
@@ -1,0 +1,175 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var real = require( '@stdlib/complex/real' );
+var imag = require( '@stdlib/complex/imag' );
+var Complex128Array = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof Complex128Array, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the main export is a `findIndex` method', function test( t ) {
+	t.strictEqual( hasOwnProp( Complex128Array.prototype, 'findIndex' ), true, 'has property' );
+	t.strictEqual( isFunction( Complex128Array.prototype.findIndex ), true, 'has method' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a complex number array instance', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new Complex128Array( 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.findIndex.call( value, predicate );
+		};
+	}
+
+	function predicate( v ) {
+		return ( real( v ) > 0 && imag( v ) < 0 );
+	}
+});
+
+tape( 'the method throws an error if operating with a first argument which is not a function', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new Complex128Array( 10 );
+
+	values = [
+		'5',
+		3.14,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[]
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.findIndex( value );
+		};
+	}
+});
+
+tape( 'the method returns `-1` if operating with an empty complex number array', function test( t ) {
+	var arr;
+	var idx;
+
+	arr = new Complex128Array();
+	idx = arr.findIndex( predicate );
+
+	t.strictEqual( idx, -1, 'returns expected value' );
+	t.end();
+
+	function predicate() {
+		t.fail( 'should not be invoked' );
+	}
+});
+
+tape( 'the method returns the index of the first element which passes a test', function test( t ) {
+	var arr;
+	var idx;
+
+	arr = new Complex128Array( [ 1.0, 1.0, 2.0, -2.0 ] );
+	idx = arr.findIndex( predicate );
+
+	t.strictEqual( idx, 1, 'returns expected value' );
+	t.end();
+
+	function predicate( v ) {
+		return ( real( v ) === -imag( v ) );
+	}
+});
+
+tape( 'the method returns `-1` if all elements fail a test', function test( t ) {
+	var arr;
+	var idx;
+
+	arr = new Complex128Array( [ 1.0, -1.0, 2.0, -2.0, 3.0, -3.0 ] );
+	idx = arr.findIndex( predicate );
+
+	t.strictEqual( idx, -1, 'returns expected value' );
+	t.end();
+
+	function predicate( v ) {
+		return ( real( v ) === imag( v ) );
+	}
+});
+
+tape( 'the method supports providing an execution context', function test( t ) {
+	var ctx;
+	var arr;
+	var idx;
+
+	ctx = {
+		'count': 0
+	};
+	arr = new Complex128Array( [ 1.0, -1.0, 2.0, -2.0, 3.0, 3.0 ] );
+	idx = arr.findIndex( predicate, ctx );
+
+	t.strictEqual( idx, 2, 'returns expected value' );
+	t.strictEqual( ctx.count, 3, 'returns expected value' );
+
+	t.end();
+
+	function predicate( v ) {
+		this.count += 1; // eslint-disable-line no-invalid-this
+		return ( imag( v ) === real( v ) );
+	}
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Adds the typed array `findIndex` method to prototype of `Complex128Array`

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
