### PR TITLE
bench: update `assert/is-boolean` benchmarks to measure affirmative/negative test values

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-boolean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-boolean/benchmark/benchmark.js
@@ -16,7 +16,7 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers, no-empty-function */
+/* eslint-disable no-empty-function */
 
 'use strict';
 
@@ -30,7 +30,32 @@ var isBoolean = require( './../lib' );
 
 // MAIN //
 
-bench( pkg+'::primitives', function benchmark( b ) {
+bench( pkg+'::primitives,true', function benchmark( b ) {
+	var values;
+	var bool;
+	var i;
+
+	values = [
+		true,
+		false
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		bool = isBoolean( values[ i % values.length ] );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean.isPrimitive( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::primitives,false', function benchmark( b ) {
 	var values;
 	var bool;
 	var i;
@@ -39,8 +64,6 @@ bench( pkg+'::primitives', function benchmark( b ) {
 		'5',
 		5,
 		NaN,
-		true,
-		false,
 		null,
 		void 0
 	];
@@ -60,16 +83,14 @@ bench( pkg+'::primitives', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::objects', function benchmark( b ) {
+bench( pkg+'::objects,true', function benchmark( b ) {
 	var values;
 	var bool;
 	var i;
 
 	values = [
-		[],
-		{},
-		function noop() {},
-		new Boolean( true )
+		new Boolean( true ),
+		new Boolean( false )
 	];
 
 	b.tic();
@@ -87,7 +108,58 @@ bench( pkg+'::objects', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::primitives:isPrimitive', function benchmark( b ) {
+bench( pkg+'::objects,false', function benchmark( b ) {
+	var values;
+	var bool;
+	var i;
+
+	values = [
+		[],
+		{},
+		function noop() {}
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		bool = isBoolean( values[ i % values.length ] );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean.isPrimitive( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::primitives:isPrimitive,true', function benchmark( b ) {
+	var values;
+	var bool;
+	var i;
+
+	values = [
+		true,
+		false
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		bool = isBoolean.isPrimitive( values[ i % values.length ] );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean.isPrimitive( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::primitives:isPrimitive,false', function benchmark( b ) {
 	var values;
 	var bool;
 	var i;
@@ -96,8 +168,6 @@ bench( pkg+'::primitives:isPrimitive', function benchmark( b ) {
 		'5',
 		5,
 		NaN,
-		true,
-		false,
 		null,
 		void 0
 	];
@@ -117,7 +187,7 @@ bench( pkg+'::primitives:isPrimitive', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::objects:isPrimitive', function benchmark( b ) {
+bench( pkg+'::objects:isPrimitive,false', function benchmark( b ) {
 	var values;
 	var bool;
 	var i;
@@ -144,7 +214,7 @@ bench( pkg+'::objects:isPrimitive', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::primitives:isObject', function benchmark( b ) {
+bench( pkg+'::primitives:isObject,false', function benchmark( b ) {
 	var values;
 	var bool;
 	var i;
@@ -174,7 +244,32 @@ bench( pkg+'::primitives:isObject', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::objects:isObject', function benchmark( b ) {
+bench( pkg+'::objects:isObject,true', function benchmark( b ) {
+	var values;
+	var bool;
+	var i;
+
+	values = [
+		new Boolean( true ),
+		new Boolean( false )
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		bool = isBoolean.isObject( values[ i % values.length ] );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean.isPrimitive( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::objects:isObject,false', function benchmark( b ) {
 	var values;
 	var bool;
 	var i;
@@ -182,8 +277,7 @@ bench( pkg+'::objects:isObject', function benchmark( b ) {
 	values = [
 		[],
 		{},
-		function noop() {},
-		new Boolean( true )
+		function noop() {}
 	];
 
 	b.tic();


### PR DESCRIPTION
Partially Resolves #1148

## Description

> What is the purpose of this pull request?

This pull request:

-  updates `@stdlib/assert/is-boolean` benchmarks to measure affirmative/negative test values for all cases

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   partially resolves #1148

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
