### PR TITLE
feat: add C implementation for `math/base/assert/int32-is-odd`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/README.md
@@ -123,10 +123,10 @@ out = stdlib_base_int32_is_odd( -2 );
 
 The function accepts the following arguments:
 
--   **x**: `[in] long` input value.
+-   **x**: `[in] double` input value.
 
 ```c
-bool stdlib_base_int32_is_odd( const long x );
+bool stdlib_base_int32_is_odd( const double x );
 ```
 
 </section>
@@ -153,7 +153,7 @@ bool stdlib_base_int32_is_odd( const long x );
 #include <stdbool.h>
 
 int main( void ) {
-    const long x[] = { 5, -5, 3, -3, 0, 0/0 };
+    const double x[] = { 5, -5, 3, -3, 0, 2 };
 
     bool b;
     int i;

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/README.md
@@ -151,15 +151,16 @@ bool stdlib_base_int32_is_odd( const double x );
 #include "stdlib/math/base/assert/int32_is_odd.h"
 #include <stdio.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 int main( void ) {
     const double x[] = { 5, -5, 3, -3, 0, 2 };
 
     bool b;
     int i;
-    for ( i = 0; i < 6; i++ ) {
+    for ( i = 0; i < 5; i++ ) {
         b = stdlib_base_int32_is_odd( x[ i ] );
-        printf( "Value: %lf. int32 Is Odd? %s.\n", x[ i ], ( b ) ? "True" : "False" );
+        printf( "Value: %d. int32 Is Odd? %s.\n", x[ i ], ( b ) ? "True" : "False" );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/README.md
@@ -154,13 +154,13 @@ bool stdlib_base_int32_is_odd( const double x );
 #include <stdint.h>
 
 int main( void ) {
-    const double x[] = { 5, -5, 3, -3, 0, 2 };
+    const int32_t x[] = { 5, -5, 3, -3, 0, 2 };
 
     bool b;
     int i;
     for ( i = 0; i < 5; i++ ) {
         b = stdlib_base_int32_is_odd( x[ i ] );
-        printf( "Value: %f. int32 Is Odd? %s.\n", x[ i ], ( b ) ? "True" : "False" );
+        printf( "Value: %d. int32 Is Odd? %s.\n", x[ i ], ( b ) ? "True" : "False" );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/README.md
@@ -160,7 +160,7 @@ int main( void ) {
     int i;
     for ( i = 0; i < 5; i++ ) {
         b = stdlib_base_int32_is_odd( x[ i ] );
-        printf( "Value: %d. int32 Is Odd? %s.\n", x[ i ], ( b ) ? "True" : "False" );
+        printf( "Value: %f. int32 Is Odd? %s.\n", x[ i ], ( b ) ? "True" : "False" );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/README.md
@@ -109,7 +109,7 @@ for ( i = 0; i < 100; i++ ) {
 
 #### stdlib_base_int32_is_odd( x )
 
-Tests if 32-bit integer is odd.
+Tests if a 32-bit integer is odd.
 
 ```c
 #include <stdbool.h>

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/README.md
@@ -81,6 +81,97 @@ for ( i = 0; i < 100; i++ ) {
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/math/base/assert/int32_is_odd.h"
+```
+
+#### stdlib_base_int32_is_odd( x )
+
+Tests if 32-bit integer is odd.
+
+```c
+#include <stdbool.h>
+
+bool out = stdlib_base_int32_is_odd( 5 );
+// returns true
+
+out = stdlib_base_int32_is_odd( -2 );
+// returns false
+```
+
+The function accepts the following arguments:
+
+-   **x**: `[in] long` input value.
+
+```c
+bool stdlib_base_int32_is_odd( const long x );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/math/base/assert/int32_is_odd.h"
+#include <stdio.h>
+#include <stdbool.h>
+
+int main( void ) {
+    const long x[] = { 5, -5, 3, -3, 0, 0/0 };
+
+    bool b;
+    int i;
+    for ( i = 0; i < 6; i++ ) {
+        b = stdlib_base_int32_is_odd( x[ i ] );
+        printf( "Value: %lf. int32 Is Odd? %s.\n", x[ i ], ( b ) ? "True" : "False" );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/benchmark/benchmark.native.js
@@ -1,0 +1,61 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var float64ToInt32 = require( '@stdlib/number/float64/base/to-float32' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var isOdd = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( isOdd instanceof Error )
+};
+
+
+// MAIN //
+
+bench( pkg+'::native', opts, function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		x = ( randu()*1.0e7 ) - 5.0e6;
+		y = isOdd( float64ToInt32( x ) );
+		if ( typeof y !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( y ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/benchmark/c/native/Makefile
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/benchmark/c/native/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/benchmark/c/native/benchmark.c
@@ -17,12 +17,13 @@
 */
 
 /**
-* Benchmark `is-odd`.
+* Benchmark `int32-is-odd`.
 */
 #include "stdlib/math/base/assert/int32_is_odd.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <math.h>
 #include <time.h>
 #include <sys/time.h>
@@ -103,7 +104,7 @@ double benchmark() {
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
 		x = ( rand_double() * 200.0 ) - 100.0;
-		b = stdlib_base_int32_is_odd( x );
+		b = stdlib_base_int32_is_odd( (int32_t)x );
 		if ( b != true && b != false ) {
 			printf( "should return either true or false\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/benchmark/c/native/benchmark.c
@@ -1,0 +1,137 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/**
+* Benchmark `is-odd`.
+*/
+#include "stdlib/math/base/assert/int32_is_odd.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "is-odd"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+void print_version() {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+double tic() {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1].
+*
+* @return random number
+*/
+double rand_double() {
+	int r = rand();
+	return (double)r / ( (double)RAND_MAX + 1 );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+double benchmark() {
+	double elapsed;
+	double x;
+	double t;
+	bool b;
+	int i;
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		x = ( rand_double() * 200.0 ) - 100.0;
+		b = stdlib_base_int32_is_odd( x );
+		if ( b != true && b != false ) {
+			printf( "should return either true or false\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( b != true && b != false ) {
+		printf( "should return either true or false\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::native::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/binding.gyp
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/examples/c/example.c
@@ -28,6 +28,6 @@ int main( void ) {
 	int i;
 	for ( i = 0; i < 5; i++ ) {
 		b = stdlib_base_int32_is_odd( x[ i ] );
-		printf( "Value: %f. int32 Is Odd? %s.\n", x[ i ], ( b ) ? "True" : "False" );
+		printf( "Value: %d. int32 Is Odd? %s.\n", x[ i ], ( b ) ? "True" : "False" );
 	}
 }

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/examples/c/example.c
@@ -1,0 +1,32 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/assert/int32_is_odd.h"
+#include <stdio.h>
+#include <stdbool.h>
+
+int main( void ) {
+    const long x[] = { 5, -5, 3, -3, 0, 0/0 };
+
+    bool b;
+    int i;
+    for ( i = 0; i < 6; i++ ) {
+        b = stdlib_base_int32_is_odd( x[ i ] );
+        printf( "Value: %lf. int32 Is Odd? %s.\n", x[ i ], ( b ) ? "True" : "False" );
+    }
+}

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/examples/c/example.c
@@ -19,14 +19,15 @@
 #include "stdlib/math/base/assert/int32_is_odd.h"
 #include <stdio.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 int main( void ) {
     const double x[] = { 5, -5, 3, -3, 0, 2 };
 
-    bool b;
-    int i;
-    for ( i = 0; i < 6; i++ ) {
-        b = stdlib_base_int32_is_odd( x[ i ] );
-        printf( "Value: %lf. int32 Is Odd? %s.\n", x[ i ], ( b ) ? "True" : "False" );
-    }
+	bool b;
+	int i;
+	for ( i = 0; i < 5; i++ ) {
+		b = stdlib_base_int32_is_odd( x[ i ] );
+		printf( "Value: %d. int32 Is Odd? %s.\n", x[ i ], ( b ) ? "True" : "False" );
+	}
 }

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/examples/c/example.c
@@ -22,12 +22,12 @@
 #include <stdint.h>
 
 int main( void ) {
-    const double x[] = { 5, -5, 3, -3, 0, 2 };
+	const int32_t x[] = { 5, -5, 3, -3, 0, 2 };
 
 	bool b;
 	int i;
 	for ( i = 0; i < 5; i++ ) {
 		b = stdlib_base_int32_is_odd( x[ i ] );
-		printf( "Value: %d. int32 Is Odd? %s.\n", x[ i ], ( b ) ? "True" : "False" );
+		printf( "Value: %f. int32 Is Odd? %s.\n", x[ i ], ( b ) ? "True" : "False" );
 	}
 }

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/examples/c/example.c
@@ -21,7 +21,7 @@
 #include <stdbool.h>
 
 int main( void ) {
-    const long x[] = { 5, -5, 3, -3, 0, 0/0 };
+    const double x[] = { 5, -5, 3, -3, 0, 2 };
 
     bool b;
     int i;

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/include.gypi
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/include/stdlib/math/base/assert/int32_is_odd.h
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/include/stdlib/math/base/assert/int32_is_odd.h
@@ -32,7 +32,7 @@ extern "C" {
 /**
 * Tests if 32-bit integer is odd.
 */
-bool stdlib_base_is_odd( const double x );
+bool stdlib_base_int32_is_odd( const double x );
 
 #ifdef __cplusplus
 }

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/include/stdlib/math/base/assert/int32_is_odd.h
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/include/stdlib/math/base/assert/int32_is_odd.h
@@ -32,7 +32,7 @@ extern "C" {
 /**
 * Tests if 32-bit integer is odd.
 */
-bool stdlib_base_int32_is_odd( const double x );
+bool stdlib_base_int32_is_odd( const int32_t x );
 
 #ifdef __cplusplus
 }

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/include/stdlib/math/base/assert/int32_is_odd.h
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/include/stdlib/math/base/assert/int32_is_odd.h
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_MATH_BASE_ASSERT_INT32_IS_ODD_H
+#define STDLIB_MATH_BASE_ASSERT_INT32_IS_ODD_H
+
+#include <stdbool.h>
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Tests if 32-bit integer is odd.
+*/
+bool stdlib_base_is_odd( const long x );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_MATH_BASE_ASSERT_INT32_IS_ODD_H

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/include/stdlib/math/base/assert/int32_is_odd.h
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/include/stdlib/math/base/assert/int32_is_odd.h
@@ -20,6 +20,7 @@
 #define STDLIB_MATH_BASE_ASSERT_INT32_IS_ODD_H
 
 #include <stdbool.h>
+#include <stdint.h>
 
 /*
 * If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/include/stdlib/math/base/assert/int32_is_odd.h
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/include/stdlib/math/base/assert/int32_is_odd.h
@@ -31,7 +31,7 @@ extern "C" {
 /**
 * Tests if 32-bit integer is odd.
 */
-bool stdlib_base_is_odd( const long x );
+bool stdlib_base_is_odd( const double x );
 
 #ifdef __cplusplus
 }

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/include/stdlib/math/base/assert/int32_is_odd.h
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/include/stdlib/math/base/assert/int32_is_odd.h
@@ -30,7 +30,7 @@ extern "C" {
 #endif
 
 /**
-* Tests if 32-bit integer is odd.
+* Tests if a 32-bit integer is odd.
 */
 bool stdlib_base_int32_is_odd( const int32_t x );
 

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/lib/native.js
@@ -1,0 +1,55 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var Boolean = require( '@stdlib/boolean/ctor' );
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Tests if a 32-bit integer is odd.
+*
+* @private
+* @param {number} x - value to test
+* @returns {boolean} boolean indicating whether the number is odd
+*
+* @example
+* var bool = isOdd( 5 );
+* // returns true
+*
+* @example
+* var bool = isOdd( -2 );
+* // returns false
+*
+* @example
+* var bool = isOdd( 0 );
+* // returns false
+*/
+function isOdd( x ) {
+	return Boolean( addon( x ) );
+}
+
+
+// EXPORTS //
+
+module.exports = isOdd;

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/manifest.json
@@ -1,41 +1,38 @@
 {
-	"options": {},
-	"fields": [
-	  {
-		"field": "src",
-		"resolve": true,
-		"relative": true
-	  },
-	  {
-		"field": "include",
-		"resolve": true,
-		"relative": true
-	  },
-	  {
-		"field": "libraries",
-		"resolve": false,
-		"relative": false
-	  },
-	  {
-		"field": "libpath",
-		"resolve": true,
-		"relative": false
-	  }
-	],
-	"confs": [
-	  {
-		"src": [
-		  "./src/main.c"
-		],
-		"include": [
-		  "./include"
-		],
-		"libraries": [],
-		"libpath": [],
-		"dependencies": [
-		  "@stdlib/math/base/assert/is-even"
-		]
-	  }
-	]
-  }
-  
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": []
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/manifest.json
@@ -1,0 +1,41 @@
+{
+	"options": {},
+	"fields": [
+	  {
+		"field": "src",
+		"resolve": true,
+		"relative": true
+	  },
+	  {
+		"field": "include",
+		"resolve": true,
+		"relative": true
+	  },
+	  {
+		"field": "libraries",
+		"resolve": false,
+		"relative": false
+	  },
+	  {
+		"field": "libpath",
+		"resolve": true,
+		"relative": false
+	  }
+	],
+	"confs": [
+	  {
+		"src": [
+		  "./src/main.c"
+		],
+		"include": [
+		  "./include"
+		],
+		"libraries": [],
+		"libpath": [],
+		"dependencies": [
+		  "@stdlib/math/base/assert/is-even"
+		]
+	  }
+	]
+  }
+  

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/src/addon.c
@@ -59,8 +59,8 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 		return NULL;
 	}
 
-	long x;
-	status = napi_get_value_long( env, argv[ 0 ], &x );
+	double x;
+	status = napi_get_value_double( env, argv[ 0 ], &x );
 	assert( status == napi_ok );
 
 	bool result = stdlib_base_int32_is_odd( x );

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/src/addon.c
@@ -1,0 +1,90 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/assert/int32_is_odd.h"
+#include <node_api.h>
+#include <stdint.h>
+#include <assert.h>
+
+/**
+* Receives JavaScript callback invocation data.
+*
+* @private
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @return       Node-API value
+*/
+static napi_value addon( napi_env env, napi_callback_info info ) {
+	napi_status status;
+
+	// Get callback arguments:
+	size_t argc = 1;
+	napi_value argv[ 1 ];
+	status = napi_get_cb_info( env, info, &argc, argv, NULL, NULL );
+	assert( status == napi_ok );
+
+	// Check whether we were provided the correct number of arguments:
+	if ( argc < 1 ) {
+		status = napi_throw_error( env, NULL, "invalid invocation. Insufficient arguments." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+	if ( argc > 1 ) {
+		status = napi_throw_error( env, NULL, "invalid invocation. Too many arguments." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	napi_valuetype vtype0;
+	status = napi_typeof( env, argv[ 0 ], &vtype0 );
+	assert( status == napi_ok );
+	if ( vtype0 != napi_number ) {
+		status = napi_throw_type_error( env, NULL, "invalid argument. First argument must be a number." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	long x;
+	status = napi_get_value_long( env, argv[ 0 ], &x );
+	assert( status == napi_ok );
+
+	bool result = stdlib_base_int32_is_odd( x );
+
+	napi_value v;
+	status = napi_create_int32( env, (int32_t)result, &v );
+	assert( status == napi_ok );
+
+	return v;
+}
+
+/**
+* Initializes a Node-API module.
+*
+* @private
+* @param env      environment under which the function is invoked
+* @param exports  exports object
+* @return         main export
+*/
+static napi_value init( napi_env env, napi_value exports ) {
+	napi_value fcn;
+	napi_status status = napi_create_function( env, "exports", NAPI_AUTO_LENGTH, addon, NULL, &fcn );
+	assert( status == napi_ok );
+	return fcn;
+}
+
+NAPI_MODULE( NODE_GYP_MODULE_NAME, init )

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/src/main.c
@@ -20,7 +20,7 @@
 #include <stdint.h>
 
 /**
-* Tests if 32-bit integer is odd.
+* Tests if a 32-bit integer is odd.
 *
 * @param x    input value
 * @return     output value

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/src/main.c
@@ -31,7 +31,7 @@
 * bool out = stdlib_base_int32_is_odd( 3 );
 * // returns true
 */
-bool stdlib_base_int32_is_odd( const long x ) {
+bool stdlib_base_int32_is_odd( const double x ) {
     // Check sign to prevent overflow...
     if ( x > 0 ) {
         return stdlib_base_is_even( x - 1 );

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/src/main.c
@@ -17,13 +17,12 @@
 */
 
 #include "stdlib/math/base/assert/int32_is_odd.h"
-#include "stdlib/math/base/assert/is_even.h"
 
 /**
 * Tests if 32-bit integer is odd.
 *
 * @param x    input value
-* @return	  output value
+* @return     output value
 *
 * @example
 * #include <stdbool.h>
@@ -32,9 +31,5 @@
 * // returns true
 */
 bool stdlib_base_int32_is_odd( const double x ) {
-    // Check sign to prevent overflow...
-    if ( x > 0 ) {
-        return stdlib_base_is_even( x - 1 );
-    }
-    return stdlib_base_is_even( x + 1 );
+	return ( x & 1 ) == 1;
 }

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/assert/int32_is_odd.h"
+#include <stdint.h>
 
 /**
 * Tests if 32-bit integer is odd.
@@ -30,6 +31,6 @@
 * bool out = stdlib_base_int32_is_odd( 3 );
 * // returns true
 */
-bool stdlib_base_int32_is_odd( const double x ) {
+bool stdlib_base_int32_is_odd( const int32_t x ) {
 	return ( x & 1 ) == 1;
 }

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/src/main.c
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/assert/int32_is_odd.h"
+#include "stdlib/math/base/assert/is_even.h"
+
+/**
+* Tests if 32-bit integer is odd.
+*
+* @param x    input value
+* @return	  output value
+*
+* @example
+* #include <stdbool.h>
+*
+* bool out = stdlib_base_int32_is_odd( 3 );
+* // returns true
+*/
+bool stdlib_base_int32_is_odd( const long x ) {
+    // Check sign to prevent overflow...
+    if ( x > 0 ) {
+        return stdlib_base_is_even( x - 1 );
+    }
+    return stdlib_base_is_even( x + 1 );
+}

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/test/test.native.js
@@ -1,0 +1,84 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var randu = require( '@stdlib/random/base/randu' );
+var round = require( '@stdlib/math/base/special/round' );
+var floor = require( '@stdlib/math/base/special/floor' );
+var MAX_INT32 = require( '@stdlib/constants/int32/max' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var HALF_MAX_INT32 = floor( MAX_INT32 / 2 );
+var isOdd = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( isOdd instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof isOdd, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `false` if provided `0`', opts, function test( t ) {
+	var bool = isOdd( 0 );
+	t.strictEqual( bool, false, 'returns false when provided 0' );
+	t.end();
+});
+
+tape( 'the function returns `false` if provided an even integer', opts, function test( t ) {
+	var bool;
+	var x;
+	var i;
+	for ( i = 0; i < 1000; i++ ) {
+		x = round( randu()*MAX_INT32 ) - HALF_MAX_INT32 - 1;
+		x *= 2; // always even
+		bool = isOdd( x );
+		t.strictEqual( bool, false, 'returns false when provided '+x );
+	}
+	t.end();
+});
+
+tape( 'the function returns `true` if provided an odd integer', opts, function test( t ) {
+	var bool;
+	var x;
+	var i;
+	for ( i = 0; i < 1000; i++ ) {
+		x = round( randu()*2*MAX_INT32 ) - MAX_INT32;
+		if ( x > 0 ) {
+			x -= 1;
+		}
+		if ( x%2 === 0 ) {
+			x += 1;
+		}
+		bool = isOdd( x );
+		t.strictEqual( bool, true, 'returns true when provided '+x );
+	}
+	t.end();
+});


### PR DESCRIPTION
Resolves #1806  .

## Description

> What is the purpose of this pull request?

This pull request:

-   add C implementation for math/base/assert/int32-is-odd

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #1806 .

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [X] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

