### PR TITLE
docs: improve README examples of stats/base/dists/triangular namespace 

### DIFF
--- a/lib/node_modules/@stdlib/math/iter/sequences/README.md
+++ b/lib/node_modules/@stdlib/math/iter/sequences/README.md
@@ -92,11 +92,24 @@ The namespace contains the following functions for creating iterator protocol-co
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var objectKeys = require( '@stdlib/utils/keys' );
-var ns = require( '@stdlib/math/iter/sequences' );
+// Require necessary modules
+var objectKeys = require('@stdlib/utils/keys');
 
-console.log( objectKeys( ns ) );
+// Log the available functions in the module
+console.log(objectKeys(ns));
+
+// Create an iterator for generating square numbers
+var it = ns.iterSquaresSeq();
+
+// Iterate over the sequence and log the values
+console.log(it.next().value); // => 0
+console.log(it.next().value); // => 1
+console.log(it.next().value); // => 4
+console.log(it.next().value); // => 9
+console.log(it.next().value); // => 16
+
 ```
+
 
 </section>
 

--- a/lib/node_modules/@stdlib/math/iter/sequences/examples/index.js
+++ b/lib/node_modules/@stdlib/math/iter/sequences/examples/index.js
@@ -18,7 +18,19 @@
 
 'use strict';
 
-var objectKeys = require( '@stdlib/utils/keys' );
-var ns = require( './../lib' );
+// Require necessary modules
+var objectKeys = require('@stdlib/utils/keys');
+var ns = require('./../lib'); // Ensure the correct path to the module
 
-console.log( objectKeys( ns ) );
+// Log the available functions in the module
+console.log(objectKeys(ns));
+
+// Create an iterator for generating square numbers
+var it = ns.iterSquaresSeq();
+
+// Iterate over the sequence and log the values
+console.log(it.next().value); // => 0
+console.log(it.next().value); // => 1
+console.log(it.next().value); // => 4
+console.log(it.next().value); // => 9
+console.log(it.next().value); // => 16

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/README.md
@@ -116,6 +116,31 @@ var objectKeys = require( '@stdlib/utils/keys' );
 var geometric = require( '@stdlib/stats/base/dists/geometric' );
 
 console.log( objectKeys( geometric ) );
+
+var p = 0.1;
+var it = geometric.stdev(p);
+console.log(it);
+// => ~9.487
+
+p = 0.5;
+it = geometric.stdev(p);
+console.log(it);
+// => ~1.414
+
+it = geometric.stdev(NaN);
+console.log(it);
+// => NaN
+
+p = 1.5;
+it = geometric.stdev(p);
+console.log(it);
+// => NaN
+
+p = -1.0;
+it = geometric.stdev(p);
+console.log(it);
+// => NaN
+
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/examples/index.js
@@ -22,3 +22,27 @@ var objectKeys = require( '@stdlib/utils/keys' );
 var geometric = require( './../lib' );
 
 console.log( objectKeys( geometric ) );
+
+var p = 0.1;
+var it = geometric.stdev(p);
+console.log(it);
+// => ~9.487
+
+p = 0.5;
+it = geometric.stdev(p);
+console.log(it);
+// => ~1.414
+
+it = geometric.stdev(NaN);
+console.log(it);
+// => NaN
+
+p = 1.5;
+it = geometric.stdev(p);
+console.log(it);
+// => NaN
+
+p = -1.0;
+it = geometric.stdev(p);
+console.log(it);
+// => NaN

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/README.md
@@ -116,6 +116,24 @@ var objectKeys = require( '@stdlib/utils/keys' );
 var triangular = require( '@stdlib/stats/base/dists/triangular' );
 
 console.log( objectKeys( triangular ) );
+
+console.log(triangular.mean(0.0, 1.0, 0.8));
+// => ~0.6
+
+console.log(triangular.mean(2.0, 8.0, 5.0));
+// => 5.0
+
+console.log(triangular.median(4.0, 12.0, 5.0));
+// => ~6.708
+
+console.log(triangular.median(2.0, 8.0, 5.0));
+// => 5.0
+
+console.log(triangular.mode(4.0, 12.0, 5.0));
+// => 5.0
+
+console.log(triangular.mode(2.0, 8.0, 5.0));
+// => 5.0
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/examples/index.js
@@ -22,3 +22,21 @@ var objectKeys = require( '@stdlib/utils/keys' );
 var triangular = require( './../lib' );
 
 console.log( objectKeys( triangular ) );
+
+console.log(triangular.mean(0.0, 1.0, 0.8));
+// => ~0.6
+
+console.log(triangular.mean(2.0, 8.0, 5.0));
+// => 5.0
+
+console.log(triangular.median(4.0, 12.0, 5.0));
+// => ~6.708
+
+console.log(triangular.median(2.0, 8.0, 5.0));
+// => 5.0
+
+console.log(triangular.mode(4.0, 12.0, 5.0));
+// => 5.0
+
+console.log(triangular.mode(2.0, 8.0, 5.0));
+// => 5.0


### PR DESCRIPTION
Resolves # .

## Description

>  purpose of this pull request to add triangular example

This pull request:

- Add examples of the functions present in ```stats/base/dists/triangular``` namespace
- adds example demonstration using mean ,mode, median functions in the README.
- Adds the same demonstration example in ```examples/index.js```

## Related Issues

> resolve improve README examples of ```stats/base/dists/triangular``` namespace #1646 

This pull request:

-   resolves #
-   fixes #

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
