### PR TITLE
feat: add `string/base/for-each-right`

### DIFF
--- a/lib/node_modules/@stdlib/string/base/for-each-right/README.md
+++ b/lib/node_modules/@stdlib/string/base/for-each-right/README.md
@@ -1,0 +1,150 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2023 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# forEachRight
+
+> Invokes a function for each UTF-16 code unit in a string from right to left.
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var forEachRight = require( '@stdlib/string/base/for-each-right' );
+```
+
+#### forEachRight( str, clbk\[, thisArg ] )
+
+Invokes a function for each UTF-16 code unit in a string from right to left.
+
+```javascript
+function log( value, index ) {
+    console.log( '%d: %s', index, value );
+}
+
+forEachRight( 'Beep!', log );
+/* =>
+    4: !
+    3: p
+    2: e
+    1: e
+    0: B
+*/
+```
+
+The invoked function is provided three arguments:
+
+-   **value**: character.
+-   **index**: character index.
+-   **str**: input string.
+
+To set the function execution context, provide a `thisArg`.
+
+```javascript
+function clbk() {
+    this.count += 1;
+}
+
+var str = '👉🏿';
+
+var ctx = {
+    'count': 0
+};
+
+forEachRight( str, clbk, ctx );
+
+var cnt = ctx.count;
+// returns 4
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var forEachRight = require( '@stdlib/string/base/for-each-right' );
+
+function log( value, index ) {
+    console.log( '%d: %s', index, value );
+}
+
+forEachRight( 'presidential election', log );
+forEachRight( 'Iñtërnâtiônàlizætiøn', log );
+forEachRight( '🌷🍕', log );
+forEachRight( '\uD834\uDD1E', log );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/string/base/for-each-right/README.md
+++ b/lib/node_modules/@stdlib/string/base/for-each-right/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2023 The Stdlib Authors.
+Copyright (c) 2024 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/string/base/for-each-right/README.md
+++ b/lib/node_modules/@stdlib/string/base/for-each-right/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # forEachRight
 
-> Invokes a function for each UTF-16 code unit in a string from right to left.
+> Invokes a function for each UTF-16 code unit in a string iterating from right to left.
 
 <!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
 
@@ -42,7 +42,7 @@ var forEachRight = require( '@stdlib/string/base/for-each-right' );
 
 #### forEachRight( str, clbk\[, thisArg ] )
 
-Invokes a function for each UTF-16 code unit in a string from right to left.
+Invokes a function for each UTF-16 code unit in a string iterating from right to left.
 
 ```javascript
 function log( value, index ) {

--- a/lib/node_modules/@stdlib/string/base/for-each-right/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/string/base/for-each-right/benchmark/benchmark.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/string/base/for-each-right/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/string/base/for-each-right/benchmark/benchmark.js
@@ -1,0 +1,61 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
+var pkg = require( './../package.json' ).name;
+var forEachRight = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var values;
+	var out;
+	var i;
+
+	values = [
+		'Iñtërnâtiônàlizætiøn',
+		'presidential election',
+		'🐶🐮🐷🐰🐸'
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = forEachRight( values[ i%values.length ], clbk );
+		if ( typeof out !== 'string' ) {
+			b.fail( 'should return a string' );
+		}
+	}
+	b.toc();
+	if ( !isString( out ) ) {
+		b.fail( 'should return a string' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+
+	function clbk( v ) {
+		if ( typeof v !== 'string' ) {
+			b.fail( 'unexpected value' );
+		}
+	}
+});

--- a/lib/node_modules/@stdlib/string/base/for-each-right/docs/repl.txt
+++ b/lib/node_modules/@stdlib/string/base/for-each-right/docs/repl.txt
@@ -14,7 +14,7 @@
         Input string over which to iterate.
 
     clbk: Function
-        The function to invoke for each UTF-16 code unit in the input string.
+        Function to invoke for each UTF-16 code unit in the input string.
 
     thisArg: any (optional)
         Execution context.

--- a/lib/node_modules/@stdlib/string/base/for-each-right/docs/repl.txt
+++ b/lib/node_modules/@stdlib/string/base/for-each-right/docs/repl.txt
@@ -1,6 +1,7 @@
 
 {{alias}}( str, clbk[, thisArg] )
-    Invokes a function for each UTF-16 code unit in a string from right to left.
+    Invokes a function for each UTF-16 code unit in a string, iterating from 
+    right to left.
 
     When invoked, the provided function is provided three arguments:
 

--- a/lib/node_modules/@stdlib/string/base/for-each-right/docs/repl.txt
+++ b/lib/node_modules/@stdlib/string/base/for-each-right/docs/repl.txt
@@ -1,0 +1,37 @@
+
+{{alias}}( str, clbk[, thisArg] )
+    Invokes a function for each UTF-16 code unit in a string from right to left.
+
+    When invoked, the provided function is provided three arguments:
+
+    - value: character
+    - index: character index
+    - str: input string
+
+    Parameters
+    ----------
+    str: string
+        Input string over which to iterate.
+
+    clbk: Function
+        The function to invoke for each UTF-16 code unit in the input string.
+
+    thisArg: any (optional)
+        Execution context.
+
+    Returns
+    -------
+    out: string
+        Input string.
+
+    Examples
+    --------
+    > var n = 0;
+    > function fcn() { n += 1; };
+    > {{alias}}( 'hello world!', fcn );
+    > n
+    12
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/string/base/for-each-right/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/base/for-each-right/docs/types/index.d.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/string/base/for-each-right/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/base/for-each-right/docs/types/index.d.ts
@@ -1,0 +1,93 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Callback invoked for each UTF-16 code unit in a string.
+*
+* @returns result
+*/
+type Nullary = () => any;
+
+/**
+* Callback invoked for each UTF-16 code unit in a string.
+*
+* @param value - character
+* @returns result
+*/
+type Unary = ( value: string ) => any;
+
+/**
+* Callback invoked for each UTF-16 code unit in a string.
+*
+* @param value - character
+* @param index - character index
+* @returns result
+*/
+type Binary = ( value: string, index: number ) => any;
+
+/**
+* Callback invoked for each UTF-16 code unit in a string.
+*
+* @param value - character
+* @param index - character index
+* @param str - input string
+* @returns result
+*/
+type Ternary = ( value: string, index: number, str: string ) => any;
+
+/**
+* Callback invoked for each UTF-16 code unit in a string.
+*
+* @param value - character
+* @param index - character index
+* @param str - input string
+* @returns result
+*/
+type Callback = Nullary | Unary | Binary | Ternary;
+
+/**
+* Invokes a function for each UTF-16 code unit in a string.
+*
+* ## Notes
+*
+* -   When invoked, the provided function is provided three arguments:
+*
+*     -   **value**: character.
+*     -   **index**: character index.
+*     -   **str**: input string.
+*
+* @param str - input string
+* @param clbk - function to invoke
+* @param thisArg - execution context
+* @returns input string
+*
+* @example
+* function log( value, index ) {
+*     console.log( '%d: %s', index, value );
+* }
+*
+* forEach( 'Hello, World!', log );
+*/
+declare function forEachRight( str: string, clbk: Callback, thisArg?: any ): string;
+
+
+// EXPORTS //
+
+export = forEachRight;

--- a/lib/node_modules/@stdlib/string/base/for-each-right/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/base/for-each-right/docs/types/index.d.ts
@@ -63,7 +63,7 @@ type Ternary = ( value: string, index: number, str: string ) => any;
 type Callback = Nullary | Unary | Binary | Ternary;
 
 /**
-* Invokes a function for each UTF-16 code unit in a string.
+* Invokes a function for each UTF-16 code unit in a string from right to left.
 *
 * ## Notes
 *

--- a/lib/node_modules/@stdlib/string/base/for-each-right/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/base/for-each-right/docs/types/index.d.ts
@@ -63,7 +63,7 @@ type Ternary = ( value: string, index: number, str: string ) => any;
 type Callback = Nullary | Unary | Binary | Ternary;
 
 /**
-* Invokes a function for each UTF-16 code unit in a string from right to left.
+* Invokes a function for each UTF-16 code unit in a string iterating from right to left.
 *
 * ## Notes
 *

--- a/lib/node_modules/@stdlib/string/base/for-each-right/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/string/base/for-each-right/docs/types/test.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/string/base/for-each-right/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/string/base/for-each-right/docs/types/test.ts
@@ -1,0 +1,86 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import forEachRight = require( './index' );
+
+/**
+* Callback function.
+*
+* @param v - argument
+* @returns result
+*/
+function clbk( v: string ): string {
+	return v;
+}
+
+
+// TESTS //
+
+// The function returns a string...
+{
+	forEachRight( 'presidential election', clbk ); // $ExpectType string
+	forEachRight( 'Iñtërnâtiônàlizætiøn', clbk, {} ); // $ExpectType string
+}
+
+// The compiler throws an error if the function is provided a first argument which is not a string...
+{
+	forEachRight( 1, clbk ); // $ExpectError
+	forEachRight( false, clbk ); // $ExpectError
+	forEachRight( true, clbk ); // $ExpectError
+	forEachRight( null, clbk ); // $ExpectError
+	forEachRight( [], clbk ); // $ExpectError
+	forEachRight( {}, clbk ); // $ExpectError
+	forEachRight( ( x: number ): number => x, clbk ); // $ExpectError
+
+	forEachRight( 1, clbk, {} ); // $ExpectError
+	forEachRight( false, clbk, {} ); // $ExpectError
+	forEachRight( true, clbk, {} ); // $ExpectError
+	forEachRight( null, clbk, {} ); // $ExpectError
+	forEachRight( [], clbk, {} ); // $ExpectError
+	forEachRight( {}, clbk, {} ); // $ExpectError
+	forEachRight( ( x: number ): number => x, clbk, {} ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument which is not a function having a supported signature...
+{
+	forEachRight( 'presidential election', 'abc' ); // $ExpectError
+	forEachRight( 'presidential election', 2 ); // $ExpectError
+	forEachRight( 'presidential election', true ); // $ExpectError
+	forEachRight( 'presidential election', false ); // $ExpectError
+	forEachRight( 'presidential election', null ); // $ExpectError
+	forEachRight( 'presidential election', {} ); // $ExpectError
+	forEachRight( 'presidential election', [] ); // $ExpectError
+
+	forEachRight( 'presidential election', 'abc', {} ); // $ExpectError
+	forEachRight( 'presidential election', 2, {} ); // $ExpectError
+	forEachRight( 'presidential election', true, {} ); // $ExpectError
+	forEachRight( 'presidential election', false, {} ); // $ExpectError
+	forEachRight( 'presidential election', null, {} ); // $ExpectError
+	forEachRight( 'presidential election', {}, {} ); // $ExpectError
+	forEachRight( 'presidential election', [], {} ); // $ExpectError
+
+	forEachRight( 'presidential election', ( x: number ): number => x ); // $ExpectError
+	forEachRight( 'presidential election', ( x: number ): number => x, {} ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	forEachRight(); // $ExpectError
+	forEachRight( 'presidential election' ); // $ExpectError
+	forEachRight( 'presidential election', clbk, {}, 3 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/string/base/for-each-right/examples/index.js
+++ b/lib/node_modules/@stdlib/string/base/for-each-right/examples/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/string/base/for-each-right/examples/index.js
+++ b/lib/node_modules/@stdlib/string/base/for-each-right/examples/index.js
@@ -1,0 +1,30 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var forEachRight = require( './../lib' );
+
+function log( value, index ) {
+	console.log( '%d: %s', index, value );
+}
+
+forEachRight( 'presidential election', log );
+forEachRight( 'Iñtërnâtiônàlizætiøn', log );
+forEachRight( '🌷🍕', log );
+forEachRight( '\uD834\uDD1E', log );

--- a/lib/node_modules/@stdlib/string/base/for-each-right/lib/index.js
+++ b/lib/node_modules/@stdlib/string/base/for-each-right/lib/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/string/base/for-each-right/lib/index.js
+++ b/lib/node_modules/@stdlib/string/base/for-each-right/lib/index.js
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Invoke a function for each UTF-16 code unit in a string from right to left.
+*
+* @module @stdlib/string/base/for-each-right
+*
+* @example
+* var forEachRight = require( '@stdlib/string/base/for-each-right' );
+*
+* function log( value, index ) {
+*     console.log( '%d: %s', index, value );
+* }
+*
+* forEachRight( 'Hello', log );
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/string/base/for-each-right/lib/index.js
+++ b/lib/node_modules/@stdlib/string/base/for-each-right/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Invoke a function for each UTF-16 code unit in a string from right to left.
+* Invoke a function for each UTF-16 code unit in a string iterating from right to left.
 *
 * @module @stdlib/string/base/for-each-right
 *

--- a/lib/node_modules/@stdlib/string/base/for-each-right/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/for-each-right/lib/main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/string/base/for-each-right/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/for-each-right/lib/main.js
@@ -21,7 +21,7 @@
 // MAIN //
 
 /**
-* Invokes a function for each UTF-16 code unit in a string from right to left.
+* Invokes a function for each UTF-16 code unit in a string iterating from right to left.
 *
 * @param {string} str - input string
 * @param {Function} clbk - function to invoke

--- a/lib/node_modules/@stdlib/string/base/for-each-right/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/for-each-right/lib/main.js
@@ -1,0 +1,49 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MAIN //
+
+/**
+* Invokes a function for each UTF-16 code unit in a string from right to left.
+*
+* @param {string} str - input string
+* @param {Function} clbk - function to invoke
+* @param {*} [thisArg] - execution context
+* @returns {string} input string
+*
+* @example
+* function log( value, index ) {
+*     console.log( '%d: %s', index, value );
+* }
+*
+* forEachRight( 'Hello', log );
+*/
+function forEachRight( str, clbk, thisArg ) {
+	var i;
+	for ( i = str.length-1; i >= 0; i-- ) {
+		clbk.call( thisArg, str[ i ], i, str );
+	}
+	return str;
+}
+
+
+// EXPORTS //
+
+module.exports = forEachRight;

--- a/lib/node_modules/@stdlib/string/base/for-each-right/package.json
+++ b/lib/node_modules/@stdlib/string/base/for-each-right/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/string/base/for-each-right",
   "version": "0.0.0",
-  "description": "Invoke a function for each UTF-16 code unit in a string from right to left.",
+  "description": "Invoke a function for each UTF-16 code unit in a string iterating from right to left.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/string/base/for-each-right/package.json
+++ b/lib/node_modules/@stdlib/string/base/for-each-right/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@stdlib/string/base/for-each-right",
+  "version": "0.0.0",
+  "description": "Invoke a function for each UTF-16 code unit in a string from right to left.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdutils",
+    "stdutil",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "for",
+    "each",
+    "foreachright",
+    "iterate",
+    "stdstring",
+    "string",
+    "str",
+    "utf16",
+    "utf-16",
+    "reverse"
+  ]
+}

--- a/lib/node_modules/@stdlib/string/base/for-each-right/test/test.js
+++ b/lib/node_modules/@stdlib/string/base/for-each-right/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/string/base/for-each-right/test/test.js
+++ b/lib/node_modules/@stdlib/string/base/for-each-right/test/test.js
@@ -1,0 +1,170 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var noop = require( '@stdlib/utils/noop' );
+var forEachRight = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof forEachRight, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'if provided an empty string, the function never invokes a provided function', function test( t ) {
+	var out = forEachRight( '', fcn );
+	t.strictEqual( out, '', 'returns expected value' );
+	t.end();
+
+	function fcn() {
+		t.fail( 'should not be invoked' );
+	}
+});
+
+tape( 'the function returns a provided string', function test( t ) {
+	var str;
+	var out;
+
+	str = 'Hello, world';
+
+	out = forEachRight( str, noop );
+	t.strictEqual( out, str, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function invokes a provided function for each UTF-16 code unit in a provided string', function test( t ) {
+	var expected;
+	var actual;
+	var str;
+
+	str = 'Hello, world';
+	expected = [
+		'd',
+		'l',
+		'r',
+		'o',
+		'w',
+		' ',
+		',',
+		'o',
+		'l',
+		'l',
+		'e',
+		'H'
+	];
+
+	actual = [];
+	forEachRight( str, copy );
+
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.end();
+
+	function copy( value ) {
+		actual.push( value );
+	}
+});
+
+tape( 'the function invokes a provided function for each UTF-16 code unit in a provided string (Unicode)', function test( t ) {
+	var expected;
+	var actual;
+	var str;
+
+	str = 'Hello, world \uD834\uDD1E';
+	expected = [
+		'\uDD1E',
+		'\uD834',
+		' ',
+		'd',
+		'l',
+		'r',
+		'o',
+		'w',
+		' ',
+		',',
+		'o',
+		'l',
+		'l',
+		'e',
+		'H'
+	];
+
+	actual = [];
+	forEachRight( str, copy );
+
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.end();
+
+	function copy( value ) {
+		actual.push( value );
+	}
+});
+
+tape( 'the function invokes a provided function for each UTF-16 code unit in a provided string (emoji)', function test( t ) {
+	var expected;
+	var actual;
+	var str;
+
+	str = '🌷🍕👉🏿';
+	expected = [
+		'\uDFFF',
+		'\uD83C',
+		'\uDC49',
+		'\uD83D',
+		'\uDF55',
+		'\uD83C',
+		'\uDF37',
+		'\uD83C'
+	];
+
+	actual = [];
+	forEachRight( str, copy );
+
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.end();
+
+	function copy( value ) {
+		actual.push( value );
+	}
+});
+
+tape( 'the function supports providing an execution context', function test( t ) {
+	var ctx;
+	var str;
+
+	str = 'Hello, world';
+	ctx = {
+		'count': 0
+	};
+
+	forEachRight( str, count, ctx );
+
+	t.strictEqual( ctx.count, 12, 'returns expected value' );
+	t.end();
+
+	function count() {
+		this.count += 1; // eslint-disable-line no-invalid-this
+	}
+});


### PR DESCRIPTION
Resolves #856 

## Description

> What is the purpose of this pull request?

Adding support for invoking a callback for each UTF-16 character of a string, while iterating from right-to-left

This pull request:

-   add `@stdlib/string/base/for-each-right `

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #856 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
