### PR TITLE
docs: improve README examples of `stats/base/dists/geometric` namespace

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/README.md
@@ -116,6 +116,30 @@ var objectKeys = require( '@stdlib/utils/keys' );
 var geometric = require( '@stdlib/stats/base/dists/geometric' );
 
 console.log( objectKeys( geometric ) );
+
+var p = 0.1;
+var it = geometric.stdev(p);
+console.log(it);
+// => ~9.487
+
+p = 0.5;
+it = geometric.stdev(p);
+console.log(it);
+// => ~1.414
+
+it = geometric.stdev(NaN);
+console.log(it);
+// => NaN
+
+p = 1.5;
+it = geometric.stdev(p);
+console.log(it);
+// => NaN
+
+p = -1.0;
+it = geometric.stdev(p);
+console.log(it);
+// => NaN
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/README.md
@@ -112,34 +112,96 @@ y = dist.logpmf( 2.3 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var objectKeys = require( '@stdlib/utils/keys' );
+var geometricRandomFactory = require( '@stdlib/random/base/geometric' ).factory;
+var negativeBinomial = require( '@stdlib/stats/base/dists/negative-binomial' );
+var filledarrayBy = require( '@stdlib/array/filled-by' );
+var variance = require( '@stdlib/stats/base/variance' );
+var linspace = require( '@stdlib/array/base/linspace' );
+var mean = require( '@stdlib/stats/base/mean' );
+var abs = require( '@stdlib/math/base/special/abs' );
 var geometric = require( '@stdlib/stats/base/dists/geometric' );
 
-console.log( objectKeys( geometric ) );
+// Define the success probability:
+var p = 0.3; // Probability of success on each trial
 
-var p = 0.1;
-var it = geometric.stdev(p);
-console.log(it);
-// => ~9.487
+// Generate an array of x values (number of failures before first success):
+var x = linspace( 0, 10, 11 ); // Geometric distribution is discrete
 
-p = 0.5;
-it = geometric.stdev(p);
-console.log(it);
-// => ~1.414
+// Compute the PMF for each x:
+var geometricPMF = geometric.pmf.factory( p );
+var pmf = filledarrayBy( x.length, 'float64', geometricPMF );
 
-it = geometric.stdev(NaN);
-console.log(it);
-// => NaN
+// Compute the CDF for each x:
+var geometricCDF = geometric.cdf.factory( p );
+var cdf = filledarrayBy( x.length, 'float64', geometricCDF );
 
-p = 1.5;
-it = geometric.stdev(p);
-console.log(it);
-// => NaN
+// Output the PMF and CDF values:
+console.log( 'x values:', x );
+console.log( 'PMF values:', pmf );
+console.log( 'CDF values:', cdf );
 
-p = -1.0;
-it = geometric.stdev(p);
-console.log(it);
-// => NaN
+// Compute statistical properties:
+var theoreticalMean = geometric.mean( p );
+var theoreticalVariance = geometric.variance( p );
+var theoreticalSkewness = geometric.skewness( p );
+var theoreticalKurtosis = geometric.kurtosis( p );
+
+console.log( 'Theoretical Mean:', theoreticalMean );
+console.log( 'Theoretical Variance:', theoreticalVariance );
+console.log( 'Skewness:', theoreticalSkewness );
+console.log( 'Kurtosis:', theoreticalKurtosis );
+
+// Generate random samples from the geometric distribution:
+var rgeom = geometricRandomFactory( p );
+var n = 1000;
+var samples = filledarrayBy( n, 'float64', rgeom );
+
+// Compute sample mean and variance:
+var sampleMean = mean( n, samples, 1 );
+var sampleVariance = variance( n, 1, samples, 1 );
+
+console.log( 'Sample Mean:', sampleMean );
+console.log( 'Sample Variance:', sampleVariance );
+
+// Demonstrate the memoryless property:
+var s = 2.0;
+var t = 3.0;
+var prob1 = ( 1.0 - geometric.cdf( s + t - 1.0, p ) ) /
+    ( 1.0 - geometric.cdf( s - 1.0, p ));
+var prob2 = 1.0 - geometric.cdf( t - 1.0, p );
+
+console.log( 'P(X > s + t | X > s):', prob1 );
+console.log( 'P(X > t):', prob2 );
+console.log( 'Difference:', abs( prob1 - prob2 ) );
+
+// Demonstrate that the sum of k independent geometric random variables follows a negative binomial distribution:
+var k = 5;
+function drawSum() {
+    var sum = 0;
+    var j;
+    for ( j = 0; j < k; j++ ) {
+        sum += rgeom();
+    }
+    return sum;
+}
+var sumSamples = filledarrayBy( n, 'float64', drawSum );
+
+// Compute sample mean and variance for the sum:
+var sumSampleMean = mean( n, sumSamples, 1 );
+var sumSampleVariance = variance( n, 1, sumSamples, 1 );
+
+// Theoretical mean and variance of Negative Binomial distribution:
+var nbMean = negativeBinomial.mean( k, p );
+var nbVariance = negativeBinomial.variance( k, p );
+
+console.log( 'Sum Sample Mean:', sumSampleMean );
+console.log( 'Sum Sample Variance:', sumSampleVariance );
+console.log( 'Negative Binomial Mean:', nbMean );
+console.log( 'Negative Binomial Variance:', nbVariance );
+
+// Compare sample statistics to theoretical values:
+console.log( 'Difference in Mean:', abs( nbMean - sumSampleMean ) );
+console.log( 'Difference in Variance:', abs( nbVariance - sumSampleVariance ) );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/examples/index.js
@@ -22,3 +22,27 @@ var objectKeys = require( '@stdlib/utils/keys' );
 var geometric = require( './../lib' );
 
 console.log( objectKeys( geometric ) );
+
+var p = 0.1;
+var it = geometric.stdev(p);
+console.log(it);
+// => ~9.487
+
+p = 0.5;
+it = geometric.stdev(p);
+console.log(it);
+// => ~1.414
+
+it = geometric.stdev(NaN);
+console.log(it);
+// => NaN
+
+p = 1.5;
+it = geometric.stdev(p);
+console.log(it);
+// => NaN
+
+p = -1.0;
+it = geometric.stdev(p);
+console.log(it);
+// => NaN

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/examples/index.js
@@ -18,31 +18,93 @@
 
 'use strict';
 
-var objectKeys = require( '@stdlib/utils/keys' );
+var geometricRandomFactory = require( '@stdlib/random/base/geometric' ).factory;
+var negativeBinomial = require( '@stdlib/stats/base/dists/negative-binomial' );
+var filledarrayBy = require( '@stdlib/array/filled-by' );
+var variance = require( '@stdlib/stats/base/variance' );
+var linspace = require( '@stdlib/array/base/linspace' );
+var mean = require( '@stdlib/stats/base/mean' );
+var abs = require( '@stdlib/math/base/special/abs' );
 var geometric = require( './../lib' );
 
-console.log( objectKeys( geometric ) );
+// Define the success probability:
+var p = 0.3; // Probability of success on each trial
 
-var p = 0.1;
-var it = geometric.stdev(p);
-console.log(it);
-// => ~9.487
+// Generate an array of x values (number of failures before first success):
+var x = linspace( 0, 10, 11 ); // Geometric distribution is discrete
 
-p = 0.5;
-it = geometric.stdev(p);
-console.log(it);
-// => ~1.414
+// Compute the PMF for each x:
+var geometricPMF = geometric.pmf.factory( p );
+var pmf = filledarrayBy( x.length, 'float64', geometricPMF );
 
-it = geometric.stdev(NaN);
-console.log(it);
-// => NaN
+// Compute the CDF for each x:
+var geometricCDF = geometric.cdf.factory( p );
+var cdf = filledarrayBy( x.length, 'float64', geometricCDF );
 
-p = 1.5;
-it = geometric.stdev(p);
-console.log(it);
-// => NaN
+// Output the PMF and CDF values:
+console.log( 'x values:', x );
+console.log( 'PMF values:', pmf );
+console.log( 'CDF values:', cdf );
 
-p = -1.0;
-it = geometric.stdev(p);
-console.log(it);
-// => NaN
+// Compute statistical properties:
+var theoreticalMean = geometric.mean( p );
+var theoreticalVariance = geometric.variance( p );
+var theoreticalSkewness = geometric.skewness( p );
+var theoreticalKurtosis = geometric.kurtosis( p );
+
+console.log( 'Theoretical Mean:', theoreticalMean );
+console.log( 'Theoretical Variance:', theoreticalVariance );
+console.log( 'Skewness:', theoreticalSkewness );
+console.log( 'Kurtosis:', theoreticalKurtosis );
+
+// Generate random samples from the geometric distribution:
+var rgeom = geometricRandomFactory( p );
+var n = 1000;
+var samples = filledarrayBy( n, 'float64', rgeom );
+
+// Compute sample mean and variance:
+var sampleMean = mean( n, samples, 1 );
+var sampleVariance = variance( n, 1, samples, 1 );
+
+console.log( 'Sample Mean:', sampleMean );
+console.log( 'Sample Variance:', sampleVariance );
+
+// Demonstrate the memoryless property:
+var s = 2.0;
+var t = 3.0;
+var prob1 = ( 1.0 - geometric.cdf( s + t - 1.0, p ) ) /
+	( 1.0 - geometric.cdf( s - 1.0, p ));
+var prob2 = 1.0 - geometric.cdf( t - 1.0, p );
+
+console.log( 'P(X > s + t | X > s):', prob1 );
+console.log( 'P(X > t):', prob2 );
+console.log( 'Difference:', abs( prob1 - prob2 ) );
+
+// Demonstrate that the sum of k independent geometric random variables follows a negative binomial distribution:
+var k = 5;
+function drawSum() {
+	var sum = 0;
+	var j;
+	for ( j = 0; j < k; j++ ) {
+		sum += rgeom();
+	}
+	return sum;
+}
+var sumSamples = filledarrayBy( n, 'float64', drawSum );
+
+// Compute sample mean and variance for the sum:
+var sumSampleMean = mean( n, sumSamples, 1 );
+var sumSampleVariance = variance( n, 1, sumSamples, 1 );
+
+// Theoretical mean and variance of Negative Binomial distribution:
+var nbMean = negativeBinomial.mean( k, p );
+var nbVariance = negativeBinomial.variance( k, p );
+
+console.log( 'Sum Sample Mean:', sumSampleMean );
+console.log( 'Sum Sample Variance:', sumSampleVariance );
+console.log( 'Negative Binomial Mean:', nbMean );
+console.log( 'Negative Binomial Variance:', nbVariance );
+
+// Compare sample statistics to theoretical values:
+console.log( 'Difference in Mean:', abs( nbMean - sumSampleMean ) );
+console.log( 'Difference in Variance:', abs( nbVariance - sumSampleVariance ) );


### PR DESCRIPTION
Resolves # .

## Description

> Purpose of this pull request is to add example in stats/base/dists/geometric

This pull request:

-  Add examples of the functions present in stats/base/dists/geometric namespace
- adds example demonstration using stdev functions in the README.
- Adds the same demonstration example in examples/index.js.

## Related Issues

> resolve improve README examples of stats/base/dists/geometric #1628 

This pull request:

-   resolves #
-   fixes #

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
