### PR TITLE
feat: add Node-API macros for binary functions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/napi/binary/README.md
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/README.md
@@ -331,6 +331,86 @@ The function accepts the following arguments:
 void stdlib_math_base_napi_di_d( napi_env env, napi_callback_info info, double (*fcn)( double, int32_t ) );
 ```
 
+#### stdlib_math_base_napi_ii_i( env, info, fcn )
+
+Invokes a binary function accepting a signed 32-bit integer and a signed 32-bit integer and returning a signed 32-bit integer.
+
+```c
+#include <node_api.h>
+#include <stdint.h>
+
+// ...
+
+static int32_t mul( const int32_t x, const int32_t y ) {
+    return x * y;
+}
+
+// ...
+
+/**
+* Receives JavaScript callback invocation data.
+*
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @return       Node-API value
+*/
+napi_value addon( napi_env env, napi_callback_info info ) {
+    return stdlib_math_base_napi_ii_i( env, info, mul );
+}
+
+// ...
+```
+
+The function accepts the following arguments:
+
+-   **env**: `[in] napi_env` environment under which the function is invoked.
+-   **info**: `[in] napi_callback_info` callback data.
+-   **fcn**: `[in] int32_t (*fcn)( int32_t, int32_t )` binary function.
+
+```c
+void stdlib_math_base_napi_ii_i( napi_env env, napi_callback_info info, int32_t (*fcn)( int32_t, int32_t ) );
+```
+
+#### stdlib_math_base_napi_ii_d( env, info, fcn )
+
+Invokes a binary function accepting a signed 32-bit integer and a signed 32-bit integer and returning a double-precision floating-point number.
+
+```c
+#include <node_api.h>
+#include <stdint.h>
+
+// ...
+
+static double mul( const int32_t x, const int32_t y ) {
+    return x * y;
+}
+
+// ...
+
+/**
+* Receives JavaScript callback invocation data.
+*
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @return       Node-API value
+*/
+napi_value addon( napi_env env, napi_callback_info info ) {
+    return stdlib_math_base_napi_ii_d( env, info, mul );
+}
+
+// ...
+```
+
+The function accepts the following arguments:
+
+-   **env**: `[in] napi_env` environment under which the function is invoked.
+-   **info**: `[in] napi_callback_info` callback data.
+-   **fcn**: `[in] double (*fcn)( int32_t, int32_t )` binary function.
+
+```c
+void stdlib_math_base_napi_ii_d( napi_env env, napi_callback_info info, double (*fcn)( int32_t, int32_t ) );
+```
+
 #### stdlib_math_base_napi_fi_f( env, info, fcn )
 
 Invokes a binary function accepting a single-precision floating-point number and a signed 32-bit integer and returning a single-precision floating-point number.

--- a/lib/node_modules/@stdlib/math/base/napi/binary/README.md
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/README.md
@@ -576,6 +576,48 @@ The macro expects the following arguments:
 
 When used, this macro should be used **instead of** `NAPI_MODULE`. The macro includes `NAPI_MODULE`, thus ensuring Node-API module registration.
 
+#### STDLIB_MATH_BASE_NAPI_MODULE_II_I( fcn )
+
+Macro for registering a Node-API module exporting an interface for invoking a binary function accepting and returning signed 32-bit integers.
+
+```c
+static int32_t add( const int32_t x, const int32_t y ) {
+    return x + y;
+}
+
+// ...
+
+// Register a Node-API module:
+STDLIB_MATH_BASE_NAPI_MODULE_II_I( add );
+```
+
+The macro expects the following arguments:
+
+-   **fcn**: `int32_t (*fcn)( int32_t, int32_t )` binary function.
+
+When used, this macro should be used **instead of** `NAPI_MODULE`. The macro includes `NAPI_MODULE`, thus ensuring Node-API module registration.
+
+#### STDLIB_MATH_BASE_NAPI_MODULE_II_D( fcn )
+
+Macro for registering a Node-API module exporting an interface for invoking a binary function accepting signed 32-bit integers and returning a double-precision floating-point number.
+
+```c
+static double add( const int32_t x, const int32_t y ) {
+    return x + y;
+}
+
+// ...
+
+// Register a Node-API module:
+STDLIB_MATH_BASE_NAPI_MODULE_II_D( add );
+```
+
+The macro expects the following arguments:
+
+-   **fcn**: `double (*fcn)( int32_t, int32_t )` binary function.
+
+When used, this macro should be used **instead of** `NAPI_MODULE`. The macro includes `NAPI_MODULE`, thus ensuring Node-API module registration.
+
 #### STDLIB_MATH_BASE_NAPI_MODULE_FF_F( fcn )
 
 Macro for registering a Node-API module exporting an interface for invoking a binary function accepting and returning single-precision floating-point numbers.

--- a/lib/node_modules/@stdlib/math/base/napi/binary/README.md
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/README.md
@@ -333,7 +333,7 @@ void stdlib_math_base_napi_di_d( napi_env env, napi_callback_info info, double (
 
 #### stdlib_math_base_napi_ii_i( env, info, fcn )
 
-Invokes a binary function accepting a signed 32-bit integer and a signed 32-bit integer and returning a signed 32-bit integer.
+Invokes a binary function accepting and returning signed 32-bit integers.
 
 ```c
 #include <node_api.h>
@@ -373,7 +373,7 @@ void stdlib_math_base_napi_ii_i( napi_env env, napi_callback_info info, int32_t 
 
 #### stdlib_math_base_napi_ii_d( env, info, fcn )
 
-Invokes a binary function accepting a signed 32-bit integer and a signed 32-bit integer and returning a double-precision floating-point number.
+Invokes a binary function accepting signed 32-bit integers and returning a double-precision floating-point number.
 
 ```c
 #include <node_api.h>

--- a/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary.h
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary.h
@@ -65,6 +65,86 @@
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_dd_d_init )
 
 /**
+* Macro for registering a Node-API module exporting an interface invoking a binary function accepting and returning signed 32-bit integer.
+*
+* @param fcn   binary function
+*
+* @example
+* static int_32 add( const int_32 x, const int_32 y ) {
+*     return x + y;
+* }
+*
+* // ...
+*
+* // Register a Node-API module:
+* STDLIB_MATH_BASE_NAPI_MODULE_II_I( add );
+*/
+#define STDLIB_MATH_BASE_NAPI_MODULE_II_I( fcn )                               \
+	static napi_value stdlib_math_base_napi_ii_i_wrapper(                      \
+		napi_env env,                                                          \
+		napi_callback_info info                                                \
+	) {                                                                        \
+		return stdlib_math_base_napi_ii_i( env, info, fcn );                   \
+	};                                                                         \
+	static napi_value stdlib_math_base_napi_ii_i_init(                         \
+		napi_env env,                                                          \
+		napi_value exports                                                     \
+	) {                                                                        \
+		napi_value fcn;                                                        \
+		napi_status status = napi_create_function(                             \
+			env,                                                               \
+			"exports",                                                         \
+			NAPI_AUTO_LENGTH,                                                  \
+			stdlib_math_base_napi_ii_i_wrapper,                                \
+			NULL,                                                              \
+			&fcn                                                               \
+		);                                                                     \
+		assert( status == napi_ok );                                           \
+		return fcn;                                                            \
+	};                                                                         \
+	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_ii_i_init )
+
+/**
+* Macro for registering a Node-API module exporting an interface invoking a binary function accepting signed 32-bit integer and returning double-precision floating-point number.
+*
+* @param fcn   binary function
+*
+* @example
+* static double add( const int_32 x, const int_32 y ) {
+*     return x + y;
+* }
+*
+* // ...
+*
+* // Register a Node-API module:
+* STDLIB_MATH_BASE_NAPI_MODULE_II_D( add );
+*/
+#define STDLIB_MATH_BASE_NAPI_MODULE_II_D( fcn )                               \
+	static napi_value stdlib_math_base_napi_ii_d_wrapper(                      \
+		napi_env env,                                                          \
+		napi_callback_info info                                                \
+	) {                                                                        \
+		return stdlib_math_base_napi_ii_d( env, info, fcn );                   \
+	};                                                                         \
+	static napi_value stdlib_math_base_napi_ii_d_init(                         \
+		napi_env env,                                                          \
+		napi_value exports                                                     \
+	) {                                                                        \
+		napi_value fcn;                                                        \
+		napi_status status = napi_create_function(                             \
+			env,                                                               \
+			"exports",                                                         \
+			NAPI_AUTO_LENGTH,                                                  \
+			stdlib_math_base_napi_ii_d_wrapper,                                \
+			NULL,                                                              \
+			&fcn                                                               \
+		);                                                                     \
+		assert( status == napi_ok );                                           \
+		return fcn;                                                            \
+	};                                                                         \
+	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_ii_d_init )
+
+/**
 * Macro for registering a Node-API module exporting an interface invoking a binary function accepting and returning single-precision floating-point numbers.
 *
 * @param fcn   binary function
@@ -521,6 +601,16 @@ napi_value stdlib_math_base_napi_cc_c( napi_env env, napi_callback_info info, st
 * Invokes a binary function accepting a double-precision floating-point number and a signed 32-bit integer and returning a double-precision floating-point number.
 */
 napi_value stdlib_math_base_napi_di_d( napi_env env, napi_callback_info info, double (*fcn)( double, int32_t ) );
+
+/**
+* Invokes a binary function accepting signed 32-bit integers and returning a double-precision floating-point number.
+*/
+napi_value stdlib_math_base_napi_ii_d( napi_env env, napi_callback_info info, double (*fcn)( int32_t, int32_t ) );
+
+/**
+* Invokes a binary function accepting signed 32-bit integers and returning a signed 32-bit integer.
+*/
+napi_value stdlib_math_base_napi_ii_i( napi_env env, napi_callback_info info, int32_t (*fcn)( int32_t, int32_t ) );
 
 /**
 * Invokes a binary function accepting a single-precision floating-point number and a signed 32-bit integer and returning a single-precision floating-point number.

--- a/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary.h
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary.h
@@ -608,7 +608,7 @@ napi_value stdlib_math_base_napi_di_d( napi_env env, napi_callback_info info, do
 napi_value stdlib_math_base_napi_ii_d( napi_env env, napi_callback_info info, double (*fcn)( int32_t, int32_t ) );
 
 /**
-* Invokes a binary function accepting signed 32-bit integers and returning a signed 32-bit integer.
+* Invokes a binary function accepting and returning signed 32-bit integers.
 */
 napi_value stdlib_math_base_napi_ii_i( napi_env env, napi_callback_info info, int32_t (*fcn)( int32_t, int32_t ) );
 

--- a/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary.h
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary.h
@@ -65,7 +65,7 @@
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_dd_d_init )
 
 /**
-* Macro for registering a Node-API module exporting an interface invoking a binary function accepting and returning signed 32-bit integer.
+* Macro for registering a Node-API module exporting an interface invoking a binary function accepting and returning signed 32-bit integers.
 *
 * @param fcn   binary function
 *
@@ -105,7 +105,7 @@
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_ii_i_init )
 
 /**
-* Macro for registering a Node-API module exporting an interface invoking a binary function accepting signed 32-bit integer and returning double-precision floating-point number.
+* Macro for registering a Node-API module exporting an interface invoking a binary function accepting signed 32-bit integers and returning a double-precision floating-point number.
 *
 * @param fcn   binary function
 *

--- a/lib/node_modules/@stdlib/math/base/napi/binary/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/src/main.c
@@ -587,7 +587,7 @@ napi_value stdlib_math_base_napi_ii_d( napi_env env, napi_callback_info info, do
 }
 
 /**
-* Invokes a binary function accepting signed 32-bit integers and returning a signed 32-bit integer.
+* Invokes a binary function accepting and returning signed 32-bit integers.
 *
 * ## Notes
 *

--- a/lib/node_modules/@stdlib/math/base/napi/binary/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/src/main.c
@@ -525,6 +525,130 @@ napi_value stdlib_math_base_napi_di_d( napi_env env, napi_callback_info info, do
 }
 
 /**
+* Invokes a binary function accepting signed 32-bit integers and returning a double-precision floating-point number.
+*
+* ## Notes
+*
+* -   This function expects that the callback `info` argument provides access to the following JavaScript arguments:
+*
+*     -   `x`: input value.
+*     -   `y`: input value.
+*
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @param fcn    binary function
+* @return       function return value as a Node-API double-precision floating-point number
+*/
+napi_value stdlib_math_base_napi_ii_d( napi_env env, napi_callback_info info, double (*fcn)( int32_t, int32_t ) ) {
+	napi_status status;
+
+	size_t argc = 2;
+	napi_value argv[ 2 ];
+	status = napi_get_cb_info( env, info, &argc, argv, NULL, NULL );
+	assert( status == napi_ok );
+
+	if ( argc < 2 ) {
+		status = napi_throw_error( env, NULL, "invalid invocation. Must provide two numbers." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	napi_valuetype vtype0;
+	status = napi_typeof( env, argv[ 0 ], &vtype0 );
+	assert( status == napi_ok );
+	if ( vtype0 != napi_number ) {
+		status = napi_throw_type_error( env, NULL, "invalid argument. First argument must be a number." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	napi_valuetype vtype1;
+	status = napi_typeof( env, argv[ 1 ], &vtype1 );
+	assert( status == napi_ok );
+	if ( vtype1 != napi_number ) {
+		status = napi_throw_type_error( env, NULL, "invalid argument. Second argument must be a number." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	int32_t x;
+	status = napi_get_value_int32( env, argv[ 0 ], &x );
+	assert( status == napi_ok );
+
+	int32_t y;
+	status = napi_get_value_int32( env, argv[ 1 ], &y );
+	assert( status == napi_ok );
+
+	napi_value v;
+	status = napi_create_double( env, fcn( x, y ), &v );
+	assert( status == napi_ok );
+
+	return v;
+}
+
+/**
+* Invokes a binary function accepting signed 32-bit integers and returning a signed 32-bit integer.
+*
+* ## Notes
+*
+* -   This function expects that the callback `info` argument provides access to the following JavaScript arguments:
+*
+*     -   `x`: input value.
+*     -   `y`: input value.
+*
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @param fcn    binary function
+* @return       function return value as a Node-API signed 32-bit integer
+*/
+napi_value stdlib_math_base_napi_ii_i( napi_env env, napi_callback_info info, int32_t (*fcn)( int32_t, int32_t ) ) {
+	napi_status status;
+
+	size_t argc = 2;
+	napi_value argv[ 2 ];
+	status = napi_get_cb_info( env, info, &argc, argv, NULL, NULL );
+	assert( status == napi_ok );
+
+	if ( argc < 2 ) {
+		status = napi_throw_error( env, NULL, "invalid invocation. Must provide two numbers." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	napi_valuetype vtype0;
+	status = napi_typeof( env, argv[ 0 ], &vtype0 );
+	assert( status == napi_ok );
+	if ( vtype0 != napi_number ) {
+		status = napi_throw_type_error( env, NULL, "invalid argument. First argument must be a number." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	napi_valuetype vtype1;
+	status = napi_typeof( env, argv[ 1 ], &vtype1 );
+	assert( status == napi_ok );
+	if ( vtype1 != napi_number ) {
+		status = napi_throw_type_error( env, NULL, "invalid argument. Second argument must be a number." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	int32_t x;
+	status = napi_get_value_int32( env, argv[ 0 ], &x );
+	assert( status == napi_ok );
+
+	int32_t y;
+	status = napi_get_value_int32( env, argv[ 1 ], &y );
+	assert( status == napi_ok );
+
+	napi_value v;
+	status = napi_create_int32( env, fcn( x, y ), &v );
+	assert( status == napi_ok );
+
+	return v;
+}
+
+/**
 * Invokes a binary function accepting a single-precision floating-point number and a signed 32-bit integer and returning a single-precision floating-point number.
 *
 * ## Notes


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request adds the following macros:

```c
/**
* Invokes a binary function accepting signed 32-bit integers and returning a double-precision floating-point number.
*/
napi_value stdlib_math_base_napi_ii_d( napi_env env, napi_callback_info info, double (*fcn)( int32_t, int32_t ) );

/**
* Invokes a binary function accepting and returning signed 32-bit integers.
*/
napi_value stdlib_math_base_napi_ii_i( napi_env env, napi_callback_info info, int32_t (*fcn)( int32_t, int32_t ) );
```

## Related Issues

> Does this pull request have any related issues?

It is a blocker for the C implementation for GCD. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
