### PR TITLE
fix: variable type declarations in `math/base/assert/int32-is-odd`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/README.md
@@ -123,10 +123,10 @@ out = stdlib_base_int32_is_odd( -2 );
 
 The function accepts the following arguments:
 
--   **x**: `[in] double` input value.
+-   **x**: `[in] int32_t` input value.
 
 ```c
-bool stdlib_base_int32_is_odd( const double x );
+bool stdlib_base_int32_is_odd( const int32_t x );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/lib/native.js
@@ -30,7 +30,7 @@ var addon = require( './../src/addon.node' );
 * Tests if a 32-bit integer is odd.
 *
 * @private
-* @param {number} x - value to test
+* @param {integer32} x - value to test
 * @returns {boolean} boolean indicating whether the number is odd
 *
 * @example

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/src/addon.c
@@ -59,8 +59,8 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 		return NULL;
 	}
 
-	double x;
-	status = napi_get_value_double( env, argv[ 0 ], &x );
+	int32_t x;
+	status = napi_get_value_int32( env, argv[ 0 ], &x );
 	assert( status == napi_ok );
 
 	bool result = stdlib_base_int32_is_odd( x );


### PR DESCRIPTION
In some places, the type declarations are inconsistent according to the function prototype. This commit aims to fix those

## Description

> What is the purpose of this pull request?
Fix variable type declarations in the namespace

## Related Issues

> Does this pull request have any related issues?
N/A

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
