### PR TITLE
feat: add `string/base/last-code-point`

### DIFF
--- a/lib/node_modules/@stdlib/string/base/last-code-point/README.md
+++ b/lib/node_modules/@stdlib/string/base/last-code-point/README.md
@@ -88,13 +88,6 @@ str = lastCodePoint( '六书/六書', 3 );
 
 <section class="related">
 
-* * *
-
-## See Also
-
--   <span class="package-name">[`@stdlib/string/base/first`][@stdlib/string/base/first]</span><span class="delimiter">: </span><span class="description">return the first UTF-16 code unit of a string.</span>
--   <span class="package-name">[`@stdlib/string/base/first-grapheme-cluster`][@stdlib/string/base/first-grapheme-cluster]</span><span class="delimiter">: </span><span class="description">return the first grapheme cluster (i.e., user-perceived character) of a string.</span>
--   <span class="package-name">[`@stdlib/string/first`][@stdlib/string/first]</span><span class="delimiter">: </span><span class="description">return the first character(s) of a string.</span>
 
 </section>
 
@@ -106,11 +99,6 @@ str = lastCodePoint( '六书/六書', 3 );
 
 <!-- <related-links> -->
 
-[@stdlib/string/base/first]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/string/base/first
-
-[@stdlib/string/base/first-grapheme-cluster]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/string/base/first-grapheme-cluster
-
-[@stdlib/string/first]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/string/first
 
 <!-- </related-links> -->
 

--- a/lib/node_modules/@stdlib/string/base/last-code-point/README.md
+++ b/lib/node_modules/@stdlib/string/base/last-code-point/README.md
@@ -1,0 +1,106 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# lastCodePoint
+
+> Return the last `n` Unicode code points of a string.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var lastCodePoint = require( '@stdlib/string/base/last-code-point' );
+```
+
+#### lastCodePoint( str, n )
+
+Returns the last `n` Unicode code points of a string.
+
+```javascript
+var s = lastCodePoint( 'JavaScript', 1 );
+// returns 't'
+
+s = lastCodePoint( 'Hello World', 5 );
+// returns 'World'
+
+s = lastCodePoint( 'Good Evening', 9 );
+// returns 'd Evening'
+
+s = lastCodePoint( 'foo bar', 10 );
+// returns 'foo bar'
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var lastCodePoint = require( '@stdlib/string/base/last-code-point' );
+
+var str = lastCodePoint( 'Hello World', 1 );
+// returns 'd'
+
+str = lastCodePoint( 'JavaScript', 6 );
+// returns 'Script'
+
+str = lastCodePoint( 'index', 10 );
+// returns 'index'
+
+str = lastCodePoint( 'अनुच्छेद', 1 );
+// returns 'द'
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+* * *
+
+## See Also
+
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+<!-- <related-links> -->
+
+
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/string/base/last-code-point/README.md
+++ b/lib/node_modules/@stdlib/string/base/last-code-point/README.md
@@ -75,6 +75,9 @@ str = lastCodePoint( 'index', 10 );
 
 str = lastCodePoint( 'अनुच्छेद', 1 );
 // returns 'द'
+
+str = lastCodePoint( '六书/六書', 3 );
+// returns '/六書'
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/string/base/last-code-point/README.md
+++ b/lib/node_modules/@stdlib/string/base/last-code-point/README.md
@@ -67,6 +67,9 @@ var str = lastCodePoint( 'Hello World', 1 );
 str = lastCodePoint( 'JavaScript', 6 );
 // returns 'Script'
 
+str = lastCodePoint( 'ASCII', 2 );
+// returns 'II'
+
 str = lastCodePoint( 'index', 10 );
 // returns 'index'
 

--- a/lib/node_modules/@stdlib/string/base/last-code-point/README.md
+++ b/lib/node_modules/@stdlib/string/base/last-code-point/README.md
@@ -106,7 +106,11 @@ str = lastCodePoint( '六书/六書', 3 );
 
 <!-- <related-links> -->
 
+[@stdlib/string/base/first]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/string/base/first
 
+[@stdlib/string/base/first-grapheme-cluster]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/string/base/first-grapheme-cluster
+
+[@stdlib/string/first]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/string/first
 
 <!-- </related-links> -->
 

--- a/lib/node_modules/@stdlib/string/base/last-code-point/README.md
+++ b/lib/node_modules/@stdlib/string/base/last-code-point/README.md
@@ -92,6 +92,9 @@ str = lastCodePoint( '六书/六書', 3 );
 
 ## See Also
 
+-   <span class="package-name">[`@stdlib/string/base/first`][@stdlib/string/base/first]</span><span class="delimiter">: </span><span class="description">return the first UTF-16 code unit of a string.</span>
+-   <span class="package-name">[`@stdlib/string/base/first-grapheme-cluster`][@stdlib/string/base/first-grapheme-cluster]</span><span class="delimiter">: </span><span class="description">return the first grapheme cluster (i.e., user-perceived character) of a string.</span>
+-   <span class="package-name">[`@stdlib/string/first`][@stdlib/string/first]</span><span class="delimiter">: </span><span class="description">return the first character(s) of a string.</span>
 
 </section>
 

--- a/lib/node_modules/@stdlib/string/base/last-code-point/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/string/base/last-code-point/benchmark/benchmark.js
@@ -1,0 +1,60 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
+var pkg = require( './../package.json' ).name;
+var lastCodePoint = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var values;
+	var out;
+	var i;
+
+	values = [
+		'hello world',
+		'new',
+		'JavaScript',
+		'beep boop',
+		'foo bar',
+		'xyz abc',
+		'🐶🐮🐷🐰🐸',
+		'अनुच्छेद'
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = lastCodePoint( values[ i%values.length ], 1 );
+		if ( typeof out !== 'string' ) {
+			b.fail( 'should return a string' );
+		}
+	}
+	b.toc();
+	if ( !isString( out ) ) {
+		b.fail( 'should return a string' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/string/base/last-code-point/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/string/base/last-code-point/benchmark/benchmark.js
@@ -23,7 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
 var pkg = require( './../package.json' ).name;
-var lastCodePoint = require( './../lib' );
+var last = require( './../lib' );
 
 
 // MAIN //
@@ -46,7 +46,7 @@ bench( pkg, function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		out = lastCodePoint( values[ i%values.length ], 1 );
+		out = last( values[ i%values.length ], 1 );
 		if ( typeof out !== 'string' ) {
 			b.fail( 'should return a string' );
 		}

--- a/lib/node_modules/@stdlib/string/base/last-code-point/docs/repl.txt
+++ b/lib/node_modules/@stdlib/string/base/last-code-point/docs/repl.txt
@@ -1,0 +1,29 @@
+
+{{alias}}( str, n )
+    Returns the last `n` Unicode code points of a string.
+
+    Parameters
+    ----------
+    str: string
+        Input string.
+
+    n: integer
+        Number of Unicode code points to return.
+
+    Returns
+    -------
+    out: string
+        Output string.
+
+    Examples
+    --------
+    > var out = {{alias}}( 'hello world', 1 )
+    'd'
+    > out = {{alias}}( 'JavaScript', 6 )
+    'Script'
+    > out = {{alias}}( 'अनुच्छेद', 1 )
+    'द'
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/string/base/last-code-point/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/base/last-code-point/docs/types/index.d.ts
@@ -1,0 +1,50 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Returns the last `n` Unicode code points of a string.
+*
+* @param str - input string
+* @param n - number of code points to return
+* @returns output string
+*
+* @example
+* var out = lastCodePoint( 'Hello World', 1 );
+* // returns 'd'
+*
+* @example
+* var out = lastCodePoint( 'JavaScript', 6 );
+* // returns 'Script'
+*
+* @example
+* var out = lastCodePoint( 'New', 5 );
+* // returns 'New'
+*
+* @example
+* var out = lastCodePoint( 'अनुच्छेद', 1 );
+* // returns 'द'
+*
+*/
+declare function lastCodePoint( str: string, n: number ): string;
+
+
+// EXPORTS //
+
+export = lastCodePoint;

--- a/lib/node_modules/@stdlib/string/base/last-code-point/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/base/last-code-point/docs/types/index.d.ts
@@ -40,7 +40,6 @@
 * @example
 * var out = lastCodePoint( 'अनुच्छेद', 1 );
 * // returns 'द'
-*
 */
 declare function lastCodePoint( str: string, n: number ): string;
 

--- a/lib/node_modules/@stdlib/string/base/last-code-point/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/base/last-code-point/docs/types/index.d.ts
@@ -26,24 +26,24 @@
 * @returns output string
 *
 * @example
-* var out = lastCodePoint( 'Hello World', 1 );
+* var out = last( 'Hello World', 1 );
 * // returns 'd'
 *
 * @example
-* var out = lastCodePoint( 'JavaScript', 6 );
+* var out = last( 'JavaScript', 6 );
 * // returns 'Script'
 *
 * @example
-* var out = lastCodePoint( 'New', 5 );
+* var out = last( 'New', 5 );
 * // returns 'New'
 *
 * @example
-* var out = lastCodePoint( 'अनुच्छेद', 1 );
+* var out = last( 'अनुच्छेद', 1 );
 * // returns 'द'
 */
-declare function lastCodePoint( str: string, n: number ): string;
+declare function last( str: string, n: number ): string;
 
 
 // EXPORTS //
 
-export = lastCodePoint;
+export = last;

--- a/lib/node_modules/@stdlib/string/base/last-code-point/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/string/base/last-code-point/docs/types/test.ts
@@ -16,42 +16,42 @@
 * limitations under the License.
 */
 
-import lastCodePoint = require( './index' );
+import last = require( './index' );
 
 
 // TESTS //
 
 // The function returns a string...
 {
-	lastCodePoint( 'abc', 1 ); // $ExpectType string
+	last( 'abc', 1 ); // $ExpectType string
 }
 
 // The compiler throws an error if the function is provided a value other than a string...
 {
-	lastCodePoint( true, 1 ); // $ExpectError
-	lastCodePoint( false, 1 ); // $ExpectError
-	lastCodePoint( null, 1 ); // $ExpectError
-	lastCodePoint( undefined, 1 ); // $ExpectError
-	lastCodePoint( 5, 1 ); // $ExpectError
-	lastCodePoint( [], 1 ); // $ExpectError
-	lastCodePoint( {}, 1 ); // $ExpectError
-	lastCodePoint( ( x: number ): number => x, 1 ); // $ExpectError
+	last( true, 1 ); // $ExpectError
+	last( false, 1 ); // $ExpectError
+	last( null, 1 ); // $ExpectError
+	last( undefined, 1 ); // $ExpectError
+	last( 5, 1 ); // $ExpectError
+	last( [], 1 ); // $ExpectError
+	last( {}, 1 ); // $ExpectError
+	last( ( x: number ): number => x, 1 ); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided a second argument that is not a number...
 {
-	lastCodePoint( 'abc', true ); // $ExpectError
-	lastCodePoint( 'abc', false ); // $ExpectError
-	lastCodePoint( 'abc', null ); // $ExpectError
-	lastCodePoint( 'abc', 'abc' ); // $ExpectError
-	lastCodePoint( 'abc', [] ); // $ExpectError
-	lastCodePoint( 'abc', {} ); // $ExpectError
-	lastCodePoint( 'abc', ( x: number ): number => x ); // $ExpectError
+	last( 'abc', true ); // $ExpectError
+	last( 'abc', false ); // $ExpectError
+	last( 'abc', null ); // $ExpectError
+	last( 'abc', 'abc' ); // $ExpectError
+	last( 'abc', [] ); // $ExpectError
+	last( 'abc', {} ); // $ExpectError
+	last( 'abc', ( x: number ): number => x ); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided an unsupported number of arguments...
 {
-	lastCodePoint(); // $ExpectError
-	lastCodePoint( 'abc' ); // $ExpectError
-	lastCodePoint( 'abc', 1, 2 ); // $ExpectError
+	last(); // $ExpectError
+	last( 'abc' ); // $ExpectError
+	last( 'abc', 1, 2 ); // $ExpectError
 }

--- a/lib/node_modules/@stdlib/string/base/last-code-point/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/string/base/last-code-point/docs/types/test.ts
@@ -1,0 +1,57 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import lastCodePoint = require( './index' );
+
+
+// TESTS //
+
+// The function returns a string...
+{
+	lastCodePoint( 'abc', 1 ); // $ExpectType string
+}
+
+// The compiler throws an error if the function is provided a value other than a string...
+{
+	lastCodePoint( true, 1 ); // $ExpectError
+	lastCodePoint( false, 1 ); // $ExpectError
+	lastCodePoint( null, 1 ); // $ExpectError
+	lastCodePoint( undefined, 1 ); // $ExpectError
+	lastCodePoint( 5, 1 ); // $ExpectError
+	lastCodePoint( [], 1 ); // $ExpectError
+	lastCodePoint( {}, 1 ); // $ExpectError
+	lastCodePoint( ( x: number ): number => x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument that is not a number...
+{
+	lastCodePoint( 'abc', true ); // $ExpectError
+	lastCodePoint( 'abc', false ); // $ExpectError
+	lastCodePoint( 'abc', null ); // $ExpectError
+	lastCodePoint( 'abc', 'abc' ); // $ExpectError
+	lastCodePoint( 'abc', [] ); // $ExpectError
+	lastCodePoint( 'abc', {} ); // $ExpectError
+	lastCodePoint( 'abc', ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	lastCodePoint(); // $ExpectError
+	lastCodePoint( 'abc' ); // $ExpectError
+	lastCodePoint( 'abc', 1, 2 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/string/base/last-code-point/examples/index.js
+++ b/lib/node_modules/@stdlib/string/base/last-code-point/examples/index.js
@@ -18,7 +18,7 @@
 
 'use strict';
 
-var lastCodePoint = require( '@stdlib/string/base/last-code-point' );
+var lastCodePoint = require( './../lib' );
 
 console.log( lastCodePoint( 'Hello World', 1 ) );
 // => 'd'

--- a/lib/node_modules/@stdlib/string/base/last-code-point/examples/index.js
+++ b/lib/node_modules/@stdlib/string/base/last-code-point/examples/index.js
@@ -1,0 +1,36 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var lastCodePoint = require( '@stdlib/string/base/last-code-point' );
+
+console.log( lastCodePoint( 'Hello World', 1 ) );
+// => 'd'
+
+console.log( lastCodePoint( 'JavaScript', 6 ) );
+// => 'Script'
+
+console.log( lastCodePoint( 'index', 10 ) );
+// => 'index'
+
+console.log( lastCodePoint( 'अनुच्छेद', 1 ) );
+// => 'द'
+
+console.log( lastCodePoint( '六书/六書', 3 ) );
+// => '/六書'

--- a/lib/node_modules/@stdlib/string/base/last-code-point/lib/index.js
+++ b/lib/node_modules/@stdlib/string/base/last-code-point/lib/index.js
@@ -24,12 +24,12 @@
 * @module @stdlib/string/base/last-code-point
 *
 * @example
-* var lastCodePoint = require( '@stdlib/string/base/last-code-point' );
+* var last = require( '@stdlib/string/base/last-code-point' );
 *
-* var out = lastCodePoint( 'Hello World', 1 );
+* var out = last( 'Hello World', 1 );
 * // returns 'd'
 *
-* out = lastCodePoint( 'अनुच्छेद', 1 );
+* out = last( 'अनुच्छेद', 1 );
 * // returns 'द';
 */
 

--- a/lib/node_modules/@stdlib/string/base/last-code-point/lib/index.js
+++ b/lib/node_modules/@stdlib/string/base/last-code-point/lib/index.js
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Return the last `n` Unicode code points of a string.
+*
+* @module @stdlib/string/base/last-code-point
+*
+* @example
+* var lastCodePoint = require( '@stdlib/string/base/last-code-point' );
+*
+* var out = lastCodePoint( 'Hello World', 1 );
+* // returns 'd'
+*
+* out = lastCodePoint( 'अनुच्छेद', 1 );
+* // returns 'द';
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/string/base/last-code-point/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/last-code-point/lib/main.js
@@ -39,19 +39,18 @@ var RE_UTF16_HIGH_SURROGATE = /[\uD800-\uDBFF]/; // TODO: replace with stdlib pk
 * @returns {string} output string
 *
 * @example
-* var out = lastCodePoint( 'Hello World', 1 );
+* var out = last( 'Hello World', 1 );
 * // returns 'd'
 *
 * @example
-* var out = lastCodePoint( 'ASCII', 2 );
+* var out = last( 'ASCII', 2 );
 * // returns 'II'
 *
 * @example
-* var out = lastCodePoint( 'JavaScript', 6 );
+* var out = last( 'JavaScript', 6 );
 * // returns 'Script'
-*
 */
-function lastCodePoint( str, n ) {
+function last( str, n ) {
 	var len;
 	var out;
 	var ch1;
@@ -71,21 +70,29 @@ function lastCodePoint( str, n ) {
 		}
 		return str[1];
 	}
+
+	// Process the string backwards one Unicode code unit at a time and count UTF-16 surrogate pairs as a single Unicode code point...
 	for ( i = len-1; i >= 0; i-- ) {
 		ch1 = str[ i ];
 		out = ch1 + out;
 		cnt += 1;
 
+		// Check for a low UTF-16 surrogate...
 		if ( RE_UTF16_LOW_SURROGATE.test( ch1 ) ) {
+			// Check for an unpaired surrogate at the start of the input string...
 			if ( i === 0 ) {
+				// We found an unpaired surrogate...
 				break;
 			}
-			ch2 = str[ i+1 ];
+			// Check whether the low surrogate is paired with a high surrogate...
+			ch2 = str[ i-1 ];
 			if ( RE_UTF16_HIGH_SURROGATE.test( ch2 ) ) {
+				// We found a surrogate pair:
 				out += ch2;
-				i -= 1;
+				i -= 1; // decrement the index to process the next code unit
 			}
 		}
+		// Check whether we've found the desired number of code points...
 		if ( cnt === n ) {
 			break;
 		}
@@ -96,4 +103,4 @@ function lastCodePoint( str, n ) {
 
 // EXPORTS //
 
-module.exports = lastCodePoint;
+module.exports = last;

--- a/lib/node_modules/@stdlib/string/base/last-code-point/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/last-code-point/lib/main.js
@@ -88,7 +88,7 @@ function last( str, n ) {
 			ch2 = str[ i-1 ];
 			if ( RE_UTF16_HIGH_SURROGATE.test( ch2 ) ) {
 				// We found a surrogate pair:
-				out += ch2;
+				out = ch2 + out;
 				i -= 1; // decrement the index to process the next code unit
 			}
 		}

--- a/lib/node_modules/@stdlib/string/base/last-code-point/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/last-code-point/lib/main.js
@@ -1,0 +1,99 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var RE_UTF16_SURROGATE_PAIR = require( '@stdlib/regexp/utf16-surrogate-pair' ).REGEXP;
+
+
+// VARIABLES //
+
+var RE_UTF16_LOW_SURROGATE = /[\uDC00-\uDFFF]/; // TODO: replace with stdlib pkg
+var RE_UTF16_HIGH_SURROGATE = /[\uD800-\uDBFF]/; // TODO: replace with stdlib pkg
+
+
+// MAIN //
+
+/**
+* Returns the last `n` Unicode code points of a string.
+*
+* @param {string} str - input string
+* @param {NonNegativeInteger} n - number of Unicode code points to return
+* @returns {string} output string
+*
+* @example
+* var out = lastCodePoint( 'Hello World', 1 );
+* // returns 'd'
+*
+* @example
+* var out = lastCodePoint( 'ASCII', 2 );
+* // returns 'II'
+*
+* @example
+* var out = lastCodePoint( 'JavaScript', 6 );
+* // returns 'Script'
+*
+*/
+function lastCodePoint( str, n ) {
+	var len;
+	var out;
+	var ch1;
+	var ch2;
+	var cnt;
+	var i;
+	len = str.length;
+	out = '';
+	cnt = 0;
+	if ( str === '' || n === 0 ) {
+		return '';
+	}
+	if ( n === 1 ) {
+		str = str.substring( len-2, len );
+		if ( RE_UTF16_SURROGATE_PAIR.test( str ) ) {
+			return str;
+		}
+		return str[1];
+	}
+	for ( i = len-1; i >= 0; i-- ) {
+		ch1 = str[ i ];
+		out = ch1 + out;
+		cnt += 1;
+
+		if ( RE_UTF16_LOW_SURROGATE.test( ch1 ) ) {
+			if ( i === 0 ) {
+				break;
+			}
+			ch2 = str[ i+1 ];
+			if ( RE_UTF16_HIGH_SURROGATE.test( ch2 ) ) {
+				out += ch2;
+				i -= 1;
+			}
+		}
+		if ( cnt === n ) {
+			break;
+		}
+	}
+	return out;
+}
+
+
+// EXPORTS //
+
+module.exports = lastCodePoint;

--- a/lib/node_modules/@stdlib/string/base/last-code-point/package.json
+++ b/lib/node_modules/@stdlib/string/base/last-code-point/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@stdlib/string/base/last-code-point",
+  "version": "0.0.0",
+  "description": "Return the last Unicode code point of a string.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdstring",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "string",
+    "str",
+    "base",
+    "last",
+    "character",
+    "char",
+    "codepoint",
+    "unicode"
+  ]
+}

--- a/lib/node_modules/@stdlib/string/base/last-code-point/test/test.js
+++ b/lib/node_modules/@stdlib/string/base/last-code-point/test/test.js
@@ -21,39 +21,39 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var lastCodePoint = require( './../lib' );
+var last = require( './../lib' );
 
 
 // TESTS //
 
 tape( 'main export is a function', function test( t ) {
 	t.ok( true, __filename );
-	t.strictEqual( typeof lastCodePoint, 'function', 'main export is a function' );
+	t.strictEqual( typeof last, 'function', 'main export is a function' );
 	t.end();
 });
 
 tape( 'the function returns an empty string if provided an empty string', function test( t ) {
-	t.strictEqual( lastCodePoint( '', 1 ), '', 'returns expected value' );
-	t.strictEqual( lastCodePoint( '', 2 ), '', 'returns expected value' );
-	t.strictEqual( lastCodePoint( '', 3 ), '', 'returns expected value' );
+	t.strictEqual( last( '', 1 ), '', 'returns expected value' );
+	t.strictEqual( last( '', 2 ), '', 'returns expected value' );
+	t.strictEqual( last( '', 3 ), '', 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns an empty string if provided zero as the second argument', function test( t ) {
-	t.strictEqual( lastCodePoint( 'hello world', 0 ), '', 'returns expected value' );
+	t.strictEqual( last( 'hello world', 0 ), '', 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns the last Unicode code point of a provided string (ascii)', function test( t ) {
 	var out;
 
-	out = lastCodePoint( 'hello world', 1 );
+	out = last( 'hello world', 1 );
 	t.strictEqual( out, 'd', 'returns expected value' );
 
-	out = lastCodePoint( '!!!', 1 );
+	out = last( '!!!', 1 );
 	t.strictEqual( out, '!', 'returns expected value' );
 
-	out = lastCodePoint( 'JavaScript', 6 );
+	out = last( 'JavaScript', 6 );
 	t.strictEqual( out, 'Script', 'returns expected value' );
 
 	t.end();
@@ -62,10 +62,10 @@ tape( 'the function returns the last Unicode code point of a provided string (as
 tape( 'the function returns the last Unicode code point of a provided string (Unicode)', function test( t ) {
 	var out;
 
-	out = lastCodePoint( 'अनुच्छेद', 1 );
+	out = last( 'अनुच्छेद', 1 );
 	t.strictEqual( out, 'द', 'returns expected value' );
 
-	out = lastCodePoint( '六书/六書', 1 );
+	out = last( '六书/六書', 1 );
 	t.strictEqual( out, '書', 'returns expected value' );
 
 	t.end();
@@ -74,31 +74,31 @@ tape( 'the function returns the last Unicode code point of a provided string (Un
 tape( 'the function supports returning the last `n` Unicode code points of a provided string', function test( t ) {
 	var out;
 
-	out = lastCodePoint( 'hello world', 1 );
+	out = last( 'hello world', 1 );
 	t.strictEqual( out, 'd', 'returns expected value' );
 
-	out = lastCodePoint( 'hello world', 7 );
+	out = last( 'hello world', 7 );
 	t.strictEqual( out, 'o world', 'returns expected value' );
 
-	out = lastCodePoint( '!!!', 2 );
+	out = last( '!!!', 2 );
 	t.strictEqual( out, '!!', 'returns expected value' );
 
-	out = lastCodePoint( '六书/六書', 3 );
+	out = last( '六书/六書', 3 );
 	t.strictEqual( out, '/六書', 'returns expected value' );
 
-	out = lastCodePoint( '六书/六書', 5 );
+	out = last( '六书/六書', 5 );
 	t.strictEqual( out, '六书/六書', 'returns expected value' );
 
-	out = lastCodePoint( '六书/六書', 10 );
+	out = last( '六书/六書', 10 );
 	t.strictEqual( out, '六书/六書', 'returns expected value' );
 
-	out = lastCodePoint( 'hello六书/六書', 6 );
+	out = last( 'hello六书/六書', 6 );
 	t.strictEqual( out, 'o六书/六書', 'returns expected value' );
 
-	out = lastCodePoint( 'hello六书/六書', 10 );
+	out = last( 'hello六书/六書', 10 );
 	t.strictEqual( out, 'hello六书/六書', 'returns expected value' );
 
-	out = lastCodePoint( '六书/hello六書', 15 );
+	out = last( '六书/hello六書', 15 );
 	t.strictEqual( out, '六书/hello六書', 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/string/base/last-code-point/test/test.js
+++ b/lib/node_modules/@stdlib/string/base/last-code-point/test/test.js
@@ -1,0 +1,105 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var lastCodePoint = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof lastCodePoint, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns an empty string if provided an empty string', function test( t ) {
+	t.strictEqual( lastCodePoint( '', 1 ), '', 'returns expected value' );
+	t.strictEqual( lastCodePoint( '', 2 ), '', 'returns expected value' );
+	t.strictEqual( lastCodePoint( '', 3 ), '', 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns an empty string if provided zero as the second argument', function test( t ) {
+	t.strictEqual( lastCodePoint( 'hello world', 0 ), '', 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns the last Unicode code point of a provided string (ascii)', function test( t ) {
+	var out;
+
+	out = lastCodePoint( 'hello world', 1 );
+	t.strictEqual( out, 'd', 'returns expected value' );
+
+	out = lastCodePoint( '!!!', 1 );
+	t.strictEqual( out, '!', 'returns expected value' );
+
+	out = lastCodePoint( 'JavaScript', 6 );
+	t.strictEqual( out, 'Script', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns the last Unicode code point of a provided string (Unicode)', function test( t ) {
+	var out;
+
+	out = lastCodePoint( 'अनुच्छेद', 1 );
+	t.strictEqual( out, 'द', 'returns expected value' );
+
+	out = lastCodePoint( '六书/六書', 1 );
+	t.strictEqual( out, '書', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports returning the last `n` Unicode code points of a provided string', function test( t ) {
+	var out;
+
+	out = lastCodePoint( 'hello world', 1 );
+	t.strictEqual( out, 'd', 'returns expected value' );
+
+	out = lastCodePoint( 'hello world', 7 );
+	t.strictEqual( out, 'o world', 'returns expected value' );
+
+	out = lastCodePoint( '!!!', 2 );
+	t.strictEqual( out, '!!', 'returns expected value' );
+
+	out = lastCodePoint( '六书/六書', 3 );
+	t.strictEqual( out, '/六書', 'returns expected value' );
+
+	out = lastCodePoint( '六书/六書', 5 );
+	t.strictEqual( out, '六书/六書', 'returns expected value' );
+
+	out = lastCodePoint( '六书/六書', 10 );
+	t.strictEqual( out, '六书/六書', 'returns expected value' );
+
+	out = lastCodePoint( 'hello六书/六書', 6 );
+	t.strictEqual( out, 'o六书/六書', 'returns expected value' );
+
+	out = lastCodePoint( 'hello六书/六書', 10 );
+	t.strictEqual( out, 'hello六书/六書', 'returns expected value' );
+
+	out = lastCodePoint( '六书/hello六書', 15 );
+	t.strictEqual( out, '六书/hello六書', 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/string/base/last-code-point/test/test.js
+++ b/lib/node_modules/@stdlib/string/base/last-code-point/test/test.js
@@ -101,5 +101,17 @@ tape( 'the function supports returning the last `n` Unicode code points of a pro
 	out = last( '六书/hello六書', 15 );
 	t.strictEqual( out, '六书/hello六書', 'returns expected value' );
 
+	out = last( '😄', 1 );
+	t.strictEqual( out, '😄', 'returns expected value' );
+
+	out = last( '👍', 1 );
+	t.strictEqual( out, '👍', 'returns expected value' );
+
+	out = last( 'abc😄def', 4 );
+	t.strictEqual( out, '😄def', 'returns expected value' );
+
+	out = last( '😄😄😄', 2 );
+	t.strictEqual( out, '😄😄', 'returns expected value' );
+
 	t.end();
 });


### PR DESCRIPTION
Resolves #1702 

## Description

> What is the purpose of this pull request?

This PR adds the package `@stdlib/string/base/last-code-point`

This pull request:

-   Adds the package `@stdlib/string/base/last-code-point`  which returns the last n Unicode code points of a string.

## Related Issues

> Does this pull request have any related issues?

#854 

This pull request:

-   resolves #1702 


## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
