### PR TITLE
feat  : add @stdlib/assert/is-nonnegative-finite

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/README.md
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2018 The Stdlib Authors.
+Copyright (c) 2024 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/README.md
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/README.md
@@ -141,7 +141,6 @@ bool = isNonNegativeFinite( null );
 ## See Also
 
 -   <span class="package-name">[`@stdlib/assert/is-number`][@stdlib/assert/is-number]</span><span class="delimiter">: </span><span class="description">test if a value is a number.</span>
-
 -   <span class="package-name">[`@stdlib/assert/is-finite`][@stdlib/assert/is-finite]</span><span class="delimiter">: </span><span class="description">test if a value is a finite number.</span>
 
 </section>

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/README.md
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/README.md
@@ -1,0 +1,164 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2018 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# isNonNegativeFinite
+
+> Test if a value is a number having a nonnegative finite value.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var isNonNegativeFinite = require( '@stdlib/assert/is-nonnegative-finite' );
+```
+
+#### isNonNegativeFinite( value )
+
+Tests if a `value` is a `number` having a nonnegative finite value.
+
+<!-- eslint-disable no-new-wrappers -->
+
+```javascript
+var Number = require( '@stdlib/number/ctor' );
+
+var bool = isNonNegativeFinite( 5.0 );
+// returns true
+
+bool = isNonNegativeFinite( new Number( 5.0 ) );
+// returns true
+
+bool = isNonNegativeFinite( 3.14 );
+// returns true
+
+bool = isNonNegativeFinite( -5.0 );
+// returns false
+
+bool = isNonNegativeFinite( null );
+// returns false
+
+bool = isNonNegativeFinite( Infinity );
+// returns false
+```
+
+#### isNonNegativeFinite.isPrimitive( value )
+
+Tests if a `value` is a primitive `number` having a nonnegative finite value.
+
+<!-- eslint-disable no-new-wrappers -->
+
+```javascript
+var Number = require( '@stdlib/number/ctor' );
+
+var bool = isNonNegativeFinite.isPrimitive( 3.0 );
+// returns true
+
+bool = isNonNegativeFinite.isPrimitive( new Number( 3.0 ) );
+// returns false
+```
+
+#### isNonNegativeFinite.isObject( value )
+
+Tests if a `value` is a `Number` object having a nonnegative finite value.
+
+<!-- eslint-disable no-new-wrappers -->
+
+```javascript
+var Number = require( '@stdlib/number/ctor' );
+
+var bool = isNonNegativeFinite.isObject( 3.0 );
+// returns false
+
+bool = isNonNegativeFinite.isObject( new Number( 3.0 ) );
+// returns true
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint-disable no-new-wrappers -->
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var Number = require( '@stdlib/number/ctor' );
+var isNonNegativeFinite = require( '@stdlib/assert/is-nonnegative-finite' );
+
+var bool = isNonNegativeFinite( 5.0 );
+// returns true
+
+bool = isNonNegativeFinite( new Number( 5.0 ) );
+// returns true
+
+bool = isNonNegativeFinite( 0.0 );
+// returns true
+
+bool = isNonNegativeFinite( 3.14 );
+// returns true
+
+bool = isNonNegativeFinite( -5.0 );
+// returns false
+
+bool = isNonNegativeFinite( '5' );
+// returns false
+
+bool = isNonNegativeFinite( null );
+// returns false
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/assert/is-number`][@stdlib/assert/is-number]</span><span class="delimiter">: </span><span class="description">test if a value is a number.</span>
+
+-   <span class="package-name">[`@stdlib/assert/is-finite`][@stdlib/assert/is-finite]</span><span class="delimiter">: </span><span class="description">test if a value is a finite number.</span>
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+<!-- <related-links> -->
+
+[@stdlib/assert/is-number]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-number
+[@stdlib/assert/is-finite]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-finite
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/benchmark/benchmark.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/benchmark/benchmark.js
@@ -16,7 +16,7 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers, no-undefined, no-empty-function */
+/* eslint-disable no-undefined, no-empty-function */
 
 'use strict';
 

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/benchmark/benchmark.js
@@ -1,0 +1,228 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* eslint-disable no-new-wrappers, no-undefined, no-empty-function */
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var Number = require( '@stdlib/number/ctor' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var pkg = require( './../package.json' ).name;
+var isNonNegativeFinite = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg+'::primitives', function benchmark( b ) {
+	var values;
+	var bool;
+	var i;
+
+	values = [
+		'5',
+		5.0,
+		4.0,
+		3.14,
+		-5.0,
+		-4.0,
+		NaN,
+		true,
+		false,
+		null,
+		Infinity,
+		-Infinity,
+		undefined
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		bool = isNonNegativeFinite( values[ i % values.length ] );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::objects', function benchmark( b ) {
+	var values;
+	var bool;
+	var i;
+
+	values = [
+		[],
+		{},
+		function noop() {},
+		new Number( 2.0 ),
+		new Number( -3.0 ),
+		new Number( 3.14 )
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		bool = isNonNegativeFinite( values[ i % values.length ] );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::primitives:isPrimitive', function benchmark( b ) {
+	var values;
+	var bool;
+	var i;
+
+	values = [
+		'5',
+		5.0,
+		4.0,
+		3.14,
+		-5.0,
+		-4.0,
+		NaN,
+		true,
+		false,
+		null,
+		undefined,
+		Infinity,
+		-Infinity
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		bool = isNonNegativeFinite.isPrimitive( values[ i % values.length ] );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::objects:isPrimitive', function benchmark( b ) {
+	var values;
+	var bool;
+	var i;
+
+	values = [
+		[],
+		{},
+		function noop() {},
+		new Number( 2.0 ),
+		new Number( -3.0 ),
+		new Number( 3.14 )
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		bool = isNonNegativeFinite.isPrimitive( values[ i % values.length ] );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::primitives:isObject', function benchmark( b ) {
+	var values;
+	var bool;
+	var i;
+
+	values = [
+		'5',
+		5.0,
+		4.0,
+		3.14,
+		-5.0,
+		-4.0,
+		NaN,
+		true,
+		false,
+		null,
+		undefined,
+		Infinity,
+		-Infinity
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		bool = isNonNegativeFinite.isObject( values[ i % values.length ] );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::objects:isObject', function benchmark( b ) {
+	var values;
+	var bool;
+	var i;
+
+	values = [
+		[],
+		{},
+		function noop() {},
+		new Number( 2.0 ),
+		new Number( -3.0 ),
+		new Number( 3.14 ),
+		new Number( Infinity )
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		bool = isNonNegativeFinite.isObject( values[ i % values.length ] );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/docs/repl.txt
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/docs/repl.txt
@@ -1,0 +1,77 @@
+
+{{alias}}( value )
+    Tests if a value is a nonnegative finite number.
+
+    Parameters
+    ----------
+    value: any
+        Value to test.
+
+    Returns
+    -------
+    bool: boolean
+        Boolean indicating whether value is a nonnegative finite number.
+
+    Examples
+    --------
+    > var bool = {{alias}}( 5.0 )
+    true
+    > bool = {{alias}}( new Number( 5.0 ) )
+    true
+    > bool = {{alias}}( 3.14 )
+    true
+    > bool = {{alias}}( -5.0 )
+    false
+    > bool = {{alias}}( null )
+    false
+    > bool = {{alias}}( Infinity )
+    false
+
+
+{{alias}}.isPrimitive( value )
+    Tests if a value is a number primitive having a nonnegative finite value.
+
+    Parameters
+    ----------
+    value: any
+        Value to test.
+
+    Returns
+    -------
+    bool: boolean
+        Boolean indicating whether value is a number primitive having a
+        nonnegative finite value.
+
+    Examples
+    --------
+    > var bool = {{alias}}.isPrimitive( 3.0 )
+    true
+    > bool = {{alias}}.isPrimitive( new Number( 3.0 ) )
+    false
+
+
+{{alias}}.isObject( value )
+    Tests if a value is a number object having a nonnegative finite value.
+
+    Parameters
+    ----------
+    value: any
+        Value to test.
+
+    Returns
+    -------
+    bool: boolean
+        Boolean indicating whether value is a number object having a nonnegative finite
+        value.
+
+    Examples
+    --------
+    > var bool = {{alias}}.isObject( 3.0 )
+    false
+    > bool = {{alias}}.isObject( new Number( 3.0 ) )
+    true
+
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/docs/repl.txt
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/docs/repl.txt
@@ -61,8 +61,8 @@
     Returns
     -------
     bool: boolean
-        Boolean indicating whether value is a number object having a nonnegative finite
-        value.
+        Boolean indicating whether value is a number object having a 
+        nonnegative finite value.
 
     Examples
     --------

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/docs/types/index.d.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2019 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/docs/types/index.d.ts
@@ -1,0 +1,142 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2019 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Interface defining `isNonNegativeFinite` with methods for testing for primitives and objects, respectively.
+*/
+interface IsNonNegativeFinite {
+	/**
+	* Tests if a value is a nonnegative finite number.
+	*
+	* @param {*} value - value to test
+	* @returns {boolean} boolean indicating whether value is a nonnegative number
+	*
+	* @example
+	* var bool = isNonNegativeFinite( 5.0 );
+	* // returns true
+	*
+	* @example
+	* var bool = isNonNegativeFinite( new Number( 5.0 ) );
+	* // returns true
+	*
+	* @example
+	* var bool = isNonNegativeFinite( 3.14 );
+	* // returns true
+	*
+	* @example
+	* var bool = isNonNegativeFinite( Infinity );
+	* // returns false
+	*
+	* @example
+	* var bool = isNonNegativeFinite( -5.0 );
+	* // returns false
+	*
+	* @example
+	* var bool = isNonNegativeFinite( null );
+	* // returns false
+	*/
+	( value: any ): value is number | Number;
+
+	/**
+	* Tests if a value is a number primitive having a nonnegative finite value.
+	*
+	* @param {*} value - value to test
+	* @returns {boolean} boolean indicating if a value is a number primitive having a nonnegative finite value
+	*
+	* @example
+	* var bool = isNonNegativeNumber( 3.0 );
+	* // returns true
+	*
+	* @example
+	* var bool = isNonNegativeNumber( new Number( 3.0 ) );
+	* // returns false
+	*
+	* @example
+	* var bool = isNonNegativeFinite( new Number( -5.0 ) );
+	* // returns false
+	*
+	* @example
+	* var bool = isNonNegativeFinite( Infinity );
+	* // returns false
+	*/
+	isPrimitive( value: any ): value is number;
+
+	/**
+	* Tests if a value is a finite number object having a nonnegative value.
+	*
+	* @param {*} value - value to test
+	* @returns {boolean} boolean indicating if a value is a number object having a nonnegative finite number value
+	*
+	* @example
+	* var bool = isNonNegativeFinite( 3.0 );
+	* // returns false
+	*
+	* @example
+	* var bool = isNonNegativeFinite( new Number( 3.0 ) );
+	* // returns true
+	*
+	* @example
+	* var bool = isNonNegativeFinite( new Number( -5.0 ) );
+	* // returns false
+	*
+	* @example
+	* var bool = isNonNegativeFinite( Infinity );
+	* // returns false
+	*/
+	isObject( value: any ): value is Number;
+}
+
+/**
+* Tests if a value is a nonnegative finite number.
+*
+* @param {*} value - value to test
+* @returns {boolean} boolean indicating whether value is a nonnegative number
+*
+* @example
+* var bool = isNonNegativeFinite( 5.0 );
+* // returns true
+*
+* @example
+* var bool = isNonNegativeFinite( new Number( 5.0 ) );
+* // returns true
+*
+* @example
+* var bool = isNonNegativeFinite( 3.14 );
+* // returns true
+*
+* @example
+* var bool = isNonNegativeFinite( Infinity );
+* // returns false
+*
+* @example
+* var bool = isNonNegativeFinite( -5.0 );
+* // returns false
+*
+* @example
+* var bool = isNonNegativeFinite( null );
+* // returns false
+*/
+
+declare var isNonNegativeFinite: IsNonNegativeFinite;
+
+
+// EXPORTS //
+
+export = isNonNegativeFinite;

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/docs/types/test.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2019 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/docs/types/test.ts
@@ -47,7 +47,7 @@ import isNonNegativeFinite = require( './index' );
 }
 
 
-// Attached to main export is an isPrimitive method which returns a boolean...
+// Attached to main export is an isObject method which returns a boolean...
 {
 	// eslint-disable-next-line no-new-wrappers
 	isNonNegativeFinite.isObject( new Number( 2 ) ); // $ExpectType boolean

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/docs/types/test.ts
@@ -1,0 +1,61 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2019 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import isNonNegativeFinite = require( './index' );
+
+
+// TESTS //
+
+// The function returns a boolean...
+{
+	isNonNegativeFinite( 1.2 ); // $ExpectType boolean
+	isNonNegativeFinite( -1.2 ); // $ExpectType boolean
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	isNonNegativeFinite(); // $ExpectError
+	isNonNegativeFinite( 2, 123 ); // $ExpectError
+}
+
+// Attached to main export is an isPrimitive method which returns a boolean...
+{
+	// eslint-disable-next-line no-new-wrappers
+	isNonNegativeFinite.isPrimitive( new Number( 2 ) ); // $ExpectType boolean
+	isNonNegativeFinite.isPrimitive( 2 ); // $ExpectType boolean
+}
+
+// The compiler throws an error if the isPrimitive method is provided an unsupported number of arguments...
+{
+	isNonNegativeFinite.isPrimitive(); // $ExpectError
+	isNonNegativeFinite.isPrimitive( 2, 123 ); // $ExpectError
+}
+
+
+// Attached to main export is an isPrimitive method which returns a boolean...
+{
+	// eslint-disable-next-line no-new-wrappers
+	isNonNegativeFinite.isObject( new Number( 2 ) ); // $ExpectType boolean
+	isNonNegativeFinite.isObject( 2 ); // $ExpectType boolean
+}
+
+// The compiler throws an error if the isObject method is provided an unsupported number of arguments...
+{
+	isNonNegativeFinite.isObject(); // $ExpectError
+	isNonNegativeFinite.isObject( 2, 123 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/docs/types/test.ts
@@ -46,7 +46,6 @@ import isNonNegativeFinite = require( './index' );
 	isNonNegativeFinite.isPrimitive( 2, 123 ); // $ExpectError
 }
 
-
 // Attached to main export is an isObject method which returns a boolean...
 {
 	// eslint-disable-next-line no-new-wrappers

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/examples/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/examples/index.js
@@ -1,0 +1,51 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* eslint-disable no-new-wrappers */
+
+'use strict';
+
+var Number = require( '@stdlib/number/ctor' );
+var isNonNegativeFinite = require( './../lib' );
+
+console.log( isNonNegativeFinite( 5.0 ) );
+// => true
+
+console.log( isNonNegativeFinite( new Number( 5.0 ) ) );
+// => true
+
+console.log( isNonNegativeFinite( new Number( Infinity ) ) );
+// => false
+
+console.log( isNonNegativeFinite( Infinity ) );
+// => false
+
+console.log( isNonNegativeFinite( 0.0 ) );
+// => true
+
+console.log( isNonNegativeFinite( 3.14 ) );
+// => true
+
+console.log( isNonNegativeFinite( -5.0 ) );
+// => false
+
+console.log( isNonNegativeFinite( '5' ) );
+// => false
+
+console.log( isNonNegativeFinite( null ) );
+// => false

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/lib/index.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/lib/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/lib/index.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/lib/index.js
@@ -1,0 +1,85 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Test if a value is a nonnegative finite number.
+*
+* @module @stdlib/assert/is-nonnegative-finite
+*
+* @example
+* var isNonNegativeFinite = require( '@stdlib/assert/is-nonnegative-finite' );
+*
+* var bool = isNonNegativeFinite( 5.0 );
+* // returns true
+*
+* bool = isNonNegativeFinite( new Number( 5.0 ) );
+* // returns true
+*
+* bool = isNonNegativeFinite( 3.14 );
+* // returns true
+*
+* var bool = isNonNegativeFinite( Infinity );
+* // returns false
+*
+* bool = isNonNegativeFinite( -5.0 );
+* // returns false
+*
+* bool = isNonNegativeFinite( null );
+* // returns false
+*
+* @example
+* var isNonNegativeFinite = require( '@stdlib/assert/is-nonnegative-finite' ).isPrimitive;
+*
+* var bool = isNonNegativeFinite( 3.0 );
+* // returns true
+*
+* bool = isNonNegativeFinite( new Number( 3.0 ) );
+* // returns false
+*
+* @example
+* var isNonNegativeFinite = require( '@stdlib/assert/is-nonnegative-finite' ).isObject;
+*
+* var bool = isNonNegativeFinite( 3.0 );
+* // returns false
+*
+* var bool = isNonNegativeFinite( Infinity );
+* // returns false
+*
+* bool = isNonNegativeFinite( new Number( 3.0 ) );
+* // returns true
+*/
+
+// MODULES //
+
+var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
+var main = require( './main.js' );
+var isPrimitive = require( './primitive.js' );
+var isObject = require( './object.js' );
+
+
+// MAIN //
+
+setReadOnly( main, 'isPrimitive', isPrimitive );
+setReadOnly( main, 'isObject', isObject );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/lib/main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/lib/main.js
@@ -1,0 +1,66 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isPrimitive = require( './primitive.js' );
+var isObject = require( './object.js' );
+
+
+// MAIN //
+
+/**
+* Tests if a value is a nonnegative finite number.
+*
+* @param {*} value - value to test
+* @returns {boolean} boolean indicating whether value is a nonnegative number
+*
+* @example
+* var bool = isNonNegativeFinite( 5.0 );
+* // returns true
+*
+* @example
+* var bool = isNonNegativeFinite( new Number( 5.0 ) );
+* // returns true
+*
+* @example
+* var bool = isNonNegativeFinite( 3.14 );
+* // returns true
+*
+* @example
+* var bool = isNonNegativeFinite( Infinity );
+* // returns false
+*
+* @example
+* var bool = isNonNegativeFinite( -5.0 );
+* // returns false
+*
+* @example
+* var bool = isNonNegativeFinite( null );
+* // returns false
+*/
+function isNonNegativeFinite( value ) {
+	return ( isPrimitive( value ) || isObject( value ) );
+}
+
+
+// EXPORTS //
+
+module.exports = isNonNegativeFinite;

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/lib/object.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/lib/object.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/lib/object.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/lib/object.js
@@ -52,7 +52,7 @@ var isFinite = require( '@stdlib/assert/is-finite' ).isObject; // eslint-disable
 function isNonNegativeFinite( value ) {
 	return (
 		isNonNegativeNumber( value ) &&
-		isFinite( value ) 
+		isFinite( value )
 	);
 }
 

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/lib/object.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/lib/object.js
@@ -20,7 +20,7 @@
 
 // MODULES //
 
-var isNonNegativeNumber = require( '@stdlib/assert/is-nonnegative-number').isObject
+var isNonNegativeNumber = require( '@stdlib/assert/is-nonnegative-number').isObject;
 var isFinite = require( '@stdlib/assert/is-finite' ).isObject;
 
 

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/lib/object.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/lib/object.js
@@ -48,7 +48,6 @@ var isFinite = require( '@stdlib/assert/is-finite' ).isObject; // eslint-disable
 * var bool = isNonNegativeFinite( Infinity );
 * // returns false
 */
-
 function isNonNegativeFinite( value ) {
 	return (
 		isNonNegativeNumber( value ) &&

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/lib/object.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/lib/object.js
@@ -1,0 +1,62 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isNonNegativeNumber = require( '@stdlib/assert/is-nonnegative-number').isObject
+var isFinite = require( '@stdlib/assert/is-finite' ).isObject;
+
+
+// MAIN //
+
+/**
+* Tests if a value is a finite number object having a nonnegative value.
+*
+* @param {*} value - value to test
+* @returns {boolean} boolean indicating if a value is a number object having a nonnegative finite number value
+*
+* @example
+* var bool = isNonNegativeFinite( 3.0 );
+* // returns false
+*
+* @example
+* var bool = isNonNegativeFinite( new Number( 3.0 ) );
+* // returns true
+*
+* @example
+* var bool = isNonNegativeFinite( new Number( -5.0 ) );
+* // returns false
+*
+* @example
+* var bool = isNonNegativeFinite( Infinity );
+* // returns false
+*/
+
+function isNonNegativeFinite( value ) {
+	return (
+		isNonNegativeNumber( value ) &&
+		isFinite( value ) 
+	);
+}
+
+
+// EXPORTS //
+
+module.exports = isNonNegativeFinite;

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/lib/object.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/lib/object.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var isNonNegativeNumber = require( '@stdlib/assert/is-nonnegative-number').isObject;
-var isFinite = require( '@stdlib/assert/is-finite' ).isObject;
+var isFinite = require( '@stdlib/assert/is-finite' ).isObject; // eslint-disable-line stdlib/no-redeclare
 
 
 // MAIN //

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/lib/primitive.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/lib/primitive.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/lib/primitive.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/lib/primitive.js
@@ -1,0 +1,61 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isNonNegativeNumber = require( '@stdlib/assert/is-nonnegative-number' ).isPrimitive;
+var isFinite = require( '@stdlib/assert/is-finite' ).isPrimitive;
+
+
+// MAIN //
+
+/**
+* Tests if a value is a number primitive having a nonnegative finite value.
+*
+* @param {*} value - value to test
+* @returns {boolean} boolean indicating if a value is a number primitive having a nonnegative finite value
+*
+* @example
+* var bool = isNonNegativeNumber( 3.0 );
+* // returns true
+*
+* @example
+* var bool = isNonNegativeNumber( new Number( 3.0 ) );
+* // returns false
+*
+* @example
+* var bool = isNonNegativeFinite( new Number( -5.0 ) );
+* // returns false
+*
+* @example
+* var bool = isNonNegativeFinite( Infinity );
+* // returns false
+*/
+function isNonNegativeFinite( value ) {
+	return (
+		isNonNegativeNumber( value ) &&
+		isFinite( value )
+	);
+}
+
+
+// EXPORTS //
+
+module.exports = isNonNegativeFinite;

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/lib/primitive.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/lib/primitive.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var isNonNegativeNumber = require( '@stdlib/assert/is-nonnegative-number' ).isPrimitive;
-var isFinite = require( '@stdlib/assert/is-finite' ).isPrimitive;
+var isFinite = require( '@stdlib/assert/is-finite' ).isPrimitive; // eslint-disable-line stdlib/no-redeclare
 
 
 // MAIN //

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/package.json
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@stdlib/assert/is-nonnegative-finite",
+  "version": "0.0.0",
+  "description": "Test if a value is a number having a nonnegative finite value.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdassert",
+    "assertion",
+    "assert",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "number",
+    "numeric",
+    "nonnegative",
+    "finite",
+    "nonnegativefinite",
+    "is",
+    "isnumber",
+    "isnumeric",
+    "type",
+    "check",
+    "primitive",
+    "object"
+  ]
+}

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/test/test.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/test/test.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/test/test.js
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isNonNegativeFinite = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof isNonNegativeFinite, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the main export is a method to test for a primitive number having a nonnegative number value', function test( t ) {
+	t.equal( typeof isNonNegativeFinite.isPrimitive, 'function', 'export is a function' );
+	t.end();
+});
+
+tape( 'attached to the main export is a method to test for a number object having a nonnegative number value', function test( t ) {
+	t.equal( typeof isNonNegativeFinite.isObject, 'function', 'export is a function' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/test/test.main.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/test/test.main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/test/test.main.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/test/test.main.js
@@ -35,7 +35,7 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function returns `true` if provided a number having a nonnegative number value', function test( t ) {
 	t.equal( isNonNegativeFinite( 5.0 ), true, 'returns true' );
-	t.equal( isNonNegativeFinite( new Number( 5.0 ) ), true, 'returns true' ); // eslint-disable-line no-new-wrappers
+	t.equal( isNonNegativeFinite( new Number( 5.0 ) ), true, 'returns true' );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/test/test.main.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/test/test.main.js
@@ -1,0 +1,64 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var Number = require( '@stdlib/number/ctor' );
+var isNonNegativeFinite = require( './../lib/main.js' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof isNonNegativeFinite, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `true` if provided a number having a nonnegative number value', function test( t ) {
+	t.equal( isNonNegativeFinite( 5.0 ), true, 'returns true' );
+	t.equal( isNonNegativeFinite( new Number( 5.0 ) ), true, 'returns true' ); // eslint-disable-line no-new-wrappers
+	t.end();
+});
+
+tape( 'the function returns `false` if not provided a number having a nonnegative finite value', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		-3.14,
+		-1.0,
+		null,
+		true,
+		void 0,
+		[],
+		{},
+		function noop() {},
+		Infinity,
+		-Infinity
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.equal( isNonNegativeFinite( values[i] ), false, 'returns false when provided '+values[i] );
+	}
+	t.end();
+});

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/test/test.object.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/test/test.object.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/test/test.object.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/test/test.object.js
@@ -1,0 +1,74 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var Number = require( '@stdlib/number/ctor' );
+var isNonNegativeFinite = require( './../lib/object.js' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof isNonNegativeFinite, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `true` if provided a number object having a nonnegative number value', function test( t ) {
+	t.equal( isNonNegativeFinite( new Number( 5.0 ) ), true, 'returns true' ); // eslint-disable-line no-new-wrappers
+	t.end();
+});
+
+tape( 'the function returns `false` if provided Infinity, even if it is positive infinity', function test( t ) {
+	t.equal( isNonNegativeFinite( Infinity ), false, 'returns false' );
+	t.end();
+});
+
+tape( 'the function returns `false` if provided Infinity, even if it is positive infinity', function test( t ) {
+	t.equal( isNonNegativeFinite( Infinity ), false, 'returns false' );
+	t.end();
+});
+
+tape( 'the function returns `false` if not provided a nonnegative number', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		new Number( -2.0 ), // eslint-disable-line no-new-wrappers
+		-3.14,
+		null,
+		true,
+		void 0,
+		[],
+		{},
+		new Date(),
+		/./,
+		new RegExp( '.' ), // eslint-disable-line prefer-regex-literals
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.equal( isNonNegativeFinite( values[i] ), false, 'returns false when provided '+values[i] );
+	}
+	t.end();
+});

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/test/test.object.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/test/test.object.js
@@ -34,7 +34,7 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'the function returns `true` if provided a number object having a nonnegative number value', function test( t ) {
-	t.equal( isNonNegativeFinite( new Number( 5.0 ) ), true, 'returns true' ); // eslint-disable-line no-new-wrappers
+	t.equal( isNonNegativeFinite( new Number( 5.0 ) ), true, 'returns true' );
 	t.end();
 });
 
@@ -54,7 +54,7 @@ tape( 'the function returns `false` if not provided a nonnegative number', funct
 
 	values = [
 		'5',
-		new Number( -2.0 ), // eslint-disable-line no-new-wrappers
+		new Number( -2.0 ),
 		-3.14,
 		null,
 		true,

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/test/test.primitive.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/test/test.primitive.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-finite/test/test.primitive.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-finite/test/test.primitive.js
@@ -1,0 +1,76 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var Number = require( '@stdlib/number/ctor' );
+var isNonNegativeFinite = require( './../lib/primitive.js' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof isNonNegativeFinite, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `true` if provided a primitive number having a nonnegative finite value', function test( t ) {
+	t.equal( isNonNegativeFinite( 3.0 ), true, 'returns true' );
+	t.end();
+});
+
+tape( 'the function returns `false` if provided a number object, even if the number has a nonnegative finite value', function test( t ) {
+	t.equal( isNonNegativeFinite( new Number( 5.0 ) ), false, 'returns false' );
+	t.end();
+});
+
+tape( 'the function returns `false` if provided Infinity, even if it is positive infinity', function test( t ) {
+	t.equal( isNonNegativeFinite( Infinity ), false, 'returns false' );
+	t.end();
+});
+
+tape( 'the function returns `false` if provided a number object with Infinity', function test( t ) {
+	t.equal( isNonNegativeFinite( new Number( Infinity ) ), false, 'returns false' );
+	t.end();
+});
+
+tape( 'the function returns `false` if not provided a nonnegative finite number', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		new Number( -1.0 ),
+		-3.14,
+		null,
+		true,
+		void 0,
+		[],
+		{},
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.equal( isNonNegativeFinite( values[i] ), false, 'returns false when provided '+values[i] );
+	}
+	t.end();
+});


### PR DESCRIPTION
Resolves #1344 .

## Description

This PR adds the package @stdlib/assert/is-nonnegative-finite.

The package implements assertion for nonnegative number except positive infinity.

Alias: isNonNegativeFinite

## Related Issues

 * resolves [[RFC]: add `@stdlib/assert/is-nonnegative-finite` #1344](https://github.com/stdlib-js/stdlib/issues/1344)


## Questions

I have used the `@stdlib/asset/is-finite` in order to achieve the desired result. Is this considered good practice, what are the guidelines for using internal packages, when and where is it ideal.


## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
