### PR TITLE
fix: resolve issue with prev-grapheme-cluster-break function

### DIFF
--- a/lib/node_modules/@stdlib/string/prev-grapheme-cluster-break/lib/main.js
+++ b/lib/node_modules/@stdlib/string/prev-grapheme-cluster-break/lib/main.js
@@ -99,7 +99,9 @@ function prevGraphemeClusterBreak( str, fromIndex ) {
 
 	// Get the corresponding grapheme break and emoji properties:
 	breaks.push( breakProperty( cp ) );
-	emoji.push( emojiProperty( cp ) );
+	if (!(cp >= 0x1F3FB && cp <= 0x1F3FF)) { // Check if the character is not a skin tone modifier
+		emoji.push( emojiProperty( cp ) );
+	}
 
 	ans = -1;
 	for ( i = 1; i <= idx; i++ ) {
@@ -114,7 +116,9 @@ function prevGraphemeClusterBreak( str, fromIndex ) {
 
 		// Get the corresponding grapheme break and emoji properties:
 		breaks.push( breakProperty( cp ) );
-		emoji.push( emojiProperty( cp ) );
+		if (!(cp >= 0x1F3FB && cp <= 0x1F3FF)) { // Check if the character is not a skin tone modifier
+			emoji.push( emojiProperty( cp ) );
+		}
 
 		// Determine if we've encountered a grapheme cluster break...
 		if ( breakType( breaks, emoji ) > 0 ) {


### PR DESCRIPTION
Resolves #1092  .

## Description

> What is the purpose of this pull request?

There's an issue with prevGraphemeClusterBreak package, if I compare the results with nextGraphemeClusterBreak for a single skin tone emoji it doesn't return the same values,

```javascript
prevGraphemeClusterBreak( '👉🏿' ) // returns 1
nextGraphemeClusterBreak( '👉🏿' ) // returns -1
```

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #1092 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
