### PR TITLE
docs: improve README examples of stats/base/dists/geometric namespace

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/README.md
@@ -116,6 +116,30 @@ var objectKeys = require( '@stdlib/utils/keys' );
 var geometric = require( '@stdlib/stats/base/dists/geometric' );
 
 console.log( objectKeys( geometric ) );
+
+var p = 0.1;
+var it = geometric.stdev(p);
+console.log(it);
+// => ~9.487
+
+p = 0.5;
+it = geometric.stdev(p);
+console.log(it);
+// => ~1.414
+
+it = geometric.stdev(NaN);
+console.log(it);
+// => NaN
+
+p = 1.5;
+it = geometric.stdev(p);
+console.log(it);
+// => NaN
+
+p = -1.0;
+it = geometric.stdev(p);
+console.log(it);
+// => NaN
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/examples/index.js
@@ -22,3 +22,27 @@ var objectKeys = require( '@stdlib/utils/keys' );
 var geometric = require( './../lib' );
 
 console.log( objectKeys( geometric ) );
+
+var p = 0.1;
+var it = geometric.stdev(p);
+console.log(it);
+// => ~9.487
+
+p = 0.5;
+it = geometric.stdev(p);
+console.log(it);
+// => ~1.414
+
+it = geometric.stdev(NaN);
+console.log(it);
+// => NaN
+
+p = 1.5;
+it = geometric.stdev(p);
+console.log(it);
+// => NaN
+
+p = -1.0;
+it = geometric.stdev(p);
+console.log(it);
+// => NaN

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/README.md
@@ -116,6 +116,24 @@ var objectKeys = require( '@stdlib/utils/keys' );
 var triangular = require( '@stdlib/stats/base/dists/triangular' );
 
 console.log( objectKeys( triangular ) );
+
+console.log(triangular.mean(0.0, 1.0, 0.8));
+// => ~0.6
+
+console.log(triangular.mean(2.0, 8.0, 5.0));
+// => 5.0
+
+console.log(triangular.median(4.0, 12.0, 5.0));
+// => ~6.708
+
+console.log(triangular.median(2.0, 8.0, 5.0));
+// => 5.0
+
+console.log(triangular.mode(4.0, 12.0, 5.0));
+// => 5.0
+
+console.log(triangular.mode(2.0, 8.0, 5.0));
+// => 5.0
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/examples/index.js
@@ -22,3 +22,21 @@ var objectKeys = require( '@stdlib/utils/keys' );
 var triangular = require( './../lib' );
 
 console.log( objectKeys( triangular ) );
+
+console.log(triangular.mean(0.0, 1.0, 0.8));
+// => ~0.6
+
+console.log(triangular.mean(2.0, 8.0, 5.0));
+// => 5.0
+
+console.log(triangular.median(4.0, 12.0, 5.0));
+// => ~6.708
+
+console.log(triangular.median(2.0, 8.0, 5.0));
+// => 5.0
+
+console.log(triangular.mode(4.0, 12.0, 5.0));
+// => 5.0
+
+console.log(triangular.mode(2.0, 8.0, 5.0));
+// => 5.0


### PR DESCRIPTION
Resolves # .

## Description

>Purpose of this pull request is to add example in stats/base/dists/geometric

This pull request:

-  Add examples of the functions present in ```stats/base/dists/geometric``` namespace
- adds example demonstration using stdev functions in the README.
- Adds the same demonstration example in examples/index.js.
## Related Issues

> resolve improve README examples of ```stats/base/dists/geometric``` #1628 

This pull request:

-   resolves #
-   fixes #

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
