### PR TITLE
docs: improve README examples of `stats/base/dists/truncated-normal`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/README.md
@@ -76,10 +76,23 @@ The namespace contains a constructor function for creating a [truncated normal][
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var objectKeys = require( '@stdlib/utils/keys' );
 var truncatedNormal = require( '@stdlib/stats/base/dists/truncated-normal' );
 
-console.log( objectKeys( truncatedNormal ) );
+/*
+* Let's consider an example where we're modeling the heights of astronauts.
+* We'll use the truncated normal distribution to model this scenario, considering constraints on their minimum and maximum heights.
+* The distribution has parameters: a (minimum height), b (maximum height), mu (location parameter), and sigma (scale parameter).
+* In this example, we'll assume a = 150 (minimum height), b = 200 (maximum height), mu = 175 (location parameter), and sigma = 10 (scale parameter).
+*/
+
+var a = 150;
+var b = 200;
+var mu = 175;
+var sigma = 10;
+
+// Calculate the probability density function (PDF) for a height of 180 cm:
+console.log(truncatedNormal.pdf(180, a, b, mu, sigma));
+// => ~0.036
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/README.md
@@ -85,13 +85,13 @@ var truncatedNormal = require( '@stdlib/stats/base/dists/truncated-normal' );
 * In this example, we'll assume a = 150 (minimum height), b = 200 (maximum height), mu = 175 (location parameter), and sigma = 10 (scale parameter).
 */
 
-var a = 150;
-var b = 200;
-var mu = 175;
-var sigma = 10;
+var a = 150.0;
+var b = 200.0;
+var mu = 175.0;
+var sigma = 10.0;
 
 // Calculate the probability density function (PDF) for a height of 180 cm:
-console.log(truncatedNormal.pdf(180, a, b, mu, sigma));
+console.log( truncatedNormal.pdf( 180, a, b, mu, sigma ) );
 // => ~0.036
 ```
 

--- a/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/examples/index.js
@@ -18,7 +18,20 @@
 
 'use strict';
 
-var objectKeys = require( '@stdlib/utils/keys' );
 var truncatedNormal = require( './../lib' );
 
-console.log( objectKeys( truncatedNormal ) );
+/*
+* Let's consider an example where we're modeling the heights of astronauts.
+* We'll use the truncated normal distribution to model this scenario, considering constraints on their minimum and maximum heights.
+* The distribution has parameters: a (minimum height), b (maximum height), mu (location parameter), and sigma (scale parameter).
+* In this example, we'll assume a = 150 (minimum height), b = 200 (maximum height), mu = 175 (location parameter), and sigma = 10 (scale parameter).
+*/
+
+var a = 150;
+var b = 200;
+var mu = 175;
+var sigma = 10;
+
+// Calculate the probability density function (PDF) for a height of 180 cm:
+console.log(truncatedNormal.pdf(180, a, b, mu, sigma));
+// => ~0.036

--- a/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/truncated-normal/examples/index.js
@@ -27,11 +27,11 @@ var truncatedNormal = require( './../lib' );
 * In this example, we'll assume a = 150 (minimum height), b = 200 (maximum height), mu = 175 (location parameter), and sigma = 10 (scale parameter).
 */
 
-var a = 150;
-var b = 200;
-var mu = 175;
-var sigma = 10;
+var a = 150.0;
+var b = 200.0;
+var mu = 175.0;
+var sigma = 10.0;
 
 // Calculate the probability density function (PDF) for a height of 180 cm:
-console.log(truncatedNormal.pdf(180, a, b, mu, sigma));
+console.log(truncatedNormal.pdf( 180, a, b, mu, sigma ) );
 // => ~0.036


### PR DESCRIPTION
Resolves #1647  .

## Description

> What is the purpose of this pull request?

This pull request:

-   improve README examples of stats/base/dists/truncated-normal

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #1647 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [X] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

