### PR TITLE
feat: add C implementation for `math/base/special/modf`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/modf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/modf/README.md
@@ -138,6 +138,7 @@ Decomposes a [double-precision floating-point number][ieee754] into integral and
 ```c
 double integral;
 double frac;
+
 stdlib_base_modf( 4.0, &integral, &frac );
 ```
 
@@ -180,8 +181,8 @@ int main( void ) {
     double frac;
     int i;
     for ( i = 0; i < 12; i++ ) {
-        stdlib_base_modf( x[i], &integral, &frac );
-        printf( "x: %f => integral: %f, frac: %f\n", x[i], integral, frac );
+        stdlib_base_modf( x[ i ], &integral, &frac );
+        printf( "x: %lf => integral: %lf, frac: %lf\n", x[ i ], integral, frac );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/math/base/special/modf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/modf/README.md
@@ -105,6 +105,98 @@ for ( i = 0; i < 100; i++ ) {
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/math/base/special/modf.h"
+```
+
+#### stdlib_base_modf( x, integral, frac )
+
+Decomposes a [double-precision floating-point number][ieee754] into integral and fractional parts, each having the same type and sign as `x`.
+
+```c
+double integral;
+double frac;
+stdlib_base_modf( 4.0, &integral, &frac );
+```
+
+The function accepts the following arguments:
+
+-   **x**: `[in] double` input value.
+-   **frac**: `[out] double*` destination for the integral part.
+-   **exp**: `[out] double*` destination for the fractional part.
+
+```c
+void stdlib_base_modf( const double x, double *integral, double *frac );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/math/base/special/modf.h"
+#include <stdio.h>
+
+#include "stdlib/math/base/special/modf.h"
+#include <stdio.h>
+
+int main( void ) {
+    const double x[] = { 4.0, 0.0, -0.0, 1.0, -1.0, 3.14, -3.14, 1.0e308, -1.0e308, 1.0/0.0, -1.0/0.0, 0.0/0.0 };
+
+    double integral;
+    double frac;
+    int i;
+    for ( i = 0; i < 12; i++ ) {
+        stdlib_base_modf( x[i], &integral, &frac );
+        printf( "x: %f => integral: %f, frac: %f\n", x[i], integral, frac );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/math/base/special/modf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/modf/README.md
@@ -173,9 +173,6 @@ void stdlib_base_modf( const double x, double *integral, double *frac );
 #include "stdlib/math/base/special/modf.h"
 #include <stdio.h>
 
-#include "stdlib/math/base/special/modf.h"
-#include <stdio.h>
-
 int main( void ) {
     const double x[] = { 4.0, 0.0, -0.0, 1.0, -1.0, 3.14, -3.14, 1.0e308, -1.0e308, 1.0/0.0, -1.0/0.0, 0.0/0.0 };
 

--- a/lib/node_modules/@stdlib/math/base/special/modf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/modf/benchmark/benchmark.native.js
@@ -1,0 +1,60 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var isArray = require( '@stdlib/assert/is-array' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var modf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( modf instanceof Error )
+};
+
+
+// MAIN //
+
+bench( pkg+'::native', opts, function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		x = ( randu() * 1.0e7 ) - 5.0e6;
+		y = modf( x );
+		if ( typeof y !== 'object' ) {
+			b.fail( 'should return an array' );
+		}
+	}
+	b.toc();
+	if ( !isArray( y ) ) {
+		b.fail( 'should return an array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/modf/benchmark/c/native/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/modf/benchmark/c/native/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/modf/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/modf/benchmark/c/native/benchmark.c
@@ -93,8 +93,8 @@ double rand_double() {
 * @return elapsed time in seconds
 */
 double benchmark() {
-	double elapsed;
 	double integral;
+	double elapsed;
 	double x;
 	double y;
 	double t;

--- a/lib/node_modules/@stdlib/math/base/special/modf/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/modf/benchmark/c/native/benchmark.c
@@ -74,7 +74,7 @@ void print_results( double elapsed ) {
 double tic() {
 	struct timeval now;
 	gettimeofday( &now, NULL );
-	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+	return (double)now.tv_sec + (double)now.tv_usec / 1.0e6;
 }
 
 /**
@@ -84,7 +84,7 @@ double tic() {
 */
 double rand_double() {
 	int r = rand();
-	return (double)r / ( (double)RAND_modf + 1.0 );
+	return (double)r / ( (double)RAND_MAX + 1.0 );
 }
 
 /**
@@ -103,7 +103,7 @@ double benchmark() {
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
 		x = ( 1.0e7 * rand_double() ) - 5.0e6;
-		y = stdlib_base_modf( x, &integral, &y );
+		stdlib_base_modf( x, &integral, &y );
 		if ( y != y || integral != integral) {
 			printf( "unexpected results\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/modf/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/modf/benchmark/c/native/benchmark.c
@@ -1,0 +1,137 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/**
+* Benchmark `modf`.
+*/
+#include "stdlib/math/base/special/modf.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "modf"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+void print_version() {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+double tic() {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1].
+*
+* @return random number
+*/
+double rand_double() {
+	int r = rand();
+	return (double)r / ( (double)RAND_modf + 1.0 );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+double benchmark() {
+	double elapsed;
+	double integral;
+	double x;
+	double y;
+	double t;
+	int i;
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		x = ( 1.0e7 * rand_double() ) - 5.0e6;
+		y = stdlib_base_modf( x, &integral, &y );
+		if ( y != y || integral != integral) {
+			printf( "unexpected results\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( y != y || integral != integral) {
+		printf( "unexpected results\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::native::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/math/base/special/modf/binding.gyp
+++ b/lib/node_modules/@stdlib/math/base/special/modf/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/math/base/special/modf/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/modf/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/modf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/modf/examples/c/example.c
@@ -1,0 +1,32 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/modf.h"
+#include <stdio.h>
+
+int main( void ) {
+    const double x[] = { 4.0, 0.0, -0.0, 1.0, -1.0, 3.14, -3.14, 1.0e308, -1.0e308, 1.0/0.0, -1.0/0.0, 0.0/0.0 };
+
+    double integral;
+    double frac;
+    int i;
+    for ( i = 0; i < 12; i++ ) {
+        stdlib_base_modf( x[i], &integral, &frac );
+        printf( "x: %f => integral: %f, frac: %f\n", x[i], integral, frac );
+    }
+}

--- a/lib/node_modules/@stdlib/math/base/special/modf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/modf/examples/c/example.c
@@ -20,13 +20,13 @@
 #include <stdio.h>
 
 int main( void ) {
-    const double x[] = { 4.0, 0.0, -0.0, 1.0, -1.0, 3.14, -3.14, 1.0e308, -1.0e308, 1.0/0.0, -1.0/0.0, 0.0/0.0 };
+	const double x[] = { 4.0, 0.0, -0.0, 1.0, -1.0, 3.14, -3.14, 1.0e308, -1.0e308, 1.0/0.0, -1.0/0.0, 0.0/0.0 };
 
-    double integral;
-    double frac;
-    int i;
-    for ( i = 0; i < 12; i++ ) {
-        stdlib_base_modf( x[i], &integral, &frac );
-        printf( "x: %f => integral: %f, frac: %f\n", x[i], integral, frac );
-    }
+	double integral;
+	double frac;
+	int i;
+	for ( i = 0; i < 12; i++ ) {
+		stdlib_base_modf( x[ i ], &integral, &frac );
+		printf( "x: %lf => integral: %lf, frac: %lf\n", x[ i ], integral, frac );
+	}
 }

--- a/lib/node_modules/@stdlib/math/base/special/modf/include.gypi
+++ b/lib/node_modules/@stdlib/math/base/special/modf/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/math/base/special/modf/include/stdlib/math/base/special/modf.h
+++ b/lib/node_modules/@stdlib/math/base/special/modf/include/stdlib/math/base/special/modf.h
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_MATH_BASE_SPECIAL_MODF_H
+#define STDLIB_MATH_BASE_SPECIAL_MODF_H
+
+#include <stdint.h>
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Decomposes a double-precision floating-point number into integral and fractional parts, each having the same type and sign as the input value.
+*/
+void stdlib_base_modf( const double x, double *integral, double *frac );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_MATH_BASE_SPECIAL_MODF_H

--- a/lib/node_modules/@stdlib/math/base/special/modf/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/modf/lib/native.js
@@ -35,7 +35,6 @@ var addon = require( './../src/addon.node' );
 * @example
 * var parts = modf( 3.14 );
 * // returns [ 3.0, 0.14000000000000012 ]
-*
 */
 function modf( x ) {
 	var out = new Float64Array( 2 );

--- a/lib/node_modules/@stdlib/math/base/special/modf/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/modf/lib/native.js
@@ -1,0 +1,49 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var Float64Array = require( '@stdlib/array/float64' );
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Decomposes a double-precision floating-point number into integral and fractional parts, each having the same type and sign as the input value.
+*
+* @param {number} x - input value
+* @returns {Array<number>} output array
+*
+* @example
+* var parts = modf( 3.14 );
+* // returns [ 3.0, 0.14000000000000012 ]
+*
+*/
+function modf( x ) {
+	var out = new Float64Array( 2 );
+	addon( out, x );
+	return [ out[ 0 ], out[ 1 ] ];
+}
+
+
+// EXPORTS //
+
+module.exports = modf;

--- a/lib/node_modules/@stdlib/math/base/special/modf/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/modf/manifest.json
@@ -1,41 +1,41 @@
 {
-	"options": {
-		"task": "build"
-	},
-	"fields": [
-		{
-			"field": "src",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "include",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "libraries",
-			"resolve": false,
-			"relative": false
-		},
-		{
-			"field": "libpath",
-			"resolve": true,
-			"relative": false
-		}
-	],
-	"confs": [
-		{
-			"task": "build",
-			"src": [
-				"./src/main.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [],
-			"libpath": [],
-			"dependencies": [
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/number/float64/base/from-words",
         "@stdlib/number/float64/base/to-words",
@@ -43,19 +43,19 @@
         "@stdlib/constants/float64/exponent-bias",
         "@stdlib/constants/float64/high-word-exponent-mask",
         "@stdlib/constants/float64/high-word-significand-mask"
-			]
-		},
-		{
-			"task": "benchmark",
-			"src": [
-				"./src/main.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [],
-			"libpath": [],
-			"dependencies": [
+      ]
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/number/float64/base/from-words",
         "@stdlib/number/float64/base/to-words",
@@ -63,19 +63,19 @@
         "@stdlib/constants/float64/exponent-bias",
         "@stdlib/constants/float64/high-word-exponent-mask",
         "@stdlib/constants/float64/high-word-significand-mask"
-			]
-		},
-		{
-			"task": "examples",
-			"src": [
-				"./src/main.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [],
-			"libpath": [],
-			"dependencies": [
+      ]
+    },
+    {
+      "task": "examples",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/number/float64/base/from-words",
         "@stdlib/number/float64/base/to-words",
@@ -83,7 +83,7 @@
         "@stdlib/constants/float64/exponent-bias",
         "@stdlib/constants/float64/high-word-exponent-mask",
         "@stdlib/constants/float64/high-word-significand-mask"
-			]
-		}
-	]
+      ]
+    }
+  ]
 }

--- a/lib/node_modules/@stdlib/math/base/special/modf/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/modf/manifest.json
@@ -33,10 +33,9 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-        "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/number/float64/base/from-words",
-        "@stdlib/number/float32/base/to-word",
+        "@stdlib/number/float64/base/to-words",
         "@stdlib/constants/float64/pinf",
         "@stdlib/constants/float64/exponent-bias",
         "@stdlib/constants/float64/high-word-exponent-mask",

--- a/lib/node_modules/@stdlib/math/base/special/modf/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/modf/manifest.json
@@ -1,0 +1,48 @@
+{
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-infinite",
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/number/float64/base/from-words",
+        "@stdlib/number/float32/base/to-word",
+        "@stdlib/constants/float64/pinf",
+        "@stdlib/constants/float64/exponent-bias",
+        "@stdlib/constants/float64/high-word-exponent-mask",
+        "@stdlib/constants/float64/high-word-significand-mask"
+      ]
+    }
+  ]
+}
+

--- a/lib/node_modules/@stdlib/math/base/special/modf/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/modf/manifest.json
@@ -1,38 +1,41 @@
 {
-  "options": {},
-  "fields": [
-    {
-      "field": "src",
-      "resolve": true,
-      "relative": true
-    },
-    {
-      "field": "include",
-      "resolve": true,
-      "relative": true
-    },
-    {
-      "field": "libraries",
-      "resolve": false,
-      "relative": false
-    },
-    {
-      "field": "libpath",
-      "resolve": true,
-      "relative": false
-    }
-  ],
-  "confs": [
-    {
-      "src": [
-        "./src/main.c"
-      ],
-      "include": [
-        "./include"
-      ],
-      "libraries": [],
-      "libpath": [],
-      "dependencies": [
+	"options": {
+		"task": "build"
+	},
+	"fields": [
+		{
+			"field": "src",
+			"resolve": true,
+			"relative": true
+		},
+		{
+			"field": "include",
+			"resolve": true,
+			"relative": true
+		},
+		{
+			"field": "libraries",
+			"resolve": false,
+			"relative": false
+		},
+		{
+			"field": "libpath",
+			"resolve": true,
+			"relative": false
+		}
+	],
+	"confs": [
+		{
+			"task": "build",
+			"src": [
+				"./src/main.c"
+			],
+			"include": [
+				"./include"
+			],
+			"libraries": [],
+			"libpath": [],
+			"dependencies": [
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/number/float64/base/from-words",
         "@stdlib/number/float64/base/to-words",
@@ -40,8 +43,47 @@
         "@stdlib/constants/float64/exponent-bias",
         "@stdlib/constants/float64/high-word-exponent-mask",
         "@stdlib/constants/float64/high-word-significand-mask"
-      ]
-    }
-  ]
+			]
+		},
+		{
+			"task": "benchmark",
+			"src": [
+				"./src/main.c"
+			],
+			"include": [
+				"./include"
+			],
+			"libraries": [],
+			"libpath": [],
+			"dependencies": [
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/number/float64/base/from-words",
+        "@stdlib/number/float64/base/to-words",
+        "@stdlib/constants/float64/pinf",
+        "@stdlib/constants/float64/exponent-bias",
+        "@stdlib/constants/float64/high-word-exponent-mask",
+        "@stdlib/constants/float64/high-word-significand-mask"
+			]
+		},
+		{
+			"task": "examples",
+			"src": [
+				"./src/main.c"
+			],
+			"include": [
+				"./include"
+			],
+			"libraries": [],
+			"libpath": [],
+			"dependencies": [
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/number/float64/base/from-words",
+        "@stdlib/number/float64/base/to-words",
+        "@stdlib/constants/float64/pinf",
+        "@stdlib/constants/float64/exponent-bias",
+        "@stdlib/constants/float64/high-word-exponent-mask",
+        "@stdlib/constants/float64/high-word-significand-mask"
+			]
+		}
+	]
 }
-

--- a/lib/node_modules/@stdlib/math/base/special/modf/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/modf/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/modf/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/modf/src/addon.c
@@ -1,0 +1,117 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/modf.h"
+#include <node_api.h>
+#include <stdint.h>
+#include <assert.h>
+
+/**
+* Receives JavaScript callback invocation data.
+*
+* @private
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @return       Node-API value
+*/
+static napi_value addon( napi_env env, napi_callback_info info ) {
+	napi_status status;
+
+	// Get callback arguments:
+	size_t argc = 2;
+	napi_value argv[ 2 ];
+	status = napi_get_cb_info( env, info, &argc, argv, NULL, NULL );
+	assert( status == napi_ok );
+
+	// Check whether we were provided the correct number of arguments:
+	if ( argc < 2 ) {
+		status = napi_throw_error( env, NULL, "invalid invocation. Insufficient arguments." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+	if ( argc > 2 ) {
+		status = napi_throw_error( env, NULL, "invalid invocation. Too many arguments." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	bool res;
+	status = napi_is_typedarray( env, argv[ 0 ], &res );
+	assert( status == napi_ok );
+	if ( res == false ) {
+		status = napi_throw_type_error( env, NULL, "invalid argument. First argument must be a Float64Array." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	napi_valuetype vtype1;
+	status = napi_typeof( env, argv[ 1 ], &vtype1 );
+	assert( status == napi_ok );
+	if ( vtype1 != napi_number ) {
+		status = napi_throw_type_error( env, NULL, "invalid argument. Second argument must be a number." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	napi_typedarray_type vtype0;
+	size_t len;
+	void *Out;
+	status = napi_get_typedarray_info( env, argv[ 0 ], &vtype0, &len, &Out, NULL, NULL );
+	assert( status == napi_ok );
+	if ( vtype0 != napi_float64_array ) {
+		status = napi_throw_type_error( env, NULL, "invalid argument. First argument must be a Float64Array." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+	if ( len != 2 ) {
+		status = napi_throw_range_error( env, NULL, "invalid argument. First argument must have 2 elements." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	double value;
+	status = napi_get_value_double( env, argv[ 1 ], &value );
+	assert( status == napi_ok );
+
+	double integral;
+	double frac;
+	stdlib_base_modf( value, &integral, &frac );
+
+	double *op = (double *)Out;
+	op[ 1 ] = integral;
+	op[ 0 ] = frac;
+
+	return NULL;
+}
+
+/**
+* Initializes a Node-API module.
+*
+* @private
+* @param env      environment under which the function is invoked
+* @param exports  exports object
+* @return         main export
+*/
+static napi_value init( napi_env env, napi_value exports ) {
+	napi_value fcn;
+	napi_status status = napi_create_function( env, "exports", NAPI_AUTO_LENGTH, addon, NULL, &fcn );
+	assert( status == napi_ok );
+	return fcn;
+}
+
+NAPI_MODULE( NODE_GYP_MODULE_NAME, init )

--- a/lib/node_modules/@stdlib/math/base/special/modf/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/modf/src/addon.c
@@ -93,8 +93,8 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	stdlib_base_modf( value, &integral, &frac );
 
 	double *op = (double *)Out;
-	op[ 1 ] = integral;
-	op[ 0 ] = frac;
+	op[ 0 ] = integral;
+	op[ 1 ] = frac;
 
 	return NULL;
 }

--- a/lib/node_modules/@stdlib/math/base/special/modf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/modf/src/main.c
@@ -24,10 +24,6 @@
 #include "stdlib/constants/float64/exponent_bias.h"
 #include "stdlib/constants/float64/high_word_exponent_mask.h"
 #include "stdlib/constants/float64/high_word_significand_mask.h"
-
-
-// VARIABLES //
-
 // 4294967295 => 0xffffffff => 11111111111111111111111111111111
 static const uint32_t ALL_ONES = 4294967295;
 
@@ -75,8 +71,8 @@ void stdlib_base_modf( const double x, double* integral, double* frac ) {
 		return;
 	}
 	if ( x == STDLIB_CONSTANT_FLOAT64_PINF ) {
-		*frac = STDLIB_CONSTANT_FLOAT64_PINF;
-		*integral = 0.0;
+		*integral = STDLIB_CONSTANT_FLOAT64_PINF;
+		*frac = 0.0;
 		return;
 	}
 	// Decompose |x|...
@@ -94,8 +90,8 @@ void stdlib_base_modf( const double x, double* integral, double* frac ) {
 
 		// Determine if `x` is integral by checking for significand bits which cannot be exponentiated away...
 		if ( ( ( high & i ) | low ) == 0 ) {
-			*frac = x;
-			*integral = 0.0;
+			*integral = x;
+			*frac = 0.0;
 			return;
 		}
 		// Turn off all the bits which cannot be exponentiated away:
@@ -104,23 +100,25 @@ void stdlib_base_modf( const double x, double* integral, double* frac ) {
 		// Generate the integral part:
 		j = i;
 		stdlib_base_float64_from_words( high, 0, &j );
-		*frac = j;
-		*integral = x - j;
+		
+		// The fractional part is whatever is leftover:
+		*integral = j;
+		*frac = x - j;
 		return;
 	}
 	// Check if `x` can even have a fractional part...
 	if ( exp > 51 ) {
 		// `x` is integral:
-		*frac = x;
-		*integral = 0.0;
+		*integral = x;
+		*frac = 0.0;
 		return;
 	}
 	i = ALL_ONES >> ( exp - 20 );
 
 	// Determine if `x` is integral by checking for less significant significand bits which cannot be exponentiated away...
 	if ( ( low & i ) == 0 ) {
-		*frac = x;
-		*integral = 0.0;
+		*integral = x;
+		*frac = 0.0;
 		return;
 	}
 	// Turn off all the bits which cannot be exponentiated away:
@@ -129,7 +127,9 @@ void stdlib_base_modf( const double x, double* integral, double* frac ) {
 	// Generate the integral part:
 	j = i;
 	stdlib_base_float64_from_words( high, low, &j );
-	*frac = j;
-	*integral = x - j;
+	
+	// The fractional part is whatever is leftover:
+	*integral = j;
+	*frac = x - j;
 	return;
 }

--- a/lib/node_modules/@stdlib/math/base/special/modf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/modf/src/main.c
@@ -53,13 +53,13 @@ void stdlib_base_modf( const double x, double* integral, double* frac ) {
 	if ( x < 1.0 ) {
 		if ( x < 0.0 ) {
 			stdlib_base_modf( -x, integral, frac );
-			*frac *= -1.0;
 			*integral *= -1.0;
+			*frac *= -1.0;
 			return;
 		}
 		if ( x == 0.0 ) { // [ +-0, +-0 ]
-			*frac = x;
 			*integral = x;
+			*frac = x;
 			return;
 		}
 		*integral = 0.0;
@@ -67,8 +67,8 @@ void stdlib_base_modf( const double x, double* integral, double* frac ) {
 		return;
 	}
 	if ( stdlib_base_is_nan( x ) ) {
-		*frac = 0.0 / 0.0; // NaN
 		*integral = 0.0 / 0.0; // NaN
+		*frac = 0.0 / 0.0; // NaN
 		return;
 	}
 	if ( x == STDLIB_CONSTANT_FLOAT64_PINF ) {

--- a/lib/node_modules/@stdlib/math/base/special/modf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/modf/src/main.c
@@ -1,0 +1,135 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/modf.h"
+#include "stdlib/math/base/assert/is_nan.h"
+#include "stdlib/number/float64/base/from_words.h"
+#include "stdlib/number/float64/base/to_words.h"
+#include "stdlib/constants/float64/pinf.h"
+#include "stdlib/constants/float64/exponent_bias.h"
+#include "stdlib/constants/float64/high_word_exponent_mask.h"
+#include "stdlib/constants/float64/high_word_significand_mask.h"
+
+
+// VARIABLES //
+
+// 4294967295 => 0xffffffff => 11111111111111111111111111111111
+static const uint32_t ALL_ONES = 4294967295;
+
+/**
+* Decomposes a double-precision floating-point number into integral and fractional parts, each having the same type and sign as the input value, and assigns results to a provided output array.
+*
+* @param x           input value
+* @param frac        destination to store the normalized fraction
+* @param integral    destination to store the exponent
+*
+* @example
+* double x = 3.141592653589793;
+*
+* double integral;
+* double frac;
+* stdlib_base_modf( x, &integral, &frac );
+*/
+void stdlib_base_modf( const double x, double* integral, double* frac ) {
+	uint32_t high;
+	uint32_t low;
+	int32_t exp;
+	int32_t i;
+	double j;
+
+	// Special cases...
+	if ( x < 1.0 ) {
+		if ( x < 0.0 ) {
+			stdlib_base_modf( -x, integral, frac );
+			*integral *= -1.0;
+			*frac *= -1.0;
+			return;
+		}
+		if ( x == 0.0 ) { // [ +-0, +-0 ]
+			*integral = x;
+			*frac = x;
+			return;
+		}
+		*frac = 0.0;
+		*integral = x;
+		return;
+	}
+	if ( stdlib_base_is_nan( x ) ) {
+		*integral = 0.0 / 0.0; // NaN
+		*frac = 0.0 / 0.0; // NaN
+		return;
+	}
+	if ( x == STDLIB_CONSTANT_FLOAT64_PINF ) {
+		*frac = STDLIB_CONSTANT_FLOAT64_PINF;
+		*integral = 0.0;
+		return;
+	}
+	// Decompose |x|...
+
+	// Extract the high and low words:
+	stdlib_base_float64_to_words( x, &high, &low );
+
+	// Extract the unbiased exponent from the high word:
+	exp = ( ( high & STDLIB_CONSTANT_FLOAT64_HIGH_WORD_EXPONENT_MASK ) >> 20 );
+	exp -= ( STDLIB_CONSTANT_FLOAT64_EXPONENT_BIAS );
+
+	// Handle smaller values (x < 2**20 = 1048576)...
+	if( exp < 20 ) {
+		i = ( STDLIB_CONSTANT_FLOAT64_HIGH_WORD_SIGNIFICAND_MASK >> exp );
+
+		// Determine if `x` is integral by checking for significand bits which cannot be exponentiated away...
+		if ( ( ( high & i ) | low ) == 0 ) {
+			*frac = x;
+			*integral = 0.0;
+			return;
+		}
+		// Turn off all the bits which cannot be exponentiated away:
+		high &= ( ~i );
+
+		// Generate the integral part:
+		j = i;
+		stdlib_base_float64_from_words( high, 0, &j );
+		*frac = j;
+		*integral = x - j;
+		return;
+	}
+	// Check if `x` can even have a fractional part...
+	if ( exp > 51 ) {
+		// `x` is integral:
+		*frac = x;
+		*integral = 0.0;
+		return;
+	}
+	i = ALL_ONES >> ( exp - 20 );
+
+	// Determine if `x` is integral by checking for less significant significand bits which cannot be exponentiated away...
+	if ( ( low & i ) == 0 ) {
+		*frac = x;
+		*integral = 0.0;
+		return;
+	}
+	// Turn off all the bits which cannot be exponentiated away:
+	low &= ( ~i );
+
+	// Generate the integral part:
+	j = i;
+	stdlib_base_float64_from_words( high, low, &j );
+	*frac = j;
+	*integral = x - j;
+	return;
+}

--- a/lib/node_modules/@stdlib/math/base/special/modf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/modf/src/main.c
@@ -24,6 +24,7 @@
 #include "stdlib/constants/float64/exponent_bias.h"
 #include "stdlib/constants/float64/high_word_exponent_mask.h"
 #include "stdlib/constants/float64/high_word_significand_mask.h"
+
 // 4294967295 => 0xffffffff => 11111111111111111111111111111111
 static const uint32_t ALL_ONES = 4294967295;
 
@@ -52,22 +53,22 @@ void stdlib_base_modf( const double x, double* integral, double* frac ) {
 	if ( x < 1.0 ) {
 		if ( x < 0.0 ) {
 			stdlib_base_modf( -x, integral, frac );
-			*integral *= -1.0;
 			*frac *= -1.0;
+			*integral *= -1.0;
 			return;
 		}
 		if ( x == 0.0 ) { // [ +-0, +-0 ]
-			*integral = x;
 			*frac = x;
+			*integral = x;
 			return;
 		}
-		*frac = 0.0;
-		*integral = x;
+		*integral = 0.0;
+		*frac = x;
 		return;
 	}
 	if ( stdlib_base_is_nan( x ) ) {
-		*integral = 0.0 / 0.0; // NaN
 		*frac = 0.0 / 0.0; // NaN
+		*integral = 0.0 / 0.0; // NaN
 		return;
 	}
 	if ( x == STDLIB_CONSTANT_FLOAT64_PINF ) {
@@ -100,8 +101,6 @@ void stdlib_base_modf( const double x, double* integral, double* frac ) {
 		// Generate the integral part:
 		j = i;
 		stdlib_base_float64_from_words( high, 0, &j );
-		
-		// The fractional part is whatever is leftover:
 		*integral = j;
 		*frac = x - j;
 		return;
@@ -127,8 +126,6 @@ void stdlib_base_modf( const double x, double* integral, double* frac ) {
 	// Generate the integral part:
 	j = i;
 	stdlib_base_float64_from_words( high, low, &j );
-	
-	// The fractional part is whatever is leftover:
 	*integral = j;
 	*frac = x - j;
 	return;

--- a/lib/node_modules/@stdlib/math/base/special/modf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/modf/test/test.native.js
@@ -1,0 +1,181 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
+var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var modf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( modf instanceof Error )
+};
+
+
+// FIXTURES //
+
+var subnormal = require( './fixtures/julia/subnormal.json' );
+var small = require( './fixtures/julia/small.json' );
+var medium = require( './fixtures/julia/medium.json' );
+var large = require( './fixtures/julia/large.json' );
+var huge = require( './fixtures/julia/huge.json' );
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof modf, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function decomposes a number into integral and fractional parts (small values)', opts, function test( t ) {
+	var integral;
+	var parts;
+	var frac;
+	var x;
+	var i;
+
+	integral = small.integral;
+	frac = small.frac;
+	x = small.x;
+	for ( i = 0; i < x.length; i++ ) {
+		parts = modf( x[ i ] );
+		t.strictEqual( parts[0], integral[i], 'returns integral part' );
+		t.strictEqual( parts[1], frac[i], 'returns fractional part' );
+	}
+	t.end();
+});
+
+tape( 'the function decomposes a number into integral and fractional parts (medium values)', opts, function test( t ) {
+	var integral;
+	var parts;
+	var frac;
+	var x;
+	var i;
+
+	integral = medium.integral;
+	frac = medium.frac;
+	x = medium.x;
+	for ( i = 0; i < x.length; i++ ) {
+		parts = modf( x[ i ] );
+		t.strictEqual( parts[0], integral[i], 'returns integral part' );
+		t.strictEqual( parts[1], frac[i], 'returns fractional part' );
+	}
+	t.end();
+});
+
+tape( 'the function decomposes a number into integral and fractional parts (large values)', opts, function test( t ) {
+	var integral;
+	var parts;
+	var frac;
+	var x;
+	var i;
+
+	integral = large.integral;
+	frac = large.frac;
+	x = large.x;
+	for ( i = 0; i < x.length; i++ ) {
+		parts = modf( x[ i ] );
+		t.strictEqual( parts[0], integral[i], 'returns integral part' );
+		t.strictEqual( parts[1], frac[i], 'returns fractional part' );
+	}
+	t.end();
+});
+
+tape( 'the function decomposes a number into integral and fractional parts (huge values)', opts, function test( t ) {
+	var integral;
+	var parts;
+	var frac;
+	var x;
+	var i;
+
+	integral = huge.integral;
+	frac = huge.frac;
+	x = huge.x;
+	for ( i = 0; i < x.length; i++ ) {
+		parts = modf( x[ i ] );
+		t.strictEqual( parts[0], integral[i], 'returns integral part' );
+		t.strictEqual( parts[1], frac[i], 'returns fractional part' );
+	}
+	t.end();
+});
+
+tape( 'the function decomposes a number into integral and fractional parts (subnormal values)', opts, function test( t ) {
+	var integral;
+	var parts;
+	var frac;
+	var x;
+	var i;
+
+	integral = subnormal.integral;
+	frac = subnormal.frac;
+	x = subnormal.x;
+	for ( i = 0; i < x.length; i++ ) {
+		parts = modf( x[ i ] );
+		t.strictEqual( parts[0], integral[i], 'returns integral part' );
+		t.strictEqual( parts[1], frac[i], 'returns fractional part' );
+	}
+	t.end();
+});
+
+tape( 'if provided `+0`, the function returns `[+0,+0]`', opts, function test( t ) {
+	var parts = modf( +0.0 );
+	t.strictEqual( isPositiveZero( parts[0] ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( parts[1] ), true, 'returns +0' );
+	t.end();
+});
+
+tape( 'if provided `-0`, the function returns `[-0,-0]`', opts, function test( t ) {
+	var parts = modf( -0.0 );
+	t.strictEqual( isNegativeZero( parts[0] ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( parts[1] ), true, 'returns -0' );
+	t.end();
+});
+
+tape( 'if provided `+infinity`, the function returns `[+infinity,+0]`', opts, function test( t ) {
+	var parts = modf( PINF );
+	t.strictEqual( parts[0], PINF, 'returns +infinity' );
+	t.strictEqual( isPositiveZero( parts[1] ), true, 'returns +0' );
+	t.end();
+});
+
+tape( 'if provided `-infinity`, the function returns `[-infinity,-0]`', opts, function test( t ) {
+	var parts = modf( NINF );
+	t.strictEqual( parts[0], NINF, 'returns -infinity' );
+	t.strictEqual( isNegativeZero( parts[1] ), true, 'returns -0' );
+	t.end();
+});
+
+tape( 'if provided `NaN`, the function returns `[NaN,NaN]`', opts, function test( t ) {
+	var parts = modf( NaN );
+	t.strictEqual( isnan( parts[0] ), true, 'returns NaN' );
+	t.strictEqual( isnan( parts[1] ), true, 'returns NaN' );
+	t.end();
+});


### PR DESCRIPTION
Resolves #1916.

## Description

> What is the purpose of this pull request?

This pull request:

-   adds C implementation for [`math/base/special/modf`](https://github.com/stdlib-js/stdlib/tree/d7798af1c843b45d0bbaddadedf7d2961a1b3f57/lib/node_modules/%40stdlib/math/base/special/modf)

```C
void stdlib_base_modf( const double x, double* integral, double* frac )
```

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves a part of #649.
-   fixes #1916.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   ☑️ Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
