### PR TITLE
docs(math/base/ops): improve `math/base/ops` README.md examples

### DIFF
--- a/lib/node_modules/@stdlib/math/base/ops/README.md
+++ b/lib/node_modules/@stdlib/math/base/ops/README.md
@@ -91,29 +91,30 @@ var Complex128 = require( '@stdlib/complex/float64' );
 var ns = require( '@stdlib/math/base/ops' );
 
 // Operations for double-precision floating point numbers:
-console.log( ns.add( 1.25, 0.45 ) ); 
+console.log( ns.add( 1.25, 0.45 ) );
 // => 1.7
 
-console.log( ns.sub( 1.25, 0.45 ) ); 
+console.log( ns.sub( 1.25, 0.45 ) );
 // => 0.8
 
 // Operations for single-precision floating point numbers:
-console.log( ns.mulf( 1.3, 1.2 ) ); 
+console.log( ns.mulf( 1.3, 1.2 ) );
 // => ~1.56
 
-console.log( ns.divf( 1.2, 0.4 ) ); 
+console.log( ns.divf( 1.2, 0.4 ) );
 // => 3.0
 
 // Operations for complex numbers:
 var z1 = new Complex128( 5.0, 3.0 );
 var z2 = new Complex128( -2.0, 1.0 );
 
-console.log( ns.cmul( z1, z2 ) ); 
+console.log( ns.cmul( z1, z2 ) );
 // => Complex128 { re: -13.0, im: -1.0 }
 
 // Operations for signed 32-bit integers:
 // 2^30 * -5 = -5368709120 => 32-bit integer overflow
-console.log( ns.imul( 1073741824|0, -5|0 ) ); // => -1073741824
+console.log( ns.imul( 1073741824|0, -5|0 ) );
+// => -1073741824
 
 // Operations for unsigned 32-bit integers:
 // 2^31 * 5 = 10737418240 => 32-bit integer overflow

--- a/lib/node_modules/@stdlib/math/base/ops/README.md
+++ b/lib/node_modules/@stdlib/math/base/ops/README.md
@@ -87,10 +87,37 @@ The namespace contains the following functions:
 <!-- eslint no-undef: "error" -->
 
 ```javascript
+var Complex128 = require( '@stdlib/complex/float64' );
 var objectKeys = require( '@stdlib/utils/keys' );
 var ns = require( '@stdlib/math/base/ops' );
 
 console.log( objectKeys( ns ) );
+
+// Operations for floating point numbers (double-precision)
+console.log( ns.add(1.25, 0.45) ); // => 1.7
+console.log( ns.sub(1.25, 0.45) ); // => 0.8
+
+// (single-precision)
+console.log( ns.mulf(1.3, 1.2) ); // => ~ 1.56
+console.log( ns.divf(1.2, 0.4) ); // => 3
+
+// Operations for complex numbers
+var z1 = new Complex128( 5.0, 3.0 );
+var z2 = new Complex128( -2.0, 1.0 );
+
+console.log( ns.cmul( z1, z2 ) ); // => Complex128 { re: -13.0, im: -1.0 }
+
+// Operations for Signed 32-bit integers
+// 2^30 * -5 = -5368709120 => 32-bit integer overflow
+console.log( ns.imul( 1073741824|0, -5|0 ) ); // => -1073741824
+
+// Operations for Unsigned 32-bit integers
+// 2^31 * 5 = 10737418240 => 32-bit integer overflow
+console.log( ns.umul( 2147483648>>>0, 5>>>0 ) ); // => 2147483648
+
+// Operations for Double word product:
+// -(2^31) * 2^30 = -2305843009213694000 => 32-bit integer overflow
+console.log( ns.imuldw( 0x80000000|0, 0x40000000|0 ) ); // => returns [ -536870912, 0 ]
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/ops/README.md
+++ b/lib/node_modules/@stdlib/math/base/ops/README.md
@@ -88,36 +88,42 @@ The namespace contains the following functions:
 
 ```javascript
 var Complex128 = require( '@stdlib/complex/float64' );
-var objectKeys = require( '@stdlib/utils/keys' );
 var ns = require( '@stdlib/math/base/ops' );
 
-console.log( objectKeys( ns ) );
+// Operations for double-precision floating point numbers:
+console.log( ns.add( 1.25, 0.45 ) ); 
+// => 1.7
 
-// Operations for floating point numbers (double-precision)
-console.log( ns.add(1.25, 0.45) ); // => 1.7
-console.log( ns.sub(1.25, 0.45) ); // => 0.8
+console.log( ns.sub( 1.25, 0.45 ) ); 
+// => 0.8
 
-// (single-precision)
-console.log( ns.mulf(1.3, 1.2) ); // => ~ 1.56
-console.log( ns.divf(1.2, 0.4) ); // => 3
+// Operations for single-precision floating point numbers:
+console.log( ns.mulf( 1.3, 1.2 ) ); 
+// => ~1.56
 
-// Operations for complex numbers
+console.log( ns.divf( 1.2, 0.4 ) ); 
+// => 3.0
+
+// Operations for complex numbers:
 var z1 = new Complex128( 5.0, 3.0 );
 var z2 = new Complex128( -2.0, 1.0 );
 
-console.log( ns.cmul( z1, z2 ) ); // => Complex128 { re: -13.0, im: -1.0 }
+console.log( ns.cmul( z1, z2 ) ); 
+// => Complex128 { re: -13.0, im: -1.0 }
 
-// Operations for Signed 32-bit integers
+// Operations for signed 32-bit integers:
 // 2^30 * -5 = -5368709120 => 32-bit integer overflow
 console.log( ns.imul( 1073741824|0, -5|0 ) ); // => -1073741824
 
-// Operations for Unsigned 32-bit integers
+// Operations for unsigned 32-bit integers:
 // 2^31 * 5 = 10737418240 => 32-bit integer overflow
-console.log( ns.umul( 2147483648>>>0, 5>>>0 ) ); // => 2147483648
+console.log( ns.umul( 2147483648>>>0, 5>>>0 ) );
+// => 2147483648
 
-// Operations for Double word product:
+// Operations for double word product:
 // -(2^31) * 2^30 = -2305843009213694000 => 32-bit integer overflow
-console.log( ns.imuldw( 0x80000000|0, 0x40000000|0 ) ); // => returns [ -536870912, 0 ]
+console.log( ns.imuldw( 0x80000000|0, 0x40000000|0 ) );
+// => [ -536870912, 0 ]
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/ops/README.md
+++ b/lib/node_modules/@stdlib/math/base/ops/README.md
@@ -107,9 +107,8 @@ console.log( ns.divf( 1.2, 0.4 ) );
 // Operations for complex numbers:
 var z1 = new Complex128( 5.0, 3.0 );
 var z2 = new Complex128( -2.0, 1.0 );
-console.log( ns.cmul( z1, z2 ) );
+console.log( ns.cmul( z1, z2 ) ); // { 're': -13.0, 'im': -1.0 }
 // => <Complex128>
-// { 're': -13.0, 'im': -1.0 }
 
 // Operations for signed 32-bit integers:
 // 2^30 * -5 = -5368709120 => 32-bit integer overflow

--- a/lib/node_modules/@stdlib/math/base/ops/README.md
+++ b/lib/node_modules/@stdlib/math/base/ops/README.md
@@ -108,7 +108,7 @@ console.log( ns.divf( 1.2, 0.4 ) );
 var z1 = new Complex128( 5.0, 3.0 );
 var z2 = new Complex128( -2.0, 1.0 );
 console.log( ns.cmul( z1, z2 ) );
-// => Complex128 { re: -13.0, im: -1.0 }
+// => <Complex128> { re: -13.0, im: -1.0 }
 
 // Operations for signed 32-bit integers:
 // 2^30 * -5 = -5368709120 => 32-bit integer overflow

--- a/lib/node_modules/@stdlib/math/base/ops/README.md
+++ b/lib/node_modules/@stdlib/math/base/ops/README.md
@@ -107,7 +107,6 @@ console.log( ns.divf( 1.2, 0.4 ) );
 // Operations for complex numbers:
 var z1 = new Complex128( 5.0, 3.0 );
 var z2 = new Complex128( -2.0, 1.0 );
-
 console.log( ns.cmul( z1, z2 ) );
 // => Complex128 { re: -13.0, im: -1.0 }
 

--- a/lib/node_modules/@stdlib/math/base/ops/README.md
+++ b/lib/node_modules/@stdlib/math/base/ops/README.md
@@ -108,7 +108,8 @@ console.log( ns.divf( 1.2, 0.4 ) );
 var z1 = new Complex128( 5.0, 3.0 );
 var z2 = new Complex128( -2.0, 1.0 );
 console.log( ns.cmul( z1, z2 ) );
-// => <Complex128> { re: -13.0, im: -1.0 }
+// => <Complex128>
+// { 're': -13.0, 'im': -1.0 }
 
 // Operations for signed 32-bit integers:
 // 2^30 * -5 = -5368709120 => 32-bit integer overflow

--- a/lib/node_modules/@stdlib/math/base/ops/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/ops/examples/index.js
@@ -39,7 +39,7 @@ console.log( ns.divf( 1.2, 0.4 ) );
 var z1 = new Complex128( 5.0, 3.0 );
 var z2 = new Complex128( -2.0, 1.0 );
 console.log( ns.cmul( z1, z2 ) );
-// => Complex128 { re: -13.0, im: -1.0 }
+// => <Complex128> { re: -13.0, im: -1.0 }
 
 // Operations for signed 32-bit integers:
 // 2^30 * -5 = -5368709120 => 32-bit integer overflow

--- a/lib/node_modules/@stdlib/math/base/ops/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/ops/examples/index.js
@@ -38,9 +38,8 @@ console.log( ns.divf( 1.2, 0.4 ) );
 // Operations for complex numbers:
 var z1 = new Complex128( 5.0, 3.0 );
 var z2 = new Complex128( -2.0, 1.0 );
-console.log( ns.cmul( z1, z2 ) );
-// => <Complex128> 
-// {'re': -13.0, 'im': -1.0 }
+console.log( ns.cmul( z1, z2 ) ); // {'re': -13.0, 'im': -1.0 }
+// => <Complex128>
 
 // Operations for signed 32-bit integers:
 // 2^30 * -5 = -5368709120 => 32-bit integer overflow

--- a/lib/node_modules/@stdlib/math/base/ops/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/ops/examples/index.js
@@ -29,16 +29,15 @@ console.log( ns.sub( 1.25, 0.45 ) );
 // => 0.8
 
 // Operations for single-precision floating point numbers:
-console.log( ns.mulf( 1.3, 1.2 ) ); 
+console.log( ns.mulf( 1.3, 1.2 ) );
 // => ~1.56
 
-console.log( ns.divf( 1.2, 0.4 ) ); 
+console.log( ns.divf( 1.2, 0.4 ) );
 // => 3.0
 
 // Operations for complex numbers:
 var z1 = new Complex128( 5.0, 3.0 );
 var z2 = new Complex128( -2.0, 1.0 );
-
 console.log( ns.cmul( z1, z2 ) );
 // => Complex128 { re: -13.0, im: -1.0 }
 

--- a/lib/node_modules/@stdlib/math/base/ops/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/ops/examples/index.js
@@ -29,14 +29,18 @@ console.log( ns.sub( 1.25, 0.45 ) );
 // => 0.8
 
 // Operations for single-precision floating point numbers:
-console.log( ns.mulf(1.3, 1.2) ); // => ~ 1.56
-console.log( ns.divf(1.2, 0.4) ); // => 3
+console.log( ns.mulf( 1.3, 1.2 ) ); 
+// => ~1.56
 
-// Operations for complex numbers
+console.log( ns.divf( 1.2, 0.4 ) ); 
+// => 3.0
+
+// Operations for complex numbers:
 var z1 = new Complex128( 5.0, 3.0 );
 var z2 = new Complex128( -2.0, 1.0 );
 
-console.log( ns.cmul( z1, z2 ) ); // => Complex128 { re: -13.0, im: -1.0 }
+console.log( ns.cmul( z1, z2 ) );
+// => Complex128 { re: -13.0, im: -1.0 }
 
 // Operations for signed 32-bit integers:
 // 2^30 * -5 = -5368709120 => 32-bit integer overflow

--- a/lib/node_modules/@stdlib/math/base/ops/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/ops/examples/index.js
@@ -18,7 +18,34 @@
 
 'use strict';
 
+var Complex128 = require( '@stdlib/complex/float64' );
 var objectKeys = require( '@stdlib/utils/keys' );
 var ns = require( './../lib' );
 
 console.log( objectKeys( ns ) );
+
+// Operations for floating point numbers (double-precision)
+console.log( ns.add(1.25, 0.45) ); // => 1.7
+console.log( ns.sub(1.25, 0.45) ); // => 0.8
+
+// (single-precision)
+console.log( ns.mulf(1.3, 1.2) ); // => ~ 1.56
+console.log( ns.divf(1.2, 0.4) ); // => 3
+
+// Operations for complex numbers
+var z1 = new Complex128( 5.0, 3.0 );
+var z2 = new Complex128( -2.0, 1.0 );
+
+console.log( ns.cmul( z1, z2 ) ); // => Complex128 { re: -13.0, im: -1.0 }
+
+// Operations for Signed 32-bit integers
+// 2^30 * -5 = -5368709120 => 32-bit integer overflow
+console.log( ns.imul( 1073741824|0, -5|0 ) ); // => -1073741824
+
+// Operations for Unsigned 32-bit integers
+// 2^31 * 5 = 10737418240 => 32-bit integer overflow
+console.log( ns.umul( 2147483648>>>0, 5>>>0 ) ); // => 2147483648
+
+// Operations for Double word product:
+// -(2^31) * 2^30 = -2305843009213694000 => 32-bit integer overflow
+console.log( ns.imuldw( 0x80000000|0, 0x40000000|0 ) ); // => returns [ -536870912, 0 ]

--- a/lib/node_modules/@stdlib/math/base/ops/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/ops/examples/index.js
@@ -39,7 +39,8 @@ console.log( ns.divf( 1.2, 0.4 ) );
 var z1 = new Complex128( 5.0, 3.0 );
 var z2 = new Complex128( -2.0, 1.0 );
 console.log( ns.cmul( z1, z2 ) );
-// => <Complex128> { re: -13.0, im: -1.0 }
+// => <Complex128> 
+// {'re': -13.0, 'im': -1.0 }
 
 // Operations for signed 32-bit integers:
 // 2^30 * -5 = -5368709120 => 32-bit integer overflow

--- a/lib/node_modules/@stdlib/math/base/ops/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/ops/examples/index.js
@@ -19,16 +19,16 @@
 'use strict';
 
 var Complex128 = require( '@stdlib/complex/float64' );
-var objectKeys = require( '@stdlib/utils/keys' );
 var ns = require( './../lib' );
 
-console.log( objectKeys( ns ) );
+// Operations for double-precision floating point numbers:
+console.log( ns.add( 1.25, 0.45 ) );
+// => 1.7
 
-// Operations for floating point numbers (double-precision)
-console.log( ns.add(1.25, 0.45) ); // => 1.7
-console.log( ns.sub(1.25, 0.45) ); // => 0.8
+console.log( ns.sub( 1.25, 0.45 ) );
+// => 0.8
 
-// (single-precision)
+// Operations for single-precision floating point numbers:
 console.log( ns.mulf(1.3, 1.2) ); // => ~ 1.56
 console.log( ns.divf(1.2, 0.4) ); // => 3
 
@@ -38,14 +38,17 @@ var z2 = new Complex128( -2.0, 1.0 );
 
 console.log( ns.cmul( z1, z2 ) ); // => Complex128 { re: -13.0, im: -1.0 }
 
-// Operations for Signed 32-bit integers
+// Operations for signed 32-bit integers:
 // 2^30 * -5 = -5368709120 => 32-bit integer overflow
-console.log( ns.imul( 1073741824|0, -5|0 ) ); // => -1073741824
+console.log( ns.imul( 1073741824|0, -5|0 ) );
+// => -1073741824
 
-// Operations for Unsigned 32-bit integers
+// Operations for unsigned 32-bit integers:
 // 2^31 * 5 = 10737418240 => 32-bit integer overflow
-console.log( ns.umul( 2147483648>>>0, 5>>>0 ) ); // => 2147483648
+console.log( ns.umul( 2147483648>>>0, 5>>>0 ) );
+// => 2147483648
 
-// Operations for Double word product:
+// Operations for couble word product:
 // -(2^31) * 2^30 = -2305843009213694000 => 32-bit integer overflow
-console.log( ns.imuldw( 0x80000000|0, 0x40000000|0 ) ); // => returns [ -536870912, 0 ]
+console.log( ns.imuldw( 0x80000000|0, 0x40000000|0 ) );
+// => [ -536870912, 0 ]


### PR DESCRIPTION
Resolves #1569 .

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds examples for methods in `math/base/ops` namespace
-   Updates ReadMe.md with the same methods.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #1569
-   fixes #1569

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
