### PR TITLE
feat: add `map` method to `array/complex64`

### DIFF
--- a/lib/node_modules/@stdlib/array/complex64/README.md
+++ b/lib/node_modules/@stdlib/array/complex64/README.md
@@ -1425,7 +1425,7 @@ var Complex64 = require( '@stdlib/complex/float32' );
 var realf = require( '@stdlib/complex/realf' );
 var imagf = require( '@stdlib/complex/imagf' );
 
-function scale( v, i ) {
+function scale( v ) {
     return new Complex64( 2.0*realf( v ), 2.0*imagf( v ) );
 }
 

--- a/lib/node_modules/@stdlib/array/complex64/README.md
+++ b/lib/node_modules/@stdlib/array/complex64/README.md
@@ -1199,7 +1199,7 @@ var count = context.count;
 
 <a name="method-for-each"></a>
 
-#### Complex64Array.prototype.forEach( predicate\[, thisArg] )
+#### Complex64Array.prototype.forEach( callbackFn\[, thisArg] )
 
 Invokes a function once for each array element.
 
@@ -1412,6 +1412,77 @@ var idx = arr.lastIndexOf( new Complex64( 3.0, -3.0 ) );
 
 idx = arr.lastIndexOf( new Complex64( 2.0, -2.0 ), 0 );
 // returns -1
+```
+
+<a name="method-map"></a>
+
+#### Complex64Array.prototype.map( callbackFn\[, thisArg] )
+
+Returns a new array with each element being the result of the callback function.
+
+```javascript
+var Complex64 = require( '@stdlib/complex/float32' );
+var realf = require( '@stdlib/complex/realf' );
+var imagf = require( '@stdlib/complex/imagf' );
+
+function scale( v, i ) {
+    return new Complex64( 2.0*realf( v ), 2.0*imagf( v ) );
+}
+
+var arr = new Complex64Array( 3 );
+
+// Set the first three elements:
+arr.set( [ 1.0, -1.0 ], 0 );
+arr.set( [ 2.0, -2.0 ], 1 );
+arr.set( [ 3.0, -3.0 ], 2 );
+
+var out = arr.map( scale );
+// returns <Complex64Array>
+
+var z = out.get( 0 );
+// returns <complex64>
+
+var re = realf( z );
+// returns 2.0
+
+var im = imagf( z );
+// returns -2.0
+```
+
+The callback function is provided three arguments:
+
+-   **value**: current array element.
+-   **index**: current array element index.
+-   **arr**: the array on which this method was called.
+
+To set the function execution context, provide a `thisArg`.
+
+```javascript
+var Complex64 = require( '@stdlib/complex/float32' );
+var realf = require( '@stdlib/complex/realf' );
+var imagf = require( '@stdlib/complex/imagf' );
+
+function scale( v ) {
+    this.count += 1;
+    return new Complex64( 2.0*realf( v ), 2.0*imagf( v ) );
+}
+
+var arr = new Complex64Array( 3 );
+
+var context = {
+    'count': 0
+};
+
+// Set the first three elements:
+arr.set( [ 1.0, 1.0 ], 0 );
+arr.set( [ 2.0, 2.0 ], 1 );
+arr.set( [ 3.0, 3.0 ], 2 );
+
+var out = arr.map( scale, context );
+// returns <Complex64Array>
+
+var count = context.count;
+// returns 3
 ```
 
 <a name="method-set"></a>

--- a/lib/node_modules/@stdlib/array/complex64/benchmark/benchmark.map.js
+++ b/lib/node_modules/@stdlib/array/complex64/benchmark/benchmark.map.js
@@ -1,0 +1,58 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isComplex64Array = require( '@stdlib/assert/is-complex64array' );
+var realf = require( '@stdlib/complex/realf' );
+var imagf = require( '@stdlib/complex/imagf' );
+var Complex64 = require('@stdlib/complex/float32');
+var pkg = require( './../package.json' ).name;
+var Complex64Array = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg+':map', function benchmark( b ) {
+	var out;
+	var arr;
+	var i;
+
+	arr = new Complex64Array( [ 1, 2, 3, 4, 5, 6 ] );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = arr.map( scale );
+		if ( typeof out !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+	if ( !isComplex64Array( out ) ) {
+		b.fail( 'should return a Complex64Array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+
+	function scale( v ) {
+		return new Complex64( realf(v)*2.0, imagf(v)*2.0 );
+	}
+});

--- a/lib/node_modules/@stdlib/array/complex64/benchmark/benchmark.map.length.js
+++ b/lib/node_modules/@stdlib/array/complex64/benchmark/benchmark.map.length.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isComplex64Array = require( '@stdlib/assert/is-complex64array' );
 var pow = require( '@stdlib/math/base/special/pow' );
+var identity = require( '@stdlib/utils/identity-function' );
 var Complex64 = require( '@stdlib/complex/float32' );
 var realf = require( '@stdlib/complex/realf' );
 var imagf = require( '@stdlib/complex/imagf' );
@@ -31,19 +32,6 @@ var Complex64Array = require( './../lib' );
 
 
 // FUNCTIONS //
-
-/**
-* Predicate function.
-*
-* @private
-* @param {Complex64} value - array element
-* @param {NonNegativeInteger} idx - array element index
-* @param {Complex64Array} arr - array instance
-* @returns {boolean} boolean indicating whether a value passes a test
-*/
-function scale( value ) {
-	return new Complex64( realf(value)*2.0, imagf(value)*2.0 );
-}
 
 /**
 * Creates a benchmark function.
@@ -76,7 +64,7 @@ function createBenchmark( len ) {
 
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
-			out = arr.map( scale );
+			out = arr.map( identity );
 			if ( typeof out !== 'object' ) {
 				b.fail( 'should return an object' );
 			}

--- a/lib/node_modules/@stdlib/array/complex64/benchmark/benchmark.map.length.js
+++ b/lib/node_modules/@stdlib/array/complex64/benchmark/benchmark.map.length.js
@@ -25,8 +25,6 @@ var isComplex64Array = require( '@stdlib/assert/is-complex64array' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var identity = require( '@stdlib/utils/identity-function' );
 var Complex64 = require( '@stdlib/complex/float32' );
-var realf = require( '@stdlib/complex/realf' );
-var imagf = require( '@stdlib/complex/imagf' );
 var pkg = require( './../package.json' ).name;
 var Complex64Array = require( './../lib' );
 

--- a/lib/node_modules/@stdlib/array/complex64/benchmark/benchmark.map.length.js
+++ b/lib/node_modules/@stdlib/array/complex64/benchmark/benchmark.map.length.js
@@ -1,0 +1,118 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isComplex64Array = require( '@stdlib/assert/is-complex64array' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var Complex64 = require( '@stdlib/complex/float32' );
+var realf = require( '@stdlib/complex/realf' );
+var imagf = require( '@stdlib/complex/imagf' );
+var pkg = require( './../package.json' ).name;
+var Complex64Array = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Predicate function.
+*
+* @private
+* @param {Complex64} value - array element
+* @param {NonNegativeInteger} idx - array element index
+* @param {Complex64Array} arr - array instance
+* @returns {boolean} boolean indicating whether a value passes a test
+*/
+function scale( value ) {
+	return new Complex64( realf(value)*2.0, imagf(value)*2.0 );
+}
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var arr;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < len; i++ ) {
+		arr.push( new Complex64( i, i ) );
+	}
+	arr = new Complex64Array( arr );
+
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var out;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			out = arr.map( scale );
+			if ( typeof out !== 'object' ) {
+				b.fail( 'should return an object' );
+			}
+		}
+		b.toc();
+		if ( !isComplex64Array( out ) ) {
+			b.fail( 'should return a Complex64Array' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':map:len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/complex64/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex64/docs/types/index.d.ts
@@ -152,46 +152,46 @@ type TernaryCallback<U> = ( this: U, value: Complex64, index: number, arr: Compl
 type Callback<U> = NullaryCallback<U> | UnaryCallback<U> | BinaryCallback<U> | TernaryCallback<U>;
 
 /**
-* Map function invoked for each element in an array.
+* Callback invoked for each element in an array.
 *
-* @returns Complex64 or array-like object containing real and imaginary components
+* @returns transformed value
 */
 type NullaryMapFcn<U> = ( this: U ) => ComplexLike | ArrayLike<number>;
 
 /**
-* Map function invoked for each element in an array.
+* Callback invoked for each element in an array.
 *
 * @param value - current array element
-* @returns Complex64 or array-like object containing real and imaginary components
+* @returns transformed value
 */
 type UnaryMapFcn<U> = ( this: U, value: Complex64 ) => ComplexLike | ArrayLike<number>;
 
 /**
-* Map function invoked for each element in an array.
+* Callback invoked for each element in an array.
 *
 * @param value - current array element
 * @param index - current array element index
-* @returns Complex64 or array-like object containing real and imaginary components
+* @returns transformed
 */
 type BinaryMapFcn<U> = ( this: U, value: Complex64, index: number ) => ComplexLike | ArrayLike<number>;
 
 /**
-* Map function invoked for each element in an array.
+* Callback invoked for each element in an array.
 *
 * @param value - current array element
 * @param index - current array element index
 * @param arr - array on which the method was called
-* @returns Complex64 or array-like object containing real and imaginary components
+* @returns transformed value
 */
 type TernaryMapFcn<U> = ( this: U, value: Complex64, index: number, arr: Complex64Array ) => ComplexLike | ArrayLike<number>;
 
 /**
-* Map function invoked for each element in an array.
+* Callback invoked for each element in an array.
 *
 * @param value - current array element
 * @param index - current array element index
 * @param arr - array on which the method was called
-* @returns Complex64 or array-like object containing real and imaginary components
+* @returns transformed value
 */
 type MapFcn<U> = NullaryMapFcn<U> | UnaryMapFcn<U> | BinaryMapFcn<U> | TernaryMapFcn<U>;
 

--- a/lib/node_modules/@stdlib/array/complex64/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex64/docs/types/index.d.ts
@@ -678,6 +678,42 @@ declare class Complex64Array implements Complex64ArrayInterface {
 	lastIndexOf( searchElement: ComplexLike, fromIndex?: number ): number;
 
 	/**
+	* Returns a new array with each element being the result of the callback function.
+	*
+	* @param fcn - callback function
+	* @param thisArg - execution context
+	* @returns new array containing elements which are the result of the callback function
+	*
+	* @example
+	* var Complex64 = require( '@stdlib/complex/float32' );
+	* var realf = require( '@stdlib/complex/realf' );
+	* var imagf = require( '@stdlib/complex/imagf' );
+	*
+	* function scale( v, i ) {
+	*     return new Complex64( 2.0*realf( v ), 2.0*imagf( v ) );
+	* }
+	*
+	* var arr = new Complex64Array( 3 );
+	*
+	* arr.set( [ 1.0, -1.0 ], 0 );
+	* arr.set( [ 2.0, -2.0 ], 1 );
+	* arr.set( [ 3.0, -3.0 ], 2 );
+	*
+	* var out = arr.map( scale );
+	* // returns <Complex64Array>
+	*
+	* var z = out.get( 0 );
+	* // returns <Complex64>
+	*
+	* var re = realf( z );
+	* // returns 2.0
+	*
+	* var im = imagf( z );
+	* // returns -2.0
+	*/
+	map<U = unknown>( fcn: Callback<U>, thisArg?: ThisParameterType<Callback<U>> ): Complex64Array;
+
+	/**
 	* Sets an array element.
 	*
 	* ## Notes

--- a/lib/node_modules/@stdlib/array/complex64/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex64/docs/types/index.d.ts
@@ -152,6 +152,50 @@ type TernaryCallback<U> = ( this: U, value: Complex64, index: number, arr: Compl
 type Callback<U> = NullaryCallback<U> | UnaryCallback<U> | BinaryCallback<U> | TernaryCallback<U>;
 
 /**
+* Map function invoked for each element in an array.
+*
+* @returns Complex64 or array-like object containing real and imaginary components
+*/
+type NullaryMapFcn<U> = ( this: U ) => ComplexLike | ArrayLike<number>;
+
+/**
+* Map function invoked for each element in an array.
+*
+* @param value - current array element
+* @returns Complex64 or array-like object containing real and imaginary components
+*/
+type UnaryMapFcn<U> = ( this: U, value: Complex64 ) => ComplexLike | ArrayLike<number>;
+
+/**
+* Map function invoked for each element in an array.
+*
+* @param value - current array element
+* @param index - current array element index
+* @returns Complex64 or array-like object containing real and imaginary components
+*/
+type BinaryMapFcn<U> = ( this: U, value: Complex64, index: number ) => ComplexLike | ArrayLike<number>;
+
+/**
+* Map function invoked for each element in an array.
+*
+* @param value - current array element
+* @param index - current array element index
+* @param arr - array on which the method was called
+* @returns Complex64 or array-like object containing real and imaginary components
+*/
+type TernaryMapFcn<U> = ( this: U, value: Complex64, index: number, arr: Complex64Array ) => ComplexLike | ArrayLike<number>;
+
+/**
+* Map function invoked for each element in an array.
+*
+* @param value - current array element
+* @param index - current array element index
+* @param arr - array on which the method was called
+* @returns Complex64 or array-like object containing real and imaginary components
+*/
+type MapFcn<U> = NullaryMapFcn<U> | UnaryMapFcn<U> | BinaryMapFcn<U> | TernaryMapFcn<U>;
+
+/**
 * Class for creating a 64-bit complex number array.
 */
 declare class Complex64Array implements Complex64ArrayInterface {
@@ -711,7 +755,7 @@ declare class Complex64Array implements Complex64ArrayInterface {
 	* var im = imagf( z );
 	* // returns -2.0
 	*/
-	map<U = unknown>( fcn: Callback<U>, thisArg?: ThisParameterType<Callback<U>> ): Complex64Array;
+	map<U = unknown>( fcn: MapFcn<U>, thisArg?: ThisParameterType<MapFcn<U>> ): Complex64Array;
 
 	/**
 	* Sets an array element.

--- a/lib/node_modules/@stdlib/array/complex64/lib/main.js
+++ b/lib/node_modules/@stdlib/array/complex64/lib/main.js
@@ -1551,10 +1551,10 @@ setReadOnlyAccessor( Complex64Array.prototype, 'length', function get() {
 * // returns <Complex64>
 *
 * var re = realf( z );
-* // returns 0
+* // returns 2
 *
 * var im = imagf( z );
-* // returns 0
+* // returns -2
 */
 setReadOnly( Complex64Array.prototype, 'map', function map( fcn, thisArg ) {
 	var outbuf;
@@ -1570,7 +1570,7 @@ setReadOnly( Complex64Array.prototype, 'map', function map( fcn, thisArg ) {
 	}
 	buf = this._buffer;
 	out = new this.constructor( this._length );
-	outbuf = out.buffer;
+	outbuf = out._buffer; // eslint-disable-line no-underscore-dangle
 	for ( i = 0; i < this._length; i++ ) {
 		v = fcn.call( thisArg, getComplex64( buf, i ), i, this );
 		if ( isComplexLike( v ) ) {

--- a/lib/node_modules/@stdlib/array/complex64/lib/main.js
+++ b/lib/node_modules/@stdlib/array/complex64/lib/main.js
@@ -1551,15 +1551,17 @@ setReadOnlyAccessor( Complex64Array.prototype, 'length', function get() {
 * // returns <Complex64>
 *
 * var re = realf( z );
-* // returns 2.0
+* // returns 0
 *
 * var im = imagf( z );
-* // returns -2.0
+* // returns 0
 */
 setReadOnly( Complex64Array.prototype, 'map', function map( fcn, thisArg ) {
+	var outbuf;
 	var buf;
 	var out;
 	var i;
+	var v;
 	if ( !isComplexArray( this ) ) {
 		throw new TypeError( 'invalid invocation. `this` is not a complex number array.' );
 	}
@@ -1567,11 +1569,21 @@ setReadOnly( Complex64Array.prototype, 'map', function map( fcn, thisArg ) {
 		throw new TypeError( format( 'invalid argument. First argument must be a function. Value: `%s`.', fcn ) );
 	}
 	buf = this._buffer;
-	out = [];
+	out = new this.constructor( this._length );
+	outbuf = out.buffer;
 	for ( i = 0; i < this._length; i++ ) {
-		out.push( fcn.call( thisArg, getComplex64( buf, i ), i, this ) );
+		v = fcn.call( thisArg, getComplex64( buf, i ), i, this );
+		if ( isComplexLike( v ) ) {
+			outbuf[ 2*i ] = realf( v );
+			outbuf[ (2*i)+1 ] = imagf( v );
+		} else if ( isArrayLikeObject( v ) && v.length === 2 ) {
+			outbuf[ 2*i ] = v[ 0 ];
+			outbuf[ (2*i)+1 ] = v[ 1 ];
+		} else {
+			throw new TypeError( format( 'invalid argument. Callback must return either a two-element array containing real and imaginary components or a complex number. Value: `%s`.', v ) );
+		}
 	}
-	return new this.constructor( out );
+	return out;
 });
 
 /**

--- a/lib/node_modules/@stdlib/array/complex64/lib/main.js
+++ b/lib/node_modules/@stdlib/array/complex64/lib/main.js
@@ -1518,6 +1518,63 @@ setReadOnlyAccessor( Complex64Array.prototype, 'length', function get() {
 });
 
 /**
+* Returns a new array with each element being the result of the callback function.
+*
+* @name map
+* @memberof Complex64Array.prototype
+* @type {Function}
+* @param {Function} fcn - callback function
+* @param {*} [thisArg] - callback function execution context
+* @throws {TypeError} `this` must be a complex number array
+* @throws {TypeError} first argument must be a function
+* @returns {Complex64Array} complex number array
+*
+* @example
+* var Complex64 = require( '@stdlib/complex/float32' );
+* var realf = require( '@stdlib/complex/realf' );
+* var imagf = require( '@stdlib/complex/imagf' );
+*
+* function scale( v, i ) {
+*     return new Complex64( 2.0*realf( v ), 2.0*imagf( v ) );
+* }
+*
+* var arr = new Complex64Array( 3 );
+*
+* arr.set( [ 1.0, -1.0 ], 0 );
+* arr.set( [ 2.0, -2.0 ], 1 );
+* arr.set( [ 3.0, -3.0 ], 2 );
+*
+* var out = arr.map( scale );
+* // returns <Complex64Array>
+*
+* var z = out.get( 0 );
+* // returns <Complex64>
+*
+* var re = realf( z );
+* // returns 2.0
+*
+* var im = imagf( z );
+* // returns -2.0
+*/
+setReadOnly( Complex64Array.prototype, 'map', function map( fcn, thisArg ) {
+	var buf;
+	var out;
+	var i;
+	if ( !isComplexArray( this ) ) {
+		throw new TypeError( 'invalid invocation. `this` is not a complex number array.' );
+	}
+	if ( !isFunction( fcn ) ) {
+		throw new TypeError( format( 'invalid argument. First argument must be a function. Value: `%s`.', fcn ) );
+	}
+	buf = this._buffer;
+	out = [];
+	for ( i = 0; i < this._length; i++ ) {
+		out.push( fcn.call( thisArg, getComplex64( buf, i ), i, this ) );
+	}
+	return new this.constructor( out );
+});
+
+/**
 * Sets an array element.
 *
 * ## Notes

--- a/lib/node_modules/@stdlib/array/complex64/test/test.map.js
+++ b/lib/node_modules/@stdlib/array/complex64/test/test.map.js
@@ -23,6 +23,7 @@
 var tape = require( 'tape' );
 var hasOwnProp = require( '@stdlib/assert/has-own-property' );
 var isFunction = require( '@stdlib/assert/is-function' );
+var identity = require( '@stdlib/utils/identity-function' );
 var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
 var realf = require( '@stdlib/complex/realf' );
@@ -72,12 +73,8 @@ tape( 'the method throws an error if invoked with a `this` context which is not 
 
 	function badValue( value ) {
 		return function badValue() {
-			return arr.map.call( value, scale );
+			return arr.map.call( value, identity );
 		};
-	}
-
-	function scale( v ) {
-		return v;
 	}
 });
 

--- a/lib/node_modules/@stdlib/array/complex64/test/test.map.js
+++ b/lib/node_modules/@stdlib/array/complex64/test/test.map.js
@@ -115,7 +115,9 @@ tape( 'the method returns an empty array if operating on an empty complex number
 	arr = new Complex64Array();
 	out = arr.map( identity );
 
+	t.strictEqual( instanceOf( out, Complex64Array ), true, 'returns expected value' );
 	t.strictEqual( out.length, 0, 'returns expected value' );
+	t.notEqual( out, arr, 'returns a new instance' );
 	t.end();
 });
 
@@ -161,5 +163,69 @@ tape( 'the method supports providing an execution context', function test( t ) {
 	function scale( v ) {
 		this.count += 1; // eslint-disable-line no-invalid-this
 		return new Complex64( realf( v )*3.0, imagf( v )*3.0 );
+	}
+});
+
+tape( 'the method supports map function which returns an array of two integers', function test( t ) {
+	var expected;
+	var actual;
+	var arr;
+
+	arr = new Complex64Array( [ 1.0, -1.0, 2.0, -2.0, 3.0, -3.0 ] );
+	expected = new Float32Array( [ 2.0, -2.0, 4.0, -4.0, 6.0, -6.0 ] );
+	actual = arr.map( scale );
+
+	t.strictEqual( instanceOf( actual, Complex64Array ), true, 'returns expected value' );
+	t.strictEqual( actual.length, expected.length/2, 'returns expected value' );
+	t.deepEqual( reinterpret64( actual, 0 ), expected, 'returns expected value' );
+	t.end();
+
+	function scale( v ) {
+		return [ realf( v )*2.0, imagf( v )*2.0 ];
+	}
+});
+
+tape( 'the method throws an error if provided a map function which does not return complex number or array of length 2 containing real and imaginary components', function test( t ) {
+	var clbks;
+	var arr;
+	var i;
+
+	arr = new Complex64Array( [ 1.0, -1.0, 2.0, -2.0, 3.0, -3.0 ] );
+	clbks = [
+		clbk1,
+		clbk2,
+		clbk3,
+		clbk4,
+		clbk5
+	];
+	for ( i = 0; i < clbks.length; i++ ) {
+		t.throws( badValue( clbks[i] ), TypeError, 'throws an error when provided callback '+i );
+	}
+	t.end();
+
+	function badValue( clbk ) {
+		return function badValue() {
+			return arr.map( clbk );
+		};
+	}
+
+	function clbk1() {
+		return 1.0;
+	}
+
+	function clbk2() {
+		return {};
+	}
+
+	function clbk3() {
+		return [ 1.0, 2.0, 3.0 ];
+	}
+
+	function clbk4() {
+		return [];
+	}
+
+	function clbk5() {
+		return [ 1.0 ];
 	}
 });

--- a/lib/node_modules/@stdlib/array/complex64/test/test.map.js
+++ b/lib/node_modules/@stdlib/array/complex64/test/test.map.js
@@ -1,0 +1,171 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
+var instanceOf = require( '@stdlib/assert/instance-of' );
+var realf = require( '@stdlib/complex/realf' );
+var imagf = require( '@stdlib/complex/imagf' );
+var Complex64 = require('@stdlib/complex/float32');
+var Float32Array = require( '@stdlib/array/float32' );
+var Complex64Array = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof Complex64Array, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the main export is a `map` method', function test( t ) {
+	t.strictEqual( hasOwnProp( Complex64Array.prototype, 'map' ), true, 'has property' );
+	t.strictEqual( isFunction( Complex64Array.prototype.map ), true, 'has method' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a complex number array instance', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new Complex64Array( 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.map.call( value, scale );
+		};
+	}
+
+	function scale( v ) {
+		return v;
+	}
+});
+
+tape( 'the method throws an error if provided a first argument which is not a function', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new Complex64Array( 10 );
+
+	values = [
+		'5',
+		3.14,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[]
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.map( value );
+		};
+	}
+});
+
+tape( 'the method returns an empty array if operating on an empty complex number array', function test( t ) {
+	var arr;
+	var out;
+
+	arr = new Complex64Array();
+	out = arr.map( predicate );
+
+	t.strictEqual( out.length, 0, 'returns expected value' );
+	t.end();
+
+	function predicate( v ) {
+		return v;
+	}
+});
+
+tape( 'the method returns a new complex number array containing elements which are the result of callback function', function test( t ) {
+	var expected;
+	var actual;
+	var arr;
+
+	arr = new Complex64Array( [ 1.0, -1.0, 2.0, -2.0, 3.0, -3.0 ] );
+	expected = new Float32Array( [ 2.0, -2.0, 4.0, -4.0, 6.0, -6.0 ] );
+	actual = arr.map( scale );
+
+	t.strictEqual( instanceOf( actual, Complex64Array ), true, 'returns expected value' );
+	t.strictEqual( actual.length, expected.length/2, 'returns expected value' );
+	t.deepEqual( reinterpret64( actual, 0 ), expected, 'returns expected value' );
+	t.end();
+
+	function scale( v ) {
+		return new Complex64( realf( v )*2.0, imagf( v )*2.0 );
+	}
+});
+
+tape( 'the method supports providing an execution context', function test( t ) {
+	var expected;
+	var actual;
+	var arr;
+	var ctx;
+
+	arr = new Complex64Array( [ 1.0, -1.0, 2.0, -2.0, 3.0, -3.0 ] );
+	expected = new Float32Array( [ 3.0, -3.0, 6.0, -6.0, 9.0, -9.0 ] );
+	ctx = {
+		'count': 0
+	};
+	actual = arr.map( scale, ctx );
+
+	t.strictEqual( instanceOf( actual, Complex64Array ), true, 'returns expected value' );
+	t.strictEqual( actual.length, expected.length/2, 'returns expected value' );
+	t.deepEqual( reinterpret64( actual, 0 ), expected, 'returns expected value' );
+	t.strictEqual( ctx.count, 3, 'returns expected value' );
+	t.end();
+
+	function scale( v ) {
+		this.count += 1; // eslint-disable-line no-invalid-this
+		return new Complex64( realf( v )*3.0, imagf( v )*3.0 );
+	}
+});

--- a/lib/node_modules/@stdlib/array/complex64/test/test.map.js
+++ b/lib/node_modules/@stdlib/array/complex64/test/test.map.js
@@ -130,6 +130,7 @@ tape( 'the method returns a new complex number array containing elements which a
 
 	t.strictEqual( instanceOf( actual, Complex64Array ), true, 'returns expected value' );
 	t.strictEqual( actual.length, expected.length/2, 'returns expected value' );
+	t.notEqual( actual, arr, 'returns a new instance' );
 	t.deepEqual( reinterpret64( actual, 0 ), expected, 'returns expected value' );
 	t.end();
 

--- a/lib/node_modules/@stdlib/array/complex64/test/test.map.js
+++ b/lib/node_modules/@stdlib/array/complex64/test/test.map.js
@@ -166,7 +166,7 @@ tape( 'the method supports providing an execution context', function test( t ) {
 	}
 });
 
-tape( 'the method supports map function which returns an array of two integers', function test( t ) {
+tape( 'the method supports a map function which returns a two-element array containing a real and an imaginary component', function test( t ) {
 	var expected;
 	var actual;
 	var arr;

--- a/lib/node_modules/@stdlib/array/complex64/test/test.map.js
+++ b/lib/node_modules/@stdlib/array/complex64/test/test.map.js
@@ -113,14 +113,10 @@ tape( 'the method returns an empty array if operating on an empty complex number
 	var out;
 
 	arr = new Complex64Array();
-	out = arr.map( predicate );
+	out = arr.map( identity );
 
 	t.strictEqual( out.length, 0, 'returns expected value' );
 	t.end();
-
-	function predicate( v ) {
-		return v;
-	}
 });
 
 tape( 'the method returns a new complex number array containing elements which are the result of callback function', function test( t ) {


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Adds the typed array `map` method to prototype of `Complex64Array`

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
