### PR TITLE
feat: add `with` method to `array/complex128`

### DIFF
--- a/lib/node_modules/@stdlib/array/complex128/README.md
+++ b/lib/node_modules/@stdlib/array/complex128/README.md
@@ -1924,6 +1924,36 @@ var str = arr.toString();
 // returns '1 + 1i,2 - 2i,3 + 3i'
 ```
 
+<a name="method-with"></a>
+
+#### Complex128Array.prototype.with( index, value )
+
+Returns a new typed array with the element at a provided index replaced with a provided value.
+
+```javascript
+var real = require( '@stdlib/complex/real' );
+var imag = require( '@stdlib/complex/imag' );
+var Complex128 = require( '@stdlib/complex/float64' );
+
+var arr = new Complex128Array( 3 );
+
+arr.set( [ 1.0, 1.0 ], 0 );
+arr.set( [ 2.0, 2.0 ], 1 );
+arr.set( [ 3.0, 3.0 ], 1 );
+
+var out = arr.with( 0, new Complex128( 4.0, 4.0 ) );
+// returns <Complex128Array>
+
+var z = out.get( 0 );
+// returns <Complex128>
+
+var re = real( z );
+// returns 4.0
+
+var im = imag( z );
+// returns 4.0
+```
+
 </section>
 
 <!-- /.usage -->

--- a/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.with.js
+++ b/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.with.js
@@ -1,0 +1,58 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var Complex128 = require( '@stdlib/complex/float64' );
+var isComplex128Array = require( '@stdlib/assert/is-complex128array' );
+var pkg = require( './../package.json' ).name;
+var Complex128Array = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg+':with', function benchmark( b ) {
+	var values;
+	var arr;
+	var out;
+	var i;
+
+	values = [
+		new Complex128( 1.0, 1.0 ),
+		new Complex128( 2.0, 2.0 ),
+		new Complex128( 3.0, 3.0 )
+	];
+	arr = new Complex128Array( 5 );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = arr.with( i%arr.length, values[ i%values.length ] );
+		if ( typeof out !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+	if ( !isComplex128Array( out ) ) {
+		b.fail( 'should return a Complex128Array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.with.length.js
+++ b/lib/node_modules/@stdlib/array/complex128/benchmark/benchmark.with.length.js
@@ -1,0 +1,102 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var Complex128 = require( '@stdlib/complex/float64' );
+var isComplex128Array = require('@stdlib/assert/is-complex128array' );
+var pkg = require( './../package.json' ).name;
+var Complex128Array = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var arr = new Complex128Array( len );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var values;
+		var out;
+		var i;
+
+		values = [
+			new Complex128( 1.0, 1.0 ),
+			new Complex128( 2.0, 2.0 ),
+			new Complex128( 3.0, 3.0 )
+		];
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			out = arr.with( i%len, values[ i%values.length ] );
+			if ( typeof out !== 'object' ) {
+				b.fail( 'should return an object' );
+			}
+		}
+		b.toc();
+		if ( !isComplex128Array( out ) ) {
+			b.fail( 'should return a Complex128Array' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':with:len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/complex128/docs/types/index.d.ts
@@ -981,6 +981,41 @@ declare class Complex128Array implements Complex128ArrayInterface {
 	* // returns '1 + 1i,2 + 2i'
 	*/
 	toString(): string;
+
+	/**
+	* Returns a new typed array with the element at a provided index replaced with a provided value.
+	*
+	* @param index - element index
+	* @param value - new value
+	* @throws first argument must be an integer
+	* @throws second argument must be a complex number
+	* @throws index argument is out-of-bounds
+	* @returns modified typed array
+	*
+	* @example
+	* var real = require( '@stdlib/complex/real' );
+	* var imag = require( '@stdlib/complex/imag' );
+	* var Complex128 = require( '@stdlib/complex/float64' );
+	*
+	* var arr = new Complex128Array( 3 );
+	*
+	* arr.set( [ 1.0, 1.0 ], 0 );
+	* arr.set( [ 2.0, 2.0 ], 1 );
+	* arr.set( [ 3.0, 3.0 ], 2 );
+	*
+	* var out = arr.with( 0, new Complex128( 4.0, 4.0 ) );
+	* // returns <Complex128Array>
+	*
+	* var z = out.get( 0 );
+	* // returns <Complex128>
+	*
+	* var re = real( z );
+	* // returns 4.0
+	*
+	* var im = imag( z );
+	* // returns 4.0
+	*/
+	with( index: number, value: ComplexLike ): Complex128Array;
 }
 
 /**

--- a/lib/node_modules/@stdlib/array/complex128/lib/main.js
+++ b/lib/node_modules/@stdlib/array/complex128/lib/main.js
@@ -2120,6 +2120,70 @@ setReadOnly( Complex128Array.prototype, 'toString', function toString() {
 	return out.join( ',' );
 });
 
+/**
+* Returns a new typed array with the element at a provided index replaced with a provided value.
+*
+* @name with
+* @memberof Complex128Array.prototype
+* @type {Function}
+* @param {integer} index - element index
+* @param {ComplexLike} value - new value
+* @throws {TypeError} `this` must be a complex number array
+* @throws {TypeError} first argument must be an integer
+* @throws {RangeError} index argument is out-of-bounds
+* @throws {TypeError} second argument must be a complex number
+* @returns {Complex128Array} new typed array
+*
+* @example
+* var real = require( '@stdlib/complex/real' );
+* var imag = require( '@stdlib/complex/imag' );
+* var Complex128 = require( '@stdlib/complex/float64' );
+*
+* var arr = new Complex128Array( 3 );
+*
+* arr.set( [ 1.0, 1.0 ], 0 );
+* arr.set( [ 2.0, 2.0 ], 1 );
+* arr.set( [ 3.0, 3.0 ], 2 );
+*
+* var out = arr.with( 0, new Complex128( 4.0, 4.0 ) );
+* // returns <Complex128Array>
+*
+* var z = out.get( 0 );
+* // returns <Complex128>
+*
+* var re = real( z );
+* // returns 4.0
+*
+* var im = imag( z );
+* // returns 4.0
+*/
+setReadOnly( Complex128Array.prototype, 'with', function copyWith( index, value ) {
+	var buf;
+	var out;
+	var len;
+	if ( !isComplexArray( this ) ) {
+		throw new TypeError( 'invalid invocation. `this` is not a complex number array.' );
+	}
+	if ( !isInteger( index ) ) {
+		throw new TypeError( format( 'invalid argument. First argument must be an integer. Value: `%s`.', index ) );
+	}
+	len = this._length;
+	if ( index < 0 ) {
+		index += len;
+	}
+	if ( index < 0 || index >= len ) {
+		throw new RangeError( format( 'invalid argument. Index argument is out-of-bounds. Value: `%s`.', index ) );
+	}
+	if ( !isComplexLike( value ) ) {
+		throw new TypeError( format( 'invalid argument. Second argument must be a complex number. Value: `%s`.', value ) );
+	}
+	out = new this.constructor( this._buffer );
+	buf = out._buffer; // eslint-disable-line no-underscore-dangle
+	buf[ 2*index ] = real( value );
+	buf[ (2*index)+1 ] = imag( value );
+	return out;
+});
+
 
 // EXPORTS //
 

--- a/lib/node_modules/@stdlib/array/complex128/test/test.with.js
+++ b/lib/node_modules/@stdlib/array/complex128/test/test.with.js
@@ -1,0 +1,203 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var Float64Array = require( '@stdlib/array/float64' );
+var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
+var Complex128 = require( '@stdlib/complex/float64' );
+var Complex128Array = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof Complex128Array, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the main export is a `with` method', function test( t ) {
+	t.strictEqual( hasOwnProp( Complex128Array.prototype, 'with' ), true, 'has property' );
+	t.strictEqual( isFunction( Complex128Array.prototype.with ), true, 'has method' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a complex number array instance', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new Complex128Array( 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.with.call( value, 0, new Complex128( 1.0, 1.0 ) );
+		};
+	}
+});
+
+tape( 'the method throws an error if provided a first argument which is not an integer', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new Complex128Array( 5 );
+
+	values = [
+		'5',
+		3.14,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.with( value, new Complex128( 1.0, 1.0 ) );
+		};
+	}
+});
+
+tape( 'the method throws an error if provided a first argument which is not in bounds', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new Complex128Array( 10 );
+
+	values = [
+		-11,
+		-12,
+		11,
+		12
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), RangeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.with( value, new Complex128( 1.0, 1.0 ) );
+		};
+	}
+});
+
+tape( 'the method throws an error if provided a second argument which is not a complex number', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new Complex128Array( 10 );
+
+	values = [
+		'5',
+		3.14,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.with( 0, value );
+		};
+	}
+});
+
+tape( 'the method does not change the array length', function test( t ) {
+	var arr;
+	var out;
+
+	arr = new Complex128Array( 10 );
+	out = arr.with( 5, new Complex128( 1.0, 1.0 ) );
+
+	t.strictEqual( out.length, 10, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method returns a new complex number array with the element at a provided index replaced with a provided value', function test( t ) {
+	var expected;
+	var arr;
+	var out;
+
+	arr = new Complex128Array( [ 1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 4.0, 4.0 ] );
+	expected = new Float64Array( [ 1.0, 1.0, 5.0, 5.0, 3.0, 3.0, 4.0, 4.0 ] );
+	out = arr.with( 1, new Complex128( 5.0, 5.0 ) );
+
+	t.strictEqual( out instanceof Complex128Array, true, 'returns expected value' );
+	t.deepEqual( reinterpret128( out, 0 ), expected, 'returns expected value' );
+	t.notEqual( out, arr, 'returns new instance' );
+	t.end();
+});
+
+tape( 'the method supports negative indices', function test( t ) {
+	var expected;
+	var arr;
+	var out;
+
+	arr = new Complex128Array( [ 1.0, 1.0, 2.0, 2.0, 3.0, 3.0 ] );
+	expected = new Float64Array( [ 1.0, 1.0, 2.0, 2.0, 1.0, 1.0 ] );
+
+	out = arr.with( -1, new Complex128( 1.0, 1.0 ) );
+
+	t.strictEqual( out instanceof Complex128Array, true, 'returns expected value' );
+	t.deepEqual( reinterpret128( out, 0 ), expected, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Adds the typed array `with` method to prototype of `Complex128Array`

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
