### PR TITLE
feat: add `assert/is-ragged-nested-array`

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/README.md
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/README.md
@@ -32,13 +32,13 @@ var isRaggedNestedArray = require( '@stdlib/assert/is-ragged-nested-array' );
 
 #### isRaggedNestedArray( value )
 
-Tests if a value is a ragged nested array. A ragged nested array is a nested array having inner dimensions of varying lengths. 
+Tests if a value is a ragged nested array. 
 
 ```javascript
-var bool = isRaggedNestedArray( [ [1, 2, 3], [4, 5] ] );
+var bool = isRaggedNestedArray( [ [ 1, 2, 3 ], [ 4, 5 ] ] );
 // returns true
 
-bool = isRaggedNestedArray( [ [1, 2, 3], [4, 5, 6] ] );
+bool = isRaggedNestedArray( [ [ 1, 2, 3 ], [ 4, 5, 6 ] ] );
 // returns false
 ```
 
@@ -57,10 +57,10 @@ bool = isRaggedNestedArray( [ [1, 2, 3], [4, 5, 6] ] );
 ```javascript
 var isRaggedNestedArray = require( '@stdlib/assert/is-ragged-nested-array' );
 
-var bool = isRaggedNestedArray( [ [1, 2, 3], [4, 5] ] );
+var bool = isRaggedNestedArray( [ [ 1, 2, 3 ], [ 4, 5 ] ] );
 // returns true
 
-bool = isRaggedNestedArray( [ [1, 2, 3], [4, 5, 6] ] );
+bool = isRaggedNestedArray( [ [ 1, 2, 3 ], [ 4, 5, 6 ] ] );
 // returns false
 
 bool = isRaggedNestedArray( 'beep' );
@@ -92,13 +92,6 @@ bool = isRaggedNestedArray( function noop() {} );
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">
-
-* * *
-
-## See Also
-
--   <span class="package-name">[`@stdlib/assert/is-array`][@stdlib/assert/is-array]</span><span class="delimiter">: </span><span class="description">test if a value is an array.</span>
--   <span class="package-name">[`@stdlib/assert/is-array-like-object`][@stdlib/assert/is-array-like-object]</span><span class="delimiter">: </span><span class="description">test if a value is an array-like object.</span>
 
 </section>
 

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/README.md
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/README.md
@@ -100,13 +100,6 @@ bool = isRaggedNestedArray( function noop() {} );
 <!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 
 <section class="links">
-<!-- <related-links> -->
-
-[@stdlib/assert/is-array-like-object]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-array-like-object
-
-[@stdlib/assert/is-array]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-array
-
-<!-- </related-links> -->
 
 </section>
 

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/README.md
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/README.md
@@ -50,7 +50,7 @@ bool = isRaggedNestedArray( [ [ 1, 2, 3 ], [ 4, 5, 6 ] ] );
 
 ## Examples
 
-<!-- eslint-disable object-curly-newline, object-curly-spacing, no-empty-function, no-restricted-syntax -->
+<!-- eslint-disable no-empty-function, no-restricted-syntax -->
 
 <!-- eslint no-undef: "error" -->
 

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/README.md
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/README.md
@@ -16,7 +16,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-
 -->
 
 # isRaggedNestedArray

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/README.md
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/README.md
@@ -1,0 +1,120 @@
+<!--
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+-->
+
+# isRaggedNestedArray
+
+> Test if a value is a ragged nested array.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var isRaggedNestedArray = require( '@stdlib/assert/is-ragged-nested-array' );
+```
+
+#### isRaggedNestedArray( value )
+
+Tests if a value is a ragged nested array. A ragged nested array is a nested array having inner dimensions of varying lengths. 
+
+```javascript
+var bool = isRaggedNestedArray( [ [1, 2, 3], [4, 5] ] );
+// returns true
+
+bool = isRaggedNestedArray( [ [1, 2, 3], [4, 5, 6] ] );
+// returns false
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint-disable object-curly-newline, object-curly-spacing, no-empty-function, no-restricted-syntax -->
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var isRaggedNestedArray = require( '@stdlib/assert/is-ragged-nested-array' );
+
+var bool = isRaggedNestedArray( [ [1, 2, 3], [4, 5] ] );
+// returns true
+
+bool = isRaggedNestedArray( [ [1, 2, 3], [4, 5, 6] ] );
+// returns false
+
+bool = isRaggedNestedArray( 'beep' );
+// returns false
+
+bool = isRaggedNestedArray( null );
+// returns false
+
+bool = isRaggedNestedArray( void 0 );
+// returns false
+
+bool = isRaggedNestedArray( 5 );
+// returns false
+
+bool = isRaggedNestedArray( true );
+// returns false
+
+bool = isRaggedNestedArray( {} );
+// returns false
+
+bool = isRaggedNestedArray( function noop() {} );
+// returns false
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/assert/is-array`][@stdlib/assert/is-array]</span><span class="delimiter">: </span><span class="description">test if a value is an array.</span>
+-   <span class="package-name">[`@stdlib/assert/is-array-like-object`][@stdlib/assert/is-array-like-object]</span><span class="delimiter">: </span><span class="description">test if a value is an array-like object.</span>
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+<!-- <related-links> -->
+
+[@stdlib/assert/is-array-like-object]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-array-like-object
+
+[@stdlib/assert/is-array]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-array
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/README.md
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/README.md
@@ -1,4 +1,5 @@
 <!--
+
 @license Apache-2.0
 
 Copyright (c) 2024 The Stdlib Authors.

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/benchmark/benchmark.js
@@ -34,7 +34,7 @@ bench( pkg+'::ragged_array', function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		arr = [ [i, i+1, i+2], [i-1, i-2] ];
+		arr = [ [ i, i+1, i+2 ], [ i-1, i-2 ] ];
 		bool = isRaggedNestedArray( arr );
 		if ( typeof bool !== 'boolean' ) {
 			b.fail( 'should return a boolean' );
@@ -55,7 +55,7 @@ bench( pkg+'::non_ragged_array', function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		arr = [ [i, i+1], [i-1, i] ];
+		arr = [ [ i, i+1], [i-1, i ] ];
 		bool = isRaggedNestedArray( arr );
 		if ( typeof bool !== 'boolean' ) {
 			b.fail( 'should return a boolean' );

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/benchmark/benchmark.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ bench( pkg+'::ragged_array', function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		arr = [ [1, 2, 3], [4, 5] ];
+		arr = [ [i, i+1, i+2], [i-1, i-2] ];
 		bool = isRaggedNestedArray( arr );
 		if ( typeof bool !== 'boolean' ) {
 			b.fail( 'should return a boolean' );
@@ -55,7 +55,7 @@ bench( pkg+'::non_ragged_array', function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		arr = [ [1, 2, 3], [4, 5, 6] ];
+		arr = [ [i, i+1], [i-1, i] ];
 		bool = isRaggedNestedArray( arr );
 		if ( typeof bool !== 'boolean' ) {
 			b.fail( 'should return a boolean' );
@@ -76,7 +76,7 @@ bench( pkg+'::non_array', function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		val = 'beep';
+		val = i;
 		bool = isRaggedNestedArray( val );
 		if ( typeof bool !== 'boolean' ) {
 			b.fail( 'should return a boolean' );

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/benchmark/benchmark.js
@@ -1,0 +1,91 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pkg = require( './../package.json' ).name;
+var isRaggedNestedArray = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg+'::ragged_array', function benchmark( b ) {
+	var bool;
+	var arr;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = [ [1, 2, 3], [4, 5] ];
+		bool = isRaggedNestedArray( arr );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !bool ) {
+		b.fail( 'should return true' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::non_ragged_array', function benchmark( b ) {
+	var bool;
+	var arr;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = [ [1, 2, 3], [4, 5, 6] ];
+		bool = isRaggedNestedArray( arr );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( bool ) {
+		b.fail( 'should return false' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::non_array', function benchmark( b ) {
+	var bool;
+	var val;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		val = 'beep';
+		bool = isRaggedNestedArray( val );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( bool ) {
+		b.fail( 'should return false' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/benchmark/benchmark.js
@@ -71,13 +71,11 @@ bench( pkg+'::non_ragged_array', function benchmark( b ) {
 
 bench( pkg+'::non_array', function benchmark( b ) {
 	var bool;
-	var val;
 	var i;
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		val = i;
-		bool = isRaggedNestedArray( val );
+		bool = isRaggedNestedArray( i );
 		if ( typeof bool !== 'boolean' ) {
 			b.fail( 'should return a boolean' );
 		}

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/docs/repl.txt
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/docs/repl.txt
@@ -1,8 +1,5 @@
-{{alias}}( value )
-    Tests if a value is a ragged nested array. A ragged nested array is a nested
-    array having inner dimensions of varying lengths. This function supports
-    two-dimensional nested arrays and uses isArrayLikeObject to check if a value
-    is an array-like object.
+{{alias}}(value)
+    Tests if a value is a ragged nested array. 
 
     Parameters
     ----------
@@ -16,11 +13,11 @@
 
     Examples
     --------
-    > var bool = {{alias}}( [ [1, 2, 3], [4, 5] ] )
+    > var bool = {{alias}}([ [1, 2, 3], [4, 5] ])
     true
-    > bool = {{alias}}( [ [1, 2, 3], [4, 5, 6] ] )
+    > bool = {{alias}}([ [1, 2, 3], [4, 5, 6] ])
     false
-    > bool = {{alias}}( 'beep' )
+    > bool = {{alias}}('beep')
     false
 
     See Also

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/docs/repl.txt
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/docs/repl.txt
@@ -13,11 +13,11 @@
 
     Examples
     --------
-    > var bool = {{alias}}([ [1, 2, 3], [4, 5] ])
+    > var bool = {{alias}}( [ [ 1, 2, 3 ], [ 4, 5 ] ] )
     true
-    > bool = {{alias}}([ [1, 2, 3], [4, 5, 6] ])
+    > bool = {{alias}}( [ [ 1, 2, 3 ], [ 4, 5, 6 ] ] )
     false
-    > bool = {{alias}}('beep')
+    > bool = {{alias}}( 'beep' )
     false
 
     See Also

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/docs/repl.txt
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/docs/repl.txt
@@ -1,3 +1,4 @@
+
 {{alias}}( value )
     Tests if a value is a ragged nested array. 
 
@@ -22,3 +23,4 @@
 
     See Also
     --------
+

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/docs/repl.txt
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/docs/repl.txt
@@ -13,9 +13,9 @@
 
     Examples
     --------
-    > var bool = {{alias}}([ [1, 2, 3], [4, 5] ])
+    > var bool = {{alias}}( [ [ 1, 2, 3 ], [ 4, 5 ] ] )
     true
-    > bool = {{alias}}([ [1, 2, 3], [4, 5, 6] ])
+    > bool = {{alias}}( [ [ 1, 2, 3 ], [ 4, 5, 6 ] ] )
     false
     > bool = {{alias}}('beep')
     false

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/docs/repl.txt
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/docs/repl.txt
@@ -1,4 +1,4 @@
-{{alias}}(value)
+{{alias}}( value )
     Tests if a value is a ragged nested array. 
 
     Parameters

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/docs/repl.txt
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/docs/repl.txt
@@ -1,0 +1,27 @@
+{{alias}}( value )
+    Tests if a value is a ragged nested array. A ragged nested array is a nested
+    array having inner dimensions of varying lengths. This function supports
+    two-dimensional nested arrays and uses isArrayLikeObject to check if a value
+    is an array-like object.
+
+    Parameters
+    ----------
+    value: any
+        Value to test.
+
+    Returns
+    -------
+    bool: boolean
+        Boolean indicating whether a value is a ragged nested array.
+
+    Examples
+    --------
+    > var bool = {{alias}}( [ [1, 2, 3], [4, 5] ] )
+    true
+    > bool = {{alias}}( [ [1, 2, 3], [4, 5, 6] ] )
+    false
+    > bool = {{alias}}( 'beep' )
+    false
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/docs/types/index.d.ts
@@ -36,7 +36,7 @@
 * var bool = isRaggedNestedArray( 'beep' );
 * // returns false
 */
-declare function isRaggedNestedArray( value: any ): value is ArrayLike<any>;
+declare function isRaggedNestedArray( value: any ): boolean;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/docs/types/index.d.ts
@@ -1,0 +1,44 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Tests if a value is a ragged nested array.
+*
+* @param value - value to test
+* @returns boolean indicating if a value is a ragged nested array
+*
+* @example
+* var bool = isRaggedNestedArray( [ [1, 2, 3], [4, 5] ] );
+* // returns true
+*
+* @example
+* var bool = isRaggedNestedArray( [ [1, 2, 3], [4, 5, 6] ] );
+* // returns false
+*
+* @example
+* var bool = isRaggedNestedArray( 'beep' );
+* // returns false
+*/
+declare function isRaggedNestedArray( value: any ): value is ArrayLike<any>;
+
+
+// EXPORTS //
+
+export = isRaggedNestedArray;

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/docs/types/index.d.ts
@@ -25,11 +25,11 @@
 * @returns boolean indicating if a value is a ragged nested array
 *
 * @example
-* var bool = isRaggedNestedArray( [ [1, 2, 3], [4, 5] ] );
+* var bool = isRaggedNestedArray( [ [ 1, 2, 3 ], [ 4, 5 ] ] );
 * // returns true
 *
 * @example
-* var bool = isRaggedNestedArray( [ [1, 2, 3], [4, 5, 6] ] );
+* var bool = isRaggedNestedArray( [ [ 1, 2, 3 ], [ 4, 5, 6 ] ] );
 * // returns false
 *
 * @example

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/docs/types/test.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2019 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/docs/types/test.ts
@@ -23,8 +23,8 @@ import isRaggedNestedArray = require( './index' );
 
 // The function returns a boolean...
 {
-	isRaggedNestedArray( [ [1, 2, 3], [4, 5] ] ); // $ExpectType boolean
-	isRaggedNestedArray( [ [1, 2, 3], [4, 5, 6] ] ); // $ExpectType boolean
+	isRaggedNestedArray( [ [ 1, 2, 3 ], [ 4, 5 ] ] ); // $ExpectType boolean
+	isRaggedNestedArray( [ [ 1, 2, 3 ], [ 4, 5, 6 ] ] ); // $ExpectType boolean
 	isRaggedNestedArray( 'beep' ); // $ExpectType boolean
 }
 

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/docs/types/test.ts
@@ -22,8 +22,8 @@ import isRaggedNestedArray = require( './index' );
 
 // The function returns a boolean...
 {
-	isRaggedNestedArray( [ [1, 2, 3], [4, 5] ] ); // $ExpectType boolean
-	isRaggedNestedArray( [ [1, 2, 3], [4, 5, 6] ] ); // $ExpectType boolean
+	isRaggedNestedArray( [ [ 1, 2, 3 ], [ 4, 5 ] ] ); // $ExpectType boolean
+	isRaggedNestedArray( [ [ 1, 2, 3 ], [ 4, 5, 6 ] ] ); // $ExpectType boolean
 	isRaggedNestedArray( 'beep' ); // $ExpectType boolean
 }
 

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/docs/types/test.ts
@@ -1,0 +1,34 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2019 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import isRaggedNestedArray = require( './index' );
+
+// TESTS //
+
+// The function returns a boolean...
+{
+	isRaggedNestedArray( [ [1, 2, 3], [4, 5] ] ); // $ExpectType boolean
+	isRaggedNestedArray( [ [1, 2, 3], [4, 5, 6] ] ); // $ExpectType boolean
+	isRaggedNestedArray( 'beep' ); // $ExpectType boolean
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	isRaggedNestedArray(); // $ExpectError
+	isRaggedNestedArray( [], 123 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/docs/types/test.ts
@@ -18,6 +18,7 @@
 
 import isRaggedNestedArray = require( './index' );
 
+
 // TESTS //
 
 // The function returns a boolean...

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/examples/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/examples/index.js
@@ -22,10 +22,10 @@
 
 var isRaggedNestedArray = require( './../lib' );
 
-console.log( isRaggedNestedArray( [ [1, 2, 3], [4, 5] ] ) );
+console.log( isRaggedNestedArray( [ [ 1, 2, 3 ], [ 4, 5 ] ] ) );
 // => true
 
-console.log( isRaggedNestedArray( [ [1, 2, 3], [4, 5, 6] ] ) );
+console.log( isRaggedNestedArray( [ [ 1, 2, 3 ], [ 4, 5, 6 ] ] ) );
 // => false
 
 console.log( isRaggedNestedArray( 'beep' ) );

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/examples/index.js
@@ -1,0 +1,50 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* eslint-disable no-empty-function, no-restricted-syntax */
+
+'use strict';
+
+var isRaggedNestedArray = require( './../lib' );
+
+console.log( isRaggedNestedArray( [ [1, 2, 3], [4, 5] ] ) );
+// => true
+
+console.log( isRaggedNestedArray( [ [1, 2, 3], [4, 5, 6] ] ) );
+// => false
+
+console.log( isRaggedNestedArray( 'beep' ) );
+// => false
+
+console.log( isRaggedNestedArray( null ) );
+// => false
+
+console.log( isRaggedNestedArray( void 0 ) );
+// => false
+
+console.log( isRaggedNestedArray( 5 ) );
+// => false
+
+console.log( isRaggedNestedArray( true ) );
+// => false
+
+console.log( isRaggedNestedArray( {} ) );
+// => false
+
+console.log( isRaggedNestedArray( function noop() {} ) );
+// => false

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/lib/index.js
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/lib/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/lib/index.js
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/lib/index.js
@@ -1,0 +1,46 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Test if a value is a ragged nested array.
+*
+* @module @stdlib/assert/is-ragged-nested-array
+*
+* @example
+* var isRaggedNestedArray = require( '@stdlib/assert/is-ragged-nested-array' );
+*
+* var bool = isRaggedNestedArray( [ [1, 2, 3], [4, 5] ] );
+* // returns true
+*
+* bool = isRaggedNestedArray( [ [1, 2, 3], [4, 5, 6] ] );
+* // returns false
+*
+* bool = isRaggedNestedArray( 'beep' );
+* // returns false
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/lib/index.js
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/lib/index.js
@@ -26,10 +26,10 @@
 * @example
 * var isRaggedNestedArray = require( '@stdlib/assert/is-ragged-nested-array' );
 *
-* var bool = isRaggedNestedArray( [ [1, 2, 3], [4, 5] ] );
+* var bool = isRaggedNestedArray( [ [ 1, 2, 3 ], [ 4, 5 ] ] );
 * // returns true
 *
-* bool = isRaggedNestedArray( [ [1, 2, 3], [4, 5, 6] ] );
+* bool = isRaggedNestedArray( [ [ 1, 2, 3 ], [ 4, 5, 6 ] ] );
 * // returns false
 *
 * bool = isRaggedNestedArray( 'beep' );

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/lib/main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/lib/main.js
@@ -32,11 +32,11 @@ var isArrayLikeObject = require( '@stdlib/assert/is-array-like-object' );
 * @returns {boolean} boolean indicating if a value is a ragged nested array
 *
 * @example
-* var bool = isRaggedNestedArray( [ [1, 2, 3], [4, 5] ] );
+* var bool = isRaggedNestedArray( [ [ 1, 2, 3 ], [ 4, 5 ] ] );
 * // returns true
 *
 * @example
-* var bool = isRaggedNestedArray( [ [1, 2, 3], [4, 5, 6] ] );
+* var bool = isRaggedNestedArray( [ [ 1, 2, 3 ], [ 4, 5, 6 ] ] );
 * // returns false
 *
 * @example
@@ -44,19 +44,17 @@ var isArrayLikeObject = require( '@stdlib/assert/is-array-like-object' );
 * // returns false
 */
 function isRaggedNestedArray( value ) {
-	var len = -1;
+	var len;
 	var i;
-
-	if ( !isArrayLikeObject( value ) ) {
+	if ( !isArrayLikeObject( value ) || value.length < 2 ) {
 		return false;
 	}
-	for ( i = 0; i < value.length; i++ ) {
-		if ( !isArrayLikeObject( value[i] ) ) {
+	len = value[ 0 ].length;
+	for ( i = 1; i < value.length; i++ ) {
+		if ( !isArrayLikeObject( value[ i ] ) ) {
 			return false;
 		}
-		if ( len === -1 ) {
-			len = value[i].length;
-		} else if ( value[i].length !== len ) {
+		if ( value[ i ].length !== len ) {
 			return true;
 		}
 	}

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/lib/main.js
@@ -1,0 +1,69 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isArrayLikeObject = require( '@stdlib/assert/is-array-like-object' );
+
+
+// MAIN //
+
+/**
+* Tests if a value is a ragged nested array.
+*
+* @param {*} value - value to test
+* @returns {boolean} boolean indicating if a value is a ragged nested array
+*
+* @example
+* var bool = isRaggedNestedArray( [ [1, 2, 3], [4, 5] ] );
+* // returns true
+*
+* @example
+* var bool = isRaggedNestedArray( [ [1, 2, 3], [4, 5, 6] ] );
+* // returns false
+*
+* @example
+* var bool = isRaggedNestedArray( 'beep' );
+* // returns false
+*/
+function isRaggedNestedArray( value ) {
+	var len = -1;
+	var i;
+
+	if ( !isArrayLikeObject( value ) ) {
+		return false;
+	}
+	for ( i = 0; i < value.length; i++ ) {
+		if ( !isArrayLikeObject( value[i] ) ) {
+			return false;
+		}
+		if ( len === -1 ) {
+			len = value[i].length;
+		} else if ( value[i].length !== len ) {
+			return true;
+		}
+	}
+	return false;
+}
+
+
+// EXPORTS //
+
+module.exports = isRaggedNestedArray;

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/package.json
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/package.json
@@ -1,75 +1,75 @@
 {
-    "name": "@stdlib/assert/is-ragged-nested-array",
-    "version": "0.0.0",
-    "description": "Test if a value is a ragged nested array",
-    "license": "Apache-2.0",
-    "author": {
+  "name": "@stdlib/assert/is-ragged-nested-array",
+  "version": "0.0.0",
+  "description": "Test if a value is a ragged nested array",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
       "name": "The Stdlib Authors",
       "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
-    },
-    "contributors": [
-      {
-        "name": "The Stdlib Authors",
-        "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
-      }
-    ],
-    "main": "./lib",
-    "directories": {
-      "benchmark": "./benchmark",
-      "doc": "./docs",
-      "example": "./examples",
-      "lib": "./lib",
-      "test": "./test"
-    },
-    "types": "./docs/types",
-    "scripts": {},
-    "homepage": "https://github.com/stdlib-js/stdlib",
-    "repository": {
-      "type": "git",
-      "url": "git://github.com/stdlib-js/stdlib.git"
-    },
-    "bugs": {
-      "url": "https://github.com/stdlib-js/stdlib/issues"
-    },
-    "dependencies": {},
-    "devDependencies": {},
-    "engines": {
-      "node": ">=0.10.0",
-      "npm": ">2.7.0"
-    },
-    "os": [
-      "aix",
-      "darwin",
-      "freebsd",
-      "linux",
-      "macos",
-      "openbsd",
-      "sunos",
-      "win32",
-      "windows"
-    ],
-    "keywords": [
-        "stdlib",
-        "stdassert",
-        "assertion",
-        "assert",
-        "utilities",
-        "utility",
-        "utils",
-        "util",
-        "array",
-        "ragged",
-        "nested",
-        "is",
-        "israggednestedarray",
-        "object",
-        "obj",
-        "type",
-        "check",
-        "test",
-        "validate",
-        "isvalid",
-        "2d",
-        "two-dimensional"
-      ]
-    }  
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdassert",
+    "assertion",
+    "assert",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "array",
+    "ragged",
+    "nested",
+    "is",
+    "isarray",
+    "object",
+    "obj",
+    "type",
+    "check",
+    "test",
+    "validate",
+    "isvalid",
+    "2d",
+    "two-dimensional"
+  ]
+}

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/package.json
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/package.json
@@ -72,6 +72,4 @@
         "2d",
         "two-dimensional"
       ]
-      
-  }
-  
+    }  

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/package.json
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/package.json
@@ -1,0 +1,77 @@
+{
+    "name": "@stdlib/assert/is-ragged-nested-array",
+    "version": "0.0.0",
+    "description": "Test if a value is a ragged nested array",
+    "license": "Apache-2.0",
+    "author": {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    },
+    "contributors": [
+      {
+        "name": "The Stdlib Authors",
+        "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+      }
+    ],
+    "main": "./lib",
+    "directories": {
+      "benchmark": "./benchmark",
+      "doc": "./docs",
+      "example": "./examples",
+      "lib": "./lib",
+      "test": "./test"
+    },
+    "types": "./docs/types",
+    "scripts": {},
+    "homepage": "https://github.com/stdlib-js/stdlib",
+    "repository": {
+      "type": "git",
+      "url": "git://github.com/stdlib-js/stdlib.git"
+    },
+    "bugs": {
+      "url": "https://github.com/stdlib-js/stdlib/issues"
+    },
+    "dependencies": {},
+    "devDependencies": {},
+    "engines": {
+      "node": ">=0.10.0",
+      "npm": ">2.7.0"
+    },
+    "os": [
+      "aix",
+      "darwin",
+      "freebsd",
+      "linux",
+      "macos",
+      "openbsd",
+      "sunos",
+      "win32",
+      "windows"
+    ],
+    "keywords": [
+        "stdlib",
+        "stdassert",
+        "assertion",
+        "assert",
+        "utilities",
+        "utility",
+        "utils",
+        "util",
+        "array",
+        "ragged",
+        "nested",
+        "is",
+        "israggednestedarray",
+        "object",
+        "obj",
+        "type",
+        "check",
+        "test",
+        "validate",
+        "isvalid",
+        "2d",
+        "two-dimensional"
+      ]
+      
+  }
+  

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/test/test.js
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/test/test.js
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/test/test.js
@@ -1,0 +1,89 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* eslint-disable no-unused-vars */
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isRaggedNestedArray = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof isRaggedNestedArray, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `true` if provided a ragged nested array', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		[ [1, 2, 3], [4, 5] ],
+		[ [1, 2, 3], [4, 5, 6, 7] ],
+		[ [1], [2, 3], [4, 5, 6] ]
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.strictEqual( isRaggedNestedArray( values[i] ), true, 'returns true when provided '+values[i] );
+	}
+	t.end();
+});
+
+tape( 'the function returns `false` if provided a non-ragged nested array', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		[ [1, 2, 3], [4, 5, 6] ],
+		[ [1, 2], [3, 4], [5, 6] ]
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.strictEqual( isRaggedNestedArray( values[i] ), false, 'returns false when provided '+values[i] );
+	}
+	t.end();
+});
+
+tape( 'the function returns `false` if not provided a nested array', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'beep',
+		5,
+		null,
+		void 0,
+		NaN,
+		true,
+		false,
+		{},
+		function boop( a, b, c ) {},
+		[1, 2, 3]
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.strictEqual( isRaggedNestedArray( values[i] ), false, 'returns false when provided '+values[i] );
+	}
+	t.end();
+});

--- a/lib/node_modules/@stdlib/assert/is-ragged-nested-array/test/test.js
+++ b/lib/node_modules/@stdlib/assert/is-ragged-nested-array/test/test.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-unused-vars */
-
 'use strict';
 
 // MODULES //
@@ -39,13 +37,13 @@ tape( 'the function returns `true` if provided a ragged nested array', function 
 	var i;
 
 	values = [
-		[ [1, 2, 3], [4, 5] ],
-		[ [1, 2, 3], [4, 5, 6, 7] ],
-		[ [1], [2, 3], [4, 5, 6] ]
+		[ [ 1, 2, 3 ], [ 4, 5 ] ],
+		[ [ 1, 2, 3 ], [ 4, 5, 6, 7 ] ],
+		[ [ 1 ], [ 2, 3 ], [ 4, 5, 6 ] ]
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		t.strictEqual( isRaggedNestedArray( values[i] ), true, 'returns true when provided '+values[i] );
+		t.strictEqual( isRaggedNestedArray(values[ i ]), true, 'returns true when provided ' + values[ i ] );
 	}
 	t.end();
 });
@@ -55,12 +53,12 @@ tape( 'the function returns `false` if provided a non-ragged nested array', func
 	var i;
 
 	values = [
-		[ [1, 2, 3], [4, 5, 6] ],
-		[ [1, 2], [3, 4], [5, 6] ]
+		[ [ 1, 2, 3 ], [ 4, 5, 6 ] ],
+		[ [ 1, 2 ], [ 3, 4 ], [ 5, 6 ] ]
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		t.strictEqual( isRaggedNestedArray( values[i] ), false, 'returns false when provided '+values[i] );
+		t.strictEqual( isRaggedNestedArray(values[ i ]), false, 'returns false when provided ' + values[ i ] );
 	}
 	t.end();
 });
@@ -78,12 +76,14 @@ tape( 'the function returns `false` if not provided a nested array', function te
 		true,
 		false,
 		{},
-		function boop( a, b, c ) {},
-		[1, 2, 3]
+		[],
+		[ [ 1, 2, 3 ] ],
+		function noop() {},
+		[ 1, 2, 3 ]
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
-		t.strictEqual( isRaggedNestedArray( values[i] ), false, 'returns false when provided '+values[i] );
+		t.strictEqual( isRaggedNestedArray( values[ i ] ), false, 'returns false when provided ' + values[ i ] );
 	}
 	t.end();
 });


### PR DESCRIPTION
Add support for checking if array-like objects are ragged and nested.

Resolves #1347

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds support for checking if array-like objects are ragged and nested.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #1347

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The test results when applied on the functionality (benchmarks, examples, tests) can be found here - https://drive.google.com/drive/folders/1AomH4BL-sKkQCO6lhFU5BUelUW3wZp4f?usp=sharing


## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
