### PR TITLE
feat: add c implementation for `math/base/assert/is-negative-finite`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/README.md
@@ -160,7 +160,7 @@ int main( void ) {
     int i;
     for ( i = 0; i < 6; i++ ) {
         b = stdlib_base_is_negative_finite( x[ i ] );
-        printf( "x = %lf, is_negative_finite(x) = %s\n", x, ( b ) ? "True" : "False" );
+        printf( "x = %lf, is_negative_finite(x) = %s\n", x[ i ], ( b ) ? "True" : "False" );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/README.md
@@ -160,7 +160,7 @@ int main( void ) {
     int i;
     for ( i = 0; i < 6; i++ ) {
         b = stdlib_base_is_negative_finite( x[ i ] );
-        printf( "x = %lf, is_negative_finite(x) = %s\n", x, ( v ) ? "True" : "False" );
+        printf( "x = %lf, is_negative_finite(x) = %s\n", x, ( b ) ? "True" : "False" );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/README.md
@@ -81,6 +81,97 @@ bool = isNegativeFinite( NaN );
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/math/base/assert/is_negative_finite.h"
+```
+
+#### stdlib_base_is_negative_finite( x )
+
+Tests if a double-precision floating-point numeric value is a negative finite number.
+
+```c
+bool out = stdlib_base_is_negative_finite( 1.0 );
+// returns false
+
+out = stdlib_base_is_negative_finite( -4.0 );
+// returns true
+```
+
+The function accepts the following arguments:
+
+-   **x**: `[in] double` input value.
+
+```c
+bool stdlib_base_is_negative_finite( const double x );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/math/base/assert/is_negative_finite.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+int main( void ) {
+    double x;
+    bool v;
+    int i;
+    
+    for ( i = 0; i < 100; i++ ) {
+        x = ( ( (double)rand() / (double)RAND_MAX ) * 100.0 );
+        v = stdlib_base_is_negative_finite( x );
+        printf( "x = %lf, is_negative_finite(x) = %s\n", x, ( v ) ? "True" : "False" );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/README.md
@@ -112,6 +112,8 @@ bool = isNegativeFinite( NaN );
 Tests if a double-precision floating-point numeric value is a negative finite number.
 
 ```c
+#include <stdbool.h>
+
 bool out = stdlib_base_is_negative_finite( 1.0 );
 // returns false
 
@@ -147,18 +149,17 @@ bool stdlib_base_is_negative_finite( const double x );
 
 ```c
 #include "stdlib/math/base/assert/is_negative_finite.h"
+#include "stdlib/constants/float64/ninf.h"
 #include <stdio.h>
-#include <stdlib.h>
 #include <stdbool.h>
 
 int main( void ) {
-    double x;
-    bool v;
+    const double x[] = { 5.0, -5.0, 3.14, -3.14, 0.0/0.0, STDLIB_CONSTANT_FLOAT64_NINF };
+
+    bool b;
     int i;
-    
-    for ( i = 0; i < 100; i++ ) {
-        x = ( ( (double)rand() / (double)RAND_MAX ) * 100.0 );
-        v = stdlib_base_is_negative_finite( x );
+    for ( i = 0; i < 6; i++ ) {
+        b = stdlib_base_is_negative_finite( x[ i ] );
         printf( "x = %lf, is_negative_finite(x) = %s\n", x, ( v ) ? "True" : "False" );
     }
 }

--- a/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/benchmark/benchmark.native.js
@@ -45,7 +45,7 @@ bench( pkg, opts, function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = (randu()*200.0) - 100.0;
+		x = ( randu()*200.0 ) - 100.0;
 		y = isNegativeFinite( x );
 		if ( typeof y !== 'boolean' ) {
 			b.fail( 'should return a boolean' );

--- a/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/benchmark/benchmark.native.js
@@ -1,0 +1,60 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var isNegativeFinite = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( isNegativeFinite instanceof Error )
+};
+
+
+// MAIN //
+
+bench( pkg, opts, function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		x = (randu()*200.0) - 100.0;
+		y = isNegativeFinite( x );
+		if ( typeof y !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( y ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/benchmark/c/native/Makefile
+++ b/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/benchmark/c/native/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/benchmark/c/native/benchmark.c
@@ -1,0 +1,137 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/**
+* Benchmark `is-negative-finite`.
+*/
+#include "stdlib/math/base/assert/is_negative_finite.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "is-negative-finite"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+void print_version() {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+double tic() {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1].
+*
+* @return random number
+*/
+double rand_double() {
+	int r = rand();
+	return (double)r / ( (double)RAND_MAX + 1.0 );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+double benchmark() {
+	double elapsed;
+	double x;
+	double t;
+	bool b;
+	int i;
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		x = ( rand_double() * 200.0 ) - 100.0;
+		b = stdlib_base_is_negative_finite( x );
+		if ( b != true && b != false ) {
+			printf( "should return either true or false\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( b != true && b != false ) {
+		printf( "should return either true or false\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::native::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/binding.gyp
+++ b/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/examples/c/example.c
@@ -1,0 +1,34 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/assert/is_negative_finite.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+int main( void ) {
+	double x;
+	bool v;
+	int i;
+
+	for ( i = 0; i < 100; i++ ) {
+		x = ( ( (double)rand() / (double)RAND_MAX ) * 100.0 );
+		v = stdlib_base_is_negative_finite( x );
+		printf( "x = %lf, is_negative_finite(x) = %s\n", x, ( v ) ? "True" : "False" );
+	}
+}

--- a/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/examples/c/example.c
@@ -17,18 +17,16 @@
 */
 
 #include "stdlib/math/base/assert/is_negative_finite.h"
+#include "stdlib/constants/float64/ninf.h"
 #include <stdio.h>
-#include <stdlib.h>
 #include <stdbool.h>
 
 int main( void ) {
-	double x;
-	bool v;
+	const double x[] = { 5.0, -5.0, 3.14, -3.14, 0.0/0.0, STDLIB_CONSTANT_FLOAT64_NINF };
+	bool b;
 	int i;
-
-	for ( i = 0; i < 100; i++ ) {
-		x = ( ( (double)rand() / (double)RAND_MAX ) * 100.0 );
-		v = stdlib_base_is_negative_finite( x );
+	for ( i = 0; i < 6; i++ ) {
+		b = stdlib_base_is_negative_finite( x[ i ] );
 		printf( "x = %lf, is_negative_finite(x) = %s\n", x, ( v ) ? "True" : "False" );
 	}
 }

--- a/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/examples/c/example.c
@@ -28,6 +28,6 @@ int main( void ) {
 	int i;
 	for ( i = 0; i < 6; i++ ) {
 		b = stdlib_base_is_negative_finite( x[ i ] );
-		printf( "x = %lf, is_negative_finite(x) = %s\n", x, ( b ) ? "True" : "False" );
+		printf( "x = %lf, is_negative_finite(x) = %s\n", x[ i ], ( b ) ? "True" : "False" );
 	}
 }

--- a/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/examples/c/example.c
@@ -23,10 +23,11 @@
 
 int main( void ) {
 	const double x[] = { 5.0, -5.0, 3.14, -3.14, 0.0/0.0, STDLIB_CONSTANT_FLOAT64_NINF };
+
 	bool b;
 	int i;
 	for ( i = 0; i < 6; i++ ) {
 		b = stdlib_base_is_negative_finite( x[ i ] );
-		printf( "x = %lf, is_negative_finite(x) = %s\n", x, ( v ) ? "True" : "False" );
+		printf( "x = %lf, is_negative_finite(x) = %s\n", x, ( b ) ? "True" : "False" );
 	}
 }

--- a/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/include.gypi
+++ b/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/include/stdlib/math/base/assert/is_negative_finite.h
+++ b/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/include/stdlib/math/base/assert/is_negative_finite.h
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_MATH_BASE_ASSERT_IS_NEGATIVE_FINITE_H
+#define STDLIB_MATH_BASE_ASSERT_IS_NEGATIVE_FINITE_H
+
+#include <stdbool.h>
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Tests if a double-precision floating-point numeric value is a negative finite number.
+*/
+bool stdlib_base_is_negative_finite( const double x );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_MATH_BASE_ASSERT_IS_NEGATIVE_FINITE_H

--- a/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/lib/native.js
@@ -1,0 +1,51 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var Boolean = require( '@stdlib/boolean/ctor' );
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Tests if a double-precision floating-point numeric value is a negative finite number.
+*
+* @private
+* @param {number} x - value to test
+* @returns {boolean} boolean indicating whether the number is negative finite
+*
+* @example
+* var bool = isNegativeFinite( -2.0 );
+* // returns true
+*
+* @example
+* var bool = isNegativeFinite( 5.0 );
+* // returns false
+*/
+function isNegativeFinite( x ) {
+	return Boolean( addon( x ) );
+}
+
+
+// EXPORTS //
+
+module.exports = isNegativeFinite;

--- a/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/manifest.json
@@ -1,0 +1,40 @@
+{
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/constants/float64/ninf"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/src/addon.c
@@ -1,0 +1,90 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/assert/is_negative_finite.h"
+#include <node_api.h>
+#include <stdint.h>
+#include <assert.h>
+
+/**
+* Receives JavaScript callback invocation data.
+*
+* @private
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @return       Node-API value
+*/
+static napi_value addon( napi_env env, napi_callback_info info ) {
+	napi_status status;
+
+	// Get callback arguments:
+	size_t argc = 1;
+	napi_value argv[ 1 ];
+	status = napi_get_cb_info( env, info, &argc, argv, NULL, NULL );
+	assert( status == napi_ok );
+
+	// Check whether we were provided the correct number of arguments:
+	if ( argc < 1 ) {
+		status = napi_throw_error( env, NULL, "invalid invocation. Insufficient arguments." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+	if ( argc > 1 ) {
+		status = napi_throw_error( env, NULL, "invalid invocation. Too many arguments." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	napi_valuetype vtype0;
+	status = napi_typeof( env, argv[ 0 ], &vtype0 );
+	assert( status == napi_ok );
+	if ( vtype0 != napi_number ) {
+		status = napi_throw_type_error( env, NULL, "invalid argument. First argument must be a number." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	double x;
+	status = napi_get_value_double( env, argv[ 0 ], &x );
+	assert( status == napi_ok );
+
+	bool result = stdlib_base_is_negative_finite( x );
+
+	napi_value v;
+	status = napi_create_int32( env, (int32_t)result, &v );
+	assert( status == napi_ok );
+
+	return v;
+}
+
+/**
+* Initializes a Node-API module.
+*
+* @private
+* @param env      environment under which the function is invoked
+* @param exports  exports object
+* @return         main export
+*/
+static napi_value init( napi_env env, napi_value exports ) {
+	napi_value fcn;
+	napi_status status = napi_create_function( env, "exports", NAPI_AUTO_LENGTH, addon, NULL, &fcn );
+	assert( status == napi_ok );
+	return fcn;
+}
+
+NAPI_MODULE( NODE_GYP_MODULE_NAME, init )

--- a/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/src/main.c
@@ -1,0 +1,36 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/assert/is_negative_finite.h"
+#include "stdlib/constants/float64/ninf.h"
+
+/**
+* Tests if a double-precision floating-point numeric value is a negative finite number.
+*
+* @param x    input value
+* @return	  output value
+*
+* @example
+* #include <stdbool.h>
+*
+* bool out = stdlib_base_is_negative_finite( 3.0 );
+* // returns false
+*/
+bool stdlib_base_is_negative_finite( const double x ) {
+	return ( x < 0.0 && x > STDLIB_CONSTANT_FLOAT64_NINF );
+}

--- a/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-negative-finite/test/test.native.js
@@ -1,0 +1,66 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var isNegativeFinite = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( isNegativeFinite instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof isNegativeFinite, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `true` if provided a negative finite number', opts, function test( t ) {
+	t.equal( isNegativeFinite( -3.14 ), true, 'returns true' );
+	t.equal( isNegativeFinite( -1.0e308 ), true, 'returns true' );
+	t.end();
+});
+
+tape( 'the function returns `false` if not provided a negative finite number', opts, function test( t ) {
+	t.equal( isNegativeFinite( 2.0 ), false, 'returns false' );
+	t.equal( isNegativeFinite( 0.0 ), false, 'returns false' );
+	t.equal( isNegativeFinite( -0.0 ), false, 'returns false' );
+	t.end();
+});
+
+tape( 'the function returns `false` if provided `-infinity`', opts, function test( t ) {
+	t.equal( isNegativeFinite( NINF ), false, 'returns false' );
+	t.end();
+});
+
+tape( 'the function returns `false` if provided `NaN`', opts, function test( t ) {
+	t.equal( isNegativeFinite( NaN ), false, 'returns false' );
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This RFC proposes adding native C implementation for [`@stdlib/math/base/assert/is-negative-finite`](https://github.com/stdlib-js/stdlib/blob/develop/lib/node_modules/%40stdlib/math/base/assert/is-negative-finite/)

```c
bool stdlib_base_is_negative_finite( const double x )
```

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
