### PR TITLE
feat: add `includes` method to `array/complex128`

### DIFF
--- a/lib/node_modules/@stdlib/array/complex128/README.md
+++ b/lib/node_modules/@stdlib/array/complex128/README.md
@@ -1230,6 +1230,33 @@ var z = arr.get( 100 );
 // returns undefined
 ```
 
+<a name="method-includes"></a>
+
+#### Complex128Array.prototype.includes( searchElement\[, fromIndex] )
+
+Returns a boolean indicating whether an array includes a provided value.
+
+```javascript
+var Complex128 = require( '@stdlib/complex/float64' );
+
+var arr = new Complex128Array( 5 );
+
+arr.set( [ 1.0, -1.0 ], 0 );
+arr.set( [ 2.0, -2.0 ], 1 );
+arr.set( [ 3.0, -3.0 ], 2 );
+arr.set( [ 4.0, -4.0 ], 3 );
+arr.set( [ 5.0, -5.0 ], 4 );
+
+var bool = arr.includes( new Complex128( 3.0, -3.0 ) );
+// returns true
+
+bool = arr.includes( new Complex128( 3.0, -3.0 ), 3 );
+// returns false
+
+bool = arr.includes( new Complex128( 4.0, -4.0 ), -3 );
+// returns true
+```
+
 <a name="method-index-of"></a>
 
 #### Complex128Array.prototype.indexOf( searchElement\[, fromIndex] )

--- a/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.includes.js
+++ b/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.includes.js
@@ -1,0 +1,59 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var Complex128 = require( '@stdlib/complex/float64' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var pkg = require( './../package.json' ).name;
+var Complex128Array = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg+':includes', function benchmark( b ) {
+	var bool;
+	var arr;
+	var v;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < 10; i++ ) {
+		arr.push( new Complex128( i, i ) );
+	}
+	arr = new Complex128Array( arr );
+
+	v = new Complex128( 10.0, 10.0 );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		bool = arr.includes( v, 0 );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.includes.length.js
+++ b/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.includes.length.js
@@ -1,0 +1,107 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var Complex128 = require( '@stdlib/complex/float64' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var pkg = require( './../package.json' ).name;
+var Complex128Array = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var arr;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < len-1; i++ ) {
+		arr.push( new Complex128( i, -i ) );
+	}
+	arr.push( new Complex128( i, i ) );
+	arr = new Complex128Array( arr );
+
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var bool;
+		var v;
+		var i;
+
+		v = new Complex128( len-1, len-1 );
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			bool = arr.includes( v );
+			if ( typeof bool !== 'boolean' ) {
+				b.fail( 'should return a boolean' );
+			}
+		}
+		b.toc();
+		if ( !isBoolean( bool ) ) {
+			b.fail( 'should return a boolean' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':includes:len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
@@ -518,6 +518,35 @@ declare class Complex128Array implements Complex128ArrayInterface {
 	get( i: number ): Complex128 | void;
 
 	/**
+	* Returns a boolean indicating whether an array contains a provided value.
+	*
+	* @param searchElement - search element
+	* @param fromIndex - starting index (inclusive)
+	* @returns boolean indicating whether an array contains a provided value
+	*
+	* @example
+	* var Complex128 = require( '@stdlib/complex/float64' );
+	*
+	* var arr = new Complex128Array( 5 );
+	*
+	* arr.set( [ 1.0, -1.0 ], 0 );
+	* arr.set( [ 2.0, -2.0 ], 1 );
+	* arr.set( [ 3.0, -3.0 ], 2 );
+	* arr.set( [ 4.0, -4.0 ], 3 );
+	* arr.set( [ 5.0, -5.0 ], 4 );
+	*
+	* var bool = arr.includes( new Complex128( 3.0, -3.0 ) );
+	* // returns true
+	*
+	* bool = arr.includes( new Complex128( 3.0, -3.0 ), 3 );
+	* // returns false
+	*
+	* bool = arr.includes( new Complex128( 4.0, -4.0 ), -3 );
+	* // returns true
+	*/
+	includes( searchElement: ComplexLike, fromIndex?: number ): boolean;
+
+	/**
 	* Returns the first index at which a given element can be found.
 	*
 	* @param searchElement - element to find

--- a/lib/node_modules/@stdlib/array/complex128/lib/main.js
+++ b/lib/node_modules/@stdlib/array/complex128/lib/main.js
@@ -1260,6 +1260,76 @@ setReadOnlyAccessor( Complex128Array.prototype, 'length', function get() {
 });
 
 /**
+* Returns a boolean indicating whether an array includes a provided value.
+*
+* @name includes
+* @memberof Complex128Array.prototype
+* @type {Function}
+* @param {Complex128} searchElement - search element
+* @param {integer} [fromIndex=0] - starting index (inclusive)
+* @throws {TypeError} `this` must be a complex number array
+* @throws {TypeError} first argument must be a complex number
+* @throws {TypeError} second argument must be an integer
+* @returns {boolean} boolean indicating whether an array includes a provided value
+*
+* @example
+* var Complex128 = require( '@stdlib/complex/float64' );
+*
+* var arr = new Complex128Array( 5 );
+*
+* arr.set( [ 1.0, -1.0 ], 0 );
+* arr.set( [ 2.0, -2.0 ], 1 );
+* arr.set( [ 3.0, -3.0 ], 2 );
+* arr.set( [ 4.0, -4.0 ], 3 );
+* arr.set( [ 5.0, -5.0 ], 4 );
+*
+* var bool = arr.includes( new Complex128( 3.0, -3.0 ) );
+* // returns true
+*
+* bool = arr.includes( new Complex128( 3.0, -3.0 ), 3 );
+* // returns false
+*
+* bool = arr.includes( new Complex128( 4.0, -4.0 ), -3 );
+* // returns true
+*/
+setReadOnly( Complex128Array.prototype, 'includes', function includes( searchElement, fromIndex ) {
+	var buf;
+	var idx;
+	var re;
+	var im;
+	var i;
+	if ( !isComplexArray( this ) ) {
+		throw new TypeError( 'invalid invocation. `this` is not a complex number array.' );
+	}
+	if ( !isComplexLike( searchElement ) ) {
+		throw new TypeError( format( 'invalid argument. First argument must be a complex number. Value: `%s`.', searchElement ) );
+	}
+	if ( arguments.length > 1 ) {
+		if ( !isInteger( fromIndex ) ) {
+			throw new TypeError( format( 'invalid argument. Second argument must be an integer. Value: `%s`.', fromIndex ) );
+		}
+		if ( fromIndex < 0 ) {
+			fromIndex += this._length;
+			if ( fromIndex < 0 ) {
+				fromIndex = 0;
+			}
+		}
+	} else {
+		fromIndex = 0;
+	}
+	re = real( searchElement );
+	im = imag( searchElement );
+	buf = this._buffer;
+	for ( i = fromIndex; i < this._length; i++ ) {
+		idx = 2 * i;
+		if ( re === buf[ idx ] && im === buf[ idx+1 ] ) {
+			return true;
+		}
+	}
+	return false;
+});
+
+/**
 * Returns the first index at which a given element can be found.
 *
 * @name indexOf

--- a/lib/node_modules/@stdlib/array/complex128/test/test.includes.js
+++ b/lib/node_modules/@stdlib/array/complex128/test/test.includes.js
@@ -1,0 +1,242 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var Complex128 = require( '@stdlib/complex/float64' );
+var Complex128Array = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof Complex128Array, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the main export is an `includes` method', function test( t ) {
+	t.strictEqual( hasOwnProp( Complex128Array.prototype, 'includes' ), true, 'has property' );
+	t.strictEqual( isFunction( Complex128Array.prototype.includes ), true, 'has method' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a complex number array instance', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new Complex128Array( 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.includes.call( value, new Complex128( 10.0, 10.0 ) );
+		};
+	}
+});
+
+tape( 'the method throws an error if provided a first argument which is not a complex number', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new Complex128Array( 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.includes( value );
+		};
+	}
+});
+
+tape( 'the method throws an error if provided a second argument which is not an integer', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new Complex128Array( 10 );
+
+	values = [
+		'5',
+		3.14,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.includes( new Complex128( 1.0, 1.0 ), value );
+		};
+	}
+});
+
+tape( 'the method returns `false` if operating on an empty complex number array', function test( t ) {
+	var bool;
+	var arr;
+
+	arr = new Complex128Array();
+	bool = arr.includes( new Complex128( 1.0, 1.0 ) );
+
+	t.strictEqual( bool, false, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method returns `false` if a complex number is not found', function test( t ) {
+	var bool;
+	var arr;
+
+	arr = new Complex128Array( 10 );
+	bool = arr.includes( new Complex128( 1.0, 1.0 ) );
+
+	t.strictEqual( bool, false, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method returns `true` if an array contains a specified complex number', function test( t ) {
+	var bool;
+	var arr;
+
+	arr = new Complex128Array( 10 );
+	arr.set( [ 1.0, 1.0 ], 0 );
+	arr.set( [ 2.0, 2.0 ], 1 );
+	arr.set( [ 3.0, 3.0 ], 2 );
+	arr.set( [ 2.0, 2.0 ], 3 );
+	bool = arr.includes( new Complex128( 2.0, 2.0 ) );
+
+	t.strictEqual( bool, true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method returns `false` if provided a second argument which exceeds the input array length', function test( t ) {
+	var bool;
+	var arr;
+
+	arr = new Complex128Array( 10 );
+	bool = arr.includes( new Complex128( 1.0, 1.0), 20 );
+
+	t.strictEqual( bool, false, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method supports specifying a starting search index', function test( t ) {
+	var bool;
+	var arr;
+
+	arr = new Complex128Array( 10 );
+	arr.set( [ 1.0, 1.0 ], 0 );
+	arr.set( [ 2.0, 2.0 ], 1 );
+	arr.set( [ 3.0, 3.0 ], 2 );
+	arr.set( [ 2.0, 2.0 ], 3 );
+
+	bool = arr.includes( new Complex128( 2.0, 2.0 ), 0 );
+	t.strictEqual( bool, true, 'returns expected value' );
+
+	bool = arr.includes( new Complex128( 2.0, 2.0 ), 2 );
+	t.strictEqual( bool, true, 'returns expected value' );
+
+	bool = arr.includes( new Complex128( 3.0, 3.0 ), 3 );
+	t.strictEqual( bool, false, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method supports specifying a starting search index (negative)', function test( t ) {
+	var bool;
+	var arr;
+
+	arr = new Complex128Array( 5 );
+	arr.set( [ 1.0, 1.0 ], 0 );
+	arr.set( [ 2.0, 2.0 ], 1 );
+	arr.set( [ 3.0, 3.0 ], 2 );
+	arr.set( [ 2.0, 2.0 ], 3 );
+	arr.set( [ 2.0, 2.0 ], 4 );
+
+	bool = arr.includes( new Complex128( 2.0, 2.0 ), -5 );
+	t.strictEqual( bool, true, 'returns expected value' );
+
+	bool = arr.includes( new Complex128( 4.0, 4.0 ), -2 );
+	t.strictEqual( bool, false, 'returns expected value' );
+	t.end();
+});
+
+tape( 'when provided a starting index which resolves to an index which is less than zero, the method searches from the first array element', function test( t ) {
+	var bool;
+	var arr;
+
+	arr = new Complex128Array( 5 );
+	arr.set( [ 1.0, 1.0 ], 0 );
+	arr.set( [ 2.0, 2.0 ], 1 );
+	arr.set( [ 3.0, 3.0 ], 2 );
+	arr.set( [ 2.0, 2.0 ], 3 );
+	arr.set( [ 2.0, 2.0 ], 4 );
+
+	bool = arr.includes( new Complex128( 2.0, 2.0 ), -10 );
+	t.strictEqual( bool, true, 'returns expected value' );
+
+	bool = arr.includes( new Complex128( 4.0, 4.0 ), -10 );
+	t.strictEqual( bool, false, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Adds the typed array `includes` method to prototype of `Complex128Array`

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
