### PR TITLE
feat: add @stdlib/utils/some-in-by

### DIFF
--- a/lib/node_modules/@stdlib/utils/some-in-by/README.md
+++ b/lib/node_modules/@stdlib/utils/some-in-by/README.md
@@ -1,0 +1,234 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# someInBy
+
+> Test whether an object contains at least `n` properties which pass a test implemented by a predicate function.
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var someInBy = require( '@stdlib/utils/some-in-by' );
+```
+
+#### someInBy( obj, n, predicate\[, thisArg ] )
+
+Tests whether an `obj` contains at least `n` properties which pass a test implemented by a `predicate` function.
+
+```javascript
+function isNegative( value ) {
+    return ( value < 0 );
+}
+
+var obj = {
+    'a': 1,
+    'b': -2,
+    'c': 3,
+    'd': -1
+};
+
+var bool = someInBy( obj, 2, isNegative );
+// returns true
+```
+
+Once the function finds `n` successful properties, the function **immediately** returns `true`.
+
+```javascript
+function isPositive( value ) {
+    if ( value < 0 ) {
+        throw new Error( 'should never reach this line' );
+    }
+    return ( value > 0 );
+}
+
+var obj = {
+    'a': 1,
+    'b': 2,
+    'c': -3,
+    'd': 4
+};
+
+var bool = someInBy( obj, 2, isPositive );
+// returns true
+```
+
+The invoked `function` is provided three arguments:
+
+-   `value`: object property value
+-   `key`: object property key
+-   `obj`: input object
+
+To set the function execution context, provide a `thisArg`.
+
+```javascript
+function sum( value ) {
+    this.sum += value;
+    this.count += 1;
+    return ( value < 0 );
+}
+
+var obj = {
+    'a': 1,
+    'b': 2,
+    'c': 3,
+    'd': -5
+};
+
+var context = {
+    'sum': 0,
+    'count': 0
+};
+
+var bool = someInBy( obj, 1, sum, context );
+// returns true
+
+var mean = context.sum / context.count;
+// returns 0.25
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   If provided an empty `obj`, the function returns `false`.
+
+    ```javascript
+    function alwaysTrue() {
+        return true;
+    }
+    var bool = someInBy( {}, 1, alwaysTrue );
+    // returns false
+    ```
+
+-   The function does **not** skip `undefined` properties.
+
+    ```javascript
+    function log( value, key ) {
+        console.log( '%s: %s', key, value );
+        return ( value < 0 );
+    }
+
+    var obj = {
+        'a': 1,
+        'b': void 0,
+        'c': void 0,
+        'd': 4,
+        'e': -1
+    };
+
+    var bool = someInBy( obj, 1, log );
+    // logs
+    // a: 1
+    // b: void 0
+    // c: void 0
+    // d: 4
+    // e: -1
+    ```
+
+-   The function provides limited support for dynamic objects (i.e., objects whose properties change during execution).
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+```javascript
+var randu = require( '@stdlib/random/base/randu' );
+var someInBy = require( '@stdlib/utils/some-in-by' );
+
+function threshold( value ) {
+    return ( value > 0.95 );
+}
+
+var bool;
+var obj = {};
+var i;
+
+for ( i = 0; i < 100; i++ ) {
+    obj[ 'key' + i ] = randu();
+}
+
+bool = someInBy( obj, 5, threshold );
+// returns <boolean>
+```
+
+</section>
+
+<!-- /.examples -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/utils/any-by`][@stdlib/utils/any-by]</span><span class="delimiter">: </span><span class="description">test whether at least one element in a collection passes a test implemented by a predicate function.</span>
+-   <span class="package-name">[`@stdlib/utils/every-by`][@stdlib/utils/every-by]</span><span class="delimiter">: </span><span class="description">test whether all elements in a collection pass a test implemented by a predicate function.</span>
+-   <span class="package-name">[`@stdlib/utils/none-by`][@stdlib/utils/none-by]</span><span class="delimiter">: </span><span class="description">test whether all elements in a collection fail a test implemented by a predicate function.</span>
+-   <span class="package-name">[`@stdlib/utils/async/some-by`][@stdlib/utils/async/some-by]</span><span class="delimiter">: </span><span class="description">test whether a collection contains `n` elements which pass a test implemented by a predicate function.</span>
+-   <span class="package-name">[`@stdlib/utils/some-by-right`][@stdlib/utils/some-by-right]</span><span class="delimiter">: </span><span class="description">test whether a collection contains at least `n` elements which pass a test implemented by a predicate function, iterating from right to left.</span>
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+<!-- <related-links> -->
+
+[@stdlib/utils/any-by]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/utils/any-by
+
+[@stdlib/utils/every-by]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/utils/every-by
+
+[@stdlib/utils/none-by]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/utils/none-by
+
+[@stdlib/utils/async/some-by]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/utils/async/some-by
+
+[@stdlib/utils/some-by-right]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/utils/some-by-right
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/utils/some-in-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/utils/some-in-by/benchmark/benchmark.js
@@ -1,0 +1,105 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var pkg = require( './../package.json' ).name;
+var someInBy = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var bool;
+	var obj;
+	var i;
+
+	function predicate( v ) {
+		return isnan( v );
+	}
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		obj = {
+			'a': i,
+			'b': i + 1,
+			'c': i + 2,
+			'd': NaN,
+			'e': i + 4,
+			'f': NaN
+		};
+		bool = someInBy( obj, 2, predicate );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg + '::loop', function benchmark( b ) {
+	var total;
+	var count;
+	var bool;
+	var obj;
+	var key;
+	var i;
+
+	total = 2;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		obj = {
+			'a': i,
+			'b': i + 1,
+			'c': i + 2,
+			'd': NaN,
+			'e': i + 4,
+			'f': NaN
+		};
+		bool = false;
+		count = 0;
+		for ( key in obj ) {
+			if ( Object.prototype.hasOwnProperty.call( obj, key ) && isnan(obj[ key ] )) {
+				count += 1;
+				if ( count === total ) {
+					bool = true;
+					break;
+				}
+			}
+		}
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should be a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/utils/some-in-by/docs/repl.txt
+++ b/lib/node_modules/@stdlib/utils/some-in-by/docs/repl.txt
@@ -23,7 +23,7 @@
         Minimum number of successful properties.
 
     predicate: Function
-        The test function.
+        Test function.
 
     thisArg: any (optional)
         Execution context.

--- a/lib/node_modules/@stdlib/utils/some-in-by/docs/repl.txt
+++ b/lib/node_modules/@stdlib/utils/some-in-by/docs/repl.txt
@@ -1,0 +1,45 @@
+
+{{alias}}( obj, n, predicate[, thisArg ] )
+    Tests whether an object contains at least `n` properties
+    (own and inherited) which pass a test
+    implemented by a predicate function.
+
+    The predicate function is provided three arguments:
+
+    - `value`: object value
+    - `key`: object key
+    - `obj`: the input object
+
+    The function immediately returns upon finding `n` successful properties.
+
+    If provided an empty object, the function returns `false`.
+
+    Parameters
+    ----------
+    obj: Object
+        Input object over which to iterate.
+
+    n: number
+        Minimum number of successful properties.
+
+    predicate: Function
+        The test function.
+
+    thisArg: any (optional)
+        Execution context.
+
+    Returns
+    -------
+    bool: boolean
+        The function returns `true` if an object contains at least `n`
+        successful properties; otherwise, the function returns `false`.
+
+    Examples
+    --------
+    > function negative( v ) { return ( v < 0 ); };
+    > var obj = { 'a': 1, 'b': 2, 'c': -3, 'd': 4, 'e': -1 };
+    > var bool = {{alias}}( obj, 2, negative )
+    true
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/utils/some-in-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/utils/some-in-by/docs/types/index.d.ts
@@ -1,0 +1,104 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+/**
+* Checks whether a property in an object passes a test.
+*
+* @returns boolean indicating whether a property in an object passes a test
+*/
+type Nullary<U> = ( this: U ) => boolean;
+
+/**
+* Checks whether a property in an object passes a test.
+*
+* @param value - object value
+* @returns boolean indicating whether a property in an object passes a test
+*/
+type Unary<T, U> = ( this: U, value: T ) => boolean;
+
+/**
+* Checks whether a property in an object passes a test.
+*
+* @param value - object value
+* @param key - object key
+* @returns boolean indicating whether a property in an object passes a test
+*/
+type Binary<T, U> = ( this: U, value: T, key: string ) => boolean;
+
+/**
+* Checks whether a property in an object passes a test.
+*
+* @param value - object value
+* @param key - object key
+* @param obj - input object
+* @returns boolean indicating whether a property in an object passes a test
+*/
+type Ternary<T, U> = ( this: U, value: T, key: string, obj: Record<keyof any, any> ) => boolean;
+
+/**
+* Checks whether a property in an object passes a test.
+*
+* @param value - object value
+* @param key - object key
+* @param obj - input object
+* @returns boolean indicating whether a property in an object passes a test
+*/
+type Predicate<T, U> = Nullary<U> | Unary<T, U> | Binary<T, U> | Ternary<T, U>;
+
+/**
+* Tests whether an object contains at least `n` properties (own and inherited) which pass a test implemented by a predicate function.
+*
+* ## Notes
+*
+* -   The predicate function is provided three arguments:
+*
+*     -   `value`: object value
+*     -   `key`: object key
+*     -   `obj`: the input object
+*
+* -   The function immediately returns upon finding `n` successful properties.
+*
+* -   If provided an empty object, the function returns `false`.
+*
+* @param obj - input object
+* @param n - number of properties
+* @param predicate - test function
+* @param thisArg - execution context
+* @throws second argument must be a positive integer
+* @returns boolean indicating whether an object contains at least `n` properties which pass a test
+*
+* @example
+* function isNegative( v ) {
+*     return ( v < 0 );
+* }
+*
+* var obj = { 'a': 1, 'b': 2, 'c': -3, 'd': 4, 'e': -1 };
+*
+* var bool = someInBy( obj, 2, isNegative );
+* // returns true
+*/
+declare function someInBy<T = unknown, U = unknown>( obj: Record<keyof any, any>, n: number, predicate: Predicate<T, U>, thisArg?: ThisParameterType<Predicate<T, U>> ): boolean;
+
+
+// EXPORTS //
+
+export = someInBy;

--- a/lib/node_modules/@stdlib/utils/some-in-by/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/utils/some-in-by/docs/types/test.ts
@@ -1,0 +1,66 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import someInBy = require( './index' );
+
+const hasUpperCase = ( v: string, key: string ): boolean => {
+	return ( key.toUpperCase() === key );
+};
+
+// TESTS //
+
+// The function returns a boolean...
+{
+	someInBy( { 'a': 0, 'B': 1, 'C': 1 }, 2, hasUpperCase ); // $ExpectType boolean
+	someInBy( { 'a': -1, 'B': 1, 'c': 2 }, 3, hasUpperCase, {} ); // $ExpectType boolean
+}
+
+// The compiler throws an error if the function is provided a first argument which is not an object...
+{
+	someInBy( 2, 2, hasUpperCase ); // $ExpectError
+	someInBy( false, 2, hasUpperCase ); // $ExpectError
+	someInBy( true, 2, hasUpperCase ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument which is not a number...
+{
+	someInBy( { 'a': -1, 'B': 1, 'c': 2 }, ( x: number ): number => x, hasUpperCase ); // $ExpectError
+	someInBy( { 'a': -1, 'B': 1, 'c': 2 }, false, hasUpperCase ); // $ExpectError
+	someInBy( { 'a': -1, 'B': 1, 'c': 2 }, true, hasUpperCase ); // $ExpectError
+	someInBy( { 'a': -1, 'B': 1, 'c': 2 }, 'abc', hasUpperCase ); // $ExpectError
+	someInBy( { 'a': -1, 'B': 1, 'c': 2 }, {}, hasUpperCase ); // $ExpectError
+	someInBy( { 'a': -1, 'B': 1, 'c': 2 }, [], hasUpperCase ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a third argument which is not a function...
+{
+	someInBy( { 'a': 1, 'B': 2, 'c': 3 }, 1, 2 ); // $ExpectError
+	someInBy( { 'a': 1, 'B': 2, 'c': 3 }, 1, false ); // $ExpectError
+	someInBy( { 'a': 1, 'B': 2, 'c': 3 }, 1, true ); // $ExpectError
+	someInBy( { 'a': 1, 'B': 2, 'c': 3 }, 1, 'abc' ); // $ExpectError
+	someInBy( { 'a': 1, 'B': 2, 'c': 3 }, 1, {} ); // $ExpectError
+	someInBy( { 'a': 1, 'B': 2, 'c': 3 }, 1, [] ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an invalid number of arguments...
+{
+	someInBy(); // $ExpectError
+	someInBy( { 'a': 1, 'B': 2, 'c': 3 } ); // $ExpectError
+	someInBy( { 'a': 1, 'B': 2, 'c': 3 }, 1 ); // $ExpectError
+	someInBy( { 'a': 1, 'B': 2, 'c': 3 }, 1, hasUpperCase, {}, 3 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/utils/some-in-by/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/some-in-by/examples/index.js
@@ -1,0 +1,37 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var randu = require( '@stdlib/random/base/randu' );
+var someInBy = require( './../lib' );
+
+function threshold( value ) {
+	return ( value > 0.95 );
+}
+
+var bool;
+var obj = {};
+var i;
+
+for ( i = 0; i < 100; i++ ) {
+	obj[ 'key' + i ] = randu();
+}
+
+bool = someInBy( obj, 5, threshold );
+console.log( bool );

--- a/lib/node_modules/@stdlib/utils/some-in-by/lib/index.js
+++ b/lib/node_modules/@stdlib/utils/some-in-by/lib/index.js
@@ -1,0 +1,46 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Test whether an object contains at least `n` properties (own or inherited) which pass a test implemented by a predicate function.
+*
+* @module @stdlib/utils/some-in-by
+*
+* @example
+* var someInBy = require( '@stdlib/utils/some-in-by' );
+*
+* function isNegative( v ) {
+*     return ( v < 0 );
+* }
+*
+* var obj = { a: 1, b: -2, c: 3, d: 4, e: -1 };
+*
+* var bool = someInBy( obj, 2, isNegative );
+* // returns true
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/utils/some-in-by/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/some-in-by/lib/main.js
@@ -1,0 +1,84 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isObject = require( '@stdlib/assert/is-object' );
+var isPositiveInteger = require( '@stdlib/assert/is-positive-integer' ).isPrimitive;
+var isFunction = require( '@stdlib/assert/is-function' );
+var format = require( '@stdlib/string/format' );
+
+
+// MAIN //
+
+/**
+* Tests whether an object contains at least `n` properties (own or inherited) which pass a test implemented by a predicate function.
+*
+* @param {Object} obj - input object
+* @param {PositiveInteger} n - number of properties
+* @param {Function} predicate - test function
+* @param {*} [thisArg] - execution context
+* @throws {TypeError} first argument must be an object
+* @throws {TypeError} second argument must be a positive integer
+* @throws {TypeError} third argument must be a function
+* @returns {boolean} boolean indicating whether an object contains at least `n` properties which pass a test
+*
+* @example
+* function isNegative( v ) {
+*     return ( v < 0 );
+* }
+*
+* var obj = { a: 1, b: -2, c: 3, d: 4, e: -1 };
+*
+* var bool = someInBy( obj, 2, isNegative );
+* // returns true
+*/
+function someInBy( obj, n, predicate, thisArg ) {
+	var count;
+	var out;
+	var key;
+	if ( !isObject( obj ) ) {
+		throw new TypeError( format( 'invalid argument. First argument must be an object. Value: `%s`.', obj ) );
+	}
+	if ( !isPositiveInteger( n ) ) {
+		throw new TypeError( format( 'invalid argument. Second argument must be a positive integer. Value: `%s`.', n ) );
+	}
+	if ( !isFunction( predicate ) ) {
+		throw new TypeError( format( 'invalid argument. Third argument must be a function. Value: `%s`.', predicate ) );
+	}
+	count = 0;
+	for ( key in obj ) {
+		if ( Object.prototype.hasOwnProperty.call(obj, key) || Object.prototype.hasOwnProperty.call(Object.getPrototypeOf(obj), key) ) {
+			out = predicate.call( thisArg, obj[ key ], key, obj );
+			if ( out ) {
+				count += 1;
+				if ( count === n ) {
+					return true;
+				}
+			}
+		}
+	}
+	return false;
+}
+
+
+// EXPORTS //
+
+module.exports = someInBy;

--- a/lib/node_modules/@stdlib/utils/some-in-by/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/some-in-by/lib/main.js
@@ -65,7 +65,10 @@ function someInBy( obj, n, predicate, thisArg ) {
 	}
 	count = 0;
 	for ( key in obj ) {
-		if ( Object.prototype.hasOwnProperty.call(obj, key) || Object.prototype.hasOwnProperty.call(Object.getPrototypeOf(obj), key) ) {
+		if ( 
+			Object.prototype.hasOwnProperty.call( obj, key ) ||
+			Object.prototype.hasOwnProperty.call( Object.getPrototypeOf( obj ), key ) 
+		) {
 			out = predicate.call( thisArg, obj[ key ], key, obj );
 			if ( out ) {
 				count += 1;

--- a/lib/node_modules/@stdlib/utils/some-in-by/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/some-in-by/lib/main.js
@@ -67,7 +67,7 @@ function someInBy( obj, n, predicate, thisArg ) {
 	for ( key in obj ) {
 		if (
 			Object.prototype.hasOwnProperty.call( obj, key ) ||
-			Object.prototype.hasOwnProperty.call( Object.getPrototypeOf( obj ), key ) 
+			Object.prototype.hasOwnProperty.call( Object.getPrototypeOf( obj ), key )
 		) {
 			out = predicate.call( thisArg, obj[ key ], key, obj );
 			if ( out ) {

--- a/lib/node_modules/@stdlib/utils/some-in-by/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/some-in-by/lib/main.js
@@ -65,7 +65,7 @@ function someInBy( obj, n, predicate, thisArg ) {
 	}
 	count = 0;
 	for ( key in obj ) {
-		if ( 
+		if (
 			Object.prototype.hasOwnProperty.call( obj, key ) ||
 			Object.prototype.hasOwnProperty.call( Object.getPrototypeOf( obj ), key ) 
 		) {

--- a/lib/node_modules/@stdlib/utils/some-in-by/package.json
+++ b/lib/node_modules/@stdlib/utils/some-in-by/package.json
@@ -1,0 +1,75 @@
+{
+  "name": "@stdlib/utils/some-in-by",
+  "version": "0.0.0",
+  "description": "Test whether an object contains at least n properties (own and inherited) which pass a test implemented by a predicate function.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdutils",
+    "stdutil",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "test",
+    "predicate",
+    "any",
+    "every",
+    "all",
+    "object.some",
+    "object.every",
+    "some",
+    "property",
+    "own",
+    "inherited",
+    "iterate",
+    "collection",
+    "array-like",
+    "validate"
+  ]
+}

--- a/lib/node_modules/@stdlib/utils/some-in-by/test/test.js
+++ b/lib/node_modules/@stdlib/utils/some-in-by/test/test.js
@@ -165,7 +165,7 @@ tape( 'the function returns `true` if an object contains at least `n` properties
 	t.end();
 });
 
-tape( 'the function returns `false` if an object does not contain at least `n` properties which pass a test (Case: At least 1)', function test( t ) {
+tape( 'the function returns `false` if an object does not contain at least `n` properties which pass a test (case: at least 1)', function test( t ) {
 	var bool;
 	var obj;
 
@@ -185,7 +185,7 @@ tape( 'the function returns `false` if an object does not contain at least `n` p
 	t.end();
 });
 
-tape( 'the function returns `false` if an object does not contain at least `n` properties which pass a test (Case: At least 2)', function test( t ) {
+tape( 'the function returns `false` if an object does not contain at least `n` properties which pass a test (case: at least 2)', function test( t ) {
 	var bool;
 	var obj;
 

--- a/lib/node_modules/@stdlib/utils/some-in-by/test/test.js
+++ b/lib/node_modules/@stdlib/utils/some-in-by/test/test.js
@@ -1,0 +1,317 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var noop = require( '@stdlib/utils/noop' );
+var someInBy = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof someInBy, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function throws an error if not provided an object', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws a type error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			someInBy( value, 2, noop );
+		};
+	}
+});
+
+tape( 'the function throws an error if not provided a second argument which is a positive integer', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		-5,
+		0,
+		3.14,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws a type error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			someInBy( {
+				'a': 1,
+				'b': 2,
+				'c': 3
+			}, value, noop );
+		};
+	}
+});
+
+tape( 'the function throws an error if not provided a predicate function', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		/.*/,
+		new Date()
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws a type error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			someInBy( {
+				'a': 1,
+				'b': 2,
+				'c': 3
+			}, 2, value );
+		};
+	}
+});
+
+tape( 'if provided an empty object, the function returns `false`', function test( t ) {
+	var bool;
+	var obj;
+
+	function foo() {
+		t.fail( 'should not be invoked' );
+	}
+	obj = {};
+	bool = someInBy( obj, 1, foo );
+
+	t.strictEqual( bool, false, 'returns false' );
+	t.end();
+});
+
+tape( 'the function returns `true` if an object contains at least `n` properties which pass a test', function test( t ) {
+	var bool;
+	var obj;
+
+	obj = {
+		'a': 1,
+		'b': -2,
+		'c': 3,
+		'd': -1
+	};
+
+	function isNegative( value ) {
+		return ( value < 0 );
+	}
+
+	bool = someInBy( obj, 2, isNegative );
+
+	t.strictEqual( bool, true, 'returns true' );
+	t.end();
+});
+
+tape( 'the function returns `false` if an object does not contain at least `n` properties which pass a test (Case: At least 1)', function test( t ) {
+	var bool;
+	var obj;
+
+	obj = {
+		'a': -1,
+		'b': -2,
+		'c': -3
+	};
+
+	function isPositive( value ) {
+		return ( value > 0 );
+	}
+
+	bool = someInBy( obj, 1, isPositive );
+
+	t.strictEqual( bool, false, 'returns false' );
+	t.end();
+});
+
+tape( 'the function returns `false` if an object does not contain at least `n` properties which pass a test (Case: At least 2)', function test( t ) {
+	var bool;
+	var obj;
+
+	obj = {
+		'a': -1,
+		'b': -2,
+		'c': -3
+	};
+
+	function isPositive( value ) {
+		return ( value > 0 );
+	}
+
+	bool = someInBy( obj, 2, isPositive );
+
+	t.strictEqual( bool, false, 'returns false' );
+	t.end();
+});
+
+tape( 'the function supports providing an execution context', function test( t ) {
+	var bool;
+	var ctx;
+	var obj;
+
+	function sum( value ) {
+		/* eslint-disable no-invalid-this */
+		this.sum += value;
+		this.count += 1;
+		return ( value < 0 );
+	}
+
+	ctx = {
+		'sum': 0,
+		'count': 0
+	};
+	obj = {
+		'a': 1.0,
+		'b': -2.0,
+		'c': 3.0,
+		'd': -1.0
+	};
+
+	bool = someInBy( obj, 2, sum, ctx );
+
+	t.strictEqual( bool, true, 'returns true' );
+	t.strictEqual( ctx.sum/ctx.count, 0.25, 'expected result' );
+
+	t.end();
+});
+
+tape( 'the function provides basic support for dynamic objects', function test( t ) {
+	var bool;
+	var obj;
+
+	obj = {
+		'a': 1,
+		'b': 2,
+		'c': 3
+	};
+
+	function isNegative( value, key, collection ) {
+		if ( key === 'c' ) {
+			collection[ 'd' ] = value-1;
+		}
+		return ( value < 0 );
+	}
+
+	bool = someInBy( obj, 1, isNegative );
+
+	t.deepEqual( obj, {
+		'a': 1,
+		'b': 2,
+		'c': 3,
+		'd': 2
+	}, 'expected result' );
+	t.strictEqual( bool, false, 'returns false' );
+
+	t.end();
+});
+
+tape( 'the function does not skip undefined properties', function test( t ) {
+	var expected;
+	var bool;
+	var obj;
+
+	obj = {
+		'a': 1,
+		'b': void 0,
+		'c': void 0,
+		'd': 4,
+		'e': -1
+	};
+	expected = {
+		'a': 1,
+		'b': void 0,
+		'c': void 0,
+		'd': 4,
+		'e': -1
+	};
+
+	function verify( value, key ) {
+		t.strictEqual( value, expected[ key ], 'provides expected value' );
+		return ( value < 0 );
+	}
+
+	bool = someInBy( obj, 1, verify );
+
+	t.strictEqual( bool, true, 'returns true' );
+	t.end();
+});
+
+tape( 'the function returns `false` if provided a regular expression or a date object with no properties passing the test', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		/.*/,
+		new Date()
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.equal( someInBy( values[ i ], 1, threshold ), false, 'returns false when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function threshold( value ) {
+		return ( typeof value === 'number' );
+	}
+});


### PR DESCRIPTION
Add support to test whether some "own" and inherited properties of a provided object satisfies a predicate function.

Fixes: #825

Resolves #825.

## Description

> What is the purpose of this pull request?
Add support to test whether some "own" and inherited properties of a provided object satisfies a predicate function.

This pull request:

-   Uses the below conditions to check whether the properties satisfy predicate function.

``` 
 Object.prototype.hasOwnProperty.call(obj, key) || Object.prototype.hasOwnProperty.call(Object.getPrototypeOf(obj), key) )
```

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #825
-   fixes #825

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
