### PR TITLE
docs: fix JSDoc description in `math/base/special/acoversin`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/acoversin/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/acoversin/lib/native.js
@@ -26,7 +26,7 @@ var addon = require( './../src/addon.node' );
 // MAIN //
 
 /**
-* Computes the inverse cotangent of a double-precision floating-point number.
+* Computes the inverse coversed sine of a double-precision floating-point number.
 *
 * @private
 * @param {number} x - input value


### PR DESCRIPTION
This PR removes invalid statement in native.js for @stdlib/math/base/special/acoversin.

## Description

> What is the purpose of this pull request?

This pull request:
- This PR removes invalid statement in native.js for @stdlib/math/base/special/acoversin

## Related Issues

> Does this pull request have any related issues?


## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [X] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

