### PR TITLE
refactor: improve type definitions for ndarray array

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/array/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/array/docs/types/index.d.ts
@@ -164,7 +164,11 @@ interface ExtendedOptions<T> extends Options {
 * var v = arr.get( 0 );
 * // returns [ 1, 2 ]
 */
-declare function array<T = unknown>( options: OptionsWithShape<T> | OptionsWithBuffer<T> ): typedndarray<typeof options['dtype'] extends undefined ? T : typeof options['dtype']>;
+
+type OptionsType<T> = OptionsWithShape<T> | OptionsWithBuffer<T>;
+declare function array<T = unknown>( options: OptionsWithShape<T> | OptionsWithBuffer<T> ): typedndarray<undefined extends T
+	? ( OptionsType<T> extends { dtype: infer D } ? D : never )
+	: ( OptionsType<T> extends { dtype: infer D } ? D : T )>;
 
 /**
 * Returns a multidimensional array.
@@ -220,7 +224,7 @@ declare function array<T = unknown>( options: OptionsWithShape<T> | OptionsWithB
 * var v = arr.get( 0, 0 );
 * // returns 1.0
 */
-declare function array<T = unknown>( buffer: ArrayLike<T>, options?: ExtendedOptions<T> ): typedndarray<T extends undefined ? ( typeof options extends { dtype: infer D } ? D : never ) : T >;
+declare function array<T = unknown>( buffer: ArrayLike<T>, options?: ExtendedOptions<T> ): typedndarray<T extends undefined ? ( typeof options extends { dtype: infer D } ? D : never ) : T>;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/ndarray/array/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/array/docs/types/index.d.ts
@@ -45,7 +45,7 @@ interface Options {
 	/**
 	* Specifies how to handle subscripts which exceed array dimensions on a per dimension basis (default: ['throw']).
 	*/
-	submode?: Array<string>;
+	submode?: Array<Mode>;
 
 	/**
 	* Boolean indicating whether to copy source data to a new data buffer (default: false).
@@ -76,7 +76,7 @@ interface Options {
 /**
 * Interface describing function options.
 */
-interface OptionsWithShape extends Options {
+interface OptionsWithShape<T> extends Options {
 	/**
 	* Array shape.
 	*/
@@ -89,13 +89,13 @@ interface OptionsWithShape extends Options {
 	*
 	* -    If provided along with a `buffer` argument, the argument takes precedence.
 	*/
-	buffer?: ArrayLike<any>;
+	buffer?: ArrayLike<T>;
 }
 
 /**
 * Interface describing function options.
 */
-interface OptionsWithBuffer extends Options {
+interface OptionsWithBuffer<T> extends Options {
 	/**
 	* Array shape.
 	*/
@@ -108,13 +108,13 @@ interface OptionsWithBuffer extends Options {
 	*
 	* -    If provided along with a `buffer` argument, the argument takes precedence.
 	*/
-	buffer: ArrayLike<any>;
+	buffer: ArrayLike<T>;
 }
 
 /**
 * Interface describing function options.
 */
-interface ExtendedOptions extends Options {
+interface ExtendedOptions<T> extends Options {
 	/**
 	* Array shape.
 	*/
@@ -127,7 +127,7 @@ interface ExtendedOptions extends Options {
 	*
 	* -    If provided along with a `buffer` argument, the argument takes precedence.
 	*/
-	buffer?: ArrayLike<any>;
+	buffer?: ArrayLike<T>;
 }
 
 /**
@@ -164,7 +164,7 @@ interface ExtendedOptions extends Options {
 * var v = arr.get( 0 );
 * // returns [ 1, 2 ]
 */
-declare function array<T = unknown>( options: OptionsWithShape | OptionsWithBuffer ): typedndarray<T>;
+declare function array<T = unknown>( options: OptionsWithShape<T> | OptionsWithBuffer<T> ): typedndarray<typeof options['dtype'] extends undefined ? T : typeof options['dtype']>;
 
 /**
 * Returns a multidimensional array.
@@ -220,7 +220,7 @@ declare function array<T = unknown>( options: OptionsWithShape | OptionsWithBuff
 * var v = arr.get( 0, 0 );
 * // returns 1.0
 */
-declare function array<T = unknown>( buffer: ArrayLike<any>, options?: ExtendedOptions ): typedndarray<T>;
+declare function array<T = unknown>( buffer: ArrayLike<T>, options?: ExtendedOptions<T> ): typedndarray<T extends undefined ? ( typeof options extends { dtype: infer D } ? D : never ) : T >;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/ndarray/array/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/array/docs/types/test.ts
@@ -23,10 +23,10 @@ import array = require( './index' );
 
 // The function returns an ndarray...
 {
-	array<number>( [ [ 1, 2 ], [ 3, 4 ] ] ); // $ExpectType typedndarray<number>
+	array<Array<number>>( [ [ 1, 2 ], [ 3, 4 ] ] ); // $ExpectType typedndarray<number[]>
 	array<number>( new Float64Array( [ 1.0, 2.0, 3.0, 4.0 ] ), { 'shape': [ 2, 2 ] } ); // $ExpectType typedndarray<number>
 	array<number>( { 'shape': [ 2, 2 ] } ); // $ExpectType typedndarray<number>
-	array<number>( { 'buffer': [ [ 1, 2 ], [ 3, 4 ] ] } ); // $ExpectType typedndarray<number>
+	array<Array<number>>( { 'buffer': [ [ 1, 2 ], [ 3, 4 ] ] } ); // $ExpectType typedndarray<number[]>
 }
 
 // The compiler throws an error if the function is provided a first argument which is not an array, buffer, or options object...


### PR DESCRIPTION
Resolves #1088 

## Description

> What is the purpose of this pull request?

This pull request:

-   Improves type definition of ndarray's `array` function.
-   Infers return type based on the passed `dtype`'s value, else uses `buffer` arguments' type.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #1088 

## Questions

> Any questions for reviewers of this pull request?

@Planeshifter From my understanding, I'm assuming the type of `buffer` argument and the type of `buffer` property in `options` argument are the same? Please let me know if otherwise. 

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
