### PR TITLE
refactor: improve type specificity for `utils/group-own`

### DIFF
--- a/lib/node_modules/@stdlib/utils/group-own/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/utils/group-own/docs/types/index.d.ts
@@ -38,7 +38,7 @@ interface Options {
 *
 * @returns group key
 */
-type Nullary = () => string | symbol;
+type Nullary<K extends string | symbol> = () => K;
 
 /**
 * Specifies which group a property belongs to.
@@ -46,16 +46,7 @@ type Nullary = () => string | symbol;
 * @param value - object value
 * @returns group key
 */
-type Unary = ( value: any ) => string | symbol;
-
-/**
-* Specifies which group a property belongs to.
-*
-* @param value - object value
-* @param key - object key
-* @returns group key
-*/
-type Binary = ( value: any, key: string | symbol ) => string | symbol;
+type Unary<V, K extends string | symbol> = ( value: V ) => K;
 
 /**
 * Specifies which group a property belongs to.
@@ -64,7 +55,16 @@ type Binary = ( value: any, key: string | symbol ) => string | symbol;
 * @param key - object key
 * @returns group key
 */
-type Indicator = Nullary | Unary | Binary;
+type Binary<V, K extends string | symbol> = ( value: V, key: string ) => K;
+
+/**
+* Specifies which group a property belongs to.
+*
+* @param value - object value
+* @param key - object key
+* @returns group key
+*/
+type Indicator<V, K extends string | symbol> = Nullary<K> | Unary<V, K> | Binary<V, K>;
 
 /**
 * Groups an object's own property values according to an indicator function.
@@ -93,15 +93,18 @@ type Indicator = Nullary | Unary | Binary;
 *     return v[ 0 ];
 * }
 * var obj = {
-*     'a': 'beep',
-*     'b': 'boop',
-*     'c': 'foo',
-*     'd': 'bar'
+*     'a': 'apple',
+*     'b': 'banana',
+*     'c': 'cherry',
+*     'd': 'date'
 * };
 * var out = groupOwn( obj, indicator );
-* // e.g., returns { 'b': [ 'beep', 'boop', 'bar' ], 'f': [ 'foo' ] }
+* // e.g., returns { 'a': [ 'apple' ], 'b': [ 'banana' ], 'c': [ 'cherry' ], 'd': [ 'date' ] }
 */
-declare function groupOwn( obj: Record<string, any>, indicator: Indicator ): Record<string, any>;
+declare function groupOwn<T extends object, K extends string | symbol>(
+	obj: T,
+	indicator: Indicator<T[keyof T], K>
+): { [P in K]: Array<T[keyof T]> };
 
 /**
 * Groups an object's own property values according to an indicator function.
@@ -124,7 +127,7 @@ declare function groupOwn( obj: Record<string, any>, indicator: Indicator ): Rec
 * @param obj - input object
 * @param options - function options
 * @param options.thisArg - execution context
-* @param options.returns - if `values`, values are returned; if `keys`, keys are returned; if `*`, both keys and values are returned (default: 'values')
+* @param options.returns - if `'values'`, values are returned; if `'indices'`, indices are returned; if `'*'`, both indices and values are returned (default: 'values')
 * @param indicator - indicator function indicating which group an element in the input object belongs to
 * @returns group results
 *
@@ -133,47 +136,116 @@ declare function groupOwn( obj: Record<string, any>, indicator: Indicator ): Rec
 *     return v[ 0 ];
 * }
 * var obj = {
-*     'a': 'beep',
-*     'b': 'boop',
-*     'c': 'foo',
-*     'd': 'bar'
-* };
-* var out = groupOwn( obj, indicator );
-* // e.g., returns { 'b': [ 'beep', 'boop', 'bar' ], 'f': [ 'foo' ] }
-*
-* @example
-* function indicator( v ) {
-*     return v[ 0 ];
-* }
-* var obj = {
-*     'a': 'beep',
-*     'b': 'boop',
-*     'c': 'foo',
-*     'd': 'bar'
+*     'a': 'apple',
+*     'b': 'banana',
+*     'c': 'cherry',
+*     'd': 'date'
 * };
 * var opts = {
-*     'returns': 'keys'
+*     'returns': 'indices'
 * };
 * var out = groupOwn( obj, opts, indicator );
-* // e.g., returns { 'b': [ 'a', 'b', 'd' ], 'f': [ 'c' ] }
+* // e.g., returns { 'a': [ 'a' ], 'b': [ 'b' ], 'c': [ 'c' ], 'd': [ 'd' ] }
+*/
+declare function groupOwn<T extends object, K extends string | symbol>(
+	obj: T,
+	options: Options & { returns: 'indices' },
+	indicator: Indicator<T[keyof T], K>
+): { [P in K]: Array<keyof T> };
+
+/**
+* Groups an object's own property values according to an indicator function.
+*
+* ## Notes
+*
+* -   When invoked, the indicator function is provided two arguments:
+*
+*     -   `value`: object value
+*     -   `key`: object key
+*
+* -   The value returned by an indicator function should be a value which can be serialized as an object key.
+*
+* -   If provided an empty object, the function returns an empty object.
+*
+* -   The function iterates over an object's own properties.
+*
+* -   Key iteration order is **not** guaranteed, and, thus, result order is **not** guaranteed.
+*
+* @param obj - input object
+* @param options - function options
+* @param options.thisArg - execution context
+* @param options.returns - if `'values'`, values are returned; if `'indices'`, indices are returned; if `'*'`, both indices and values are returned (default: 'values')
+* @param indicator - indicator function indicating which group an element in the input object belongs to
+* @returns group results
 *
 * @example
 * function indicator( v ) {
 *     return v[ 0 ];
 * }
 * var obj = {
-*     'a': 'beep',
-*     'b': 'boop',
-*     'c': 'foo',
-*     'd': 'bar'
+*     'a': 'apple',
+*     'b': 'banana',
+*     'c': 'cherry',
+*     'd': 'date'
 * };
 * var opts = {
 *     'returns': '*'
 * };
 * var out = groupOwn( obj, opts, indicator );
-* // e.g., returns { 'b': [ [ 'a', 'beep' ], [ 'b', 'boop' ], [ 'd', 'bar' ] ], 'f': [ [ 'c', 'foo' ] ] }
+* // e.g., returns { 'a': [ [ 'a', 'apple' ] ], 'b': [ [ 'b', 'banana' ] ], 'c': [ [ 'c', 'cherry' ] ], 'd': [ [ 'd', 'date' ] ] }
 */
-declare function groupOwn( obj: Record<string, any>, options: Options, indicator: Indicator ): Record<string, any>;
+declare function groupOwn<T extends object, K extends string | symbol>(
+	obj: T,
+	options: Options & { returns: '*' },
+	indicator: Indicator<T[keyof T], K>
+): { [P in K]: Array<[keyof T, T[keyof T]]> };
+
+/**
+* Groups an object's own property values according to an indicator function.
+*
+* ## Notes
+*
+* -   When invoked, the indicator function is provided two arguments:
+*
+*     -   `value`: object value
+*     -   `key`: object key
+*
+* -   The value returned by an indicator function should be a value which can be serialized as an object key.
+*
+* -   If provided an empty object, the function returns an empty object.
+*
+* -   The function iterates over an object's own properties.
+*
+* -   Key iteration order is **not** guaranteed, and, thus, result order is **not** guaranteed.
+*
+* @param obj - input object
+* @param options - function options
+* @param options.thisArg - execution context
+* @param options.returns - if `'values'`, values are returned; if `'indices'`, indices are returned; if `'*'`, both indices and values are returned (default: 'values')
+* @param indicator - indicator function indicating which group an element in the input object belongs to
+* @returns group results
+*
+* @example
+* function indicator( v ) {
+*     return v[ 0 ];
+* }
+* var obj = {
+*     'a': 'apple',
+*     'b': 'banana',
+*     'c': 'cherry',
+*     'd': 'date'
+* };
+* var opts = {
+*     'returns': 'values'
+* };
+* var out = groupOwn( obj, opts, indicator );
+* // e.g., returns { 'a': [ 'apple' ], 'b': [ 'banana' ], 'c': [ 'cherry' ], 'd': [ 'date' ] }
+*/
+declare function groupOwn<T extends object, K extends string | symbol>(
+	obj: T,
+	options: Options & { returns?: 'values' },
+	indicator: Indicator<T[keyof T], K>
+): { [P in K]: Array<T[keyof T]> };
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/utils/group-own/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/utils/group-own/docs/types/index.d.ts
@@ -101,7 +101,7 @@ type Indicator = Nullary | Unary | Binary;
 * var out = groupOwn( obj, indicator );
 * // e.g., returns { 'b': [ 'beep', 'boop', 'bar' ], 'f': [ 'foo' ] }
 */
-declare function groupOwn( obj: Record<string, any>, indicator: Indicator ): Record<string, string[]>;
+declare function groupOwn( obj: Record<string, any>, indicator: Indicator ): Record<string, any>;
 
 /**
 * Groups an object's own property values according to an indicator function.
@@ -173,7 +173,7 @@ declare function groupOwn( obj: Record<string, any>, indicator: Indicator ): Rec
 * var out = groupOwn( obj, opts, indicator );
 * // e.g., returns { 'b': [ [ 'a', 'beep' ], [ 'b', 'boop' ], [ 'd', 'bar' ] ], 'f': [ [ 'c', 'foo' ] ] }
 */
-declare function groupOwn( obj: Record<string, any>, indicator: Indicator ): Record<string, string[]>;
+declare function groupOwn( obj: Record<string, any>, options: Options, indicator: Indicator ): Record<string, any>;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/utils/group-own/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/utils/group-own/docs/types/index.d.ts
@@ -101,7 +101,7 @@ type Indicator = Nullary | Unary | Binary;
 * var out = groupOwn( obj, indicator );
 * // e.g., returns { 'b': [ 'beep', 'boop', 'bar' ], 'f': [ 'foo' ] }
 */
-declare function groupOwn( obj: any, indicator: Indicator ): any;
+declare function groupOwn( obj: Record<string, any>, indicator: Indicator ): Record<string, string[]>;
 
 /**
 * Groups an object's own property values according to an indicator function.
@@ -173,7 +173,7 @@ declare function groupOwn( obj: any, indicator: Indicator ): any;
 * var out = groupOwn( obj, opts, indicator );
 * // e.g., returns { 'b': [ [ 'a', 'beep' ], [ 'b', 'boop' ], [ 'd', 'bar' ] ], 'f': [ [ 'c', 'foo' ] ] }
 */
-declare function groupOwn( obj: any, options: Options, indicator: Indicator ): any;
+declare function groupOwn( obj: Record<string, any>, indicator: Indicator ): Record<string, string[]>;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/utils/group-own/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/utils/group-own/docs/types/test.ts
@@ -46,12 +46,31 @@ class Foo {
 // The function returns an object...
 {
 	const obj = new Foo();
-	groupOwn( obj, indicator ); // $ExpectType any
-	groupOwn( {}, indicator ); // $ExpectType any
+	groupOwn( obj, indicator ); // $ExpectType { [x: string]: string[]; }
+	groupOwn( {}, indicator ); // $ExpectType { [x: string]: never[]; }
 	const opts = {
-		'returns': 'indices' as 'indices'
+		'returns': 'indices' as const
 	};
-	groupOwn( obj, opts, indicator ); // $ExpectType any
+	groupOwn( obj, opts, indicator ); // $ExpectType { [x: string]: (keyof Foo)[]; }
+
+	const opts2 = {
+		'returns': 'values' as const
+	};
+	groupOwn( obj, opts2, indicator ); // $ExpectType { [x: string]: string[]; }
+
+	const opts3 = {
+		'returns': '*' as const
+	};
+	groupOwn( obj, opts3, indicator ); // $ExpectType { [x: string]: [keyof Foo, string][]; }
+
+	const obj2 = {
+		'beep': 'boop',
+		'foo': 'bar'
+	} as const;
+
+	groupOwn( obj2, opts,  indicator ); // $ExpectType { [x: string]: ("beep" | "foo")[]; }
+	groupOwn( obj2, opts2, indicator ); // $ExpectType { [x: string]: ("boop" | "bar")[]; }
+	groupOwn( obj2, opts3, indicator ); // $ExpectType { [x: string]: ["beep" | "foo", "boop" | "bar"][]; }
 }
 
 // The compiler throws an error if the function is provided a last argument which is not a function...


### PR DESCRIPTION
Resolves  #1085

## Description

> What is the purpose of this pull request?

This pull request:
- Adds generics for improved type safety for the group-own function.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves stdlib-js/stdlib/issues/1085

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md