### PR TITLE
feat: add C implementation for `math/base/special/factorial2`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/factorial2/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2/README.md
@@ -119,7 +119,7 @@ for ( i = 0; i < values.length; i++ ) {
 #include "stdlib/math/base/special/factorial2.h"
 ```
 
-#### stdlib_base_factorial2( x )
+#### stdlib_base_factorial2( n )
 
 Evaluates the [double factorial][double-factorial] of `n`.
 

--- a/lib/node_modules/@stdlib/math/base/special/factorial2/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2/README.md
@@ -93,6 +93,92 @@ for ( i = 0; i < values.length; i++ ) {
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/math/base/special/factorial2.h"
+```
+
+#### stdlib_base_factorial2( x )
+
+Evaluates the [double factorial][double-factorial] of `n`.
+
+```c
+double out = stdlib_base_factorial2( 3 );
+// returns 3
+```
+
+The function accepts the following arguments:
+
+-   **x**: `[in] int32_t` input value.
+
+```c
+double stdlib_base_factorial2( const int32_t x );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/math/base/special/factorial2.h"
+#include <stdio.h>
+#include <stdint.h>
+
+int main( void ) {
+    const int32_t x[] = { 1, 10, 1, 301, 302 };
+
+    double b;
+    int i;
+    for ( i = 0; i < 5; i++ ){
+        b = stdlib_base_factorial2( x[ i ] );
+        printf ( "factorial2(%d) = %lf\n", x[ i ], b );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/math/base/special/factorial2/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2/benchmark/benchmark.native.js
@@ -1,0 +1,57 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var factorial2 = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( factorial2 instanceof Error )
+};
+
+
+// MAIN //
+
+bench( pkg+'::native', opts, function benchmark( b ) {
+	var y;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		y = factorial2(i % 301);
+		if ( isnan( y ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnan( y ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/factorial2/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2/benchmark/benchmark.native.js
@@ -43,7 +43,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = factorial2(i % 301);
+		y = factorial2( i % 301 );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/factorial2/benchmark/c/native/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2/benchmark/c/native/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/factorial2/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2/benchmark/c/native/benchmark.c
@@ -1,0 +1,137 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/**
+* Benchmark `factorial2`.
+*/
+#include "stdlib/math/base/special/factorial2.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "factorial2"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+void print_version() {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+double tic() {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1].
+*
+* @return random number
+*/
+double rand_double() {
+	int r = rand();
+	return (double)r / ( (double)RAND_MAX + 1.0 );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+double benchmark() {
+	double elapsed;
+	double x;
+	double y;
+	double t;
+	int i;
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		x = (int32_t)(rand_double() * 301);
+		y = stdlib_base_factorial2( x );
+		if ( y != y ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( y != y ) {
+		printf( "should not return NaN\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::native::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/math/base/special/factorial2/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2/benchmark/c/native/benchmark.c
@@ -95,7 +95,7 @@ double rand_double() {
 */
 double benchmark() {
 	double elapsed;
-	double x;
+	int32_t x;
 	double y;
 	double t;
 	int i;

--- a/lib/node_modules/@stdlib/math/base/special/factorial2/binding.gyp
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/math/base/special/factorial2/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/factorial2/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2/examples/c/example.c
@@ -1,0 +1,32 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/factorial2.h"
+#include <stdio.h>
+#include <stdint.h>
+
+int main( void ) {
+	const int32_t x[] = { 1, 10, 1, 301, 302 };
+	double b;
+	int i;
+
+	for ( i = 0; i < 5; i++ ){
+		b = stdlib_base_factorial2( x[ i ] );
+		printf ( "factorial2(%d) = %lf\n", x[ i ], b );
+	}
+}

--- a/lib/node_modules/@stdlib/math/base/special/factorial2/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2/examples/c/example.c
@@ -22,9 +22,9 @@
 
 int main( void ) {
 	const int32_t x[] = { 1, 10, 1, 301, 302 };
+
 	double b;
 	int i;
-
 	for ( i = 0; i < 5; i++ ){
 		b = stdlib_base_factorial2( x[ i ] );
 		printf ( "factorial2(%d) = %lf\n", x[ i ], b );

--- a/lib/node_modules/@stdlib/math/base/special/factorial2/include.gypi
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/math/base/special/factorial2/include/stdlib/math/base/special/factorial2.h
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2/include/stdlib/math/base/special/factorial2.h
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_MATH_BASE_SPECIAL_FACTORIAL2_H
+#define STDLIB_MATH_BASE_SPECIAL_FACTORIAL2_H
+
+#include <stdint.h>
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Evaluates the double factorial of `n`.
+*/
+double stdlib_base_factorial2( const int32_t x );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_MATH_BASE_SPECIAL_FACTORIAL2_H

--- a/lib/node_modules/@stdlib/math/base/special/factorial2/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2/lib/native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -20,15 +20,7 @@
 
 // MODULES //
 
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var isInteger = require( '@stdlib/math/base/assert/is-integer' );
-var isEven = require( '@stdlib/math/base/assert/is-even' );
-var PINF = require( '@stdlib/constants/float64/pinf' );
-
-
-// VARIABLES //
-
-var MAX_FACTORIAL2 = 301; // TODO: consider extracting as a constant
+var addon = require( './../src/addon.node' );
 
 
 // MAIN //
@@ -56,33 +48,7 @@ var MAX_FACTORIAL2 = 301; // TODO: consider extracting as a constant
 * // returns Infinity
 */
 function factorial2( n ) {
-	var last;
-	var out;
-	var v;
-	var i;
-	if ( isnan( n ) ) {
-		return NaN;
-	}
-	if ( n >= MAX_FACTORIAL2 ) {
-		return PINF;
-	}
-	if ( n < 0 || isInteger( n ) === false ) {
-		return NaN;
-	}
-	v = n|0; // asm type annotation
-	if ( v === 0|0 || v === 1|0 ) {
-		return 1|0; // asm type annotation
-	}
-	if ( isEven( v ) ) {
-		last = 2|0; // asm type annotation
-	} else {
-		last = 3|0; // asm type annotation
-	}
-	out = 1;
-	for ( i = v|0; i >= last; i -= 2|0 ) {
-		out *= i|0; // asm type annotation
-	}
-	return out;
+	return addon( n );
 }
 
 

--- a/lib/node_modules/@stdlib/math/base/special/factorial2/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2/manifest.json
@@ -37,10 +37,10 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/napi/unary",
-        "@stdlib/math/base/assert/is_nan.h",
-        "@stdlib/math/base/assert/is_integer.h",
-        "@stdlib/math/base/assert/is_even.h",
-        "@stdlib/constants/float64/pinf.h"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/assert/is-integer",
+        "@stdlib/math/base/assert/is-even",
+        "@stdlib/constants/float64/pinf"
       ]
     },
     {
@@ -54,10 +54,10 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-        "@stdlib/math/base/assert/is_nan.h",
-        "@stdlib/math/base/assert/is_integer.h",
-        "@stdlib/math/base/assert/is_even.h",
-        "@stdlib/constants/float64/pinf.h"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/assert/is-integer",
+        "@stdlib/math/base/assert/is-even",
+        "@stdlib/constants/float64/pinf"
       ]
     },
     {
@@ -71,10 +71,10 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-        "@stdlib/math/base/assert/is_nan.h",
-        "@stdlib/math/base/assert/is_integer.h",
-        "@stdlib/math/base/assert/is_even.h",
-        "@stdlib/constants/float64/pinf.h"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/assert/is-integer",
+        "@stdlib/math/base/assert/is-even",
+        "@stdlib/constants/float64/pinf"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/factorial2/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2/manifest.json
@@ -1,0 +1,81 @@
+{
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/napi/unary",
+        "@stdlib/math/base/assert/is_nan.h",
+        "@stdlib/math/base/assert/is_integer.h",
+        "@stdlib/math/base/assert/is_even.h",
+        "@stdlib/constants/float64/pinf.h"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is_nan.h",
+        "@stdlib/math/base/assert/is_integer.h",
+        "@stdlib/math/base/assert/is_even.h",
+        "@stdlib/constants/float64/pinf.h"
+      ]
+    },
+    {
+      "task": "examples",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is_nan.h",
+        "@stdlib/math/base/assert/is_integer.h",
+        "@stdlib/math/base/assert/is_even.h",
+        "@stdlib/constants/float64/pinf.h"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/special/factorial2/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/factorial2/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2/src/addon.c
@@ -1,0 +1,22 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/factorial2.h"
+#include "stdlib/math/base/napi/unary.h"
+
+STDLIB_MATH_BASE_NAPI_MODULE_I_D( stdlib_base_factorial2 )

--- a/lib/node_modules/@stdlib/math/base/special/factorial2/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2/src/main.c
@@ -1,0 +1,66 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/factorial2.h"
+#include "stdlib/math/base/assert/is_nan.h"
+#include "stdlib/math/base/assert/is_integer.h"
+#include "stdlib/math/base/assert/is_even.h"
+#include "stdlib/constants/float64/pinf.h"
+#include <stdint.h>
+
+#define MAX_FACTORIAL2 301
+
+/**
+* Evaluates the double factorial of `n`.
+*
+* @param x         input value
+* @return          Double factorial
+*
+* @example
+* double v = stdlib_base_factorial2( 3 );
+* // returns ~3
+*/
+double stdlib_base_factorial2(const int32_t n) {
+    int last;
+    double out;
+    int v;
+    int i;
+    if ( stdlib_base_is_nan( n ) ){
+		return 0.0/0.0; // NaN
+	}
+	if (n >= MAX_FACTORIAL2 ){
+		return STDLIB_CONSTANT_FLOAT64_PINF;
+	}
+	if ( n < 0 || !stdlib_base_is_integer( n )) {
+        return 0.0/0.0;
+    }
+    v = n;
+    if (v == 0 || v == 1) {
+        return 1;
+    }
+    if (stdlib_base_is_even( v )) {
+        last = 2;
+    } else {
+        last = 3;
+    }
+    out = 1;
+    for (i = v; i >= last; i -= 2) {
+        out *= i;
+    }
+    return out;
+}

--- a/lib/node_modules/@stdlib/math/base/special/factorial2/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2/src/main.c
@@ -29,37 +29,37 @@
 * Evaluates the double factorial of `n`.
 *
 * @param x         input value
-* @return          Double factorial
+* @return          double factorial
 *
 * @example
 * double v = stdlib_base_factorial2( 3 );
-* // returns ~3
+* // returns 3
 */
-double stdlib_base_factorial2(const int32_t n) {
+double stdlib_base_factorial2( const int32_t n ) {
 	int32_t last;
 	double out;
 	int32_t v;
 	int32_t i;
-	if ( stdlib_base_is_nan( n ) ){
+	if ( stdlib_base_is_nan( n ) ) {
 		return 0.0/0.0; // NaN
 	}
-	if (n >= MAX_FACTORIAL2 ){
+	if ( n >= MAX_FACTORIAL2 ) {
 		return STDLIB_CONSTANT_FLOAT64_PINF;
 	}
-	if ( n < 0 || !stdlib_base_is_integer( n )) {
+	if ( n < 0 || !stdlib_base_is_integer( n ) ) {
 		return 0.0/0.0;
 	}
 	v = n;
-	if (v == 0 || v == 1) {
+	if ( v == 0 || v == 1 ) {
 		return 1;
 	}
-	if (stdlib_base_is_even( v )) {
+	if ( stdlib_base_is_even( v ) ) {
 		last = 2;
 	} else {
 		last = 3;
 	}
 	out = 1;
-	for (i = v; i >= last; i -= 2) {
+	for ( i = v; i >= last; i -= 2 ) {
 		out *= i;
 	}
 	return out;

--- a/lib/node_modules/@stdlib/math/base/special/factorial2/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2/src/main.c
@@ -36,31 +36,31 @@
 * // returns ~3
 */
 double stdlib_base_factorial2(const int32_t n) {
-    int last;
-    double out;
-    int v;
-    int i;
-    if ( stdlib_base_is_nan( n ) ){
+	int32_t last;
+	double out;
+	int32_t v;
+	int32_t i;
+	if ( stdlib_base_is_nan( n ) ){
 		return 0.0/0.0; // NaN
 	}
 	if (n >= MAX_FACTORIAL2 ){
 		return STDLIB_CONSTANT_FLOAT64_PINF;
 	}
 	if ( n < 0 || !stdlib_base_is_integer( n )) {
-        return 0.0/0.0;
-    }
-    v = n;
-    if (v == 0 || v == 1) {
-        return 1;
-    }
-    if (stdlib_base_is_even( v )) {
-        last = 2;
-    } else {
-        last = 3;
-    }
-    out = 1;
-    for (i = v; i >= last; i -= 2) {
-        out *= i;
-    }
-    return out;
+		return 0.0/0.0;
+	}
+	v = n;
+	if (v == 0 || v == 1) {
+		return 1;
+	}
+	if (stdlib_base_is_even( v )) {
+		last = 2;
+	} else {
+		last = 3;
+	}
+	out = 1;
+	for (i = v; i >= last; i -= 2) {
+		out *= i;
+	}
+	return out;
 }

--- a/lib/node_modules/@stdlib/math/base/special/factorial2/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/factorial2/test/test.native.js
@@ -1,0 +1,89 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var incrspace = require( '@stdlib/array/base/incrspace' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// FIXTURES //
+
+var integers = require( './fixtures/integers.json' );
+
+
+// VARIABLES //
+
+var factorial2 = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( factorial2 instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof factorial2, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'if provided a negative integer, the function returns `NaN`', opts, function test( t ) {
+	var values;
+	var v;
+	var i;
+
+	values = incrspace( -1.0, -1000.0, -25.0 );
+	for ( i = 0; i < values.length; i++ ) {
+		v = factorial2( values[ i ] );
+		t.strictEqual( isnan( v ), true, 'returns expected value when provided ' + values[ i ] );
+	}
+	t.end();
+});
+
+tape( 'the function evaluates the double factorial', opts, function test( t ) {
+	var expected;
+	var x;
+	var v;
+	var i;
+
+	x = integers.x;
+	expected = integers.expected;
+
+	for ( i = 0; i < x.length; i++ ) {
+		v = factorial2( x[ i ] );
+		t.strictEqual( v, expected[ i ], 'returns expected value when provided ' + x[ i ] );
+	}
+	t.end();
+});
+
+tape( 'if provided integers greater than `300`, the function returns `+infinity`', opts, function test( t ) {
+	var i;
+	var v;
+	for ( i = 301; i < 500; i++ ) {
+		v = factorial2( i );
+		t.strictEqual( v, PINF, 'returns expected value when provided ' + i );
+	}
+	t.end();
+});


### PR DESCRIPTION
This commit if applied adds the C implementation to `@stdlib/math/base/special/factorial2` package

## Description

This pull request:

-   adds the native C implementation to `@stdlib/math/base/special/factorial2`

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #1892 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
