### PR TITLE
docs: improve README examples of `ndarray/base` namespace

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/README.md
+++ b/lib/node_modules/@stdlib/ndarray/base/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2018 The Stdlib Authors.
+Copyright (c) 2024 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/ndarray/base/README.md
+++ b/lib/node_modules/@stdlib/ndarray/base/README.md
@@ -163,10 +163,46 @@ The namespace contains the following sub-namespaces:
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var objectKeys = require( '@stdlib/utils/keys' );
+var Float64Array = require( '@stdlib/array/float64' );
+var linspace = require( '@stdlib/array/linspace' );
+var ddot = require( '@stdlib/blas/base/ddot' );
+var sin = require( '@stdlib/math/base/special/sin' );
+var cos = require( '@stdlib/math/base/special/cos' );
+var PI = require( '@stdlib/constants/float64/pi' );
 var ns = require( '@stdlib/ndarray/base' );
 
-console.log( objectKeys( ns ) );
+var resultData;
+var yStrides;
+var xStrides;
+var xShape;
+var yData;
+var xData;
+var y;
+var x;
+var i;
+
+xData = linspace( 0, 2 * PI, 100 );
+yData = linspace( 0, PI, 100 );
+x = ns.ndarray( 'float64', xData, [ 100 ], [ 1 ], 0, 'row-major' );
+y = ns.ndarray( 'float64', yData, [ 100 ], [ 1 ], 0, 'row-major' );
+
+// Apply sin function to each element of x and cos function to each element of y
+for ( i = 0; i < x.shape[ 0 ]; i++ ) {
+    x.set( i, sin( x.get( i ) ) );
+    y.set( i, cos( y.get( i ) ) );
+}
+
+resultData = new Float64Array( 1 );
+
+xShape = x.shape[ 0 ];
+xStrides = x.strides[ 0 ];
+yStrides = y.strides[ 0 ];
+
+// Calculate dot product of x and y
+resultData[ 0 ] = ddot( xShape, x.data, xStrides, y.data, yStrides );
+
+// Logs 42.00632598024892
+console.log( resultData[ 0 ] );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/ndarray/base/examples/index.js
+++ b/lib/node_modules/@stdlib/ndarray/base/examples/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,7 +18,43 @@
 
 'use strict';
 
-var objectKeys = require( '@stdlib/utils/keys' );
+var Float64Array = require( '@stdlib/array/float64' );
+var linspace = require( '@stdlib/array/linspace' );
+var ddot = require( '@stdlib/blas/base/ddot' );
+var sin = require( '@stdlib/math/base/special/sin' );
+var cos = require( '@stdlib/math/base/special/cos' );
+var PI = require( '@stdlib/constants/float64/pi' );
 var ns = require( './../lib' );
 
-console.log( objectKeys( ns ) );
+var resultData;
+var yStrides;
+var xStrides;
+var xShape;
+var yData;
+var xData;
+var y;
+var x;
+var i;
+
+xData = linspace( 0, 2 * PI, 100 );
+yData = linspace( 0, PI, 100 );
+x = ns.ndarray( 'float64', xData, [ 100 ], [ 1 ], 0, 'row-major' );
+y = ns.ndarray( 'float64', yData, [ 100 ], [ 1 ], 0, 'row-major' );
+
+// Apply sin function to each element of x and cos function to each element of y
+for ( i = 0; i < x.shape[ 0 ]; i++ ) {
+	x.set( i, sin( x.get( i ) ) );
+	y.set( i, cos( y.get( i ) ) );
+}
+
+resultData = new Float64Array( 1 );
+
+xShape = x.shape[ 0 ];
+xStrides = x.strides[ 0 ];
+yStrides = y.strides[ 0 ];
+
+// Calculate dot product of x and y
+resultData[ 0 ] = ddot( xShape, x.data, xStrides, y.data, yStrides );
+
+// Logs 42.00632598024892
+console.log( resultData[ 0 ] );


### PR DESCRIPTION
Updated examples for ndarray/base namespace

Fixes: #1588

Resolves #1588 .

## Description

> What is the purpose of this pull request?
Improve examples in the namespace to demonstrate its functionalities.

This pull request:

-   Uses array, blas, math, ndarray, and constants to perform dot product to the linearly spaced arrays with values ranging from 0-2π for xData and 0-π for yData transformed into sines and cosines respectively.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #1588 
-   fixes #1588 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
