### PR TITLE
Update example code in stats/base/dists/studentized-range namespace(prince-patel23)

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/examples/index.js
@@ -18,7 +18,22 @@
 
 'use strict';
 
-var objectKeys = require( '@stdlib/utils/keys' );
-var tukey = require( './../lib' );
+// Import required modules
+var objectKeys = require('@stdlib/utils/keys');
+var tukey = require('./../lib');
 
-console.log( objectKeys( tukey ) );
+// Example usage of the Tukey range function
+function example() {
+    // Define parameters
+    var df = 10; // Degrees of freedom
+    var alpha = 0.05; // Significance level
+
+    // Compute the Tukey range
+    var range = tukey.range( df, alpha );
+
+    // Output the computed Tukey range
+    console.log( 'Tukey Range:', range );
+}
+
+// Run the example
+example();


### PR DESCRIPTION
This pull request aims to enhance the example code within the `stats/base/dists/studentized-range` namespace. The current example lacked clarity and failed to sufficiently demonstrate the functionality of the Tukey range computation function.

To address this, the example code has been updated to include detailed comments explaining each step of the computation process. Additionally, parameters such as degrees of freedom (`df`) and significance level (`alpha`) have been defined to showcase the function's flexibility. The computed Tukey range is now outputted to the console for demonstration purposes, providing users with a clearer understanding of how to use the function.

These improvements aim to make the example code more informative and accessible to users, helping them better utilize the Tukey range computation function within the `stats/base/dists/studentized-range` namespace.
