### PR TITLE
feat: add `join` method to `array/complex128`

### DIFF
--- a/lib/node_modules/@stdlib/array/complex128/README.md
+++ b/lib/node_modules/@stdlib/array/complex128/README.md
@@ -1475,6 +1475,36 @@ idx = arr.indexOf( new Complex128( 1.0, -1.0 ), 1 );
 // returns -1
 ```
 
+<a name="method-join"></a>
+
+#### Complex128Array.prototype.join( \[separator] )
+
+Returns a new string by concatenating all array elements.
+
+```javascript
+var arr = new Complex128Array( 3 );
+
+arr.set( [ 1.0, 1.0 ], 0 );
+arr.set( [ 2.0, -2.0 ], 1 );
+arr.set( [ 3.0, 3.0 ], 2 );
+
+var str = arr.join();
+// returns '1 + 1i,2 - 2i,3 + 3i'
+```
+
+By default, the method separates serialized array elements with a comma. To use an alternative separator, provide a `separator` string.
+
+```javascript
+var arr = new Complex128Array( 3 );
+
+arr.set( [ 1.0, 1.0 ], 0 );
+arr.set( [ 2.0, -2.0 ], 1 );
+arr.set( [ 3.0, 3.0 ], 2 );
+
+var str = arr.join( '/' );
+// returns '1 + 1i/2 - 2i/3 + 3i'
+```
+
 <a name="method-last-index-of"></a>
 
 #### Complex128Array.prototype.lastIndexOf( searchElement\[, fromIndex] )

--- a/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.join.js
+++ b/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.join.js
@@ -1,0 +1,50 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pkg = require( './../package.json' ).name;
+var Complex128Array = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg+':join', function benchmark( b ) {
+	var out;
+	var arr;
+	var i;
+
+	arr = new Complex128Array( [ 1, 2, 3, 4, 5, 6 ] );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = arr.join();
+		if ( typeof out !== 'string' ) {
+			b.fail( 'should return a string' );
+		}
+	}
+	b.toc();
+	if ( typeof out !== 'string' ) {
+		b.fail( 'should return a string' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.join.length.js
+++ b/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.join.length.js
@@ -1,0 +1,102 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var Complex128 = require( '@stdlib/complex/float64' );
+var pkg = require( './../package.json' ).name;
+var Complex128Array = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var arr;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < len; i++ ) {
+		arr.push( new Complex128( i, i ) );
+	}
+	arr = new Complex128Array( arr );
+
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var out;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			out = arr.join( '/' );
+			if ( typeof out !== 'string' ) {
+				b.fail( 'should return a string' );
+			}
+		}
+		b.toc();
+		if ( typeof out !== 'string' ) {
+			b.fail( 'should return a string' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':join:len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
@@ -727,6 +727,26 @@ declare class Complex128Array implements Complex128ArrayInterface {
 	indexOf( searchElement: ComplexLike, fromIndex?: number ): number;
 
 	/**
+	* Returns a new string by concatenating all array elements.
+	*
+	* @param separator - value separator (default: ',')
+	* @returns string
+	*
+	* @example
+	* var arr = new Complex128Array( 2 );
+	*
+	* arr.set( [ 1.0, 1.0 ], 0 );
+	* arr.set( [ 2.0, 2.0 ], 1 );
+	*
+	* var str = arr.join();
+	* // returns '1 + 1i,2 + 2i'
+	*
+	* str = arr.join( '/' );
+	* // returns '1 + 1i/2 + 2i'
+	*/
+	join( separator?: string ): string;
+
+	/**
 	* Returns the last index at which a given element can be found.
 	*
 	* @param searchElement - element to find

--- a/lib/node_modules/@stdlib/array/complex128/lib/main.js
+++ b/lib/node_modules/@stdlib/array/complex128/lib/main.js
@@ -28,6 +28,7 @@ var isCollection = require( '@stdlib/assert/is-collection' );
 var isArrayBuffer = require( '@stdlib/assert/is-arraybuffer' );
 var isObject = require( '@stdlib/assert/is-object' );
 var isArray = require( '@stdlib/assert/is-array' );
+var isString = require( '@stdlib/assert/is-string' );
 var isFunction = require( '@stdlib/assert/is-function' );
 var isComplexLike = require( '@stdlib/assert/is-complex-like' );
 var isEven = require( '@stdlib/math/base/assert/is-even' );
@@ -1535,6 +1536,52 @@ setReadOnly( Complex128Array.prototype, 'indexOf', function indexOf( searchEleme
 		}
 	}
 	return -1;
+});
+
+/**
+* Returns a new string by concatenating all array elements.
+*
+* @name join
+* @memberof Complex128Array.prototype
+* @type {Function}
+* @param {string} [separator=','] - element separator
+* @throws {TypeError} `this` must be a complex number array
+* @throws {TypeError} first argument must be a string
+* @returns {string} string representation
+*
+* @example
+* var arr = new Complex128Array( 2 );
+*
+* arr.set( [ 1.0, 1.0 ], 0 );
+* arr.set( [ 2.0, 2.0 ], 1 );
+*
+* var str = arr.join();
+* // returns '1 + 1i,2 + 2i'
+*
+* str = arr.join( '/' );
+* // returns '1 + 1i/2 + 2i'
+*/
+setReadOnly( Complex128Array.prototype, 'join', function join( separator ) {
+	var out;
+	var buf;
+	var sep;
+	var i;
+	if ( !isComplexArray( this ) ) {
+		throw new TypeError( 'invalid invocation. `this` is not a complex number array.' );
+	}
+	if ( arguments.length === 0 ) {
+		sep = ',';
+	} else if ( isString( separator ) ) {
+		sep = separator;
+	} else {
+		throw new TypeError( format( 'invalid argument. First argument must be a string. Value: `%s`.', separator ) );
+	}
+	out = [];
+	buf = this._buffer;
+	for ( i = 0; i < this._length; i++ ) {
+		out.push( getComplex128( buf, i ).toString() );
+	}
+	return out.join( sep );
 });
 
 /**

--- a/lib/node_modules/@stdlib/array/complex128/test/test.join.js
+++ b/lib/node_modules/@stdlib/array/complex128/test/test.join.js
@@ -1,0 +1,162 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var Complex128Array = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof Complex128Array, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the main export is a `join` method', function test( t ) {
+	t.strictEqual( hasOwnProp( Complex128Array.prototype, 'join' ), true, 'has property' );
+	t.strictEqual( isFunction( Complex128Array.prototype.join ), true, 'has method' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a complex number array instance', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new Complex128Array( 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.join.call( value );
+		};
+	}
+});
+
+tape( 'the method throws an error if invoked with a `separator` argument which is not a string', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new Complex128Array( 5 );
+
+	values = [
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.join( value );
+		};
+	}
+});
+
+tape( 'the method returns an empty string if invoked on an empty array', function test( t ) {
+	var str;
+	var arr;
+
+	arr = new Complex128Array();
+	str = arr.join();
+
+	t.strictEqual( str, '', 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method returns a string representation of a complex number array with elements separated by a separator', function test( t ) {
+	var expected;
+	var str;
+	var arr;
+
+	arr = new Complex128Array( [ 1, 2, -3, -4 ] );
+	expected = '1 + 2i@-3 - 4i';
+
+	str = arr.join( '@' );
+
+	t.strictEqual( str, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method returns a string representation of a complex number array with elements separated by a separator (single element)', function test( t ) {
+	var expected;
+	var str;
+	var arr;
+
+	arr = new Complex128Array( [ 1, 2 ] );
+	expected = '1 + 2i';
+
+	str = arr.join();
+
+	t.strictEqual( str, expected, 'returns expected value' );
+
+	arr = new Complex128Array( [ 1, 2 ] );
+	expected = '1 + 2i';
+
+	str = arr.join( '@' );
+
+	t.strictEqual( str, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'if method invoked without a separator argument, the method returns a string representation of a complex number array with elements separated by a comma', function test( t ) {
+	var expected;
+	var str;
+	var arr;
+
+	arr = new Complex128Array( [ 1, 2, -3, -4 ] );
+	expected = '1 + 2i,-3 - 4i';
+
+	str = arr.join();
+
+	t.strictEqual( str, expected, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Adds the typed array `join` method to prototype of `Complex128Array`

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
