### PR TITLE
bench: update benchmarks to measure affirmative/negative test values

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-cube-number/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-cube-number/benchmark/benchmark.js
@@ -39,12 +39,12 @@ bench( pkg+'::primitives,true', function benchmark( b ) {
 	values = [
 		8,
 		64,
-		1.0,
+		1,
 		-27,
-		-8.0,
+		-8,
 		125,
-		-1000.0,
-		-8
+		-1000,
+		27
 	];
 
 	b.tic();
@@ -101,12 +101,12 @@ bench( pkg+'::objects,true', function benchmark( b ) {
 	values = [
 		new Number( 8 ),
 		new Number( 64 ),
-		new Number( 1.0 ),
+		new Number( 1 ),
 		new Number( -27 ),
-		new Number( -8.0 ),
+		new Number( -8 ),
 		new Number( 125 ),
-		new Number( -1000.0 ),
-		new Number( -8 )
+		new Number( -1000 ),
+		new Number( 27 )
 	];
 
 	b.tic();
@@ -130,14 +130,14 @@ bench( pkg+'::objects,false', function benchmark( b ) {
 	var i;
 
 	values = [
-		[],
-		{},
-		function noop() {},
-		new Number( 0.5 ),
+		new Number( 5 ),
 		new Number( NaN ),
 		new Number( 3.14 ),
 		new Number( -6 ),
-		new Number( 7.25 )
+		new Number( 7.25 ),
+		[],
+		{},
+		function noop() {}
 	];
 
 	b.tic();
@@ -163,20 +163,12 @@ bench( pkg+'::primitives:isPrimitive,true', function benchmark( b ) {
 	values = [
 		8,
 		64,
-		1.0,
+		1,
 		-27,
-		-8.0,
-		125,
-		-1000.0,
 		-8,
-		'5',
-		NaN,
-		true,
-		false,
-		null,
-		void 0,
-		-6,
-		7.25
+		125,
+		-1000,
+		27
 	];
 
 	b.tic();
@@ -200,54 +192,6 @@ bench( pkg+'::primitives:isPrimitive,false', function benchmark( b ) {
 	var i;
 
 	values = [
-		new Number( 8 ),
-		new Number( 64 ),
-		new Number( 1.0 ),
-		new Number( -27 ),
-		new Number( -8.0 ),
-		new Number( 125 ),
-		new Number( -1000.0 ),
-		new Number( -8 ),
-		[],
-		{},
-		function noop() {},
-		new Number( 0.5 ),
-		new Number( NaN ),
-		new Number( 3.14 ),
-		new Number( -6 ),
-		new Number( 7.25 )
-		
-	];
-
-	b.tic();
-	for ( i = 0; i < b.iterations; i++ ) {
-		bool = isCubeNumber.isPrimitive( values[ i % values.length ] );
-		if ( typeof bool !== 'boolean' ) {
-			b.fail( 'should return a boolean' );
-		}
-	}
-	b.toc();
-	if ( !isBoolean( bool ) ) {
-		b.fail( 'should return a boolean' );
-	}
-	b.pass( 'benchmark finished' );
-	b.end();
-});
-
-bench( pkg+'::objects:isPrimitive,true', function benchmark( b ) {
-	var values;
-	var bool;
-	var i;
-
-	values = [
-		8,
-		64,
-		1.0,
-		-27,
-		-8.0,
-		125,
-		-1000.0,
-		-8,
 		'5',
 		NaN,
 		true,
@@ -281,64 +225,20 @@ bench( pkg+'::objects:isPrimitive,false', function benchmark( b ) {
 	values = [
 		new Number( 8 ),
 		new Number( 64 ),
-		new Number( 1.0 ),
+		new Number( 1 ),
 		new Number( -27 ),
-		new Number( -8.0 ),
-		new Number( 125 ),
-		new Number( -1000.0 ),
 		new Number( -8 ),
+		new Number( 125 ),
+		new Number( -1000 ),
+		new Number( 27 ),
 		[],
 		{},
-		function noop() {},
-		new Number( 0.5 ),
-		new Number( NaN ),
-		new Number( 3.14 ),
-		new Number( -6 ),
-		new Number( 7.25 )
+		function noop() {}
 	];
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
 		bool = isCubeNumber.isPrimitive( values[ i % values.length ] );
-		if ( typeof bool !== 'boolean' ) {
-			b.fail( 'should return a boolean' );
-		}
-	}
-	b.toc();
-	if ( !isBoolean( bool ) ) {
-		b.fail( 'should return a boolean' );
-	}
-	b.pass( 'benchmark finished' );
-	b.end();
-});
-
-bench( pkg+'::primitives:isObject,true', function benchmark( b ) {
-	var values;
-	var bool;
-	var i;
-
-	values = [
-		new Number( 8 ),
-		new Number( 64 ),
-		new Number( 1.0 ),
-		new Number( -27 ),
-		new Number( -8.0 ),
-		new Number( 125 ),
-		new Number( -1000.0 ),
-		new Number( -8 ),
-		[],
-		{},
-		function noop() {},
-		new Number( 0.5 ),
-		new Number( NaN ),
-		new Number( 3.14 ),
-		new Number( -6 ),
-		new Number( 7.25 )
-	];
-
-	b.tic();
-	for ( i = 0; i < b.iterations; i++ ) {
-		bool = isCubeNumber.isObject( values[ i % values.length ] );
 		if ( typeof bool !== 'boolean' ) {
 			b.fail( 'should return a boolean' );
 		}
@@ -357,14 +257,6 @@ bench( pkg+'::primitives:isObject,false', function benchmark( b ) {
 	var i;
 
 	values = [
-		8,
-		64,
-		1.0,
-		-27,
-		-8.0,
-		125,
-		-1000.0,
-		-8,
 		'5',
 		NaN,
 		true,
@@ -398,20 +290,12 @@ bench( pkg+'::objects:isObject,true', function benchmark( b ) {
 	values = [
 		new Number( 8 ),
 		new Number( 64 ),
-		new Number( 1.0 ),
+		new Number( 1 ),
 		new Number( -27 ),
-		new Number( -8.0 ),
-		new Number( 125 ),
-		new Number( -1000.0 ),
 		new Number( -8 ),
-		[],
-		{},
-		function noop() {},
-		new Number( 0.5 ),
-		new Number( NaN ),
-		new Number( 3.14 ),
-		new Number( -6 ),
-		new Number( 7.25 )
+		new Number( 125 ),
+		new Number( -1000 ),
+		new Number( 27 )
 	];
 
 	b.tic();
@@ -435,22 +319,14 @@ bench( pkg+'::objects:isObject,false', function benchmark( b ) {
 	var i;
 
 	values = [
-		8,
-		64,
-		1.0,
-		-27,
-		-8.0,
-		125,
-		-1000.0,
-		-8,
-		'5',
-		NaN,
-		true,
-		false,
-		null,
-		void 0,
-		-6,
-		7.25
+		new Number( 5 ),
+		new Number( NaN ),
+		new Number( 3.14 ),
+		new Number( -6 ),
+		new Number( 7.25 ),
+		[],
+		{},
+		function noop() {}
 	];
 
 	b.tic();

--- a/lib/node_modules/@stdlib/assert/is-cube-number/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-cube-number/benchmark/benchmark.js
@@ -155,26 +155,28 @@ bench( pkg+'::objects,false', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::primitives:isPrimitive', function benchmark( b ) {
+bench( pkg+'::primitives:isPrimitive,true', function benchmark( b ) {
 	var values;
 	var bool;
 	var i;
 
 	values = [
-		'5',
-		5,
-		4,
-		3.14,
-		0.5,
+		8,
+		64,
 		1.0,
-		0.0,
-		-5,
-		-4,
+		-27,
+		-8.0,
+		125,
+		-1000.0,
+		-8,
+		'5',
 		NaN,
 		true,
 		false,
 		null,
-		void 0
+		void 0,
+		-6,
+		7.25
 	];
 
 	b.tic();
@@ -192,19 +194,29 @@ bench( pkg+'::primitives:isPrimitive', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::objects:isPrimitive', function benchmark( b ) {
+bench( pkg+'::primitives:isPrimitive,false', function benchmark( b ) {
 	var values;
 	var bool;
 	var i;
 
 	values = [
+		new Number( 8 ),
+		new Number( 64 ),
+		new Number( 1.0 ),
+		new Number( -27 ),
+		new Number( -8.0 ),
+		new Number( 125 ),
+		new Number( -1000.0 ),
+		new Number( -8 ),
 		[],
 		{},
 		function noop() {},
-		new Number( 8.0 ),
 		new Number( 0.5 ),
 		new Number( NaN ),
-		new Number( 3.14 )
+		new Number( 3.14 ),
+		new Number( -6 ),
+		new Number( 7.25 )
+		
 	];
 
 	b.tic();
@@ -222,26 +234,106 @@ bench( pkg+'::objects:isPrimitive', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::primitives:isObject', function benchmark( b ) {
+bench( pkg+'::objects:isPrimitive,true', function benchmark( b ) {
 	var values;
 	var bool;
 	var i;
 
 	values = [
-		'5',
-		5,
-		4,
-		3.14,
-		0.5,
+		8,
+		64,
 		1.0,
-		0.0,
-		-5,
-		-4,
+		-27,
+		-8.0,
+		125,
+		-1000.0,
+		-8,
+		'5',
 		NaN,
 		true,
 		false,
 		null,
-		void 0
+		void 0,
+		-6,
+		7.25
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		bool = isCubeNumber.isPrimitive( values[ i % values.length ] );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::objects:isPrimitive,false', function benchmark( b ) {
+	var values;
+	var bool;
+	var i;
+
+	values = [
+		new Number( 8 ),
+		new Number( 64 ),
+		new Number( 1.0 ),
+		new Number( -27 ),
+		new Number( -8.0 ),
+		new Number( 125 ),
+		new Number( -1000.0 ),
+		new Number( -8 ),
+		[],
+		{},
+		function noop() {},
+		new Number( 0.5 ),
+		new Number( NaN ),
+		new Number( 3.14 ),
+		new Number( -6 ),
+		new Number( 7.25 )
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		bool = isCubeNumber.isPrimitive( values[ i % values.length ] );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::primitives:isObject,true', function benchmark( b ) {
+	var values;
+	var bool;
+	var i;
+
+	values = [
+		new Number( 8 ),
+		new Number( 64 ),
+		new Number( 1.0 ),
+		new Number( -27 ),
+		new Number( -8.0 ),
+		new Number( 125 ),
+		new Number( -1000.0 ),
+		new Number( -8 ),
+		[],
+		{},
+		function noop() {},
+		new Number( 0.5 ),
+		new Number( NaN ),
+		new Number( 3.14 ),
+		new Number( -6 ),
+		new Number( 7.25 )
 	];
 
 	b.tic();
@@ -259,19 +351,106 @@ bench( pkg+'::primitives:isObject', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::objects:isObject', function benchmark( b ) {
+bench( pkg+'::primitives:isObject,false', function benchmark( b ) {
 	var values;
 	var bool;
 	var i;
 
 	values = [
+		8,
+		64,
+		1.0,
+		-27,
+		-8.0,
+		125,
+		-1000.0,
+		-8,
+		'5',
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		-6,
+		7.25
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		bool = isCubeNumber.isObject( values[ i % values.length ] );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::objects:isObject,true', function benchmark( b ) {
+	var values;
+	var bool;
+	var i;
+
+	values = [
+		new Number( 8 ),
+		new Number( 64 ),
+		new Number( 1.0 ),
+		new Number( -27 ),
+		new Number( -8.0 ),
+		new Number( 125 ),
+		new Number( -1000.0 ),
+		new Number( -8 ),
 		[],
 		{},
 		function noop() {},
-		new Number( 8.0 ),
 		new Number( 0.5 ),
 		new Number( NaN ),
-		new Number( 3.14 )
+		new Number( 3.14 ),
+		new Number( -6 ),
+		new Number( 7.25 )
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		bool = isCubeNumber.isObject( values[ i % values.length ] );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::objects:isObject,false', function benchmark( b ) {
+	var values;
+	var bool;
+	var i;
+
+	values = [
+		8,
+		64,
+		1.0,
+		-27,
+		-8.0,
+		125,
+		-1000.0,
+		-8,
+		'5',
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		-6,
+		7.25
 	];
 
 	b.tic();

--- a/lib/node_modules/@stdlib/assert/is-cube-number/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-cube-number/benchmark/benchmark.js
@@ -37,14 +37,14 @@ bench( pkg+'::primitives,true', function benchmark( b ) {
 	var i;
 
 	values = [
-		5,
-		4,
-		0.5,
+		8,
+		64,
 		1.0,
-		0.0,
-		3.14,
-		-5,
-		-4
+		-27,
+		-8.0,
+		125,
+		-1000.0,
+		-8
 	];
 
 	b.tic();
@@ -73,7 +73,9 @@ bench( pkg+'::primitives,false', function benchmark( b ) {
 		true,
 		false,
 		null,
-		void 0
+		void 0,
+		-6,
+		7.25
 	];
 
 	b.tic();
@@ -97,10 +99,14 @@ bench( pkg+'::objects,true', function benchmark( b ) {
 	var i;
 
 	values = [
-		new Number( 8.0 ),
-		new Number( 0.5 ),
-		new Number( NaN ),
-		new Number( 3.14 )
+		new Number( 8 ),
+		new Number( 64 ),
+		new Number( 1.0 ),
+		new Number( -27 ),
+		new Number( -8.0 ),
+		new Number( 125 ),
+		new Number( -1000.0 ),
+		new Number( -8 )
 	];
 
 	b.tic();
@@ -126,7 +132,12 @@ bench( pkg+'::objects,false', function benchmark( b ) {
 	values = [
 		[],
 		{},
-		function noop() {}
+		function noop() {},
+		new Number( 0.5 ),
+		new Number( NaN ),
+		new Number( 3.14 ),
+		new Number( -6 ),
+		new Number( 7.25 )
 	];
 
 	b.tic();

--- a/lib/node_modules/@stdlib/assert/is-cube-number/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-cube-number/benchmark/benchmark.js
@@ -154,3 +154,137 @@ bench( pkg+'::objects,false', function benchmark( b ) {
 	b.pass( 'benchmark finished' );
 	b.end();
 });
+
+bench( pkg+'::primitives:isPrimitive', function benchmark( b ) {
+	var values;
+	var bool;
+	var i;
+
+	values = [
+		'5',
+		5,
+		4,
+		3.14,
+		0.5,
+		1.0,
+		0.0,
+		-5,
+		-4,
+		NaN,
+		true,
+		false,
+		null,
+		void 0
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		bool = isCubeNumber.isPrimitive( values[ i % values.length ] );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::objects:isPrimitive', function benchmark( b ) {
+	var values;
+	var bool;
+	var i;
+
+	values = [
+		[],
+		{},
+		function noop() {},
+		new Number( 8.0 ),
+		new Number( 0.5 ),
+		new Number( NaN ),
+		new Number( 3.14 )
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		bool = isCubeNumber.isPrimitive( values[ i % values.length ] );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::primitives:isObject', function benchmark( b ) {
+	var values;
+	var bool;
+	var i;
+
+	values = [
+		'5',
+		5,
+		4,
+		3.14,
+		0.5,
+		1.0,
+		0.0,
+		-5,
+		-4,
+		NaN,
+		true,
+		false,
+		null,
+		void 0
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		bool = isCubeNumber.isObject( values[ i % values.length ] );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::objects:isObject', function benchmark( b ) {
+	var values;
+	var bool;
+	var i;
+
+	values = [
+		[],
+		{},
+		function noop() {},
+		new Number( 8.0 ),
+		new Number( 0.5 ),
+		new Number( NaN ),
+		new Number( 3.14 )
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		bool = isCubeNumber.isObject( values[ i % values.length ] );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/assert/is-cube-number/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-cube-number/benchmark/benchmark.js
@@ -16,7 +16,7 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers, no-empty-function */
+/* eslint-disable no-empty-function */
 
 'use strict';
 
@@ -31,13 +31,12 @@ var isCubeNumber = require( './../lib' );
 
 // MAIN //
 
-bench( pkg+'::primitives', function benchmark( b ) {
+bench( pkg+'::primitives,true', function benchmark( b ) {
 	var values;
 	var bool;
 	var i;
 
 	values = [
-		'5',
 		5,
 		4,
 		0.5,
@@ -45,7 +44,31 @@ bench( pkg+'::primitives', function benchmark( b ) {
 		0.0,
 		3.14,
 		-5,
-		-4,
+		-4
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		bool = isCubeNumber( values[ i % values.length ] );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::primitives,false', function benchmark( b ) {
+	var values;
+	var bool;
+	var i;
+
+	values = [
+		'5',
 		NaN,
 		true,
 		false,
@@ -68,15 +91,12 @@ bench( pkg+'::primitives', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::objects', function benchmark( b ) {
+bench( pkg+'::objects,true', function benchmark( b ) {
 	var values;
 	var bool;
 	var i;
 
 	values = [
-		[],
-		{},
-		function noop() {},
 		new Number( 8.0 ),
 		new Number( 0.5 ),
 		new Number( NaN ),
@@ -98,44 +118,7 @@ bench( pkg+'::objects', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::primitives:isPrimitive', function benchmark( b ) {
-	var values;
-	var bool;
-	var i;
-
-	values = [
-		'5',
-		5,
-		4,
-		3.14,
-		0.5,
-		1.0,
-		0.0,
-		-5,
-		-4,
-		NaN,
-		true,
-		false,
-		null,
-		void 0
-	];
-
-	b.tic();
-	for ( i = 0; i < b.iterations; i++ ) {
-		bool = isCubeNumber.isPrimitive( values[ i % values.length ] );
-		if ( typeof bool !== 'boolean' ) {
-			b.fail( 'should return a boolean' );
-		}
-	}
-	b.toc();
-	if ( !isBoolean( bool ) ) {
-		b.fail( 'should return a boolean' );
-	}
-	b.pass( 'benchmark finished' );
-	b.end();
-});
-
-bench( pkg+'::objects:isPrimitive', function benchmark( b ) {
+bench( pkg+'::objects,false', function benchmark( b ) {
 	var values;
 	var bool;
 	var i;
@@ -143,83 +126,12 @@ bench( pkg+'::objects:isPrimitive', function benchmark( b ) {
 	values = [
 		[],
 		{},
-		function noop() {},
-		new Number( 8.0 ),
-		new Number( 0.5 ),
-		new Number( NaN ),
-		new Number( 3.14 )
+		function noop() {}
 	];
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		bool = isCubeNumber.isPrimitive( values[ i % values.length ] );
-		if ( typeof bool !== 'boolean' ) {
-			b.fail( 'should return a boolean' );
-		}
-	}
-	b.toc();
-	if ( !isBoolean( bool ) ) {
-		b.fail( 'should return a boolean' );
-	}
-	b.pass( 'benchmark finished' );
-	b.end();
-});
-
-bench( pkg+'::primitives:isObject', function benchmark( b ) {
-	var values;
-	var bool;
-	var i;
-
-	values = [
-		'5',
-		5,
-		4,
-		3.14,
-		0.5,
-		1.0,
-		0.0,
-		-5,
-		-4,
-		NaN,
-		true,
-		false,
-		null,
-		void 0
-	];
-
-	b.tic();
-	for ( i = 0; i < b.iterations; i++ ) {
-		bool = isCubeNumber.isObject( values[ i % values.length ] );
-		if ( typeof bool !== 'boolean' ) {
-			b.fail( 'should return a boolean' );
-		}
-	}
-	b.toc();
-	if ( !isBoolean( bool ) ) {
-		b.fail( 'should return a boolean' );
-	}
-	b.pass( 'benchmark finished' );
-	b.end();
-});
-
-bench( pkg+'::objects:isObject', function benchmark( b ) {
-	var values;
-	var bool;
-	var i;
-
-	values = [
-		[],
-		{},
-		function noop() {},
-		new Number( 8.0 ),
-		new Number( 0.5 ),
-		new Number( NaN ),
-		new Number( 3.14 )
-	];
-
-	b.tic();
-	for ( i = 0; i < b.iterations; i++ ) {
-		bool = isCubeNumber.isObject( values[ i % values.length ] );
+		bool = isCubeNumber( values[ i % values.length ] );
 		if ( typeof bool !== 'boolean' ) {
 			b.fail( 'should return a boolean' );
 		}


### PR DESCRIPTION
Partially resolves #1148

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors `assert/is-cube-number` benchmarks to measure affirmative/negative test values in separate benchmark runs to have a better handle on performance depending on the input value type.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   partially resolves https://github.com/stdlib-js/stdlib/issues/1148

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Benchmark results after refactor: [isCubeNumberBenchmarks.txt](https://github.com/stdlib-js/stdlib/files/14462428/isCubeNumberBenchmarks.txt)


## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
