### PR TITLE
feat: added @stdlib/utils/none-own-by

### DIFF
--- a/lib/node_modules/@stdlib/utils/none-own-by/README.md
+++ b/lib/node_modules/@stdlib/utils/none-own-by/README.md
@@ -40,7 +40,7 @@ limitations under the License.
 var noneOwnBy = require( '@stdlib/utils/none-own-by' );
 ```
 
-#### noneOwnBy( collection, predicate\[, thisArg ] )
+#### noneOwnBy( object, predicate\[, thisArg ] )
 
 Tests whether every `own` property of an object fails a test implemented by a `predicate` function.
 
@@ -86,18 +86,17 @@ var bool = noneOwnBy( obj, isUnderage );
 
 ## Notes
 
--   If the 1st argument is not an object or the second argument is not a fuction , the 
-    function throws a Type Error.
+-   If the 1st argument is not an object or the second argument is not a fuction , the function throws a Type Error.
 
 -   If provided an empty object, the function returns `true`.
 
-```javascript
-function truthy() {
-    return true;
-}
-var bool = noneOwnBy( {}, truthy );
-// returns true
-```
+   ```javascript
+   function truthy() {
+       return true;
+   }
+   var bool = noneOwnBy( {}, truthy );
+   // returns true
+   ```
 
 </section>
 

--- a/lib/node_modules/@stdlib/utils/none-own-by/README.md
+++ b/lib/node_modules/@stdlib/utils/none-own-by/README.md
@@ -1,0 +1,165 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# noneOwnBy
+
+> Tests whether every own property of an object fails a test implemented by a predicate function.
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var noneOwnBy = require( '@stdlib/utils/none-own-by' );
+```
+
+#### noneOwnBy( collection, predicate\[, thisArg ] )
+
+Tests whether every `own` property of an object fails a test implemented by a `predicate` function.
+
+```javascript
+function isUnderage( age ) {
+    return ( age < 18 );
+}
+
+var obj = {
+    'a': 28,
+    'b': 22,
+    'c': 25
+};
+
+var bool = noneOwnBy( obj, isUnderage );
+// returns true
+```
+
+If a `predicate` function returns a truthy value, the function **immediately** returns `false`.
+
+```javascript
+function isUnderage( age ) {
+    return ( age < 18 );
+}
+
+var obj = {
+    'a': 12,
+    'b': 22,
+    'c': 25
+};
+
+var bool = noneOwnBy( obj, isUnderage );
+// returns false
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+## Notes
+
+-   If the 1st argument is not an object or the second argument is not a fuction , the 
+    function throws a Type Error.
+
+-   If provided an empty object, the function returns `true`.
+
+```javascript
+function truthy() {
+    return true;
+}
+var bool = noneOwnBy( {}, truthy );
+// returns true
+```
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var noneOwnBy = require( '@stdlib/utils/none-own-by' );
+
+function isUnderage( age ) {
+    return age < 18;
+}
+
+var obj = {
+    'a': 26,
+    'b': 20,
+    'c': 25
+};
+
+var bool = noneOwnBy( obj, isUnderage );
+// returns true
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+* * *
+
+## See Also
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/utils/none-own-by/README.md
+++ b/lib/node_modules/@stdlib/utils/none-own-by/README.md
@@ -90,13 +90,13 @@ var bool = noneOwnBy( obj, isUnderage );
 
 -   If provided an empty object, the function returns `true`.
 
-   ```javascript
-   function truthy() {
-       return true;
-   }
-   var bool = noneOwnBy( {}, truthy );
-   // returns true
-   ```
+    ```javascript
+    function truthy() {
+        return true;
+    }
+    var bool = noneOwnBy( {}, truthy );
+    // returns true
+    ```
 
 </section>
 

--- a/lib/node_modules/@stdlib/utils/none-own-by/benchmark/index.js
+++ b/lib/node_modules/@stdlib/utils/none-own-by/benchmark/index.js
@@ -1,0 +1,60 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var pkg = require( './../package.json' ).name;
+var noneOwnBy = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var bool;
+	var obj;
+	var i;
+
+	function predicate( v ) {
+		return isnan( v );
+	}
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		obj = {
+			'a': i,
+			'b': i+1,
+			'c': i+2,
+			'd': i+3
+		};
+		bool = noneOwnBy( obj, predicate );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/utils/none-own-by/docs/repl.txt
+++ b/lib/node_modules/@stdlib/utils/none-own-by/docs/repl.txt
@@ -19,7 +19,7 @@
         Input object.
 
     predicate: Function
-        The test function.
+        Test function.
 
     thisArg: any (optional)
         Execution context.

--- a/lib/node_modules/@stdlib/utils/none-own-by/docs/repl.txt
+++ b/lib/node_modules/@stdlib/utils/none-own-by/docs/repl.txt
@@ -1,0 +1,42 @@
+
+{{alias}}( object, predicate[, thisArg ] )
+    Tests whether every own property of an object fails a test implemented
+    by a predicate function.
+
+    The predicate function is provided three arguments:
+
+    - `value`: property value
+    - `index`: property key
+    - `object`: the input object
+
+    The function immediately returns upon encountering a truthy return value.
+
+    If provided an empty object, the function returns `true`.
+
+    Parameters
+    ----------
+    object: Object
+        Input object.
+
+    predicate: Function
+        The test function.
+
+    thisArg: any (optional)
+        Execution context.
+
+    Returns
+    -------
+    bool: boolean
+        The function returns `true` if the predicate function returns a falsy
+        value for all own properties; otherwise, the function returns `false`.
+
+    Examples
+    --------
+    > function isUnderage( v ) { return ( v < 18 ); };
+    > var obj = { 'a': 11, 'b': 12, 'c': 22 };
+    > var bool = {{alias}}( obj, isUnderage )
+    false
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/utils/none-own-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/utils/none-own-by/docs/types/index.d.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2019 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/utils/none-own-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/utils/none-own-by/docs/types/index.d.ts
@@ -1,0 +1,102 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2019 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+
+/**
+* Checks whether an own property of the object passes the test.
+*
+* @returns boolean indicating whether an own property of the object passes the teste
+*/
+type Nullary<U> = ( this: U ) => boolean;
+
+/**
+* Checks whether an own property of the object passes the test.
+*
+* @param value - collection value
+* @returns boolean indicating whether an own property of the object passes the teste
+*/
+type Unary<T, U> = ( this: U, value: T ) => boolean;
+
+/**
+* Checks whether an own property of the object passes the test.
+*
+* @param value - collection value
+* @param key - collection key
+* @returns boolean indicating whether an own property of the object passes the teste
+*/
+type Binary<T, U> = ( this: U, value: T, key: number ) => boolean;
+
+/**
+* Checks whether an own property of the object passes the test.
+*
+* @param value - collection value
+* @param key - collection key
+* @param object - input object
+* @returns boolean indicating whether an own property of the object passes the teste
+*/
+type Ternary<T, U> = ( this: U, value: T, key: number, object: Object ) => boolean;
+
+/**
+* Checks whether an own property of the object passes the test.
+*
+* @param value - collection value
+* @param key - collection key
+* @param object - input object
+* @returns boolean indicating whether an own property of the object passes the teste
+*/
+type Predicate<T, U> = Nullary<U> | Unary<T, U> | Binary<T, U> | Ternary<T, U>;
+
+/**
+* Tests whether every property of an object fails a test implemented by a predicate function.
+*
+* ## Notes
+*
+* -   The predicate function is provided three arguments:
+*
+*     -   `value`: collection value
+*     -   `key`: collection key
+*     -   `collection`: the input object
+*
+* -   The function immediately returns upon encountering a truthy return value.
+* -   If provided an empty object, the function returns `true`.
+*
+* @param object - input object
+* @param predicate - test function
+* @param thisArg - execution context
+* @returns boolean indicating whether every property fails a test
+*
+* @example
+* function isUnderage( v ) {
+*     return ( v < 18 );
+* }
+*
+* var obj = { 'a':20, 'b':22, 'c':25 };
+*
+* var bool = noneOwnBy( obj, isUnderage );
+* // returns true
+*/
+declare function noneOwnBy<T = unknown, U = unknown>( object: Record<string, unknown>, predicate: Predicate<T, U>, thisArg?: ThisParameterType<Predicate<T, U>> ): boolean;
+
+
+// EXPORTS //
+
+export = noneOwnBy;

--- a/lib/node_modules/@stdlib/utils/none-own-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/utils/none-own-by/docs/types/index.d.ts
@@ -24,44 +24,44 @@
 /**
 * Checks whether an own property of the object passes the test.
 *
-* @returns boolean indicating whether an own property of the object passes the teste
+* @returns boolean indicating whether an own property of the object passes the test
 */
 type Nullary<U> = ( this: U ) => boolean;
 
 /**
 * Checks whether an own property of the object passes the test.
 *
-* @param value - collection value
-* @returns boolean indicating whether an own property of the object passes the teste
+* @param value - property value
+* @returns boolean indicating whether an own property of the object passes the test
 */
 type Unary<T, U> = ( this: U, value: T ) => boolean;
 
 /**
 * Checks whether an own property of the object passes the test.
 *
-* @param value - collection value
-* @param key - collection key
-* @returns boolean indicating whether an own property of the object passes the teste
+* @param value - property value
+* @param key - property key
+* @returns boolean indicating whether an own property of the object passes the test
 */
 type Binary<T, U> = ( this: U, value: T, key: number ) => boolean;
 
 /**
 * Checks whether an own property of the object passes the test.
 *
-* @param value - collection value
-* @param key - collection key
+* @param value - property value
+* @param key - property key
 * @param object - input object
-* @returns boolean indicating whether an own property of the object passes the teste
+* @returns boolean indicating whether an own property of the object passes the test
 */
 type Ternary<T, U> = ( this: U, value: T, key: number, object: Object ) => boolean;
 
 /**
 * Checks whether an own property of the object passes the test.
 *
-* @param value - collection value
-* @param key - collection key
+* @param value - object value
+* @param key - object key
 * @param object - input object
-* @returns boolean indicating whether an own property of the object passes the teste
+* @returns boolean indicating whether an own property of the object passes the test
 */
 type Predicate<T, U> = Nullary<U> | Unary<T, U> | Binary<T, U> | Ternary<T, U>;
 
@@ -72,9 +72,9 @@ type Predicate<T, U> = Nullary<U> | Unary<T, U> | Binary<T, U> | Ternary<T, U>;
 *
 * -   The predicate function is provided three arguments:
 *
-*     -   `value`: collection value
-*     -   `key`: collection key
-*     -   `collection`: the input object
+*     -   `value`: property value
+*     -   `key`: property key
+*     -   `object`: the input object
 *
 * -   The function immediately returns upon encountering a truthy return value.
 * -   If provided an empty object, the function returns `true`.
@@ -89,7 +89,7 @@ type Predicate<T, U> = Nullary<U> | Unary<T, U> | Binary<T, U> | Ternary<T, U>;
 *     return ( v < 18 );
 * }
 *
-* var obj = { 'a':20, 'b':22, 'c':25 };
+* var obj = { 'a': 20, 'b': 22, 'c': 25 };
 *
 * var bool = noneOwnBy( obj, isUnderage );
 * // returns true

--- a/lib/node_modules/@stdlib/utils/none-own-by/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/utils/none-own-by/docs/types/test.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2019 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/utils/none-own-by/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/utils/none-own-by/docs/types/test.ts
@@ -24,18 +24,18 @@ const isUnderAge = ( v: number ): boolean => {
 
 // TESTS //
 
-var obj = {
-	'a':10,
-	'b':12,
-	'c':22
+const obj = {
+	'a': 10,
+	'b': 12,
+	'c': 22
 };
+
 // The function returns a boolean...
 {
 	noneOwnBy( obj, isUnderAge ); // $ExpectType boolean
-	noneOwnBy( obj, isUnderAge ); // $ExpectType boolean
 }
 
-// The compiler throws an error if the function is provided a first argument which is not a object...
+// The compiler throws an error if the function is provided a first argument which is not an object...
 {
 	noneOwnBy( 2, isUnderAge ); // $ExpectError
 	noneOwnBy( false, isUnderAge ); // $ExpectError

--- a/lib/node_modules/@stdlib/utils/none-own-by/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/utils/none-own-by/docs/types/test.ts
@@ -1,0 +1,61 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2019 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import noneOwnBy = require( './index' );
+
+const isUnderAge = ( v: number ): boolean => {
+	return ( v < 18 );
+};
+
+// TESTS //
+
+var obj = {
+	'a':10,
+	'b':12,
+	'c':22
+};
+// The function returns a boolean...
+{
+	noneOwnBy( obj, isUnderAge ); // $ExpectType boolean
+	noneOwnBy( obj, isUnderAge ); // $ExpectType boolean
+}
+
+// The compiler throws an error if the function is provided a first argument which is not a object...
+{
+	noneOwnBy( 2, isUnderAge ); // $ExpectError
+	noneOwnBy( false, isUnderAge ); // $ExpectError
+	noneOwnBy( true, isUnderAge ); // $ExpectError
+	noneOwnBy( [ 1, 2 ], isUnderAge ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument which is not a function...
+{
+	noneOwnBy( obj , 2 ); // $ExpectError
+	noneOwnBy( obj , false ); // $ExpectError
+	noneOwnBy( obj , true ); // $ExpectError
+	noneOwnBy( obj , 'abc' ); // $ExpectError
+	noneOwnBy( obj , {} ); // $ExpectError
+	noneOwnBy( obj , [] ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an invalid number of arguments...
+{
+	noneOwnBy(); // $ExpectError
+	noneOwnBy( [ 1, 2, 3 ] ); // $ExpectError
+	noneOwnBy( [ 1, 2, 3 ], isUnderAge, {}, 3 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/utils/none-own-by/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/none-own-by/examples/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/utils/none-own-by/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/none-own-by/examples/index.js
@@ -32,4 +32,4 @@ var obj = {
 
 var bool = noneOwnBy( obj, isUnderage );
 console.log( bool );
-// => true 
+// => true

--- a/lib/node_modules/@stdlib/utils/none-own-by/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/none-own-by/examples/index.js
@@ -32,3 +32,4 @@ var obj = {
 
 var bool = noneOwnBy( obj, isUnderage );
 console.log( bool );
+// => true 

--- a/lib/node_modules/@stdlib/utils/none-own-by/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/none-own-by/examples/index.js
@@ -1,0 +1,34 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var noneOwnBy = require( './../lib' );
+
+function isUnderage( age ) {
+	return age < 18;
+}
+
+var obj = {
+	'a': 26,
+	'b': 20,
+	'c': 25
+};
+
+var bool = noneOwnBy( obj, isUnderage );
+console.log( bool );

--- a/lib/node_modules/@stdlib/utils/none-own-by/lib/index.js
+++ b/lib/node_modules/@stdlib/utils/none-own-by/lib/index.js
@@ -19,14 +19,14 @@
 'use strict';
 
 /**
-* Test whether every "own" property of a provided object fail a test implemented by a predicate function.
+* Test whether every "own" property of a provided object fails a test implemented by a predicate function.
 *
 * @module @stdlib/utils/none-own-by
 *
 * @example
 * var noneOwnBy = require( '@stdlib/utils/none-own-by' );
 *
-* function isUnderage(age) {
+* function isUnderage( age ) {
 *    return age < 18;
 * }
 *

--- a/lib/node_modules/@stdlib/utils/none-own-by/lib/index.js
+++ b/lib/node_modules/@stdlib/utils/none-own-by/lib/index.js
@@ -1,0 +1,50 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Test whether every "own" property of a provided object fail a test implemented by a predicate function.
+*
+* @module @stdlib/utils/none-own-by
+*
+* @example
+* var noneOwnBy = require( '@stdlib/utils/none-own-by' );
+*
+* function isUnderage(age) {
+*    return age < 18;
+* }
+*
+* var obj = {
+*   a : 10,
+*   b : 12,
+*   c : 15
+* };
+*
+* var bool = noneOwnBy( obj, isUnderage );
+* // returns true
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/utils/none-own-by/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/none-own-by/lib/main.js
@@ -1,0 +1,75 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var isObject = require( '@stdlib/assert/is-object' );
+var format = require( '@stdlib/string/format' );
+
+
+// MAIN //
+
+/**
+* Tests whether every own property of a object fails a test implemented by a predicate function.
+*
+* @param {Object} obj - input object
+* @param {Function} predicate - test function
+* @param {*} [thisArg] - execution context
+* @throws {TypeError} first argument must be a object
+* @throws {TypeError} second argument must be a function
+* @returns {boolean} boolean indicating whether all elements fail a test
+*
+* @example
+* function isUnderage(age) {
+*    return ( age < 18 );
+* };
+*
+* var obj = {
+*   'a': 10,
+*   'b': 12,
+*   'c': 15
+* };
+*
+* var bool = noneOwnBy( obj, isUnderage );
+* // returns false
+*/
+function noneOwnBy( obj, predicate, thisArg ) {
+	var key;
+
+	if ( !isObject( obj ) ) {
+		throw new TypeError( format(' invalid argument. First argument must be an object. Value: `%s`.', obj ) );
+	}
+	if ( !isFunction( predicate ) ) {
+		throw new TypeError( format( 'invalid argument. Second argument must be a function. Value: `%s`.', predicate ) );
+	}
+	for ( key in obj ) {
+		if (hasOwnProp( obj, key ) && predicate.call( thisArg, obj[key], key, obj)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+
+// EXPORTS //
+
+module.exports = noneOwnBy;

--- a/lib/node_modules/@stdlib/utils/none-own-by/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/none-own-by/lib/main.js
@@ -29,12 +29,12 @@ var format = require( '@stdlib/string/format' );
 // MAIN //
 
 /**
-* Tests whether every own property of a object fails a test implemented by a predicate function.
+* Tests whether every own property of an object fails a test implemented by a predicate function.
 *
 * @param {Object} obj - input object
 * @param {Function} predicate - test function
 * @param {*} [thisArg] - execution context
-* @throws {TypeError} first argument must be a object
+* @throws {TypeError} first argument must be an object
 * @throws {TypeError} second argument must be a function
 * @returns {boolean} boolean indicating whether all elements fail a test
 *

--- a/lib/node_modules/@stdlib/utils/none-own-by/package.json
+++ b/lib/node_modules/@stdlib/utils/none-own-by/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@stdlib/utils/none-own-by",
+  "version": "0.0.0",
+  "description": "Tests whether every own property of a object fails a test implemented by a predicate function.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdutils",
+    "stdutil",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "test",
+    "predicate",
+    "none",
+    "all",
+    "every",
+    "array.every",
+    "iterate",
+    "collection",
+    "array-like",
+    "validate"
+  ]
+}
+  

--- a/lib/node_modules/@stdlib/utils/none-own-by/package.json
+++ b/lib/node_modules/@stdlib/utils/none-own-by/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/utils/none-own-by",
   "version": "0.0.0",
-  "description": "Tests whether every own property of a object fails a test implemented by a predicate function.",
+  "description": "Tests whether every own property of an object fails a test implemented by a predicate function.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",
@@ -61,10 +61,8 @@
     "none",
     "all",
     "every",
-    "array.every",
+    "object",
     "iterate",
-    "collection",
-    "array-like",
     "validate"
   ]
 }

--- a/lib/node_modules/@stdlib/utils/none-own-by/test/test.js
+++ b/lib/node_modules/@stdlib/utils/none-own-by/test/test.js
@@ -33,7 +33,7 @@ tape( 'main export is a function', function test( t ) {
 	t.end();
 });
 
-tape( 'the function throws an error if not provided a object', function test( t ) {
+tape( 'the function throws an error if not provided an object', function test( t ) {
 	var values;
 	var i;
 
@@ -101,7 +101,7 @@ tape( 'the function returns `true` if all own properties fail a test ', function
 	t.end();
 });
 
-tape( 'the function returns `false` if one or more own properties pass a test ', function test( t ) {
+tape( 'the function returns `false` if one or more own properties pass a test', function test( t ) {
 	var bool;
 	var obj;
 

--- a/lib/node_modules/@stdlib/utils/none-own-by/test/test.js
+++ b/lib/node_modules/@stdlib/utils/none-own-by/test/test.js
@@ -1,0 +1,122 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var noop = require( '@stdlib/utils/noop' );
+var noneOwnBy = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof noneOwnBy, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function throws an error if not provided a object', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		function noop() {},
+		/.*/,
+		new Date()
+	];
+	for (i =0; i < values.length; i++) {
+		t.throws( badValue( values ), TypeError, 'throws a type error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			noneOwnBy( value, noop );
+		};
+	}
+});
+
+tape( 'the function throws an error if not provided a predicate function', function test( t ) {
+	var values;
+
+	values = {
+		'a': 10,
+		'b': 12,
+		'c': 15
+	};
+
+	t.throws( badValue( values ), TypeError, 'throws a type error when provided '+values );
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			noneOwnBy( value, value );
+		};
+	}
+});
+
+tape( 'the function returns `true` if all own properties fail a test ', function test( t ) {
+	var bool;
+	var obj;
+
+	obj = {
+		'a': 20,
+		'b': 22,
+		'c': 25
+	};
+
+	function underAge( value ) {
+		return ( value < 18 );
+	}
+
+	bool = noneOwnBy( obj, underAge );
+
+	t.strictEqual( bool, true, 'returns true' );
+	t.end();
+});
+
+tape( 'the function returns `false` if one or more own properties pass a test ', function test( t ) {
+	var bool;
+	var obj;
+
+	obj = {
+		'a': 10,
+		'b': 12,
+		'c': 15
+	};
+
+	function underAge( value ) {
+		return ( value < 18 );
+	}
+
+	bool = noneOwnBy( obj, underAge );
+
+	t.strictEqual( bool, false, 'returns false' );
+	t.end();
+});


### PR DESCRIPTION
checks whether every own property of an object does not satisfy a predicate function

Fixes #820

Resolves # .820

## Description

> What is the purpose of this pull request?

This pull request:

-   adds utils/none-own-by package
-   checks whether every own property of an object does not satisfy a predicate function

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #
-   fixes #

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
