### PR TITLE
feat: add C implementation for `math/base/special/fast/pow-int`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/README.md
@@ -216,7 +216,7 @@ int main( void ) {
     int i;
     for ( i = 0; i < 4; i++ ) {
         z = stdlib_base_fast_pow( x[ i ], y[ i ] );
-        printf( "pow( %lf, %lf ) = %lf\n", x[ i ], y[ i ], z );
+        printf( "pow( %lf, %d ) = %lf\n", x[ i ], y[ i ], z );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/README.md
@@ -182,7 +182,7 @@ The function accepts the following arguments:
 -   **y**: `[in] double` exponent.
 
 ```c
-double stdlib_base_fast_pow( const double x, int32_t y );
+double stdlib_base_fast_pow( const double x, const int32_t y );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/README.md
@@ -138,6 +138,97 @@ for ( y = 0; y < 309; y++ ) {
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/math/base/special/fast/pow.h"
+```
+
+#### stdlib_base_fast_pow( x, y )
+
+Evaluates the [exponential function][exponential-function] given a signed 32-bit integer `exponent`.
+
+```c
+double out = stdlib_base_fast_pow( 2.0, 3 );
+// returns 8.0
+
+out = stdlib_base_fast_pow( 3.14, 0 );
+// returns 1.0
+```
+
+The function accepts the following arguments:
+
+-   **x**: `[in] double` base.
+-   **y**: `[in] double` exponent.
+
+```c
+double stdlib_base_fast_pow( const double x, int32_t y );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/math/base/special/fast/pow.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+int main( void ) {
+    const double x[] = { 3.14, 2.0, 2.0, 0.0 };
+    const int32_t y[] = { 0, 3, -2, 0 };
+
+    double z;
+    int i;
+    for ( i = 0; i < 4; i++ ) {
+        z = stdlib_base_fast_pow( x[ i ], y[ i ] );
+        printf( "pow( %lf, %lf ) = %lf\n", x[ i ], y[ i ], z );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/benchmark/benchmark.native.js
@@ -1,0 +1,64 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var floor = require( '@stdlib/math/base/special/floor' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var pow = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( pow instanceof Error )
+};
+
+
+// MAIN //
+
+bench( pkg+'::native', opts, function benchmark( b ) {
+	var x;
+	var y;
+	var z;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		x = ( randu() * 100.0 ) - 50.0;
+		y = floor( randu() * 100.0 ) - 50;
+		z = pow( x, y );
+		if ( isnan( z ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnan( z ) ) {
+		b.fail( 'should not return NaN' );
+	} else {
+		b.pass( 'benchmark finished' );
+	}
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/benchmark/c/native/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/benchmark/c/native/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/benchmark/c/native/benchmark.c
@@ -34,7 +34,7 @@
 * Prints the TAP version.
 */
 void print_version() {
-    printf( "TAP version 13\n" );
+	printf( "TAP version 13\n" );
 }
 
 /**
@@ -44,12 +44,12 @@ void print_version() {
 * @param passing   total number of passing tests
 */
 void print_summary( int total, int passing ) {
-    printf( "#\n" );
-    printf( "1..%d\n", total ); // TAP plan
-    printf( "# total %d\n", total );
-    printf( "# pass  %d\n", passing );
-    printf( "#\n" );
-    printf( "# ok\n" );
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
 }
 
 /**
@@ -58,12 +58,12 @@ void print_summary( int total, int passing ) {
 * @param elapsed   elapsed time in seconds
 */
 void print_results( double elapsed ) {
-    double rate = (double)ITERATIONS / elapsed;
-    printf( "  ---\n" );
-    printf( "  iterations: %d\n", ITERATIONS );
-    printf( "  elapsed: %0.9f\n", elapsed );
-    printf( "  rate: %0.9f\n", rate );
-    printf( "  ...\n" );
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
 }
 
 /**
@@ -72,9 +72,9 @@ void print_results( double elapsed ) {
 * @return clock time
 */
 double tic() {
-    struct timeval now;
-    gettimeofday( &now, NULL );
-    return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec / 1.0e6;
 }
 
 /**
@@ -83,8 +83,8 @@ double tic() {
 * @return random number
 */
 double rand_double() {
-    int r = rand();
-    return (double)r / ( (double)RAND_MAX + 1.0 );
+	int r = rand();
+	return (double)r / ( (double)RAND_MAX + 1.0 );
 }
 
 /**
@@ -93,46 +93,46 @@ double rand_double() {
 * @return elapsed time in seconds
 */
 double benchmark() {
-    double elapsed;
-    int32_t x;
-    double t;
-    double y;
-    double z;
-    int i;
+	double elapsed;
+	int32_t x;
+	double t;
+	double y;
+	double z;
+	int i;
 
-    t = tic();
-    for ( i = 0; i < ITERATIONS; i++ ) {
-        x = ( 100.0 * rand_double() ) - 50.00;
-        y = floor( 100.0 * rand_double() ) - 50.00;
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		x = ( 100.0 * rand_double() ) - 50.00;
+		y = floor( 100.0 * rand_double() ) - 50.00;
 		z = stdlib_base_fast_pow( x, y );
-        if ( z != z) {
-            printf( "should not return NaN\n" );
-            break;
-        }
-    }
-    elapsed = tic() - t;
-    if ( z != z ) {
-        printf( "should not return NaN\n" );
-    }
-    return elapsed;
+		if ( z != z) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( z != z ) {
+		printf( "should not return NaN\n" );
+	}
+	return elapsed;
 }
 
 /**
 * Main execution sequence.
 */
 int main( void ) {
-    double elapsed;
-    int i;
+	double elapsed;
+	int i;
 
-    // Use the current time to seed the random number generator:
-    srand( time( NULL ) );
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
 
-    print_version();
-    for ( i = 0; i < REPEATS; i++ ) {
-        printf( "# c::native::%s\n", NAME );
-        elapsed = benchmark();
-        print_results( elapsed );
-        printf( "ok %d benchmark finished\n", i+1 );
-    }
-    print_summary( REPEATS, REPEATS );
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::native::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
 }

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/benchmark/c/native/benchmark.c
@@ -1,0 +1,138 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/**
+* Benchmark `pow`.
+*/
+#include "stdlib/math/base/special/fast/pow.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "pow"
+#define ITERATIONS 100
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+void print_version() {
+    printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+void print_summary( int total, int passing ) {
+    printf( "#\n" );
+    printf( "1..%d\n", total ); // TAP plan
+    printf( "# total %d\n", total );
+    printf( "# pass  %d\n", passing );
+    printf( "#\n" );
+    printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+void print_results( double elapsed ) {
+    double rate = (double)ITERATIONS / elapsed;
+    printf( "  ---\n" );
+    printf( "  iterations: %d\n", ITERATIONS );
+    printf( "  elapsed: %0.9f\n", elapsed );
+    printf( "  rate: %0.9f\n", rate );
+    printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+double tic() {
+    struct timeval now;
+    gettimeofday( &now, NULL );
+    return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1].
+*
+* @return random number
+*/
+double rand_double() {
+    int r = rand();
+    return (double)r / ( (double)RAND_MAX + 1.0 );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+double benchmark() {
+    double elapsed;
+    int32_t x;
+    double t;
+    double y;
+    double z;
+    int i;
+
+    t = tic();
+    for ( i = 0; i < ITERATIONS; i++ ) {
+        x = ( 100.0 * rand_double() ) - 50.00;
+        y = floor( 100.0 * rand_double() ) - 50.00;
+		z = stdlib_base_fast_pow( x, y );
+        if ( z != z) {
+            printf( "should not return NaN\n" );
+            break;
+        }
+    }
+    elapsed = tic() - t;
+    if ( z != z ) {
+        printf( "should not return NaN\n" );
+    }
+    return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+    double elapsed;
+    int i;
+
+    // Use the current time to seed the random number generator:
+    srand( time( NULL ) );
+
+    print_version();
+    for ( i = 0; i < REPEATS; i++ ) {
+        printf( "# c::native::%s\n", NAME );
+        elapsed = benchmark();
+        print_results( elapsed );
+        printf( "ok %d benchmark finished\n", i+1 );
+    }
+    print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/binding.gyp
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/examples/c/example.c
@@ -27,6 +27,6 @@ int main( void ) {
 	int i;
 	for ( i = 0; i < 4; i++ ) {
 		z = stdlib_base_fast_pow( x[ i ], y[ i ] );
-		printf( "pow( %lf, %lf ) = %lf\n", x[ i ], y[ i ], z );
+		printf( "pow( %lf, %d ) = %lf\n", x[ i ], y[ i ], z );
 	}
 }

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/examples/c/example.c
@@ -1,0 +1,32 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/fast/pow.h"
+#include <stdio.h>
+
+int main( void ) {
+	const double x[] = { 3.14, 2.0, 2.0, 0.0 };
+	const int32_t y[] = { 0, 3, -2, 0 };
+
+	double z;
+	int i;
+	for ( i = 0; i < 4; i++ ) {
+		z = stdlib_base_fast_pow( x[ i ], y[ i ] );
+		printf( "pow( %lf, %lf ) = %lf\n", x[ i ], y[ i ], z );
+	}
+}

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/include.gypi
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/include/stdlib/math/base/special/fast/pow.h
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/include/stdlib/math/base/special/fast/pow.h
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_MATH_BASE_SPECIAL_FAST_POW_H
+#define STDLIB_MATH_BASE_SPECIAL_FAST_POW_H
+
+#include <stdint.h>
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Evaluates the exponential function.
+*/
+double stdlib_base_fast_pow( const double x, const int32_t y );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_MATH_BASE_SPECIAL_FAST_POW_H

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/lib/native.js
@@ -1,0 +1,66 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Evaluates the exponential function.
+*
+* @param {number} x - base
+* @param {integer32} y - exponent
+* @returns {number} function value
+*
+* @example
+* var v = pow( 2.0, 3 );
+* // returns 8.0
+*
+* @example
+* var v = pow( 3.14, 0 );
+* // returns 1.0
+*
+* @example
+* var v = pow( 2.0, -2 );
+* // returns 0.25
+*
+* @example
+* var v = pow( 0.0, 0 );
+* // returns 1.0
+*
+* @example
+* var v = pow( -3.14, 1 );
+* // returns -3.14
+*
+* @example
+* var v = pow( NaN, 0 );
+* // returns NaN
+*/
+function pow( x, y ) {
+	return addon( x, y );
+}
+
+
+// EXPORTS //
+
+module.exports = pow;

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/manifest.json
@@ -1,81 +1,81 @@
 {
-	"options": {
-		"task": "build"
-	},
-	"fields": [
-		{
-			"field": "src",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "include",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "libraries",
-			"resolve": false,
-			"relative": false
-		},
-		{
-			"field": "libpath",
-			"resolve": true,
-			"relative": false
-		}
-	],
-	"confs": [
-		{
-			"task": "build",
-			"src": [
-				"./src/main.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [
-				"-lm"
-			],
-			"libpath": [],
-			"dependencies": [
-				"@stdlib/math/base/napi/binary",
-				"@stdlib/math/base/assert/is-nan",
-				"@stdlib/constants/float64/pinf"
-			]
-		},
-		{
-			"task": "benchmark",
-			"src": [
-				"./src/main.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [
-				"-lm"
-			],
-			"libpath": [],
-			"dependencies": [
-				"@stdlib/math/base/assert/is-nan",
-				"@stdlib/constants/float64/pinf"
-			]
-		},
-		{
-			"task": "examples",
-			"src": [
-				"./src/main.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [
-				"-lm"
-			],
-			"libpath": [],
-			"dependencies": [
-				"@stdlib/math/base/assert/is-nan",
-				"@stdlib/constants/float64/pinf"
-			]
-		}
-	]
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [
+        "-lm"
+      ],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/napi/binary",
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/pinf"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [
+        "-lm"
+      ],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/pinf"
+      ]
+    },
+    {
+      "task": "examples",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [
+        "-lm"
+      ],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/pinf"
+      ]
+    }
+  ]
 }

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/manifest.json
@@ -40,7 +40,7 @@
 			"dependencies": [
 				"@stdlib/math/base/napi/binary",
 				"@stdlib/math/base/assert/is-nan",
-        "@stdlib/constants/float64/pinf"
+				"@stdlib/constants/float64/pinf"
 			]
 		},
 		{
@@ -57,7 +57,7 @@
 			"libpath": [],
 			"dependencies": [
 				"@stdlib/math/base/assert/is-nan",
-        "@stdlib/constants/float64/pinf"
+				"@stdlib/constants/float64/pinf"
 			]
 		},
 		{
@@ -74,7 +74,7 @@
 			"libpath": [],
 			"dependencies": [
 				"@stdlib/math/base/assert/is-nan",
-        "@stdlib/constants/float64/pinf"
+				"@stdlib/constants/float64/pinf"
 			]
 		}
 	]

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/manifest.json
@@ -1,0 +1,81 @@
+{
+	"options": {
+		"task": "build"
+	},
+	"fields": [
+		{
+			"field": "src",
+			"resolve": true,
+			"relative": true
+		},
+		{
+			"field": "include",
+			"resolve": true,
+			"relative": true
+		},
+		{
+			"field": "libraries",
+			"resolve": false,
+			"relative": false
+		},
+		{
+			"field": "libpath",
+			"resolve": true,
+			"relative": false
+		}
+	],
+	"confs": [
+		{
+			"task": "build",
+			"src": [
+				"./src/main.c"
+			],
+			"include": [
+				"./include"
+			],
+			"libraries": [
+				"-lm"
+			],
+			"libpath": [],
+			"dependencies": [
+				"@stdlib/math/base/napi/binary",
+				"@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/pinf"
+			]
+		},
+		{
+			"task": "benchmark",
+			"src": [
+				"./src/main.c"
+			],
+			"include": [
+				"./include"
+			],
+			"libraries": [
+				"-lm"
+			],
+			"libpath": [],
+			"dependencies": [
+				"@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/pinf"
+			]
+		},
+		{
+			"task": "examples",
+			"src": [
+				"./src/main.c"
+			],
+			"include": [
+				"./include"
+			],
+			"libraries": [
+				"-lm"
+			],
+			"libpath": [],
+			"dependencies": [
+				"@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/pinf"
+			]
+		}
+	]
+}

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/src/addon.c
@@ -1,0 +1,22 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/fast/pow.h"
+#include "stdlib/math/base/napi/binary.h"
+
+STDLIB_MATH_BASE_NAPI_MODULE_DI_D( stdlib_base_fast_pow )

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/src/main.c
@@ -55,16 +55,16 @@ double stdlib_base_fast_pow( const double x, const int32_t y ) {
 		}
 		xc = 1.0 / xc;
 	}
-	else if ( y == ZERO ) {
+	else if ( yc == ZERO ) {
 		return 1.0;
 	}
 	v = 1.0;
-	while ( yy != ZERO ) {
-		if ( ( yy & ONE ) == ONE ) {
-			v *= xx;
+	while ( yc != ZERO ) {
+		if ( ( yc & ONE ) == ONE ) {
+			v *= xc;
 		}
-		xx *= xx;
-		yy >>= ONE;
+		xc *= xc;
+		yc >>= ONE;
 	}
 	return v;
 }

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/src/main.c
@@ -39,8 +39,8 @@ double stdlib_base_fast_pow( const double x, const int32_t y ) {
 	double xx;
 	int32_t yy;
 
-	xx = x;
-	yy = y;
+	xc = x;
+	yc = y;
 	if ( stdlib_base_is_nan( x ) ) {
 		return 0.0 / 0.0; // NaN
 	}

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/src/main.c
@@ -35,9 +35,9 @@ int32_t ZERO = 0;
 * // returns 8.0
 */
 double stdlib_base_fast_pow( const double x, const int32_t y ) {
+	int32_t yc;
+	double xc;
 	double v;
-	double xx;
-	int32_t yy;
 
 	xc = x;
 	yc = y;

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/src/main.c
@@ -1,0 +1,68 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/fast/pow.h"
+#include "stdlib/math/base/assert/is_nan.h"
+#include "stdlib/constants/float64/pinf.h"
+
+/**
+* Evaluates the exponential function.
+*
+* @param x    base
+* @param y    exponent
+* @return     function value
+*
+* @example
+* double y = stdlib_base_pow( 2.0, 3 );
+* // returns 8.0
+*/
+double stdlib_base_fast_pow( const double x, const int32_t y ) {
+	double v;
+	double xx;
+	int32_t yy;
+
+	xx = x;
+	yy = y;
+	if ( stdlib_base_is_nan( x ) ) {
+		return 0.0 / 0.0; // NaN
+	}
+	if ( yy < 0 ) {
+		yy = -yy;
+		if ( x == 0.0 ) {
+			xx = 1.0 / x;
+			if ( ( yy & 1 ) == 1 ) {
+				return xx;
+			}
+			return STDLIB_CONSTANT_FLOAT64_PINF;
+		}
+		xx = 1.0 / x;
+	}
+	else if ( y == 0 ) {
+		return 1.0;
+	}
+	v = 1.0;
+	while ( yy != 0 ) {
+		if ( ( yy & 1 ) == 1 ) {
+			v *= xx;
+		}
+		xx *= xx;
+		yy >>= 1;
+	}
+	return v;
+}
+

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/src/main.c
@@ -31,7 +31,7 @@ int32_t ZERO = 0;
 * @return     function value
 *
 * @example
-* double y = stdlib_base_pow( 2.0, 3 );
+* double y = stdlib_base_fast_pow( 2.0, 3 );
 * // returns 8.0
 */
 double stdlib_base_fast_pow( const double x, const int32_t y ) {

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/src/main.c
@@ -44,16 +44,16 @@ double stdlib_base_fast_pow( const double x, const int32_t y ) {
 	if ( stdlib_base_is_nan( xc ) ) {
 		return 0.0 / 0.0; // NaN
 	}
-	if ( yy < ZERO ) {
-		yy = -yy;
-		if ( x == 0.0 ) {
-			xx = 1.0 / x;
-			if ( ( yy & ONE ) == ONE ) {
-				return xx;
+	if ( yc < ZERO ) {
+		yc = -yc;
+		if ( xc == 0.0 ) {
+			xc = 1.0 / xc;
+			if ( ( yc & ONE ) == ONE ) {
+				return xc;
 			}
 			return STDLIB_CONSTANT_FLOAT64_PINF;
 		}
-		xx = 1.0 / x;
+		xc = 1.0 / xc;
 	}
 	else if ( y == ZERO ) {
 		return 1.0;

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/src/main.c
@@ -41,7 +41,7 @@ double stdlib_base_fast_pow( const double x, const int32_t y ) {
 
 	xc = x;
 	yc = y;
-	if ( stdlib_base_is_nan( x ) ) {
+	if ( stdlib_base_is_nan( xc ) ) {
 		return 0.0 / 0.0; // NaN
 	}
 	if ( yy < ZERO ) {

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/src/main.c
@@ -20,6 +20,9 @@
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/constants/float64/pinf.h"
 
+int32_t ONE = 1;
+int32_t ZERO = 0;
+
 /**
 * Evaluates the exponential function.
 *
@@ -41,27 +44,27 @@ double stdlib_base_fast_pow( const double x, const int32_t y ) {
 	if ( stdlib_base_is_nan( x ) ) {
 		return 0.0 / 0.0; // NaN
 	}
-	if ( yy < 0 ) {
+	if ( yy < ZERO ) {
 		yy = -yy;
 		if ( x == 0.0 ) {
 			xx = 1.0 / x;
-			if ( ( yy & 1 ) == 1 ) {
+			if ( ( yy & ONE ) == ONE ) {
 				return xx;
 			}
 			return STDLIB_CONSTANT_FLOAT64_PINF;
 		}
 		xx = 1.0 / x;
 	}
-	else if ( y == 0 ) {
+	else if ( y == ZERO ) {
 		return 1.0;
 	}
 	v = 1.0;
-	while ( yy != 0 ) {
-		if ( ( yy & 1 ) == 1 ) {
+	while ( yy != ZERO ) {
+		if ( ( yy & ONE ) == ONE ) {
 			v *= xx;
 		}
 		xx *= xx;
-		yy >>= 1;
+		yy >>= ONE;
 	}
 	return v;
 }

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/test/test.native.js
@@ -1,0 +1,322 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var abs = require( '@stdlib/math/base/special/abs' );
+var randu = require( '@stdlib/random/base/randu' );
+var round = require( '@stdlib/math/base/special/round' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+var EPS = require( '@stdlib/constants/float64/eps' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
+var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var pow = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( pow instanceof Error )
+};
+
+
+// FIXTURES //
+
+var decimalInteger = require( './fixtures/julia/decimal_integer.json' );
+var integerInteger = require( './fixtures/julia/integer_integer.json' );
+var multiplesOfTen = require( './fixtures/julia/multiples_of_ten.json' );
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof pow, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function accepts two parameters: a base and an exponent', opts, function test( t ) {
+	t.strictEqual( pow.length, 2, 'arity is 2' );
+	t.end();
+});
+
+tape( 'the function evaluates the exponential function (decimal `x`, integer `y`)', opts, function test( t ) {
+	var expected;
+	var actual;
+	var delta;
+	var tol;
+	var x;
+	var y;
+	var i;
+
+	x = decimalInteger.x;
+	y = decimalInteger.y;
+	expected = decimalInteger.expected;
+	for ( i = 0; i < x.length; i++ ) {
+		actual = pow( x[i], y[i] );
+		if ( actual === expected[ i ] ) {
+			t.strictEqual( actual, expected[i], 'pow('+x[i]+','+y[i]+') returns '+expected[i] );
+		} else {
+			delta = abs( actual - expected[i] );
+			tol = 70.0 * EPS * abs( expected[i] );
+			t.strictEqual( delta <= tol, true, 'x: '+x[i]+'. y: '+y[i]+'. v: '+actual+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol+'.' );
+		}
+	}
+	t.end();
+});
+
+tape( 'the function evaluates the exponential function (integer `x`, integer `y`)', opts, function test( t ) {
+	var expected;
+	var actual;
+	var delta;
+	var tol;
+	var x;
+	var y;
+	var i;
+
+	x = integerInteger.x;
+	y = integerInteger.y;
+	expected = integerInteger.expected;
+	for ( i = 0; i < x.length; i++ ) {
+		actual = pow( x[i], y[i] );
+		if ( expected[ i ] === null ) {
+			// Expected value is infinity:
+			t.strictEqual( actual, PINF, 'pow('+x[i]+','+y[i]+') returns +infinity' );
+		}
+		else if ( actual === expected[ i ] ) {
+			t.strictEqual( actual, expected[i], 'pow('+x[i]+','+y[i]+') returns '+expected[i] );
+		}
+		else {
+			delta = abs( actual - expected[i] );
+			tol = 61.0 * EPS * abs( expected[i] );
+			t.strictEqual( delta <= tol, true, 'x: '+x[i]+'. y: '+y[i]+'. v: '+actual+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol+'.' );
+		}
+	}
+	t.end();
+});
+
+tape( 'the function evaluates the exponential function (multiples of ten)', opts, function test( t ) {
+	var expected;
+	var actual;
+	var delta;
+	var tol;
+	var x;
+	var y;
+	var i;
+
+	x = multiplesOfTen.x;
+	y = multiplesOfTen.y;
+	expected = multiplesOfTen.expected;
+	for ( i = 0; i < x.length; i++ ) {
+		actual = pow( x[i], y[i] );
+		if ( actual === expected[ i ] ) {
+			t.strictEqual( actual, expected[i], 'pow('+x[i]+','+y[i]+') returns '+expected[i] );
+		} else {
+			delta = abs( actual - expected[i] );
+			tol = 3.75 * EPS * abs( expected[i] );
+			t.strictEqual( delta <= tol, true, 'x: '+x[i]+'. y: '+y[i]+'. v: '+actual+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol+'.' );
+		}
+	}
+	t.end();
+});
+
+tape( 'the function returns `NaN` if provided `NaN` for the base', opts, function test( t ) {
+	var v;
+
+	v = pow( NaN, 5 );
+	t.strictEqual( isnan( v ), true, 'returns NaN' );
+
+	v = pow( NaN, 1 );
+	t.strictEqual( isnan( v ), true, 'returns NaN' );
+
+	v = pow( NaN, 0 );
+	t.strictEqual( isnan( v ), true, 'returns NaN' );
+
+	t.end();
+});
+
+tape( 'any number raised to the zero power is `1`', opts, function test( t ) {
+	var x;
+	var v;
+	var i;
+	for ( i = 0; i < 100; i++ ) {
+		x = ( randu() * 1.0e6 ) - 5.0e5;
+		v = pow( x, 0 );
+		t.strictEqual( v, 1.0, 'pow('+x+',0.0) returns 1' );
+	}
+	t.strictEqual( pow( PINF, 0 ), 1.0, 'inf^0 = 1' );
+	t.strictEqual( pow( NINF, 0 ), 1.0, '(-inf)^0 = 1' );
+	t.strictEqual( pow( 0.0, 0 ), 1.0, '0^0 = 1' );
+	t.end();
+});
+
+tape( 'any number raised to the `-1` power is the reciprocal of that number', opts, function test( t ) {
+	var x;
+	var v;
+	var i;
+	for ( i = 0; i < 100; i++ ) {
+		x = ( randu() * 1.0e6 ) - 5.0e5;
+		v = pow( x, -1 );
+		t.strictEqual( v, 1 / x, 'pow('+x+',0.0) returns '+( 1 / x ) );
+	}
+	t.strictEqual( isPositiveZero( pow( PINF, -1 ) ), true, 'inf^-1 = 0' );
+	t.strictEqual( isNegativeZero( pow( NINF, -1 ) ), true, '(-inf)^0 = -0' );
+	t.strictEqual( pow( 0.0, -1 ), PINF, '0^-1 = +infinity' );
+	t.strictEqual( pow( -0.0, -1 ), NINF, '(-0)^-1 = -infinity' );
+	t.end();
+});
+
+tape( 'unity raised to any power is `1`', opts, function test( t ) {
+	var y;
+	var v;
+	var i;
+	for ( i = 0; i < 100; i++ ) {
+		y = ( randu() * 1.0e6 ) - 5.0e5;
+		v = pow( 1.0, y );
+		t.strictEqual( v, 1.0, 'pow(1.0,'+y+') returns 1' );
+	}
+	t.strictEqual( pow( 1.0, 0 ), 1.0, '1^0 = 1' );
+	t.end();
+});
+
+tape( '`-1` raised to any odd integer is `-1`', opts, function test( t ) {
+	var v;
+	var i;
+	for ( i = -51; i < 53; i += 2 ) {
+		v = pow( -1.0, i );
+		t.strictEqual( v, -1.0, 'pow(1.0,'+i+') returns -1' );
+	}
+	t.end();
+});
+
+tape( '`+-0` raised to a positive even integer is `0`', opts, function test( t ) {
+	var y;
+	var i;
+	var v;
+
+	for ( i = 0; i < 100; i++ ) {
+		y = ( i + 1 ) * 2;
+		v = pow( +0.0, y );
+		t.strictEqual( isPositiveZero( v ), true, 'pow(0,'+y+') returns +0' );
+
+		v = pow( -0.0, y);
+		t.strictEqual( isPositiveZero( v ), true, 'pow(-0,'+y+') returns +0' );
+	}
+	t.end();
+});
+
+tape( '`+-0` raised to a positive odd integer is `+-0`', opts, function test( t ) {
+	var i;
+	var v;
+
+	for ( i = 1; i < 101; i += 2 ) {
+		v = pow( +0.0, i );
+		t.strictEqual( isPositiveZero( v ), true, 'pow(0,'+i+') returns +0' );
+
+		v = pow( -0.0, i );
+		t.strictEqual( isNegativeZero( v ), true, 'pow(-0,'+i+') returns -0' );
+	}
+	t.end();
+});
+
+tape( '`+-0` raised to a negative even integer is `+infinity`', opts, function test( t ) {
+	var y;
+	var i;
+	var v;
+
+	for ( i = 0; i < 100; i++ ) {
+		y = -( i + 1 ) * 2;
+		v = pow( +0.0, y );
+		t.strictEqual( v, PINF, 'pow(0,'+y+') returns +infinity' );
+
+		v = pow( -0.0, y );
+		t.strictEqual( v, PINF, 'pow(-0,'+y+') returns +infinity' );
+	}
+	t.end();
+});
+
+tape( '`+-0` raised to a negative odd integer is `+-infinity`', opts, function test( t ) {
+	var i;
+	var v;
+
+	for ( i = -101; i < 0; i += 2 ) {
+		v = pow( +0.0, i );
+		t.strictEqual( v, PINF, 'pow(0,'+i+') returns +infinity' );
+
+		v = pow( -0.0, i );
+		t.strictEqual( v, NINF, 'pow(-0,'+i+') returns -infinity' );
+	}
+	t.end();
+});
+
+tape( 'the function returns `(-0)^y` if `-infinity` is raised to a `y` power', opts, function test( t ) {
+	var y;
+	var v;
+	var i;
+
+	for ( i = 0; i < 100; i++ ) {
+		y = round( randu() * 100.0 );
+		v = pow( NINF, y );
+		t.strictEqual( v, pow( -0.0, -y ), 'pow(-infinity,'+y+') returns pow(-0,-'+y+')' );
+	}
+
+	v = pow( NINF, 5 );
+	t.strictEqual( v, pow( -0.0, -5 ), 'pow(-infinity,5) returns pow(-0,-5)' );
+
+	v = pow( NINF, 2 );
+	t.strictEqual( v, pow( -0.0, -2 ), 'pow(-infinity,2) returns pow(-0,-2)' );
+
+	v = pow( NINF, -5 );
+	t.strictEqual( v, pow( -0.0, 5 ), 'pow(-infinity,-5) returns pow(-0,5)' );
+
+	v = pow( NINF, -2 );
+	t.strictEqual( v, pow( -0.0, 2 ), 'pow(-infinity,-2) returns pow(-0,2)' );
+
+	t.end();
+});
+
+tape( 'the function returns `0` if `+infinity` is raised to any negative finite integer', opts, function test( t ) {
+	var y;
+	var v;
+	var i;
+	for ( i = 0; i < 100; i++ ) {
+		y = -round( randu() * 1.0e5 ) - 1;
+		v = pow( PINF, y );
+		t.strictEqual( isPositiveZero( v ), true, 'returns 0' );
+	}
+	t.end();
+});
+
+tape( 'the function returns `+infinity` if `+infinity` is raised to any positive finite integer', opts, function test( t ) {
+	var y;
+	var v;
+	var i;
+	for ( i = 0; i < 100; i++ ) {
+		y = round( randu() * 1.0e5 ) + 1;
+		v = pow( PINF, y );
+		t.strictEqual( v, PINF, 'returns +infinity' );
+	}
+	t.end();
+});


### PR DESCRIPTION
Resolves a part of #1917.

## Description

> What is the purpose of this pull request?

This pull request:

-   adds C implementation for [`math/base/special/fast/pow-int`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/fast/pow-int).

```C
double stdlib_base_fast_pow( const double x, const int32_t y )
```

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves a part of #1917.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   ☑️ Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
