### PR TITLE
feat: add `string/base/last-grapheme-cluster`

### DIFF
--- a/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/README.md
+++ b/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/README.md
@@ -70,8 +70,8 @@ str = lastGraphemeCluster( 'Stdlib', 10 );
 str = lastGraphemeCluster( '🐶🐮🐷🐰🐸', 2 );
 // returns '🐰🐸'
 
-str = lastGraphemeCluster( '🐶🐮🐷🐰🐸', 10 );
-// returns '🐶🐮🐷🐰🐸'
+str = lastGraphemeCluster( '六书/六書', 2 );
+// returns '六書'
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/README.md
+++ b/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/README.md
@@ -1,0 +1,113 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# lastGraphemeCluster
+
+> Return the last `n` grapheme clusters (i.e., user-perceived characters) of a string.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var lastGraphemeCluster = require( '@stdlib/string/base/last-grapheme-cluster' );
+```
+
+#### lastGraphemeCluster( str, n )
+
+Returns the last `n` grapheme clusters (i.e., user-perceived characters) of a string.
+
+```javascript
+var out = lastGraphemeCluster( 'Hello World', 1 );
+// returns 'd'
+
+out = lastGraphemeCluster( 'Evening', 3 );
+// returns 'ing'
+
+out = lastGraphemeCluster( 'foo bar', 10 );
+// returns 'foo bar'
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var lastGraphemeCluster = require( '@stdlib/string/base/last-grapheme-cluster' );
+
+var str = lastGraphemeCluster( 'Hello World!', 1 );
+// returns '!'
+
+str = lastGraphemeCluster( 'JavaScript', 6 );
+// returns 'Script'
+
+str = lastGraphemeCluster( 'Stdlib', 10 );
+// returns 'Stdlib'
+
+str = lastGraphemeCluster( '🐶🐮🐷🐰🐸', 2 );
+// returns '🐰🐸'
+
+str = lastGraphemeCluster( '🐶🐮🐷🐰🐸', 10 );
+// returns '🐶🐮🐷🐰🐸'
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/string/base/last`][@stdlib/string/base/last]</span><span class="delimiter">: </span><span class="description">return the last UTF-16 code unit of a string.</span>
+-   <span class="package-name">[`@stdlib/string/base/last-code-point`][@stdlib/string/base/last-code-point]</span><span class="delimiter">: </span><span class="description">return the last Unicode code point of a string.</span>
+-   <span class="package-name">[`@stdlib/string/last`][@stdlib/string/last]</span><span class="delimiter">: </span><span class="description">return the last character(s) of a string.</span>
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+<!-- <related-links> -->
+
+[@stdlib/string/base/last]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/string/base/last
+
+[@stdlib/string/base/last-code-point]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/string/base/last-code-point
+
+[@stdlib/string/last]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/string/last
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/README.md
+++ b/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/README.md
@@ -64,8 +64,8 @@ var str = lastGraphemeCluster( 'Hello World!', 1 );
 str = lastGraphemeCluster( 'JavaScript', 6 );
 // returns 'Script'
 
-str = lastGraphemeCluster( 'Stdlib', 10 );
-// returns 'Stdlib'
+str = lastGraphemeCluster( 'stdlib', 10 );
+// returns 'stdlib'
 
 str = lastGraphemeCluster( '🐶🐮🐷🐰🐸', 2 );
 // returns '🐰🐸'

--- a/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/README.md
+++ b/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/README.md
@@ -82,14 +82,6 @@ str = lastGraphemeCluster( '六书/六書', 2 );
 
 <section class="related">
 
-* * *
-
-## See Also
-
--   <span class="package-name">[`@stdlib/string/base/last`][@stdlib/string/base/last]</span><span class="delimiter">: </span><span class="description">return the last UTF-16 code unit of a string.</span>
--   <span class="package-name">[`@stdlib/string/base/last-code-point`][@stdlib/string/base/last-code-point]</span><span class="delimiter">: </span><span class="description">return the last Unicode code point of a string.</span>
--   <span class="package-name">[`@stdlib/string/last`][@stdlib/string/last]</span><span class="delimiter">: </span><span class="description">return the last character(s) of a string.</span>
-
 </section>
 
 <!-- /.related -->
@@ -97,16 +89,6 @@ str = lastGraphemeCluster( '六书/六書', 2 );
 <!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 
 <section class="links">
-
-<!-- <related-links> -->
-
-[@stdlib/string/base/last]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/string/base/last
-
-[@stdlib/string/base/last-code-point]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/string/base/last-code-point
-
-[@stdlib/string/last]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/string/last
-
-<!-- </related-links> -->
 
 </section>
 

--- a/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/benchmark/benchmark.js
@@ -1,0 +1,58 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
+var pkg = require( './../package.json' ).name;
+var last = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var values;
+	var out;
+	var i;
+
+	values = [
+		'beep boop',
+		'foo bar',
+		'六書',
+		'xyz abc',
+		'🐶🐮🐷🐰🐸',
+		'🌷🌷🌷🌷🌷'
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = last( values[ i%values.length ], 1 );
+		if ( typeof out !== 'string' ) {
+			b.fail( 'should return a string' );
+		}
+	}
+	b.toc();
+	if ( !isString( out ) ) {
+		b.fail( 'should return a string' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/docs/repl.txt
+++ b/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/docs/repl.txt
@@ -1,0 +1,30 @@
+
+{{alias}}( str, n )
+    Returns the last `n` grapheme clusters (i.e., user-perceived characters) of
+    a string.
+
+    Parameters
+    ----------
+    str: string
+        Input string.
+
+    n: integer
+        Number of grapheme clusters to return.
+
+    Returns
+    -------
+    out: string
+        Output string.
+
+    Examples
+    --------
+    > var out = {{alias}}( 'beep', 1 )
+    'p'
+    > out = {{alias}}( 'Boop', 2 )
+    'op'
+    > out = {{alias}}( 'JavaScript', 6 )
+    'Script'
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/docs/types/index.d.ts
@@ -1,0 +1,53 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Returns the last `n` grapheme clusters (i.e., user-perceived characters) of a string.
+*
+* @param str - input string
+* @param n - number of grapheme clusters to return
+* @returns output string
+*
+* @example
+* var out = last( 'Hello World', 1 );
+* // returns 'd'
+*
+* @example
+* var out = last( 'Evening', 3 );
+* // returns 'ing'
+*
+* @example
+* var out = last( 'JavaScript', 6 );
+* // returns 'Script'
+*
+* @example
+* var out = last( '🐶🐮🐷🐰🐸', 2 );
+* // returns '🐰🐸'
+*
+* @example
+* var out = last( 'foo bar', 5 );
+* // returns 'o bar'
+*/
+declare function last( str: string, n: number ): string;
+
+
+// EXPORTS //
+
+export = last;

--- a/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/docs/types/test.ts
@@ -1,0 +1,57 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import last = require( './index' );
+
+
+// TESTS //
+
+// The function returns a string...
+{
+	last( 'abc', 1 ); // $ExpectType string
+}
+
+// The compiler throws an error if the function is provided a value other than a string...
+{
+	last( true, 1 ); // $ExpectError
+	last( false, 1 ); // $ExpectError
+	last( null, 1 ); // $ExpectError
+	last( undefined, 1 ); // $ExpectError
+	last( 5, 1 ); // $ExpectError
+	last( [], 1 ); // $ExpectError
+	last( {}, 1 ); // $ExpectError
+	last( ( x: number ): number => x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument that is not a number...
+{
+	last( 'abc', true ); // $ExpectError
+	last( 'abc', false ); // $ExpectError
+	last( 'abc', null ); // $ExpectError
+	last( 'abc', 'abc' ); // $ExpectError
+	last( 'abc', [] ); // $ExpectError
+	last( 'abc', {} ); // $ExpectError
+	last( 'abc', ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	last(); // $ExpectError
+	last( 'abc' ); // $ExpectError
+	last( 'abc', 1, 2 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/examples/index.js
+++ b/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/examples/index.js
@@ -1,0 +1,36 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var lastGraphemeCluster = require( './../lib' );
+
+console.log( lastGraphemeCluster( 'Hello World!', 1 ) );
+// => '!'
+
+console.log( lastGraphemeCluster( 'JavaScript', 6 ) );
+// => 'Script'
+
+console.log( lastGraphemeCluster( 'Stdlib', 10 ) );
+// => 'Stdlib'
+
+console.log( lastGraphemeCluster( '🐶🐮🐷🐰🐸', 2 ) );
+// => '🐰🐸'
+
+console.log( lastGraphemeCluster( '六书/六書', 2 ) );
+// => '六書'

--- a/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/examples/index.js
+++ b/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/examples/index.js
@@ -26,8 +26,8 @@ console.log( lastGraphemeCluster( 'Hello World!', 1 ) );
 console.log( lastGraphemeCluster( 'JavaScript', 6 ) );
 // => 'Script'
 
-console.log( lastGraphemeCluster( 'Stdlib', 10 ) );
-// => 'Stdlib'
+console.log( lastGraphemeCluster( 'stdlib', 10 ) );
+// => 'stdlib'
 
 console.log( lastGraphemeCluster( '🐶🐮🐷🐰🐸', 2 ) );
 // => '🐰🐸'

--- a/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/lib/index.js
+++ b/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/lib/index.js
@@ -1,0 +1,46 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Return the last `n` grapheme clusters (i.e., user-perceived characters) of a string.
+*
+* @module @stdlib/string/base/last-grapheme-cluster
+*
+* @example
+* var last = require( '@stdlib/string/base/last-grapheme-cluster' );
+*
+* var out = last( 'Hello', 1 );
+* // returns 'o';
+*
+* out = last( 'JavaScript', 1 );
+* // returns 'Script';
+*
+* out = last( '🐮🐷🐸🐵', 2 );
+* // returns '🐸🐵';
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/lib/main.js
@@ -20,7 +20,8 @@
 
 // MODULES //
 
-var prevGraphemeClusterBreak = require( '@stdlib/string/prev-grapheme-cluster-break' );
+var nextGraphemeClusterBreak = require( '@stdlib/string/next-grapheme-cluster-break' );
+var circularBuffer = require('@stdlib/utils/circular-buffer');
 
 
 // MAIN //
@@ -53,19 +54,36 @@ var prevGraphemeClusterBreak = require( '@stdlib/string/prev-grapheme-cluster-br
 * // returns '🐰🐸'
 */
 function last( str, n ) {
-	var len;
+	var prevIndex;
+	var count;
+	var out;
+	var buf;
+	var it;
 	var i;
-	len = str.length;
-	i = len - 1;
-	while ( n > 0 ) {
-		i = prevGraphemeClusterBreak( str, i );
-		n -= 1;
+	out = '';
+	prevIndex = 0;
+	i = 0;
+	count = 0;
+
+	if ( n === 0 || str === '' )
+	{
+		return '';
 	}
-	// Value of `i` will be -1 if and only if `str` is an empty string or `str` has only 1 extended grapheme cluster...
-	if ( str === '' || i === -1 ) {
-		return str;
+	buf = circularBuffer( n );
+	i = nextGraphemeClusterBreak( str, prevIndex );
+	while ( i !== -1 ) {
+		buf.push( str.substring( prevIndex, i ) );
+		prevIndex = i;
+		i = nextGraphemeClusterBreak( str, prevIndex );
 	}
-	return str.substring( i + 1, len );
+	buf.push( str.substring( prevIndex ) );
+	it = buf.iterator();
+	while ( count < n )
+	{
+		out += it.next().value;
+		count += 1;
+	}
+	return out;
 }
 
 

--- a/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/lib/main.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var nextGraphemeClusterBreak = require( '@stdlib/string/next-grapheme-cluster-break' );
-var circularBuffer = require('@stdlib/utils/circular-buffer');
+var circularBuffer = require( '@stdlib/utils/circular-buffer' );
 
 
 // MAIN //
@@ -77,11 +77,16 @@ function last( str, n ) {
 		i = nextGraphemeClusterBreak( str, prevIndex );
 	}
 	buf.push( str.substring( prevIndex ) );
-	it = buf.iterator();
-	while ( count < n )
-	{
-		out += it.next().value;
-		count += 1;
+	if ( buf.full ) {
+		it = buf.iterator();
+		while ( count < n && count < buf.count )
+		{
+			out += it.next().value;
+			count += 1;
+		}
+	}
+	else {
+		out = buf.toArray().join( '' );
 	}
 	return out;
 }

--- a/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/lib/main.js
@@ -1,0 +1,74 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var prevGraphemeClusterBreak = require( '@stdlib/string/prev-grapheme-cluster-break' );
+
+
+// MAIN //
+
+/**
+* Returns the last `n` grapheme clusters (i.e., user-perceived characters) of a string.
+*
+* @param {string} str - input string
+* @param {NonNegativeInteger} n - number of grapheme clusters to return
+* @returns {string} output string
+*
+* @example
+* var out = last( 'Hello World', 1 );
+* // returns 'd'
+*
+* @example
+* var out = last( 'Evening', 3 );
+* // returns 'ing'
+*
+* @example
+* var out = last( 'JavaScript', 6 );
+* // returns 'Script'
+*
+* @example
+* var out = last( '六书/六書', 1 );
+* // returns '書'
+*
+* @example
+* var out = last( '🐶🐮🐷🐰🐸', 2 );
+* // returns '🐰🐸'
+*/
+function last( str, n ) {
+	var len;
+	var i;
+	len = str.length;
+	i = len - 1;
+	while ( n > 0 ) {
+		i = prevGraphemeClusterBreak( str, i );
+		n -= 1;
+	}
+	// Value of `i` will be -1 if and only if `str` is an empty string or `str` has only 1 extended grapheme cluster...
+	if ( str === '' || i === -1 ) {
+		return str;
+	}
+	return str.substring( i + 1, len );
+}
+
+
+// EXPORTS //
+
+module.exports = last;

--- a/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/lib/main.js
@@ -63,12 +63,6 @@ function last( str, n ) {
 	if ( n === 0 || str === '' ) {
 		return '';
 	}
-	// Initialize a buffer for keeping track of cluster break indices:
-	buf = zeros( n );
-
-	// Wrap the buffer to create a circular buffer serving as a FIFO stack where we can keep at most `n` indices as we iterate from left-to-right:
-	cbuf = new CircularBuffer( buf );
-
 	// Resolve the first cluster break:
 	i = nextGraphemeClusterBreak( str, 0 );
 
@@ -76,6 +70,12 @@ function last( str, n ) {
 	if ( i === -1 ) {
 		return str;
 	}
+	// Initialize a buffer for keeping track of cluster break indices:
+	buf = zeros( n );
+
+	// Wrap the buffer to create a circular buffer serving as a FIFO stack where we can keep at most `n` indices as we iterate from left-to-right:
+	cbuf = new CircularBuffer( buf );
+
 	// Add the first character index:
 	cbuf.push( 0 );
 

--- a/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/lib/main.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var nextGraphemeClusterBreak = require( '@stdlib/string/next-grapheme-cluster-break' );
-var circularBuffer = require( '@stdlib/utils/circular-buffer' );
+var CircularBuffer = require( '@stdlib/utils/circular-buffer' );
+var zeros = require( '@stdlib/array/base/zeros' );
 
 
 // MAIN //
@@ -54,41 +55,48 @@ var circularBuffer = require( '@stdlib/utils/circular-buffer' );
 * // returns '🐰🐸'
 */
 function last( str, n ) {
-	var prevIndex;
 	var count;
-	var out;
+	var cbuf;
 	var buf;
-	var it;
 	var i;
-	out = '';
-	prevIndex = 0;
-	i = 0;
-	count = 0;
 
-	if ( n === 0 || str === '' )
-	{
+	if ( n === 0 || str === '' ) {
 		return '';
 	}
-	buf = circularBuffer( n );
-	i = nextGraphemeClusterBreak( str, prevIndex );
-	while ( i !== -1 ) {
-		buf.push( str.substring( prevIndex, i ) );
-		prevIndex = i;
-		i = nextGraphemeClusterBreak( str, prevIndex );
+	// Initialize a buffer for keeping track of cluster break indices:
+	buf = zeros( n );
+
+	// Wrap the buffer to create a circular buffer serving as a FIFO stack where we can keep at most `n` indices as we iterate from left-to-right:
+	cbuf = new CircularBuffer( buf );
+
+	// Resolve the first cluster break:
+	i = nextGraphemeClusterBreak( str, 0 );
+
+	// If we received a sentinel value, return the input string, as there are no more cluster breaks to iterate over...
+	if ( i === -1 ) {
+		return str;
 	}
-	buf.push( str.substring( prevIndex ) );
-	if ( buf.full ) {
-		it = buf.iterator();
-		while ( count < n && count < buf.count )
-		{
-			out += it.next().value;
-			count += 1;
+	// Add the first character index:
+	cbuf.push( 0 );
+
+	// Add the index of the first grapheme cluster break to our buffer:
+	cbuf.push( i );
+
+	// Slide a window over the string from left-to-right...
+	count = 0;
+	while ( true ) {
+		count += 1;
+		i = nextGraphemeClusterBreak( str, i );
+		if ( i === -1 ) {
+			break;
 		}
+		cbuf.push( i );
 	}
-	else {
-		out = buf.toArray().join( '' );
-	}
-	return out;
+	// Resolve the leftmost index:
+	i = buf[ (count+1)%n ]; // count+1 as count%n corresponds to the index of the "newest" element in the circular buffer and count+1 is the next element to replace (i.e., the "oldest" index)
+
+	// Return the last `n` grapheme clusters:
+	return str.substring( i );
 }
 
 

--- a/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/package.json
+++ b/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@stdlib/string/base/last-grapheme-cluster",
+  "version": "0.0.0",
+  "description": "Return the last grapheme cluster (i.e., user-perceived character) of a string.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdstring",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "string",
+    "str",
+    "base",
+    "last",
+    "character",
+    "char",
+    "grapheme",
+    "cluster",
+    "unicode"
+  ]
+}

--- a/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/test/test.js
+++ b/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/test/test.js
@@ -56,9 +56,6 @@ tape( 'the function returns the last grapheme cluster of a provided string (asci
 	out = last( 'JavaScript', 1 );
 	t.strictEqual( out, 't', 'returns expected value' );
 
-	out = last( 'JavaScript', 15 );
-	t.strictEqual( out, 'JavaScript', 'returns expected value' );
-
 	t.end();
 });
 
@@ -70,9 +67,6 @@ tape( 'the function returns the last grapheme cluster of a provided string (Unic
 
 	out = last( '六书/六書', 1 );
 	t.strictEqual( out, '書', 'returns expected value' );
-
-	out = last( '六书/六書', 10 );
-	t.strictEqual( out, '六书/六書', 'returns expected value' );
 
 	t.end();
 });
@@ -98,6 +92,9 @@ tape( 'the function supports returning the last `n` grapheme clusters of a provi
 	out = last( 'hello world', 7 );
 	t.strictEqual( out, 'o world', 'returns expected value' );
 
+	out = last( 'JavaScript', 15 );
+	t.strictEqual( out, 'JavaScript', 'returns expected value' );
+
 	out = last( '!!!', 1 );
 	t.strictEqual( out, '!', 'returns expected value' );
 
@@ -115,6 +112,9 @@ tape( 'the function supports returning the last `n` grapheme clusters of a provi
 
 	out = last( '六书/六書()!', 4 );
 	t.strictEqual( out, '書()!', 'returns expected value' );
+
+	out = last( '六书/六書', 10 );
+	t.strictEqual( out, '六书/六書', 'returns expected value' );
 
 	out = last( '🌷🌷🌷🌷🌷', 2 );
 	t.strictEqual( out, '🌷🌷', 'returns expected value' );

--- a/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/test/test.js
+++ b/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/test/test.js
@@ -50,6 +50,9 @@ tape( 'the function returns the last grapheme cluster of a provided string (asci
 	out = last( 'hello world', 1 );
 	t.strictEqual( out, 'd', 'returns expected value' );
 
+	out = last( 'h', 1 );
+	t.strictEqual( out, 'h', 'returns expected value' );
+
 	out = last( '!!!', 1 );
 	t.strictEqual( out, '!', 'returns expected value' );
 
@@ -66,6 +69,9 @@ tape( 'the function returns the last grapheme cluster of a provided string (Unic
 	t.strictEqual( out, 'द', 'returns expected value' );
 
 	out = last( '六书/六書', 1 );
+	t.strictEqual( out, '書', 'returns expected value' );
+
+	out = last( '書', 1 );
 	t.strictEqual( out, '書', 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/test/test.js
+++ b/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/test/test.js
@@ -1,0 +1,117 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var last = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof last, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns an empty string if provided an empty string', function test( t ) {
+	t.strictEqual( last( '', 1 ), '', 'returns expected value' );
+	t.strictEqual( last( '', 2 ), '', 'returns expected value' );
+	t.strictEqual( last( '', 3 ), '', 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns an empty string if provided zero as the second argument', function test( t ) {
+	t.strictEqual( last( 'hello world', 0 ), '', 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns the last grapheme cluster of a provided string (ascii)', function test( t ) {
+	var out;
+
+	out = last( 'hello world', 1 );
+	t.strictEqual( out, 'd', 'returns expected value' );
+
+	out = last( '!!!', 1 );
+	t.strictEqual( out, '!', 'returns expected value' );
+
+	out = last( 'JavaScript', 1 );
+	t.strictEqual( out, 't', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns the last grapheme cluster of a provided string (Unicode)', function test( t ) {
+	var out;
+
+	out = last( 'अनुच्छेद', 1 );
+	t.strictEqual( out, 'द', 'returns expected value' );
+
+	out = last( '六书/六書', 1 );
+	t.strictEqual( out, '書', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns the last grapheme cluster of a provided string (emoji)', function test( t ) {
+	var out;
+
+	out = last( '🌷', 1 );
+	t.strictEqual( out, '🌷', 'returns expected value' );
+
+	out = last( '🏝️🌷', 1 );
+	t.strictEqual( out, '🌷', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports returning the last `n` grapheme clusters of a provided string', function test( t ) {
+	var out;
+
+	out = last( 'hello world', 1 );
+	t.strictEqual( out, 'd', 'returns expected value' );
+
+	out = last( 'hello world', 7 );
+	t.strictEqual( out, 'o world', 'returns expected value' );
+
+	out = last( '!!!', 1 );
+	t.strictEqual( out, '!', 'returns expected value' );
+
+	out = last( '!!!', 2 );
+	t.strictEqual( out, '!!', 'returns expected value' );
+
+	out = last( 'अनुच्छेद', 1 );
+	t.strictEqual( out, 'द', 'returns expected value' );
+
+	out = last( 'अनुच्छेद+o', 3 );
+	t.strictEqual( out, 'द+o', 'returns expected value' );
+
+	out = last( '六书/六書', 2 );
+	t.strictEqual( out, '六書', 'returns expected value' );
+
+	out = last( '六书/六書()!', 4 );
+	t.strictEqual( out, '書()!', 'returns expected value' );
+
+	out = last( '🌷🌷🌷🌷🌷', 2 );
+	t.strictEqual( out, '🌷🌷', 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/test/test.js
+++ b/lib/node_modules/@stdlib/string/base/last-grapheme-cluster/test/test.js
@@ -56,6 +56,9 @@ tape( 'the function returns the last grapheme cluster of a provided string (asci
 	out = last( 'JavaScript', 1 );
 	t.strictEqual( out, 't', 'returns expected value' );
 
+	out = last( 'JavaScript', 15 );
+	t.strictEqual( out, 'JavaScript', 'returns expected value' );
+
 	t.end();
 });
 
@@ -67,6 +70,9 @@ tape( 'the function returns the last grapheme cluster of a provided string (Unic
 
 	out = last( '六书/六書', 1 );
 	t.strictEqual( out, '書', 'returns expected value' );
+
+	out = last( '六书/六書', 10 );
+	t.strictEqual( out, '六书/六書', 'returns expected value' );
 
 	t.end();
 });


### PR DESCRIPTION
Resolves #1729 

## Description

> What is the purpose of this pull request?

This PR adds the package `@stdlib/string/base/last-grapheme-cluster`

This pull request:

-   Adds the package `@stdlib/string/base/last-grapheme-cluster` which returns the last `n` grapheme clusters (i.e., user-perceived characters) of a string.

## Related Issues

> Does this pull request have any related issues?

#854 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
