### PR TITLE
docs: improve README examples of `stats/base/dists/triangular` namespace

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/README.md
@@ -112,28 +112,91 @@ y = dist.quantile( 1.9 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var objectKeys = require( '@stdlib/utils/keys' );
+var triangularRandomFactory = require( '@stdlib/random/base/triangular' ).factory;
+var uniformRandomFactory = require( '@stdlib/random/base/uniform' ).factory;
+var filledarrayBy = require( '@stdlib/array/filled-by' );
+var variance = require( '@stdlib/stats/base/variance' );
+var linspace = require( '@stdlib/array/base/linspace' );
+var mean = require( '@stdlib/stats/base/mean' );
+var abs = require( '@stdlib/math/base/special/abs' );
 var triangular = require( '@stdlib/stats/base/dists/triangular' );
 
-console.log( objectKeys( triangular ) );
+// Define the parameters of the triangular distribution:
+var a = 0.0;   // Minimum value
+var b = 10.0;  // Maximum value
+var c = 4.0;   // Mode (most likely value)
 
-console.log(triangular.mean(0.0, 1.0, 0.8));
-// => ~0.6
+// Generate an array of x values:
+var x = linspace( a, b, 100 );
 
-console.log(triangular.mean(2.0, 8.0, 5.0));
-// => 5.0
+// Compute the PDF for each x:
+var triangularPDF = triangular.pdf.factory( a, b, c );
+var pdf = filledarrayBy( x.length, 'float64', triangularPDF );
 
-console.log(triangular.median(4.0, 12.0, 5.0));
-// => ~6.708
+// Compute the CDF for each x:
+var triangularCDF = triangular.cdf.factory( a, b, c );
+var cdf = filledarrayBy( x.length, 'float64', triangularCDF );
 
-console.log(triangular.median(2.0, 8.0, 5.0));
-// => 5.0
+// Output the PDF and CDF values:
+console.log( 'x values:', x );
+console.log( 'PDF values:', pdf );
+console.log( 'CDF values:', cdf );
 
-console.log(triangular.mode(4.0, 12.0, 5.0));
-// => 5.0
+// Compute statistical properties:
+var theoreticalMean = triangular.mean( a, b, c );
+var theoreticalVariance = triangular.variance( a, b, c );
+var theoreticalSkewness = triangular.skewness( a, b, c );
+var theoreticalKurtosis = triangular.kurtosis( a, b, c );
 
-console.log(triangular.mode(2.0, 8.0, 5.0));
-// => 5.0
+console.log( 'Theoretical Mean:', theoreticalMean );
+console.log( 'Theoretical Variance:', theoreticalVariance );
+console.log( 'Skewness:', theoreticalSkewness );
+console.log( 'Kurtosis:', theoreticalKurtosis );
+
+// Generate random samples from the triangular distribution:
+var rtriangular = triangularRandomFactory( a, b, c );
+var n = 1000;
+var samples = filledarrayBy( n, 'float64', rtriangular );
+
+// Compute sample mean and variance:
+var sampleMean = mean( n, samples, 1 );
+var sampleVariance = variance( n, 1, samples, 1 );
+
+console.log( 'Sample Mean:', sampleMean );
+console.log( 'Sample Variance:', sampleVariance );
+
+// Compare sample statistics to theoretical values:
+console.log( 'Difference in Mean:', abs( theoreticalMean - sampleMean ) );
+console.log( 'Difference in Variance:', abs( theoreticalVariance - sampleVariance ) );
+
+// Demonstrate the relationship between the triangular distribution and the sum of uniform distributions, namely that the sum of two independent Uniform(0, 1) random variables follows a Triangular(0, 2, 1) distribution.
+
+// Generate samples by summing two independent Uniform(0, 1) random variables:
+var runiform = uniformRandomFactory( 0.0, 1.0 );
+
+function runiformSum() {
+    return runiform() + runiform();
+}
+var sumSamples = filledarrayBy( n, 'float64', runiformSum );
+
+// Compute sample mean and variance for the sum:
+var sumSampleMean = mean( n, sumSamples, 1 );
+var sumSampleVariance = variance( n, 1, sumSamples, 1 );
+
+// Theoretical mean and variance of Triangular(0, 2, 1):
+var a2 = 0.0;
+var b2 = 2.0;
+var c2 = 1.0;
+
+var triMean = triangular.mean( a2, b2, c2 );
+var triVariance = triangular.variance( a2, b2, c2 );
+
+console.log( 'Sum Sample Mean:', sumSampleMean );
+console.log( 'Sum Sample Variance:', sumSampleVariance );
+console.log( 'Theoretical Mean (Sum of Uniforms):', triMean );
+console.log( 'Theoretical Variance (Sum of Uniforms):', triVariance );
+console.log( 'Difference in Mean:', abs( triMean - sumSampleMean ) );
+console.log( 'Difference in Variance:', abs( triVariance - sumSampleVariance ) );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/README.md
@@ -116,6 +116,24 @@ var objectKeys = require( '@stdlib/utils/keys' );
 var triangular = require( '@stdlib/stats/base/dists/triangular' );
 
 console.log( objectKeys( triangular ) );
+
+console.log(triangular.mean(0.0, 1.0, 0.8));
+// => ~0.6
+
+console.log(triangular.mean(2.0, 8.0, 5.0));
+// => 5.0
+
+console.log(triangular.median(4.0, 12.0, 5.0));
+// => ~6.708
+
+console.log(triangular.median(2.0, 8.0, 5.0));
+// => 5.0
+
+console.log(triangular.mode(4.0, 12.0, 5.0));
+// => 5.0
+
+console.log(triangular.mode(2.0, 8.0, 5.0));
+// => 5.0
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/examples/index.js
@@ -18,25 +18,88 @@
 
 'use strict';
 
-var objectKeys = require( '@stdlib/utils/keys' );
+var triangularRandomFactory = require( '@stdlib/random/base/triangular' ).factory;
+var uniformRandomFactory = require( '@stdlib/random/base/uniform' ).factory;
+var filledarrayBy = require( '@stdlib/array/filled-by' );
+var variance = require( '@stdlib/stats/base/variance' );
+var linspace = require( '@stdlib/array/base/linspace' );
+var mean = require( '@stdlib/stats/base/mean' );
+var abs = require( '@stdlib/math/base/special/abs' );
 var triangular = require( './../lib' );
 
-console.log( objectKeys( triangular ) );
+// Define the parameters of the triangular distribution:
+var a = 0.0;   // Minimum value
+var b = 10.0;  // Maximum value
+var c = 4.0;   // Mode (most likely value)
 
-console.log(triangular.mean(0.0, 1.0, 0.8));
-// => ~0.6
+// Generate an array of x values:
+var x = linspace( a, b, 100 );
 
-console.log(triangular.mean(2.0, 8.0, 5.0));
-// => 5.0
+// Compute the PDF for each x:
+var triangularPDF = triangular.pdf.factory( a, b, c );
+var pdf = filledarrayBy( x.length, 'float64', triangularPDF );
 
-console.log(triangular.median(4.0, 12.0, 5.0));
-// => ~6.708
+// Compute the CDF for each x:
+var triangularCDF = triangular.cdf.factory( a, b, c );
+var cdf = filledarrayBy( x.length, 'float64', triangularCDF );
 
-console.log(triangular.median(2.0, 8.0, 5.0));
-// => 5.0
+// Output the PDF and CDF values:
+console.log( 'x values:', x );
+console.log( 'PDF values:', pdf );
+console.log( 'CDF values:', cdf );
 
-console.log(triangular.mode(4.0, 12.0, 5.0));
-// => 5.0
+// Compute statistical properties:
+var theoreticalMean = triangular.mean( a, b, c );
+var theoreticalVariance = triangular.variance( a, b, c );
+var theoreticalSkewness = triangular.skewness( a, b, c );
+var theoreticalKurtosis = triangular.kurtosis( a, b, c );
 
-console.log(triangular.mode(2.0, 8.0, 5.0));
-// => 5.0
+console.log( 'Theoretical Mean:', theoreticalMean );
+console.log( 'Theoretical Variance:', theoreticalVariance );
+console.log( 'Skewness:', theoreticalSkewness );
+console.log( 'Kurtosis:', theoreticalKurtosis );
+
+// Generate random samples from the triangular distribution:
+var rtriangular = triangularRandomFactory( a, b, c );
+var n = 1000;
+var samples = filledarrayBy( n, 'float64', rtriangular );
+
+// Compute sample mean and variance:
+var sampleMean = mean( n, samples, 1 );
+var sampleVariance = variance( n, 1, samples, 1 );
+
+console.log( 'Sample Mean:', sampleMean );
+console.log( 'Sample Variance:', sampleVariance );
+
+// Compare sample statistics to theoretical values:
+console.log( 'Difference in Mean:', abs( theoreticalMean - sampleMean ) );
+console.log( 'Difference in Variance:', abs( theoreticalVariance - sampleVariance ) );
+
+// Demonstrate the relationship between the triangular distribution and the sum of uniform distributions, namely that the sum of two independent Uniform(0, 1) random variables follows a Triangular(0, 2, 1) distribution.
+
+// Generate samples by summing two independent Uniform(0, 1) random variables:
+var runiform = uniformRandomFactory( 0.0, 1.0 );
+
+function runiformSum() {
+	return runiform() + runiform();
+}
+var sumSamples = filledarrayBy( n, 'float64', runiformSum );
+
+// Compute sample mean and variance for the sum:
+var sumSampleMean = mean( n, sumSamples, 1 );
+var sumSampleVariance = variance( n, 1, sumSamples, 1 );
+
+// Theoretical mean and variance of Triangular(0, 2, 1):
+var a2 = 0.0;
+var b2 = 2.0;
+var c2 = 1.0;
+
+var triMean = triangular.mean( a2, b2, c2 );
+var triVariance = triangular.variance( a2, b2, c2 );
+
+console.log( 'Sum Sample Mean:', sumSampleMean );
+console.log( 'Sum Sample Variance:', sumSampleVariance );
+console.log( 'Theoretical Mean (Sum of Uniforms):', triMean );
+console.log( 'Theoretical Variance (Sum of Uniforms):', triVariance );
+console.log( 'Difference in Mean:', abs( triMean - sumSampleMean ) );
+console.log( 'Difference in Variance:', abs( triVariance - sumSampleVariance ) );

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/examples/index.js
@@ -22,3 +22,21 @@ var objectKeys = require( '@stdlib/utils/keys' );
 var triangular = require( './../lib' );
 
 console.log( objectKeys( triangular ) );
+
+console.log(triangular.mean(0.0, 1.0, 0.8));
+// => ~0.6
+
+console.log(triangular.mean(2.0, 8.0, 5.0));
+// => 5.0
+
+console.log(triangular.median(4.0, 12.0, 5.0));
+// => ~6.708
+
+console.log(triangular.median(2.0, 8.0, 5.0));
+// => 5.0
+
+console.log(triangular.mode(4.0, 12.0, 5.0));
+// => 5.0
+
+console.log(triangular.mode(2.0, 8.0, 5.0));
+// => 5.0


### PR DESCRIPTION
…e mean mode median

Resolves # .

## Description

>Purpose of this pull request is to add example in ```stats/base/dists/triangular ```

This pull request:

-   Add examples of the functions present in ```stats/base/dists/triangular ``` namespace
-   adds example demonstration using mean, mode, median functions in the README.
-   Adds the same demonstration example in ```examples/index.js.```

## Related Issues

> resolve improve README examples of  ```stats/base/dists/triangular ``` namespace #1792 

This pull request:

-   resolves #
-   fixes #

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
