### PR TITLE
feat: add `map` method to `array/complex128`

### DIFF
--- a/lib/node_modules/@stdlib/array/complex128/README.md
+++ b/lib/node_modules/@stdlib/array/complex128/README.md
@@ -1345,6 +1345,77 @@ idx = arr.lastIndexOf( new Complex128( 2.0, -2.0 ), 0 );
 // returns -1
 ```
 
+<a name="method-map"></a>
+
+#### Complex128Array.prototype.map( callbackFn\[, thisArg] )
+
+Returns a new array with each element being the result of the callback function.
+
+```javascript
+var Complex128 = require( '@stdlib/complex/float64' );
+var real = require( '@stdlib/complex/real' );
+var imag = require( '@stdlib/complex/imag' );
+
+function scale( v ) {
+    return new Complex128( 2.0*real( v ), 2.0*imag( v ) );
+}
+
+var arr = new Complex128Array( 3 );
+
+// Set the first three elements:
+arr.set( [ 1.0, -1.0 ], 0 );
+arr.set( [ 2.0, -2.0 ], 1 );
+arr.set( [ 3.0, -3.0 ], 2 );
+
+var out = arr.map( scale );
+// returns <Complex128Array>
+
+var z = out.get( 0 );
+// returns <Complex128>
+
+var re = real( z );
+// returns 2.0
+
+var im = imag( z );
+// returns -2.0
+```
+
+The callback function is provided three arguments:
+
+-   **value**: current array element.
+-   **index**: current array element index.
+-   **arr**: the array on which this method was called.
+
+To set the function execution context, provide a `thisArg`.
+
+```javascript
+var Complex128 = require( '@stdlib/complex/float64' );
+var real = require( '@stdlib/complex/real' );
+var imag = require( '@stdlib/complex/imag' );
+
+function scale( v ) {
+    this.count += 1;
+    return new Complex128( 2.0*real( v ), 2.0*imag( v ) );
+}
+
+var arr = new Complex128Array( 3 );
+
+var context = {
+    'count': 0
+};
+
+// Set the first three elements:
+arr.set( [ 1.0, 1.0 ], 0 );
+arr.set( [ 2.0, 2.0 ], 1 );
+arr.set( [ 3.0, 3.0 ], 2 );
+
+var out = arr.map( scale, context );
+// returns <Complex128Array>
+
+var count = context.count;
+// returns 3
+```
+
 <a name="method-set"></a>
 
 #### Complex128Array.prototype.set( z\[, i] )

--- a/lib/node_modules/@stdlib/array/complex128/README.md
+++ b/lib/node_modules/@stdlib/array/complex128/README.md
@@ -1349,7 +1349,7 @@ idx = arr.lastIndexOf( new Complex128( 2.0, -2.0 ), 0 );
 
 #### Complex128Array.prototype.map( callbackFn\[, thisArg] )
 
-Returns a new array with each element being the result of the callback function.
+Returns a new array with each element being the result of a provided callback function.
 
 ```javascript
 var Complex128 = require( '@stdlib/complex/float64' );

--- a/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.map.js
+++ b/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.map.js
@@ -1,0 +1,58 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isComplex128Array = require( '@stdlib/assert/is-complex128array' );
+var realf = require( '@stdlib/complex/realf' );
+var imagf = require( '@stdlib/complex/imagf' );
+var Complex128 = require('@stdlib/complex/float64');
+var pkg = require( './../package.json' ).name;
+var Complex128Array = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg+':map', function benchmark( b ) {
+	var out;
+	var arr;
+	var i;
+
+	arr = new Complex128Array( [ 1, 2, 3, 4, 5, 6 ] );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = arr.map( scale );
+		if ( typeof out !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+	if ( !isComplex128Array( out ) ) {
+		b.fail( 'should return a Complex128Array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+
+	function scale( v ) {
+		return new Complex128( realf(v)*2.0, imagf(v)*2.0 );
+	}
+});

--- a/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.map.length.js
+++ b/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.map.length.js
@@ -1,0 +1,104 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isComplex128Array = require( '@stdlib/assert/is-complex128array' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var identity = require( '@stdlib/utils/identity-function' );
+var Complex128 = require( '@stdlib/complex/float64' );
+var pkg = require( './../package.json' ).name;
+var Complex128Array = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var arr;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < len; i++ ) {
+		arr.push( new Complex128( i, i ) );
+	}
+	arr = new Complex128Array( arr );
+
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var out;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			out = arr.map( identity );
+			if ( typeof out !== 'object' ) {
+				b.fail( 'should return an object' );
+			}
+		}
+		b.toc();
+		if ( !isComplex128Array( out ) ) {
+			b.fail( 'should return a Complex128Array' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':map:len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
@@ -127,7 +127,7 @@ type UnaryMapFcn<U> = ( this: U, value: Complex128 ) => ComplexLike | ArrayLike<
 *
 * @param value - current array element
 * @param index - current array element index
-* @returns transformed
+* @returns transformed value
 */
 type BinaryMapFcn<U> = ( this: U, value: Complex128, index: number ) => ComplexLike | ArrayLike<number>;
 

--- a/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
@@ -649,11 +649,11 @@ declare class Complex128Array implements Complex128ArrayInterface {
 	lastIndexOf( searchElement: ComplexLike, fromIndex?: number ): number;
 
 	/**
-	* Returns a new array with each element being the result of the callback function.
+	* Returns a new array with each element being the result of a provided callback function.
 	*
 	* @param fcn - callback function
 	* @param thisArg - execution context
-	* @returns new array containing elements which are the result of the callback function
+	* @returns new array containing transformed elements
 	*
 	* @example
 	* var Complex128 = require( '@stdlib/complex/float64' );

--- a/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
@@ -1,3 +1,5 @@
+/* eslint-disable max-lines */
+
 /*
 * @license Apache-2.0
 *
@@ -104,6 +106,50 @@ type TernaryPredicate<U> = ( this: U, value: Complex128, index: number, arr: Com
 * @returns boolean indicating whether an element in an array passes a test
 */
 type Predicate<U> = NullaryPredicate<U> | UnaryPredicate<U> | BinaryPredicate<U> | TernaryPredicate<U>;
+
+/**
+* Callback invoked for each element in an array.
+*
+* @returns transformed value
+*/
+type NullaryMapFcn<U> = ( this: U ) => ComplexLike | ArrayLike<number>;
+
+/**
+* Callback invoked for each element in an array.
+*
+* @param value - current array element
+* @returns transformed value
+*/
+type UnaryMapFcn<U> = ( this: U, value: Complex128 ) => ComplexLike | ArrayLike<number>;
+
+/**
+* Callback invoked for each element in an array.
+*
+* @param value - current array element
+* @param index - current array element index
+* @returns transformed
+*/
+type BinaryMapFcn<U> = ( this: U, value: Complex128, index: number ) => ComplexLike | ArrayLike<number>;
+
+/**
+* Callback invoked for each element in an array.
+*
+* @param value - current array element
+* @param index - current array element index
+* @param arr - array on which the method was called
+* @returns transformed value
+*/
+type TernaryMapFcn<U> = ( this: U, value: Complex128, index: number, arr: Complex128Array ) => ComplexLike | ArrayLike<number>;
+
+/**
+* Callback invoked for each element in an array.
+*
+* @param value - current array element
+* @param index - current array element index
+* @param arr - array on which the method was called
+* @returns transformed value
+*/
+type MapFcn<U> = NullaryMapFcn<U> | UnaryMapFcn<U> | BinaryMapFcn<U> | TernaryMapFcn<U>;
 
 /**
 * Class for creating a 128-bit complex number array.
@@ -601,6 +647,42 @@ declare class Complex128Array implements Complex128ArrayInterface {
 	* // returns 1
 	*/
 	lastIndexOf( searchElement: ComplexLike, fromIndex?: number ): number;
+
+	/**
+	* Returns a new array with each element being the result of the callback function.
+	*
+	* @param fcn - callback function
+	* @param thisArg - execution context
+	* @returns new array containing elements which are the result of the callback function
+	*
+	* @example
+	* var Complex128 = require( '@stdlib/complex/float64' );
+	* var real = require( '@stdlib/complex/real' );
+	* var imag = require( '@stdlib/complex/imag' );
+	*
+	* function scale( v, i ) {
+	*     return new Complex128( 2.0*real( v ), 2.0*imag( v ) );
+	* }
+	*
+	* var arr = new Complex128Array( 3 );
+	*
+	* arr.set( [ 1.0, -1.0 ], 0 );
+	* arr.set( [ 2.0, -2.0 ], 1 );
+	* arr.set( [ 3.0, -3.0 ], 2 );
+	*
+	* var out = arr.map( scale );
+	* // returns <Complex128Array>
+	*
+	* var z = out.get( 0 );
+	* // returns <Complex128>
+	*
+	* var re = real( z );
+	* // returns 2.0
+	*
+	* var im = imag( z );
+	* // returns -2.0
+	*/
+	map<U = unknown>( fcn: MapFcn<U>, thisArg?: ThisParameterType<MapFcn<U>> ): Complex128Array;
 
 	/**
 	* Sets an array element.

--- a/lib/node_modules/@stdlib/array/complex128/lib/main.js
+++ b/lib/node_modules/@stdlib/array/complex128/lib/main.js
@@ -1472,7 +1472,7 @@ setReadOnly( Complex128Array.prototype, 'lastIndexOf', function lastIndexOf( sea
 });
 
 /**
-* Returns a new array with each element being the result of the callback function.
+* Returns a new array with each element being the result of a provided callback function.
 *
 * @name map
 * @memberof Complex128Array.prototype
@@ -1505,10 +1505,10 @@ setReadOnly( Complex128Array.prototype, 'lastIndexOf', function lastIndexOf( sea
 * // returns <Complex128>
 *
 * var re = real( z );
-* // returns 2
+* // returns 2.0
 *
 * var im = imag( z );
-* // returns -2
+* // returns -2.0
 */
 setReadOnly( Complex128Array.prototype, 'map', function map( fcn, thisArg ) {
 	var outbuf;

--- a/lib/node_modules/@stdlib/array/complex128/lib/main.js
+++ b/lib/node_modules/@stdlib/array/complex128/lib/main.js
@@ -1472,6 +1472,75 @@ setReadOnly( Complex128Array.prototype, 'lastIndexOf', function lastIndexOf( sea
 });
 
 /**
+* Returns a new array with each element being the result of the callback function.
+*
+* @name map
+* @memberof Complex128Array.prototype
+* @type {Function}
+* @param {Function} fcn - callback function
+* @param {*} [thisArg] - callback function execution context
+* @throws {TypeError} `this` must be a complex number array
+* @throws {TypeError} first argument must be a function
+* @returns {Complex128Array} complex number array
+*
+* @example
+* var Complex128 = require( '@stdlib/complex/float64' );
+* var real = require( '@stdlib/complex/real' );
+* var imag = require( '@stdlib/complex/imag' );
+*
+* function scale( v, i ) {
+*     return new Complex128( 2.0*real( v ), 2.0*imag( v ) );
+* }
+*
+* var arr = new Complex128Array( 3 );
+*
+* arr.set( [ 1.0, -1.0 ], 0 );
+* arr.set( [ 2.0, -2.0 ], 1 );
+* arr.set( [ 3.0, -3.0 ], 2 );
+*
+* var out = arr.map( scale );
+* // returns <Complex128Array>
+*
+* var z = out.get( 0 );
+* // returns <Complex128>
+*
+* var re = real( z );
+* // returns 2
+*
+* var im = imag( z );
+* // returns -2
+*/
+setReadOnly( Complex128Array.prototype, 'map', function map( fcn, thisArg ) {
+	var outbuf;
+	var buf;
+	var out;
+	var i;
+	var v;
+	if ( !isComplexArray( this ) ) {
+		throw new TypeError( 'invalid invocation. `this` is not a complex number array.' );
+	}
+	if ( !isFunction( fcn ) ) {
+		throw new TypeError( format( 'invalid argument. First argument must be a function. Value: `%s`.', fcn ) );
+	}
+	buf = this._buffer;
+	out = new this.constructor( this._length );
+	outbuf = out._buffer; // eslint-disable-line no-underscore-dangle
+	for ( i = 0; i < this._length; i++ ) {
+		v = fcn.call( thisArg, getComplex128( buf, i ), i, this );
+		if ( isComplexLike( v ) ) {
+			outbuf[ 2*i ] = real( v );
+			outbuf[ (2*i)+1 ] = imag( v );
+		} else if ( isArrayLikeObject( v ) && v.length === 2 ) {
+			outbuf[ 2*i ] = v[ 0 ];
+			outbuf[ (2*i)+1 ] = v[ 1 ];
+		} else {
+			throw new TypeError( format( 'invalid argument. Callback must return either a two-element array containing real and imaginary components or a complex number. Value: `%s`.', v ) );
+		}
+	}
+	return out;
+});
+
+/**
 * Sets an array element.
 *
 * ## Notes

--- a/lib/node_modules/@stdlib/array/complex128/test/test.map.js
+++ b/lib/node_modules/@stdlib/array/complex128/test/test.map.js
@@ -121,7 +121,7 @@ tape( 'the method returns an empty array if operating on an empty complex number
 	t.end();
 });
 
-tape( 'the method returns a new complex number array containing elements which are the result of callback function', function test( t ) {
+tape( 'the method returns a new complex number array containing elements which are the result of a callback function', function test( t ) {
 	var expected;
 	var actual;
 	var arr;
@@ -185,7 +185,7 @@ tape( 'the method supports a map function which returns a two-element array cont
 	}
 });
 
-tape( 'the method throws an error if provided a map function which does not return complex number or array of length 2 containing real and imaginary components', function test( t ) {
+tape( 'the method throws an error if provided a map function which does not return a complex number or an array of length 2 containing real and imaginary components', function test( t ) {
 	var clbks;
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/array/complex128/test/test.map.js
+++ b/lib/node_modules/@stdlib/array/complex128/test/test.map.js
@@ -1,0 +1,231 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var identity = require( '@stdlib/utils/identity-function' );
+var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
+var instanceOf = require( '@stdlib/assert/instance-of' );
+var real = require( '@stdlib/complex/real' );
+var imag = require( '@stdlib/complex/imag' );
+var Complex128 = require('@stdlib/complex/float64');
+var Float64Array = require( '@stdlib/array/float64' );
+var Complex128Array = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof Complex128Array, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the main export is a `map` method', function test( t ) {
+	t.strictEqual( hasOwnProp( Complex128Array.prototype, 'map' ), true, 'has property' );
+	t.strictEqual( isFunction( Complex128Array.prototype.map ), true, 'has method' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a complex number array instance', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new Complex128Array( 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.map.call( value, identity );
+		};
+	}
+});
+
+tape( 'the method throws an error if provided a first argument which is not a function', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new Complex128Array( 10 );
+
+	values = [
+		'5',
+		3.14,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[]
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.map( value );
+		};
+	}
+});
+
+tape( 'the method returns an empty array if operating on an empty complex number array', function test( t ) {
+	var arr;
+	var out;
+
+	arr = new Complex128Array();
+	out = arr.map( identity );
+
+	t.strictEqual( instanceOf( out, Complex128Array ), true, 'returns expected value' );
+	t.strictEqual( out.length, 0, 'returns expected value' );
+	t.notEqual( out, arr, 'returns a new instance' );
+	t.end();
+});
+
+tape( 'the method returns a new complex number array containing elements which are the result of callback function', function test( t ) {
+	var expected;
+	var actual;
+	var arr;
+
+	arr = new Complex128Array( [ 1.0, -1.0, 2.0, -2.0, 3.0, -3.0 ] );
+	expected = new Float64Array( [ 2.0, -2.0, 4.0, -4.0, 6.0, -6.0 ] );
+	actual = arr.map( scale );
+
+	t.strictEqual( instanceOf( actual, Complex128Array ), true, 'returns expected value' );
+	t.strictEqual( actual.length, expected.length/2, 'returns expected value' );
+	t.notEqual( actual, arr, 'returns a new instance' );
+	t.deepEqual( reinterpret128( actual, 0 ), expected, 'returns expected value' );
+	t.end();
+
+	function scale( v ) {
+		return new Complex128( real( v )*2.0, imag( v )*2.0 );
+	}
+});
+
+tape( 'the method supports providing an execution context', function test( t ) {
+	var expected;
+	var actual;
+	var arr;
+	var ctx;
+
+	arr = new Complex128Array( [ 1.0, -1.0, 2.0, -2.0, 3.0, -3.0 ] );
+	expected = new Float64Array( [ 3.0, -3.0, 6.0, -6.0, 9.0, -9.0 ] );
+	ctx = {
+		'count': 0
+	};
+	actual = arr.map( scale, ctx );
+
+	t.strictEqual( instanceOf( actual, Complex128Array ), true, 'returns expected value' );
+	t.strictEqual( actual.length, expected.length/2, 'returns expected value' );
+	t.deepEqual( reinterpret128( actual, 0 ), expected, 'returns expected value' );
+	t.strictEqual( ctx.count, 3, 'returns expected value' );
+	t.end();
+
+	function scale( v ) {
+		this.count += 1; // eslint-disable-line no-invalid-this
+		return new Complex128( real( v )*3.0, imag( v )*3.0 );
+	}
+});
+
+tape( 'the method supports a map function which returns a two-element array containing a real and an imaginary component', function test( t ) {
+	var expected;
+	var actual;
+	var arr;
+
+	arr = new Complex128Array( [ 1.0, -1.0, 2.0, -2.0, 3.0, -3.0 ] );
+	expected = new Float64Array( [ 2.0, -2.0, 4.0, -4.0, 6.0, -6.0 ] );
+	actual = arr.map( scale );
+
+	t.strictEqual( instanceOf( actual, Complex128Array ), true, 'returns expected value' );
+	t.strictEqual( actual.length, expected.length/2, 'returns expected value' );
+	t.deepEqual( reinterpret128( actual, 0 ), expected, 'returns expected value' );
+	t.end();
+
+	function scale( v ) {
+		return [ real( v )*2.0, imag( v )*2.0 ];
+	}
+});
+
+tape( 'the method throws an error if provided a map function which does not return complex number or array of length 2 containing real and imaginary components', function test( t ) {
+	var clbks;
+	var arr;
+	var i;
+
+	arr = new Complex128Array( [ 1.0, -1.0, 2.0, -2.0, 3.0, -3.0 ] );
+	clbks = [
+		clbk1,
+		clbk2,
+		clbk3,
+		clbk4,
+		clbk5
+	];
+	for ( i = 0; i < clbks.length; i++ ) {
+		t.throws( badValue( clbks[i] ), TypeError, 'throws an error when provided callback '+i );
+	}
+	t.end();
+
+	function badValue( clbk ) {
+		return function badValue() {
+			return arr.map( clbk );
+		};
+	}
+
+	function clbk1() {
+		return 1.0;
+	}
+
+	function clbk2() {
+		return {};
+	}
+
+	function clbk3() {
+		return [ 1.0, 2.0, 3.0 ];
+	}
+
+	function clbk4() {
+		return [];
+	}
+
+	function clbk5() {
+		return [ 1.0 ];
+	}
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Adds the typed array `map` method to prototype of `Complex128Array`

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
