### PR TITLE
feat: add C implementation for `constants/int32/max`

### DIFF
--- a/lib/node_modules/@stdlib/constants/int32/max/README.md
+++ b/lib/node_modules/@stdlib/constants/int32/max/README.md
@@ -62,6 +62,60 @@ console.log( INT32_MAX );
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/constants/int32/max.h"
+```
+
+#### STDLIB_CONSTANT_INT32_MAX
+
+Macro for maximum [signed 32-bit integer][max-int32].
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/constants/int32/max/README.md
+++ b/lib/node_modules/@stdlib/constants/int32/max/README.md
@@ -90,7 +90,7 @@ console.log( INT32_MAX );
 
 #### STDLIB_CONSTANT_INT32_MAX
 
-Macro for maximum [signed 32-bit integer][max-int32].
+Macro for the maximum [signed 32-bit integer][max-int32].
 
 </section>
 

--- a/lib/node_modules/@stdlib/constants/int32/max/include/stdlib/constants/int32/max.h
+++ b/lib/node_modules/@stdlib/constants/int32/max/include/stdlib/constants/int32/max.h
@@ -1,0 +1,27 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_CONSTANTS_INT32_MAX_H
+#define STDLIB_CONSTANTS_INT32_MAX_H
+
+/**
+* Macro for maximum signed 32-bit integer.
+*/
+#define STDLIB_CONSTANT_INT32_MAX 2147483647|0
+
+#endif // !STDLIB_CONSTANTS_INT32_MAX_H

--- a/lib/node_modules/@stdlib/constants/int32/max/include/stdlib/constants/int32/max.h
+++ b/lib/node_modules/@stdlib/constants/int32/max/include/stdlib/constants/int32/max.h
@@ -20,8 +20,8 @@
 #define STDLIB_CONSTANTS_INT32_MAX_H
 
 /**
-* Macro for maximum signed 32-bit integer.
+* Macro for the maximum signed 32-bit integer.
 */
-#define STDLIB_CONSTANT_INT32_MAX 2147483647|0
+#define STDLIB_CONSTANT_INT32_MAX 2147483647
 
 #endif // !STDLIB_CONSTANTS_INT32_MAX_H

--- a/lib/node_modules/@stdlib/constants/int32/max/manifest.json
+++ b/lib/node_modules/@stdlib/constants/int32/max/manifest.json
@@ -1,0 +1,36 @@
+{
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": []
+    }
+  ]
+}


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request adds C implementation for `@stdlib/constants/int32/max`

## Related Issues

> Does this pull request have any related issues?

Removes blocker for `gcd`, requested by @aman-095.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
