### PR TITLE
feat: add `assert/is-complex-string`

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-complex-string/README.md
+++ b/lib/node_modules/@stdlib/assert/is-complex-string/README.md
@@ -1,0 +1,115 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# isComplexString
+
+> Tests whether input string is a complex number representation`.
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+
+```js
+var isComplexString = require( '@stdlib/assert/is-complex-string' );
+```
+
+#### isComplexString( str )
+
+Tests whether input string is a complex number representation`.
+
+```js
+var isComplexString = require( '@stdlib/assert/is-complex-string' );
+
+var str = '5 + 3i';
+
+var b = isComplexString( str );
+// returns true
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```js
+var isComplexString = require( '@stdlib/assert/is-complex-string' );
+
+var str;
+var b;
+
+b = isComplexString( '5 + 4i' );
+// returns true
+
+b = isComplexString( 'Infinity + 2.34i' );
+// returns true
+
+b = isComplexString( 'NaN + 4i' );
+// returns true
+
+b = isComplexString( '45i55 + 5' );
+// returns false
+
+b = isComplexString( '5 + 6 + 10e4i' );
+// returns true
+
+b = isComplexString( {} );
+// returns false
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">

--- a/lib/node_modules/@stdlib/assert/is-complex-string/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-complex-string/benchmark/benchmark.js
@@ -1,0 +1,49 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isComplexString = require( '@stdlib/assert/is-complex-string/lib' );
+var pkg = require( '@stdlib/assert/is-complex-string/package.json' ).name;
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var str;
+	var v;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		str = '4 + 3i';
+		v = isComplexString( str );
+		if ( typeof v !== 'boolean' ) {
+			v.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( typeof v !== 'boolean' ) {
+		v.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/assert/is-complex-string/docs/repl.txt
+++ b/lib/node_modules/@stdlib/assert/is-complex-string/docs/repl.txt
@@ -1,0 +1,19 @@
+{{alias}}( str )
+    Tests whether input string is a complex number representation.
+
+    Parameters
+    ----------
+    str: string
+
+    Returns
+    -------
+    out: boolean
+
+    Examples
+    --------
+    > var str = '4 + 9i';
+    > var b = {{alias}}( str )
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/assert/is-complex-string/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/is-complex-string/docs/types/index.d.ts
@@ -1,0 +1,40 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Tests whether input string is a complex number representation.
+*
+* @param str
+* @returns boolean
+*
+* @example
+* var isComplexString = require( '@stdlib/assert/is-complex-string' );
+*
+* var str = '4 + 6i';
+*
+* var b = isComplexString( str );
+* returns true
+*/
+declare function isComplexString( str: string ): boolean;
+
+
+// EXPORTS //
+
+export = isComplexString;

--- a/lib/node_modules/@stdlib/assert/is-complex-string/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/assert/is-complex-string/docs/types/test.ts
@@ -1,0 +1,34 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import isComplexString = require( './index' );
+
+
+// TESTS //
+
+// The function returns a complex like object...
+{
+	const str = '54 + 3i';
+	isComplexString( str ); // $ExpectType boolean
+}
+
+// The compiler throws an error if the function is provided insufficient arguments...
+{
+	isComplexString(); // $ExpectError
+	isComplexString( 'beep', 'boop' ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/assert/is-complex-string/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-complex-string/examples/index.js
@@ -1,0 +1,51 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var isComplexString = require( './../lib' );
+
+var str = '5 + 4i';
+var b = isComplexString( str );
+console.log( b );
+// => true
+
+str = 'Infinity + 2.34i';
+b = isComplexString( str );
+console.log( b);
+// => true
+
+str = 'NaN + i4';
+b = isComplexString( str );
+console.log( b );
+// => false
+
+str = '45i55 + 5';
+b = isComplexString( str );
+console.log( b );
+// => false
+
+str = '5 + 6 + 10e4i';
+b = isComplexString( str );
+console.log( b );
+// => true
+
+str = {};
+b = isComplexString( str );
+console.log( b );
+// => false

--- a/lib/node_modules/@stdlib/assert/is-complex-string/lib/index.js
+++ b/lib/node_modules/@stdlib/assert/is-complex-string/lib/index.js
@@ -1,0 +1,42 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Test whether input string is a complex number representation.
+*
+* @module @stdlib/assert/is-complex-string
+*
+* @example
+* var isComplexString = require( '@stdlib/assert/is-complex-string' );
+*
+* var str = '4 + 6i';
+*
+* var isCmplx = isComplexString( str );
+* // returns true
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/assert/is-complex-string/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/is-complex-string/lib/main.js
@@ -1,0 +1,51 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isString = require( '@stdlib/assert/is-string' );
+var parse = require( '@stdlib/complex/base/parse');
+
+
+// MAIN //
+
+/**
+* Test whether input string is a complex number representation.
+*
+* @param {string} str - input string
+* @returns {boolean} a boolean indicated if the string is a valid complex number representation.
+*
+* @example
+* var str = '4 + 6i';
+*
+* var isCmplx = isComplexString( str );
+* // returns true
+*/
+function isComplexString( str ) {
+	return (
+		isString( str ) &&
+		parse( str ) !== null
+	);
+}
+
+
+// EXPORTS //
+
+module.exports = isComplexString;

--- a/lib/node_modules/@stdlib/assert/is-complex-string/package.json
+++ b/lib/node_modules/@stdlib/assert/is-complex-string/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@stdlib/complex/base/assert/is-complex-string",
+  "version": "0.0.0",
+  "description": "Test whether input string is a complex number representation.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdtypes",
+    "utils",
+    "util",
+    "utilities",
+    "utility",
+    "complex",
+    "cmplx",
+    "json",
+    "parse",
+    "parser",
+    "unmarshal",
+    "deserialize",
+    "from",
+    "convert",
+    "string",
+    "object",
+    "obj"
+  ]
+}

--- a/lib/node_modules/@stdlib/assert/is-complex-string/test/test.js
+++ b/lib/node_modules/@stdlib/assert/is-complex-string/test/test.js
@@ -1,0 +1,82 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require('tape');
+var isComplexString = require('./../lib');
+
+
+// TESTS //
+
+tape('main export is a function', function test(t) {
+	t.ok(true, __filename);
+	t.strictEqual(typeof isComplexString, 'function', 'main export is a function');
+	t.end();
+});
+
+tape('the function returns true if provided valid complex string', function test(t) {
+	var tests;
+	var i;
+
+	tests = ['1 + 2i',
+		'1',
+		'2i',
+		'-2i',
+		'2i',
+		'1.523 - 4.234i',
+		'-1.5 + 4.2i',
+		'1.0e10 -2.0e-10i',
+		'1.0E10 + 4.1e+10i',
+		'1+2i',
+		'1-0i',
+		'0+1i',
+		'-0.0 + 2.0i',
+		'-Infinity + 5i',
+
+		'Infinity-Infinityi'
+
+	];
+
+	for (i = 0; i < tests.length; i++) {
+		t.strictEqual(isComplexString(tests[i]), true, 'returns true for valid complex representation');
+	}
+	t.end();
+});
+
+tape('the function returns false if provided input is not a complex number string', function test(t) {
+	var values;
+	var i;
+
+	values = [
+		'boop',
+		'4 + 5i5',
+		null,
+		Infinity,
+		'55555555555555boop5',
+		{},
+		NaN
+	];
+
+	for (i = 0; i < values.length; i++) {
+		t.strictEqual(isComplexString(values[i]), false, 'returns false for not comlplex string');
+	}
+	t.end();
+});


### PR DESCRIPTION
Resolves #1370

## Description
This PR adds the package @stdlib/assert/is-complex-string

The package implements assertion for a string represeting a complex number.

Alias: isComplexString

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #1370

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
