### PR TITLE
feat: add `utils/any-own-by`

### DIFF
--- a/lib/node_modules/@stdlib/utils/any-own-by/README.md
+++ b/lib/node_modules/@stdlib/utils/any-own-by/README.md
@@ -1,0 +1,206 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# anyOwnBy
+
+> Test whether at least one own property of a provided object passes a test implemented by a predicate function.
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var anyOwnBy = require( '@stdlib/utils/any-own-by' );
+```
+
+#### anyBy( collection, predicate\[, thisArg ] )
+
+Tests whether at least one own property of a provided [`object`][mdn-object] passes a test implemented by a `predicate` function.
+
+```javascript
+function isNegative( value ) {
+    return ( value < 0 );
+}
+
+var obj = {
+    'a': 1,
+    'b': 2,
+    'c': 3,
+    'd': -24,
+    'e': 12
+};
+
+var bool = anyOwnBy( obj, isNegative );
+// returns true
+```
+
+If a `predicate` function returns a truthy value, the function **immediately** returns `true`.
+
+```javascript
+function isPositive( value ) {
+    if ( value < 0 ) {
+        throw new Error( 'should never reach this line' );
+    }
+    return ( value > 0 );
+}
+
+var obj = {
+    'a': 1,
+    'b': 2,
+    'c': 3,
+    'd': -24,
+    'e': 12
+};
+
+var bool = anyOwnBy( obj, isPositive );
+// returns true
+```
+
+The invoked `function` is provided three arguments:
+
+-   `value`: property value
+-   `key`: property key
+-   `obj`: input object
+
+To set the function execution context, provide a `thisArg`.
+
+```javascript
+function verify( value ) {
+    this.sum += value;
+    this.count += 1;
+    return ( value > 0 );
+}
+
+var obj = {
+    'a': -1,
+    'b': -2,
+    'c': 3,
+    'd': -14
+};
+
+var context = {
+    'sum': 0,
+    'count': 0
+};
+
+var bool = anyOwnBy( obj, verify, context );
+// returns true
+
+var mean = context.sum / context.count;
+// returns 0
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+## Notes
+
+-   If provided an empty object, the function returns `false`.
+
+    ```javascript
+    function verify() {
+        return true;
+    }
+    var bool = anyOwnBy( {}, verify );
+    // returns false
+    ```
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var randu = require( '@stdlib/random/base/randu' );
+var anyOwnBy = require( '@stdlib/utils/any-own-by' );
+
+function threshold( value ) {
+    return ( value > 0.94 );
+}
+
+var bool;
+var obj = {};
+var keys = [ 'a', 'b', 'c', 'd', 'e' ];
+var i;
+for ( i = 0; i < keys.length; i++ ) {
+    obj[ keys[ i ] ] = randu();
+}
+
+bool = anyOwnBy( obj, threshold );
+// returns <boolean>
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[mdn-object]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object
+
+<!-- <related-links> -->
+
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/utils/any-own-by/docs/repl.txt
+++ b/lib/node_modules/@stdlib/utils/any-own-by/docs/repl.txt
@@ -1,0 +1,42 @@
+{{alias}}( object, predicate[, thisArg ] )
+    Tests whether at least one own property of an object passes a 
+    test implemented by a predicate function.
+
+    The predicate function is provided three arguments:
+
+    - `value`: property value
+    - `index`: property key
+    - `object`: the input object
+
+    The function immediately returns upon encountering a truthy return
+    value.
+
+    If provided an empty object, the function returns `false`.
+
+    Parameters
+    ----------
+    object: Object
+        Input object.
+
+    predicate: Function
+        Test function.
+
+    thisArg: any (optional)
+        Execution context.
+
+    Returns
+    -------
+    bool: boolean
+        The function returns `true` if the predicate function returns a truthy
+        value for one own property; otherwise, the function returns `false`.
+
+    Examples
+    --------
+    > function positive( v ) { return ( v > 0 ); };
+    > var obj = { 'a': -1, 'b': 2, 'c': -3 };
+    > var bool = {{alias}}( obj, positive )
+    true
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/utils/any-own-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/utils/any-own-by/docs/types/index.d.ts
@@ -71,8 +71,8 @@ type Predicate<T, U> = Nullary<U> | Unary<T, U> | Binary<T, U> | Ternary<T, U>;
 *
 * -   The predicate function is provided three arguments:
 *
-*     -   `value`: collection value
-*     -   `key`: collection key
+*     -   `value`: property value
+*     -   `key`: property key
 *     -   `object`: the input object
 *
 * -   The function immediately returns upon encountering a truthy return value.

--- a/lib/node_modules/@stdlib/utils/any-own-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/utils/any-own-by/docs/types/index.d.ts
@@ -1,0 +1,101 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+/**
+* Checks whether an own property of the object passes the test.
+*
+* @returns boolean indicating whether an own property of the object passes the test
+*/
+type Nullary<U> = ( this: U ) => boolean;
+
+/**
+* Checks whether an own property of the object passes the test.
+*
+* @param value - collection value
+* @returns boolean indicating whether an own property of the object passes the test
+*/
+type Unary<T, U> = ( this: U, value: T ) => boolean;
+
+/**
+* Checks whether an own property of the object passes the test.
+*
+* @param value - property value
+* @param key - property key
+* @returns boolean indicating whether an own property of the object passes the test
+*/
+type Binary<T, U> = ( this: U, value: T, key: number ) => boolean;
+
+/**
+* Checks whether an own property of the object passes the test.
+*
+* @param value - property value
+* @param key - property key
+* @param object - input object
+* @returns boolean indicating whether an own property of the object passes the test
+*/
+type Ternary<T, U> = ( this: U, value: T, key: number, object: Object ) => boolean;
+
+/**
+* Checks whether an own property of the object passes the test.
+*
+* @param value - property value
+* @param key - property key
+* @param object - input object
+* @returns boolean indicating whether an own property of the object passes the tests
+*/
+type Predicate<T, U> = Nullary<U> | Unary<T, U> | Binary<T, U> | Ternary<T, U>;
+
+/**
+* Tests whether any property of an object passes a test implemented by a predicate function.
+*
+* ## Notes
+*
+* -   The predicate function is provided three arguments:
+*
+*     -   `value`: collection value
+*     -   `key`: collection key
+*     -   `object`: the input object
+*
+* -   The function immediately returns upon encountering a truthy return value.
+* -   If provided an empty object, the function returns `false`.
+*
+* @param object - input object
+* @param predicate - test function
+* @param thisArg - execution context
+* @returns boolean indicating whether any own property pass a test
+*
+* @example
+* function isPositive( v ) {
+*     return ( v > 0 );
+* }
+*
+* var obj = { 'a': -1, 'b': 2, 'c': -3 };
+*
+* var bool = anyOwnBy( obj, isPositive );
+* // returns true
+*/
+declare function anyOwnBy<T = unknown, U = unknown>( object: Record<string, unknown>, predicate: Predicate<T, U>, thisArg?: ThisParameterType<Predicate<T, U>> ): boolean;
+
+
+// EXPORTS //
+
+export = anyOwnBy;

--- a/lib/node_modules/@stdlib/utils/any-own-by/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/utils/any-own-by/docs/types/test.ts
@@ -1,0 +1,63 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import anyOwnBy = require( './index' );
+
+const isPositive = ( v: number ): boolean => {
+	return ( v > 0 );
+};
+
+// TESTS //
+
+var obj = {
+	'a':-1,
+	'b':2,
+	'c':-3
+};
+
+// The function returns a boolean...
+{
+	anyOwnBy( obj, isPositive ); // $ExpectType boolean
+	anyOwnBy( obj, isPositive ); // $ExpectType boolean
+}
+
+// The compiler throws an error if the function is provided a first argument which is not an object...
+{
+	anyOwnBy( 2, isPositive ); // $ExpectError
+	anyOwnBy( false, isPositive ); // $ExpectError
+	anyOwnBy( true, isPositive ); // $ExpectError
+	anyOwnBy( [ 1, 2 ], isPositive ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument which is not a function...
+{
+	anyOwnBy( obj , 2 ); // $ExpectError
+	anyOwnBy( obj , false ); // $ExpectError
+	anyOwnBy( obj , true ); // $ExpectError
+	anyOwnBy( obj , 'abc' ); // $ExpectError
+	anyOwnBy( obj , {} ); // $ExpectError
+	anyOwnBy( obj , [] ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an invalid number of arguments...
+{
+	anyOwnBy(); // $ExpectError
+	anyOwnBy( [ 1, 2, 3 ] ); // $ExpectError
+	anyOwnBy( [ 1, 2, 3 ], isPositive, {}, 3 ); // $ExpectError
+}
+

--- a/lib/node_modules/@stdlib/utils/any-own-by/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/utils/any-own-by/docs/types/test.ts
@@ -22,13 +22,13 @@ const isPositive = ( v: number ): boolean => {
 	return ( v > 0 );
 };
 
-// TESTS //
-
-var obj = {
+const obj = {
 	'a':-1,
 	'b':2,
 	'c':-3
 };
+
+// TESTS //
 
 // The function returns a boolean...
 {

--- a/lib/node_modules/@stdlib/utils/any-own-by/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/any-own-by/examples/index.js
@@ -1,0 +1,37 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var randu = require( '@stdlib/random/base/randu' );
+var anyOwnBy = require( './../lib' );
+
+function threshold( value ) {
+	return ( value > 0.94 );
+}
+
+var bool;
+var obj = {};
+var keys = [ 'a', 'b', 'c', 'd', 'e' ];
+var i;
+for ( i = 0; i < keys.length; i++ ) {
+	obj[ keys[ i ] ] = randu();
+}
+
+bool = anyOwnBy( obj, threshold );
+console.log( bool );

--- a/lib/node_modules/@stdlib/utils/any-own-by/lib/index.js
+++ b/lib/node_modules/@stdlib/utils/any-own-by/lib/index.js
@@ -1,0 +1,46 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Test whether any 'own' property of a provided object satisfies a predicate function.
+*
+* @module @stdlib/utils/any-own-by
+*
+* @example
+* var anyOwnBy = require( '@stdlib/utils/any-own-by' );
+*
+* function isPositive( v ) {
+*     return ( v > 0 );
+* }
+*
+* var obj = { 'a': -1, 'b': 2, 'c': -3 };
+*
+* var bool = anyOwnBy( obj, isPositive );
+* // returns true
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/utils/any-own-by/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/any-own-by/lib/main.js
@@ -1,0 +1,77 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isObject = require( '@stdlib/assert/is-object' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var format = require( '@stdlib/string/format' );
+
+
+// MAIN //
+
+/**
+* Tests whether any 'own' property of a provided object satisfies a predicate function.
+*
+* @param {Object} obj - input object
+* @param {Function} predicate - test function
+* @param {*} [thisArg] - execution context
+* @throws {TypeError} first argument must be an object
+* @throws {TypeError} second argument must be a function
+* @returns {boolean} boolean returned indicating whether any own property of an object pass a test
+*
+* @example
+* var anyOwnBy = require( '@stdlib/utils/any-own-by' );
+*
+* function isPositive( v ) {
+*     return ( v > 0 );
+* }
+*
+* var obj = { 'a': -1, 'b': 2, 'c': -3 };
+*
+* var bool = anyOwnBy( obj, isPositive );
+* // returns true
+*/
+function anyOwnBy( obj, predicate, thisArg ) {
+	var result;
+	var key;
+	if ( !isObject( obj ) ) {
+		throw new TypeError( format( 'invalid argument. First argument must be an object. Value: `%s`.', obj ) );
+	}
+	if ( !isFunction( predicate ) ) {
+		throw new TypeError( format( 'invalid argument. Second argument must be a function. Value: `%s`.', predicate ) );
+	}
+
+	for ( key in obj ) {
+		if ( hasOwnProp( obj, key ) ) {
+			result = predicate.call( thisArg, obj[ key ], key, obj );
+			if ( result ) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+
+// EXPORTS //
+
+module.exports = anyOwnBy;

--- a/lib/node_modules/@stdlib/utils/any-own-by/package.json
+++ b/lib/node_modules/@stdlib/utils/any-own-by/package.json
@@ -1,0 +1,71 @@
+{
+    "name": "@stdlib/utils/any-own-by",
+    "version": "0.0.0",
+    "description": "Test whether whether any 'own' property of a provided object satisfies a predicate function.",
+    "license": "Apache-2.0",
+    "author": {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    },
+    "contributors": [
+      {
+        "name": "The Stdlib Authors",
+        "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+      }
+    ],
+    "main": "./lib",
+    "directories": {
+      "benchmark": "./benchmark",
+      "doc": "./docs",
+      "example": "./examples",
+      "lib": "./lib",
+      "test": "./test"
+    },
+    "types": "./docs/types",
+    "scripts": {},
+    "homepage": "https://github.com/stdlib-js/stdlib",
+    "repository": {
+      "type": "git",
+      "url": "git://github.com/stdlib-js/stdlib.git"
+    },
+    "bugs": {
+      "url": "https://github.com/stdlib-js/stdlib/issues"
+    },
+    "dependencies": {},
+    "devDependencies": {},
+    "engines": {
+      "node": ">=0.10.0",
+      "npm": ">2.7.0"
+    },
+    "os": [
+      "aix",
+      "darwin",
+      "freebsd",
+      "linux",
+      "macos",
+      "openbsd",
+      "sunos",
+      "win32",
+      "windows"
+    ],
+    "keywords": [
+      "stdlib",
+      "stdutils",
+      "stdutil",
+      "utilities",
+      "utility",
+      "utils",
+      "util",
+      "test",
+      "predicate",
+      "any",
+      "iterate",
+      "object",
+      "property",
+      "properties",
+      "props",
+      "keys",
+      "obj",
+      "validate"
+    ]
+  }

--- a/lib/node_modules/@stdlib/utils/any-own-by/test/test.js
+++ b/lib/node_modules/@stdlib/utils/any-own-by/test/test.js
@@ -33,7 +33,7 @@ tape( 'main export is a function', function test( t ) {
 	t.end();
 });
 
-tape( 'the function throws an error if not provided an object to the first argument', function test( t ) {
+tape( 'the function throws an error if provided a first argument which is not an object', function test( t ) {
 	var values;
 	var i;
 
@@ -62,7 +62,7 @@ tape( 'the function throws an error if not provided an object to the first argum
 	}
 });
 
-tape( 'the function throws an error if not provided a predicate function to the second argument', function test( t ) {
+tape( 'the function throws an error if provided a second argument which is not a predicate function' , function test( t ) {
 	var values;
 	var i;
 

--- a/lib/node_modules/@stdlib/utils/any-own-by/test/test.js
+++ b/lib/node_modules/@stdlib/utils/any-own-by/test/test.js
@@ -1,0 +1,180 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var noop = require( '@stdlib/utils/noop' );
+var anyOwnBy = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof anyOwnBy, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function throws an error if not provided an object to the first argument', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		function noop() {},
+		/.*/,
+		new Date()
+	];
+	for ( i =0; i < values.length; i++ ) {
+		t.throws( badValue( values ), TypeError, 'throws a type error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			anyOwnBy( value, noop );
+		};
+	}
+});
+
+tape( 'the function throws an error if not provided a predicate function to the second argument', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		/.*/,
+		new Date()
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws a type error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			anyOwnBy( {}, value );
+		};
+	}
+});
+
+tape( 'if provided an empty object, the function returns `false`', function test( t ) {
+	var bool;
+	var obj;
+
+	function foo() {
+		t.fail( 'should not be invoked' );
+	}
+	obj = {};
+	bool = anyOwnBy( obj, foo );
+
+	t.strictEqual( bool, false, 'returns false' );
+	t.end();
+});
+
+tape( 'the function returns `true` if any one property pass a test', function test( t ) {
+	var bool;
+	var obj;
+
+	obj = {
+		'a': -1,
+		'b': 2,
+		'c': -3
+	};
+
+	function isPositive( v ) {
+		return ( v > 0 );
+	}
+
+	bool = anyOwnBy( obj, isPositive );
+
+	t.strictEqual( bool, true, 'returns true' );
+	t.end();
+});
+
+tape( 'the function returns `false` if no properties pass a test', function test( t ) {
+	var bool;
+	var obj;
+
+	obj = {
+		'a': -1,
+		'b': -2,
+		'c': -3,
+		'd': -34
+	};
+
+	function isPositive( v ) {
+		return ( v > 0 );
+	}
+
+	bool = anyOwnBy( obj, isPositive );
+
+	t.strictEqual( bool, false, 'returns false' );
+	t.end();
+});
+
+tape( 'the function supports providing an execution context', function test( t ) {
+	var bool;
+	var ctx;
+	var obj;
+
+	function verify( value ) {
+		/* eslint-disable no-invalid-this */
+		this.sum += value;
+		this.count += 1;
+		return ( value > 0 );
+	}
+
+	ctx = {
+		'sum': 0,
+		'count': 0
+	};
+
+	obj = {
+		'a': -1,
+		'b': -2,
+		'c': 3,
+		'd': -14
+	};
+
+	bool = anyOwnBy( obj, verify, ctx );
+
+	t.strictEqual( bool, true, 'returns true' );
+	t.strictEqual( ctx.sum/ctx.count, 0, 'expected result' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/utils/any-own-by/test/test.js
+++ b/lib/node_modules/@stdlib/utils/any-own-by/test/test.js
@@ -62,7 +62,7 @@ tape( 'the function throws an error if provided a first argument which is not an
 	}
 });
 
-tape( 'the function throws an error if provided a second argument which is not a predicate function' , function test( t ) {
+tape( 'the function throws an error if provided a second argument which is not a predicate function', function test( t ) {
 	var values;
 	var i;
 


### PR DESCRIPTION
Resolves #819.

## Description

> What is the purpose of this pull request?

This pull request adds a utility to test whether any "own" property of a provided object satisfies a predicate function.

```js
var anyOwnBy = require( '@stdlib/utils/any-own-by' );

function isNegative( value ) {
    return ( value < 0 );
}

var obj = {
    'a': 1,
    'b': 2,
    'c': 3,
    'd': -24,
    'e': 12
};

var bool = anyOwnBy( obj, isNegative );
// returns true
```

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #819 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
