### PR TITLE
feat: add `utils/some-own-by`

### DIFF
--- a/lib/node_modules/@stdlib/utils/some-own-by/README.md
+++ b/lib/node_modules/@stdlib/utils/some-own-by/README.md
@@ -139,6 +139,8 @@ var mean = context.sum / context.count;
 
 -   The function does **not** skip `undefined` elements.
 
+    <!-- eslint-disable no-sparse-arrays, stdlib/doctest-marker -->
+
     ```javascript
     function log( value, key ) {
         console.log( '%s: %s', key, value );
@@ -154,12 +156,13 @@ var mean = context.sum / context.count;
     };
 
     var bool = someOwnBy( obj, 1, log );
-    // logs
-    // a: 1
-    // b: void 0
-    // c: void 0
-    // d: 4
-    // e: -1
+    /* =>
+        a: 1
+        b: void 0
+        c: void 0
+        d: 4
+        e: -1
+    */
     ```
 
 -   The function provides limited support for dynamic objects (i.e., objects whose `length` changes during execution).
@@ -173,6 +176,8 @@ var mean = context.sum / context.count;
 <section class="examples">
 
 ## Examples
+
+<!-- eslint no-undef: "error" -->
 
 ```javascript
 var randu = require( '@stdlib/random/base/randu' );

--- a/lib/node_modules/@stdlib/utils/some-own-by/README.md
+++ b/lib/node_modules/@stdlib/utils/some-own-by/README.md
@@ -42,7 +42,7 @@ var someOwnBy = require( '@stdlib/utils/some-own-by' );
 
 #### someOwnBy( obj, n, predicate\[, thisArg ] )
 
-Tests whether an obj contains at least n own properties which pass a test implemented by a predicate function.
+Tests whether an `object` contains at least `n` own properties which pass a test implemented by a `predicate` function.
 
 ```javascript
 function isNegative( value ) {
@@ -60,7 +60,8 @@ var bool = someOwnBy( obj, 2, isNegative );
 // returns true
 ```
 
-Once the function finds n successful properties, the function immediately returns true.
+Once the function finds `n` successful properties, the function **immediately** 
+returns `true`.
 
 ```javascript
 function isPositive( value ) {
@@ -81,9 +82,9 @@ var bool = someOwnBy( obj, 2, isPositive );
 // returns true
 ```
 
-The invoked function is provided three arguments:
+The invoked `function` is provided three arguments:
 
--   `value:` object property value
+-   `value`: object property value
 -   `key`: object property key
 -   `obj`: input object
 
@@ -127,7 +128,7 @@ var mean = context.sum / context.count;
 
 -   An [`Object`][mdn-object] refers to a JavaScript object, which is a collection of properties. Each property is an association between a key (or name) and a value. The key can be a string or a symbol, and the value can be any JavaScript value, including functions and other objects
 
--   If provided an empty obj, the function returns false.
+-   If provided an empty `object`, the function returns `false`.
 
     ```javascript
     function alwaysTrue() {
@@ -165,7 +166,8 @@ var mean = context.sum / context.count;
     */
     ```
 
--   The function provides limited support for dynamic collections (i.e., collections whose `length` changes during execution).
+-   The function provides limited support for dynamic objects (i.e., objects
+whose `length` changes during execution).
 
 </section>
 

--- a/lib/node_modules/@stdlib/utils/some-own-by/README.md
+++ b/lib/node_modules/@stdlib/utils/some-own-by/README.md
@@ -190,9 +190,10 @@ function threshold( value ) {
 }
 
 var bool;
-var obj = {};
+var obj;
 var i;
 
+obj = {};
 for ( i = 0; i < 100; i++ ) {
     obj[ 'key'+i ] = randu();
 }

--- a/lib/node_modules/@stdlib/utils/some-own-by/README.md
+++ b/lib/node_modules/@stdlib/utils/some-own-by/README.md
@@ -42,7 +42,7 @@ var someOwnBy = require( '@stdlib/utils/some-own-by' );
 
 #### someOwnBy( obj, n, predicate\[, thisArg ] )
 
-Tests whether an obj contains at least n own properties which pass a test implemented by a predicate function.
+Tests whether an `object` contains at least `n` own properties which pass a test implemented by a `predicate` function.
 
 ```javascript
 function isNegative( value ) {
@@ -60,7 +60,7 @@ var bool = someOwnBy( obj, 2, isNegative );
 // returns true
 ```
 
-Once the function finds n successful properties, the function immediately returns true.
+Once the function finds `n` successful properties, the function **immediately** returns `true`.
 
 ```javascript
 function isPositive( value ) {
@@ -81,9 +81,9 @@ var bool = someOwnBy( obj, 2, isPositive );
 // returns true
 ```
 
-The invoked function is provided three arguments:
+The invoked `function` is provided three arguments:
 
--   `value:` object property value
+-   `value`: object property value
 -   `key`: object property key
 -   `obj`: input object
 
@@ -127,7 +127,7 @@ var mean = context.sum / context.count;
 
 -   An [`Object`][mdn-object] refers to a JavaScript object, which is a collection of properties. Each property is an association between a key (or name) and a value. The key can be a string or a symbol, and the value can be any JavaScript value, including functions and other objects
 
--   If provided an empty obj, the function returns false.
+-   If provided an empty `object`, the function returns `false`.
 
     ```javascript
     function alwaysTrue() {
@@ -165,7 +165,7 @@ var mean = context.sum / context.count;
     */
     ```
 
--   The function provides limited support for dynamic collections (i.e., collections whose `length` changes during execution).
+-   The function provides limited support for dynamic objects (i.e., objects whose `length` changes during execution).
 
 </section>
 

--- a/lib/node_modules/@stdlib/utils/some-own-by/README.md
+++ b/lib/node_modules/@stdlib/utils/some-own-by/README.md
@@ -42,7 +42,7 @@ var someOwnBy = require( '@stdlib/utils/some-own-by' );
 
 #### someOwnBy( obj, n, predicate\[, thisArg ] )
 
-Tests whether an `object` contains at least `n` own properties which pass a test implemented by a `predicate` function.
+Tests whether an obj contains at least n own properties which pass a test implemented by a predicate function.
 
 ```javascript
 function isNegative( value ) {
@@ -60,7 +60,7 @@ var bool = someOwnBy( obj, 2, isNegative );
 // returns true
 ```
 
-Once the function finds `n` successful properties, the function **immediately** returns `true`.
+Once the function finds n successful properties, the function immediately returns true.
 
 ```javascript
 function isPositive( value ) {
@@ -81,9 +81,9 @@ var bool = someOwnBy( obj, 2, isPositive );
 // returns true
 ```
 
-The invoked `function` is provided three arguments:
+The invoked function is provided three arguments:
 
--   `value`: object property value
+-   `value:` object property value
 -   `key`: object property key
 -   `obj`: input object
 
@@ -127,7 +127,7 @@ var mean = context.sum / context.count;
 
 -   An [`Object`][mdn-object] refers to a JavaScript object, which is a collection of properties. Each property is an association between a key (or name) and a value. The key can be a string or a symbol, and the value can be any JavaScript value, including functions and other objects
 
--   If provided an empty `object`, the function returns `false`.
+-   If provided an empty obj, the function returns false.
 
     ```javascript
     function alwaysTrue() {
@@ -165,7 +165,7 @@ var mean = context.sum / context.count;
     */
     ```
 
--   The function provides limited support for dynamic objects (i.e., objects whose `length` changes during execution).
+-   The function provides limited support for dynamic collections (i.e., collections whose `length` changes during execution).
 
 </section>
 

--- a/lib/node_modules/@stdlib/utils/some-own-by/README.md
+++ b/lib/node_modules/@stdlib/utils/some-own-by/README.md
@@ -60,8 +60,7 @@ var bool = someOwnBy( obj, 2, isNegative );
 // returns true
 ```
 
-Once the function finds `n` successful properties, the function **immediately** 
-returns `true`.
+Once the function finds `n` successful properties, the function **immediately** returns `true`.
 
 ```javascript
 function isPositive( value ) {
@@ -166,8 +165,7 @@ var mean = context.sum / context.count;
     */
     ```
 
--   The function provides limited support for dynamic objects (i.e., objects
-whose `length` changes during execution).
+-   The function provides limited support for dynamic objects (i.e., objects whose `length` changes during execution).
 
 </section>
 
@@ -190,10 +188,9 @@ function threshold( value ) {
 }
 
 var bool;
-var obj;
+var obj = {};
 var i;
 
-obj = {};
 for ( i = 0; i < 100; i++ ) {
     obj[ 'key'+i ] = randu();
 }

--- a/lib/node_modules/@stdlib/utils/some-own-by/README.md
+++ b/lib/node_modules/@stdlib/utils/some-own-by/README.md
@@ -139,8 +139,6 @@ var mean = context.sum / context.count;
 
 -   The function does **not** skip `undefined` elements.
 
-    <!-- eslint-disable no-sparse-arrays, stdlib/doctest-marker -->
-
     ```javascript
     function log( value, key ) {
         console.log( '%s: %s', key, value );
@@ -156,13 +154,12 @@ var mean = context.sum / context.count;
     };
 
     var bool = someOwnBy( obj, 1, log );
-    /* =>
-        a: 1
-        b: void 0
-        c: void 0
-        d: 4
-        e: -1
-    */
+    // logs
+    // a: 1
+    // b: void 0
+    // c: void 0
+    // d: 4
+    // e: -1
     ```
 
 -   The function provides limited support for dynamic objects (i.e., objects whose `length` changes during execution).

--- a/lib/node_modules/@stdlib/utils/some-own-by/README.md
+++ b/lib/node_modules/@stdlib/utils/some-own-by/README.md
@@ -1,0 +1,238 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# someOwnBy
+
+> Test whether an object contains at least `n` own properties which pass a test implemented by a predicate function.
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var someOwnBy = require( '@stdlib/utils/some-own-by' );
+```
+
+#### someOwnBy( obj, n, predicate\[, thisArg ] )
+
+Tests whether an obj contains at least n own properties which pass a test implemented by a predicate function.
+
+```javascript
+function isNegative( value ) {
+    return ( value < 0 );
+}
+
+var obj = {
+    'a': 1,
+    'b': -2,
+    'c': 3,
+    'd': -1
+};
+
+var bool = someOwnBy( obj, 2, isNegative );
+// returns true
+```
+
+Once the function finds n successful properties, the function immediately returns true.
+
+```javascript
+function isPositive( value ) {
+    if ( value < 0 ) {
+        throw new Error( 'should never reach this line' );
+    }
+    return ( value > 0 );
+}
+
+var obj = {
+    'a': 1,
+    'b': 2,
+    'c': -3,
+    'd': 4
+};
+
+var bool = someOwnBy( obj, 2, isPositive );
+// returns true
+```
+
+The invoked function is provided three arguments:
+
+-   `value:` object property value
+-   `key`: object property key
+-   `obj`: input object
+
+To set the function execution context, provide a `thisArg`.
+
+```javascript
+function sum( value ) {
+    this.sum += value;
+    this.count += 1;
+    return ( value < 0 );
+}
+
+var obj = {
+    'a': 1,
+    'b': 2,
+    'c': 3,
+    'd': -5
+};
+
+var context = {
+    'sum': 0,
+    'count': 0
+};
+
+var bool = someOwnBy( obj, 1, sum, context );
+// returns true
+
+var mean = context.sum / context.count;
+// returns 0.25
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+## Notes
+
+-   An [`Object`][mdn-object] refers to a JavaScript object, which is a collection of properties. Each property is an association between a key (or name) and a value. The key can be a string or a symbol, and the value can be any JavaScript value, including functions and other objects
+
+-   If provided an empty obj, the function returns false.
+
+    ```javascript
+    function alwaysTrue() {
+        return true;
+    }
+    var bool = someOwnBy( {}, 1, alwaysTrue );
+    // returns false
+    ```
+
+-   The function does **not** skip `undefined` elements.
+
+    <!-- eslint-disable no-sparse-arrays, stdlib/doctest-marker -->
+
+    ```javascript
+    function log( value, key ) {
+        console.log( '%s: %s', key, value );
+        return ( value < 0 );
+    }
+
+    var obj = {
+        'a': 1,
+        'b': void 0,
+        'c': void 0,
+        'd': 4,
+        'e': -1
+    };
+
+    var bool = someOwnBy( obj, 1, log );
+    /* =>
+        a: 1
+        b: void 0
+        c: void 0
+        d: 4
+        e: -1
+    */
+    ```
+
+-   The function provides limited support for dynamic collections (i.e., collections whose `length` changes during execution).
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var randu = require( '@stdlib/random/base/randu' );
+var someOwnBy = require( '@stdlib/utils/some-own-by' );
+
+function threshold( value ) {
+    return ( value > 0.95 );
+}
+
+var bool;
+var obj = {};
+var i;
+
+for ( i = 0; i < 100; i++ ) {
+    obj[ 'key'+i ] = randu();
+}
+
+bool = someOwnBy( obj, 5, threshold );
+// returns <boolean>
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+* * *
+
+## See Also
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[mdn-object]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/utils/some-own-by/README.md
+++ b/lib/node_modules/@stdlib/utils/some-own-by/README.md
@@ -174,8 +174,6 @@ var mean = context.sum / context.count;
 
 ## Examples
 
-<!-- eslint no-undef: "error" -->
-
 ```javascript
 var randu = require( '@stdlib/random/base/randu' );
 var someOwnBy = require( '@stdlib/utils/some-own-by' );

--- a/lib/node_modules/@stdlib/utils/some-own-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/utils/some-own-by/benchmark/benchmark.js
@@ -1,0 +1,109 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var pkg = require( './../package.json' ).name;
+var someOwnBy = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var bool;
+	var obj;
+	var i;
+
+	function predicate( v ) {
+		return isnan( v );
+	}
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		obj = {
+			'a': i,
+			'b': i+1,
+			'c': i+2,
+			'd': NaN,
+			'e': i+4,
+			'f': NaN
+		};
+		bool = someOwnBy( obj, 2, predicate );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::loop', function benchmark( b ) {
+	var total;
+	var count;
+	var bool;
+	var keys;
+	var obj;
+	var key;
+	var i;
+	var j;
+
+	total = 2;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		obj = {
+			'a': i,
+			'b': i+1,
+			'c': i+2,
+			'd': NaN,
+			'e': i+4,
+			'f': NaN
+		};
+		bool = false;
+		count = 0;
+		keys = Object.keys( obj );
+		for ( j = 0; j < keys.length; j++ ) {
+			key = keys[ j ];
+			if ( isnan( obj[ key ] ) ) {
+				count += 1;
+				if ( count === total ) {
+					bool = true;
+					break;
+				}
+			}
+		}
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should be a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/utils/some-own-by/docs/repl.txt
+++ b/lib/node_modules/@stdlib/utils/some-own-by/docs/repl.txt
@@ -22,7 +22,7 @@
         Minimum number of successful properties.
 
     predicate: Function
-        The test function.
+        Test function.
 
     thisArg: any (optional)
         Execution context.

--- a/lib/node_modules/@stdlib/utils/some-own-by/docs/repl.txt
+++ b/lib/node_modules/@stdlib/utils/some-own-by/docs/repl.txt
@@ -1,7 +1,7 @@
 
 {{alias}}( obj, n, predicate[, thisArg ] )
     Tests whether some `own` properties of a provided object
-    satisfies a predicate function for at least `n` properties.
+    satisfy a predicate function for at least `n` properties.
 
     The predicate function is provided three arguments:
 

--- a/lib/node_modules/@stdlib/utils/some-own-by/docs/repl.txt
+++ b/lib/node_modules/@stdlib/utils/some-own-by/docs/repl.txt
@@ -31,8 +31,8 @@
     -------
     bool: boolean
         The function returns `true` if an object's own properties satisfy a 
-        predicate
-        for at least `n` properties; otherwise, the function returns `false`.
+        predicate for at least `n` properties; otherwise, the function 
+        returns `false`.
 
     Examples
     --------

--- a/lib/node_modules/@stdlib/utils/some-own-by/docs/repl.txt
+++ b/lib/node_modules/@stdlib/utils/some-own-by/docs/repl.txt
@@ -1,0 +1,46 @@
+{{alias}}( obj, n, predicate[, thisArg ] )
+    Tests whether an object's own properties 
+    satisfy a predicate function for at least `n` properties.
+
+    The predicate function is provided three arguments:
+
+    - `value`: object value
+    - `key`: object key
+    - `obj`: the input object
+
+    The function immediately returns 
+    upon finding `n` successful properties.
+
+    If provided an empty object, the function returns `false`.
+
+    Parameters
+    ----------
+    obj: Object
+        Input object over which to iterate.
+
+    n: number
+        Minimum number of successful properties.
+
+    predicate: Function
+        Test function.
+
+    thisArg: any (optional)
+        Execution context.
+
+    Returns
+    -------
+    bool: boolean
+        The function returns `true` 
+        if an object's own properties satisfy a predicate 
+        for at least `n` properties; 
+        otherwise, the function returns `false`.
+
+    Examples
+    --------
+    > function negative( v ) { return ( v < 0 ); };
+    > var obj = { a: 1, b: 2, c: -3, d: 4, e: -1 };
+    > var bool = {{alias}}( obj, 2, negative )
+    true
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/utils/some-own-by/docs/repl.txt
+++ b/lib/node_modules/@stdlib/utils/some-own-by/docs/repl.txt
@@ -1,6 +1,7 @@
+
 {{alias}}( obj, n, predicate[, thisArg ] )
-    Tests whether an object's own properties 
-    satisfy a predicate function for at least `n` properties.
+    Tests whether some `own` properties of a provided object
+    satisfies a predicate function for at least `n` properties.
 
     The predicate function is provided three arguments:
 
@@ -8,8 +9,7 @@
     - `key`: object key
     - `obj`: the input object
 
-    The function immediately returns 
-    upon finding `n` successful properties.
+    The function immediately returns upon finding `n` successful properties.
 
     If provided an empty object, the function returns `false`.
 
@@ -22,7 +22,7 @@
         Minimum number of successful properties.
 
     predicate: Function
-        Test function.
+        The test function.
 
     thisArg: any (optional)
         Execution context.
@@ -30,10 +30,9 @@
     Returns
     -------
     bool: boolean
-        The function returns `true` 
-        if an object's own properties satisfy a predicate 
-        for at least `n` properties; 
-        otherwise, the function returns `false`.
+        The function returns `true` if an object's own properties satisfy a 
+        predicate
+        for at least `n` properties; otherwise, the function returns `false`.
 
     Examples
     --------

--- a/lib/node_modules/@stdlib/utils/some-own-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/utils/some-own-by/docs/types/index.d.ts
@@ -1,0 +1,102 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+/**
+* Checks whether an own property in an object passes a test.
+*
+* @returns boolean indicating whether an own property in an object passes a test
+*/
+type Nullary = () => boolean;
+
+/**
+* Checks whether an own property in an object passes a test.
+*
+* @param value - object value
+* @returns boolean indicating whether an own property in an object passes a test
+*/
+type Unary<T> = ( value: T ) => boolean;
+
+/**
+* Checks whether an own property in an object passes a test.
+*
+* @param value - object value
+* @param key - object key
+* @returns boolean indicating whether an own property in an object passes a test
+*/
+type Binary<T> = ( value: T, key: keyof any ) => boolean;
+
+/**
+* Checks whether an own property in an object passes a test.
+*
+* @param value - object value
+* @param key - object key
+* @param obj - input object
+* @returns boolean indicating whether an own property in an object passes a test
+*/
+type Ternary<T> = ( value: T, key: keyof any, obj: Record<keyof any, any> ) => boolean;
+
+/**
+* Checks whether an own property in an object passes a test.
+*
+* @param value - object value
+* @param key - object key
+* @param obj - input object
+* @returns boolean indicating whether an own property in an object passes a test
+*/
+type Predicate<T> = Nullary | Unary<T> | Binary<T> | Ternary<T>;
+
+/**
+* Tests whether an object contains at least `n` own properties which pass a test implemented by a predicate function.
+*
+* ## Notes
+*
+* -   The predicate function is provided three arguments:
+*
+*     -   `value`: object value
+*     -   `key`: object key
+*     -   `obj`: the input object
+*
+* -   The function immediately returns upon finding `n` successful properties.
+*
+* -   If provided an empty object, the function returns `false`.
+*
+* @param obj - input object
+* @param n - number of properties
+* @param predicate - test function
+* @returns boolean indicating whether an object contains at least `n` own properties which pass a test
+*
+* @example
+* function isNegative( v ) {
+*     return ( v < 0 );
+* }
+*
+* var obj = { a: 1, b: 2, c: -3, d: 4, e: -1 };
+*
+* var bool = someOwnBy( obj, 2, isNegative );
+* // returns true
+*/
+declare function someOwnBy<T = unknown>( obj: Record<keyof any, any>, n: number, predicate: Predicate<T> ): boolean;
+
+
+// EXPORTS //
+
+export = someOwnBy;

--- a/lib/node_modules/@stdlib/utils/some-own-by/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/utils/some-own-by/docs/types/test.ts
@@ -1,0 +1,66 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import someOwnBy = require( './index' );
+
+const isPositive = ( v: number ): boolean => {
+	return ( v > 0 );
+};
+
+// TESTS //
+
+// The function returns a boolean...
+{
+	someOwnBy( { 'a': 0, 'b': 1, 'c': 1 }, 2, isPositive ); // $ExpectType boolean
+	someOwnBy( { 'a': -1, 'b': 1, 'c': 2 }, 3, isPositive, {} ); // $ExpectType boolean
+}
+
+// The compiler throws an error if the function is provided a first argument which is not an object...
+{
+	someOwnBy( 2, 2, isPositive ); // $ExpectError
+	someOwnBy( false, 2, isPositive ); // $ExpectError
+	someOwnBy( true, 2, isPositive ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument which is not a number...
+{
+	someOwnBy( { 'a': -1, 'b': 1, 'c': 2 }, ( x: number ): number => x, isPositive ); // $ExpectError
+	someOwnBy( { 'a': -1, 'b': 1, 'c': 2 }, false, isPositive ); // $ExpectError
+	someOwnBy( { 'a': -1, 'b': 1, 'c': 2 }, true, isPositive ); // $ExpectError
+	someOwnBy( { 'a': -1, 'b': 1, 'c': 2 }, 'abc', isPositive ); // $ExpectError
+	someOwnBy( { 'a': -1, 'b': 1, 'c': 2 }, {}, isPositive ); // $ExpectError
+	someOwnBy( { 'a': -1, 'b': 1, 'c': 2 }, [], isPositive ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a third argument which is not a function...
+{
+	someOwnBy( { 'a': 1, 'b': 2, 'c': 3 }, 1, 2 ); // $ExpectError
+	someOwnBy( { 'a': 1, 'b': 2, 'c': 3 }, 1, false ); // $ExpectError
+	someOwnBy( { 'a': 1, 'b': 2, 'c': 3 }, 1, true ); // $ExpectError
+	someOwnBy( { 'a': 1, 'b': 2, 'c': 3 }, 1, 'abc' ); // $ExpectError
+	someOwnBy( { 'a': 1, 'b': 2, 'c': 3 }, 1, {} ); // $ExpectError
+	someOwnBy( { 'a': 1, 'b': 2, 'c': 3 }, 1, [] ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an invalid number of arguments...
+{
+	someOwnBy(); // $ExpectError
+	someOwnBy( { 'a': 1, 'b': 2, 'c': 3 } ); // $ExpectError
+	someOwnBy( { 'a': 1, 'b': 2, 'c': 3 }, 1 ); // $ExpectError
+	someOwnBy( { 'a': 1, 'b': 2, 'c': 3 }, 1, isPositive, {}, 3 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/utils/some-own-by/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/some-own-by/examples/index.js
@@ -26,9 +26,10 @@ function threshold( value ) {
 }
 
 var bool;
-var obj = {};
+var obj;
 var i;
 
+obj = {};
 for ( i = 0; i < 100; i++ ) {
 	obj[ 'key' + i ] = randu();
 }

--- a/lib/node_modules/@stdlib/utils/some-own-by/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/some-own-by/examples/index.js
@@ -1,0 +1,37 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var randu = require( '@stdlib/random/base/randu' );
+var someOwnBy = require( './../lib' );
+
+function threshold( value ) {
+	return ( value > 0.95 );
+}
+
+var bool;
+var obj = {};
+var i;
+
+for ( i = 0; i < 100; i++ ) {
+	obj[ 'key' + i ] = randu();
+}
+
+bool = someOwnBy( obj, 5, threshold );
+console.log( bool );

--- a/lib/node_modules/@stdlib/utils/some-own-by/lib/index.js
+++ b/lib/node_modules/@stdlib/utils/some-own-by/lib/index.js
@@ -1,0 +1,46 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Test whether some own properties of a provided object satisfy a predicate function.
+*
+* @module @stdlib/utils/some-own-by
+*
+* @example
+* var someOwnBy = require( '@stdlib/utils/some-own-by' );
+*
+* function isNegative( v ) {
+*     return ( v < 0 );
+* }
+*
+* var obj = { a: 1, b: 2, c: -3, d: 4, e: -1 };
+*
+* var bool = someOwnBy( obj, 2, isNegative );
+* // returns true
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/utils/some-own-by/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/some-own-by/lib/main.js
@@ -67,7 +67,7 @@ function someOwnBy( obj, n, predicate, thisArg ) {
 	count = 0;
 	for ( key in obj ) {
 		if ( hasOwnProp( obj, key ) ) {
-			out = predicate.call( thisArg, obj[ keys[ i ] ], keys[ i ], obj );
+			out = predicate.call( thisArg, obj[ key ], key, obj );
 			if ( out ) {
 				count += 1;
 				if ( count === n ) {

--- a/lib/node_modules/@stdlib/utils/some-own-by/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/some-own-by/lib/main.js
@@ -66,11 +66,12 @@ function someOwnBy( obj, n, predicate, thisArg ) {
 	count = 0;
 	for ( key in obj ) {
 		if ( hasOwnProp( obj, key ) ) {
-		out = predicate.call( thisArg, obj[ keys[ i ] ], keys[ i ], obj );
-		if ( out ) {
-			count += 1;
-			if ( count === n ) {
-				return true;
+			out = predicate.call( thisArg, obj[ keys[ i ] ], keys[ i ], obj );
+			if ( out ) {
+				count += 1;
+				if ( count === n ) {
+					return true;
+				}
 			}
 		}
 	}

--- a/lib/node_modules/@stdlib/utils/some-own-by/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/some-own-by/lib/main.js
@@ -52,10 +52,7 @@ var format = require( '@stdlib/string/format' );
 */
 function someOwnBy( obj, n, predicate, thisArg ) {
 	var count;
-	var keys;
 	var out;
-	var len;
-	var i;
 	if ( !isObject( obj ) ) {
 		throw new TypeError( format( 'invalid argument. First argument must be an object. Value: `%s`.', obj ) );
 	}
@@ -65,10 +62,9 @@ function someOwnBy( obj, n, predicate, thisArg ) {
 	if ( !isFunction( predicate ) ) {
 		throw new TypeError( format( 'invalid argument. Third argument must be a function. Value: `%s`.', predicate ) );
 	}
-	keys = Object.keys( obj );
-	len = keys.length;
 	count = 0;
-	for ( i = 0; i < len; i++ ) {
+	for ( key in obj ) {
+		if ( hasOwnProp( obj, key ) ) {
 		out = predicate.call( thisArg, obj[ keys[ i ] ], keys[ i ], obj );
 		if ( out ) {
 			count += 1;
@@ -76,8 +72,6 @@ function someOwnBy( obj, n, predicate, thisArg ) {
 				return true;
 			}
 		}
-		// Account for dynamically resizing an object:
-		len = keys.length;
 	}
 	return false;
 }

--- a/lib/node_modules/@stdlib/utils/some-own-by/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/some-own-by/lib/main.js
@@ -1,0 +1,88 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isObject = require( '@stdlib/assert/is-object' );
+var isPositiveInteger = require( '@stdlib/assert/is-positive-integer' ).isPrimitive;
+var isFunction = require( '@stdlib/assert/is-function' );
+var format = require( '@stdlib/string/format' );
+
+
+// MAIN //
+
+/**
+* Tests whether some own properties of a provided object satisfy a predicate function.
+*
+* @param {Object} obj - input object
+* @param {PositiveInteger} n - number of properties
+* @param {Function} predicate - test function
+* @param {*} [thisArg] - execution context
+* @throws {TypeError} first argument must be an object
+* @throws {TypeError} second argument must be a positive integer
+* @throws {TypeError} third argument must be a function
+* @returns {boolean} boolean indicating whether an object contains at least `n` properties which pass a test
+*
+* @example
+* function isNegative( v ) {
+*     return ( v < 0 );
+* }
+*
+* var obj = { a: 1, b: 2, c: -3, d: 4, e: -1 };
+*
+* var bool = someOwnBy( obj, 2, isNegative );
+* // returns true
+*/
+function someOwnBy( obj, n, predicate, thisArg ) {
+	var count;
+	var keys;
+	var out;
+	var len;
+	var i;
+	if ( !isObject( obj ) ) {
+		throw new TypeError( format( 'invalid argument. First argument must be an object. Value: `%s`.', obj ) );
+	}
+	if ( !isPositiveInteger( n ) ) {
+		throw new TypeError( format( 'invalid argument. Second argument must be a positive integer. Value: `%s`.', n ) );
+	}
+	if ( !isFunction( predicate ) ) {
+		throw new TypeError( format( 'invalid argument. Third argument must be a function. Value: `%s`.', predicate ) );
+	}
+	keys = Object.keys( obj );
+	len = keys.length;
+	count = 0;
+	for ( i = 0; i < len; i++ ) {
+		out = predicate.call( thisArg, obj[ keys[ i ] ], keys[ i ], obj );
+		if ( out ) {
+			count += 1;
+			if ( count === n ) {
+				return true;
+			}
+		}
+		// Account for dynamically resizing an object:
+		len = keys.length;
+	}
+	return false;
+}
+
+
+// EXPORTS //
+
+module.exports = someOwnBy;

--- a/lib/node_modules/@stdlib/utils/some-own-by/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/some-own-by/lib/main.js
@@ -22,6 +22,7 @@
 
 var isObject = require( '@stdlib/assert/is-object' );
 var isPositiveInteger = require( '@stdlib/assert/is-positive-integer' ).isPrimitive;
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
 var isFunction = require( '@stdlib/assert/is-function' );
 var format = require( '@stdlib/string/format' );
 

--- a/lib/node_modules/@stdlib/utils/some-own-by/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/some-own-by/lib/main.js
@@ -54,6 +54,7 @@ var format = require( '@stdlib/string/format' );
 function someOwnBy( obj, n, predicate, thisArg ) {
 	var count;
 	var out;
+	var key;
 	if ( !isObject( obj ) ) {
 		throw new TypeError( format( 'invalid argument. First argument must be an object. Value: `%s`.', obj ) );
 	}

--- a/lib/node_modules/@stdlib/utils/some-own-by/package.json
+++ b/lib/node_modules/@stdlib/utils/some-own-by/package.json
@@ -63,7 +63,6 @@
         "object",
         "object.keys",
         "iterate",
-        "collection",
         "predicate",
         "own",
         "some",

--- a/lib/node_modules/@stdlib/utils/some-own-by/package.json
+++ b/lib/node_modules/@stdlib/utils/some-own-by/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@stdlib/utils/some-own-by",
     "version": "0.0.0",
-    "description": "Test whether some `own` properties of a provided object satisfies a predicate function for at least `n` properties.",
+    "description": "Test whether some `own` properties of a provided object satisfy a predicate function for at least `n` properties.",
     "license": "Apache-2.0",
     "author": {
         "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/utils/some-own-by/package.json
+++ b/lib/node_modules/@stdlib/utils/some-own-by/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@stdlib/utils/some-own-by",
     "version": "0.0.0",
-    "description": "Test whether some own properties of a provided object satisfies a predicate function.",
+    "description": "Test whether some `own` properties of a provided object satisfies a predicate function for at least `n` properties.",
     "license": "Apache-2.0",
     "author": {
         "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/utils/some-own-by/package.json
+++ b/lib/node_modules/@stdlib/utils/some-own-by/package.json
@@ -1,0 +1,73 @@
+{
+    "name": "@stdlib/utils/some-own-by",
+    "version": "0.0.0",
+    "description": "Test whether some own properties of a provided object satisfies a predicate function.",
+    "license": "Apache-2.0",
+    "author": {
+        "name": "The Stdlib Authors",
+        "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    },
+    "contributors": [
+        {
+            "name": "The Stdlib Authors",
+            "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+        }
+    ],
+    "main": "./lib",
+    "directories": {
+        "benchmark": "./benchmark",
+        "doc": "./docs",
+        "example": "./examples",
+        "lib": "./lib",
+        "test": "./test"
+    },
+    "types": "./docs/types",
+    "scripts": {},
+    "homepage": "https://github.com/stdlib-js/stdlib",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/stdlib-js/stdlib.git"
+    },
+    "bugs": {
+        "url": "https://github.com/stdlib-js/stdlib/issues"
+    },
+    "dependencies": {},
+    "devDependencies": {},
+    "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+    },
+    "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+    ],
+    "keywords": [
+        "stdlib",
+        "stdutils",
+        "stdutil",
+        "utilities",
+        "utility",
+        "utils",
+        "util",
+        "test",
+        "any",
+        "every",
+        "all",
+        "object",
+        "object.keys",
+        "iterate",
+        "collection",
+        "predicate",
+        "own",
+        "some",
+        "values",
+        "validate"
+    ]
+}

--- a/lib/node_modules/@stdlib/utils/some-own-by/test/test.js
+++ b/lib/node_modules/@stdlib/utils/some-own-by/test/test.js
@@ -1,0 +1,256 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var noop = require( '@stdlib/utils/noop' );
+var someOwnBy = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof someOwnBy, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function throws an error if not provided an object', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws a type error when provided '+ values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			someOwnBy( value, 2, noop );
+		};
+	}
+});
+
+tape( 'the function throws an error if not provided a second argument which is a positive integer', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		-5,
+		0,
+		3.14,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws a type error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			someOwnBy( {
+				'a': 1,
+				'b': 2,
+				'c': 3
+			}, value, noop );
+		};
+	}
+});
+
+tape( 'the function throws an error if not provided a predicate function', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		/.*/,
+		new Date()
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws a type error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			someOwnBy( {
+				'a': 1,
+				'b': 2,
+				'c': 3
+			}, 2, value );
+		};
+	}
+});
+
+tape( 'if provided an empty object, the function returns `false`', function test( t ) {
+	var bool;
+	var obj;
+
+	function foo() {
+		t.fail( 'should not be invoked' );
+	}
+	obj = {};
+	bool = someOwnBy( obj, 1, foo );
+
+	t.strictEqual( bool, false, 'returns false' );
+	t.end();
+});
+
+tape( 'the function returns `true` if an object contains at least `n` own properties which pass a test', function test( t ) {
+	var bool;
+	var obj;
+
+	obj = {
+		'a': 1,
+		'b': -2,
+		'c': 3,
+		'd': -1
+	};
+
+	function isNegative( value ) {
+		return ( value < 0 );
+	}
+
+	bool = someOwnBy( obj, 2, isNegative );
+
+	t.strictEqual( bool, true, 'returns true' );
+	t.end();
+});
+
+tape( 'the function returns `false` if an object does not contain at least `n` own properties which pass a test', function test( t ) {
+	var bool;
+	var obj;
+
+	obj = {
+		'a': -1,
+		'b': -2,
+		'c': -3
+	};
+
+	function isPositive( value ) {
+		return ( value > 0 );
+	}
+
+	bool = someOwnBy( obj, 1, isPositive );
+
+	t.strictEqual( bool, false, 'returns false' );
+	t.end();
+});
+
+tape( 'the function returns `false` if an object does not contain at least `n` own properties which pass a test', function test( t ) {
+	var bool;
+	var obj;
+
+	obj = {
+		'a': -1.0,
+		'b': -2.0,
+		'c': -3.0
+	};
+
+	function isPositive( value ) {
+		return ( value > 0 );
+	}
+
+	bool = someOwnBy( obj, 4, isPositive );
+
+	t.strictEqual( bool, false, 'returns false' );
+	t.end();
+});
+
+tape( 'the function supports providing an execution context', function test( t ) {
+	var bool;
+	var ctx;
+	var obj;
+
+	function sum( value ) {
+		/* eslint-disable no-invalid-this */
+		this.sum += value;
+		this.count += 1;
+		return ( value < 0 );
+	}
+
+	ctx = {
+		'sum': 0,
+		'count': 0
+	};
+	obj = {
+		'a': 1.0,
+		'b': -2.0,
+		'c': 3.0,
+		'd': -1.0
+	};
+
+	bool = someOwnBy( obj, 2, sum, ctx );
+
+	t.strictEqual( bool, true, 'returns true' );
+	t.strictEqual( ctx.sum/ctx.count, 0.25, 'expected result' );
+
+	t.end();
+});
+
+tape( 'the function returns `false` if provided a regular expression or a date object (no own properties to test)', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		/.*/,
+		new Date()
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.equal( someOwnBy( values[ i ], 1, threshold ), false, 'returns false when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function threshold( value ) {
+		return ( typeof value === 'number' );
+	}
+});


### PR DESCRIPTION
Add a utility to test whether some own properties of a provided object satisfies a predicate function

Fixes: #821

Resolves #821.

## Description

> What is the purpose of this pull request?
Add a utility to test whether some own properties of a provided object satisfies a predicate function

This pull request:

-  The function  implementation works by iterating over the “own” properties of an object and applying a predicate function to each property.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #821
-   fixes #821

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
