### PR TITLE
fix: remove invalid examples in `native.js` for `@stdlib/math/base/special/fibonacci`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/fibonacci/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/fibonacci/lib/native.js
@@ -59,6 +59,10 @@ var addon = require( './../src/addon.node' );
 * @example
 * var y = fibonacci( 6 );
 * // returns 8
+*
+* @example
+* var y = fibonacci( -1 );
+* // returns NaN
 */
 function fibonacci( n ) {
 	return addon( n );

--- a/lib/node_modules/@stdlib/math/base/special/fibonacci/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/fibonacci/lib/native.js
@@ -59,18 +59,6 @@ var addon = require( './../src/addon.node' );
 * @example
 * var y = fibonacci( 6 );
 * // returns 8
-*
-* @example
-* var y = fibonacci( NaN );
-* // returns NaN
-*
-* @example
-* var y = fibonacci( 3.14 );
-* // returns NaN
-*
-* @example
-* var y = fibonacci( -1.0 );
-* // returns NaN
 */
 function fibonacci( n ) {
 	return addon( n );


### PR DESCRIPTION
## Description

This PR removes invalid examples in `native.js` for `@stdlib/math/base/special/fibonacci`, which were the non-integer and NaN input examples, as suggested [here](https://github.com/stdlib-js/stdlib/issues/1758#issuecomment-1986997423).

> What is the purpose of this pull request?

This pull request:

-   removes invalid examples in `native.js` for `@stdlib/math/base/special/fibonacci`.

## Related Issues

> Does this pull request have any related issues?

n/a

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   ☑️ Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
