### PR TITLE
feat: add C implementation for `math/base/special/fast/uint32-log2`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/README.md
@@ -88,6 +88,97 @@ for ( i = 1; i < 101; i++ ) {
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/math/base/special/fast/uint32_log2.h"
+```
+
+#### stdlib_base_fast_uint32_log2( x )
+
+Compute an integer [binary logarithm][binary-logarithm].
+
+```c
+#include <stdint.h>
+
+uint32_t out = stdlib_base_fast_uint32_log2( 4 );
+// returns 2
+
+out = stdlib_base_uint32_is_pow2( 9 );
+// returns 3
+```
+
+The function accepts the following arguments:
+
+-   **x**: `[in] uint32_t` input value.
+
+```c
+uint32_t stdlib_base_uint32_is_pow2( const uint32_t x );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/math/base/special/fast/uint32_log2.h"
+#include <stdio.h>
+#include <stdint.h>
+
+int main( void ) {
+    const uint32_t x[] = { 5, 7, 10, 22, 98 };
+
+    uint32_t y;
+    int i;
+    for ( i = 0; i < 5; i++ ) {
+        y = stdlib_base_fast_uint32_log2( x[ i ] );
+        printf( "uint32_log2(%u) ≈ %u\n", x[ i ], y );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/README.md
@@ -166,7 +166,7 @@ int main( void ) {
     int i;
     for ( i = 0; i < 5; i++ ) {
         y = stdlib_base_fast_uint32_log2( x[ i ] );
-        printf( "uint32_log2(%u) ≈ %u\n", x[ i ], y );
+        printf( "uint32_log2(%u) = %u\n", x[ i ], y );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/README.md
@@ -124,7 +124,7 @@ Compute an integer [binary logarithm][binary-logarithm].
 uint32_t out = stdlib_base_fast_uint32_log2( 4 );
 // returns 2
 
-out = stdlib_base_uint32_is_pow2( 9 );
+out = stdlib_base_fast_uint32_log2( 9 );
 // returns 3
 ```
 
@@ -133,7 +133,7 @@ The function accepts the following arguments:
 -   **x**: `[in] uint32_t` input value.
 
 ```c
-uint32_t stdlib_base_uint32_is_pow2( const uint32_t x );
+uint32_t stdlib_base_fast_uint32_log2( const uint32_t x );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/README.md
@@ -116,7 +116,7 @@ for ( i = 1; i < 101; i++ ) {
 
 #### stdlib_base_fast_uint32_log2( x )
 
-Compute an integer [binary logarithm][binary-logarithm].
+Returns an **approximate** [binary logarithm][binary-logarithm] of an unsigned 32-bit integer `x`.
 
 ```c
 #include <stdint.h>

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/benchmark/benchmark.native.js
@@ -1,0 +1,58 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var minstd = require( '@stdlib/random/base/minstd-shuffle' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var log2Uint32 = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( log2Uint32 instanceof Error )
+};
+
+
+// MAIN //
+
+bench( pkg+'::native', opts, function benchmark( b ) {
+	var y;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		y = log2Uint32( minstd() >>> 0 );
+		if ( isnan( y ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnan( y ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/benchmark/c/native/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/benchmark/c/native/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/benchmark/c/native/benchmark.c
@@ -104,14 +104,14 @@ double benchmark() {
 	for ( i = 0; i < ITERATIONS; i++ ) {
 		x = (uint32_t)rand();
 		y = stdlib_base_fast_uint32_log2( x );
-		if ( y != y ) {
-			printf( "should not return NaN\n" );
+		if ( y > x ) {
+			printf( "unexpected result\n" );
 			break;
 		}
 	}
 	elapsed = tic() - t;
-	if ( y != y ) {
-		printf( "should not return NaN\n" );
+	if ( y > x ) {
+		printf( "unexpected result\n" );
 	}
 	return elapsed;
 }

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/benchmark/c/native/benchmark.c
@@ -1,0 +1,137 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/**
+* Benchmark `uint32_log2`.
+*/
+#include "stdlib/math/base/special/fast/uint32_log2.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "uint32_log2"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+void print_version() {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+double tic() {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1].
+*
+* @return random number
+*/
+double rand_double() {
+	int r = rand();
+	return (double)r / ( (double)RAND_MAX + 1.0 );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+double benchmark() {
+	double elapsed;
+	uint32_t x;
+	uint32_t y;
+	double t;
+	int i;
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		x = (uint32_t)rand();
+		y = stdlib_base_fast_uint32_log2( x );
+		if ( y != y ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( y != y ) {
+		printf( "should not return NaN\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::native::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/binding.gyp
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/examples/c/example.c
@@ -1,0 +1,32 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/fast/uint32_log2.h"
+#include <stdio.h>
+#include <stdint.h>
+
+int main( void ) {
+	const uint32_t x[] = { 5, 7, 10, 22, 98 };
+
+	uint32_t y;
+	int i;
+	for ( i = 0; i < 5; i++ ) {
+		y = stdlib_base_fast_uint32_log2( x[ i ] );
+		printf( "uint32_log2(%u) ≈ %u\n", x[ i ], y );
+	}
+}

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/examples/c/example.c
@@ -27,6 +27,6 @@ int main( void ) {
 	int i;
 	for ( i = 0; i < 5; i++ ) {
 		y = stdlib_base_fast_uint32_log2( x[ i ] );
-		printf( "uint32_log2(%u) ≈ %u\n", x[ i ], y );
+		printf( "uint32_log2(%u) = %u\n", x[ i ], y );
 	}
 }

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/include.gypi
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/include/stdlib/math/base/special/fast/uint32_log2.h
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/include/stdlib/math/base/special/fast/uint32_log2.h
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/**
+* Header file containing function declarations.
+*/
+#ifndef STDLIB_MATH_BASE_SPECIAL_FAST_UINT32_LOG2_H
+#define STDLIB_MATH_BASE_SPECIAL_FAST_UINT32_LOG2_H
+
+#include <stdint.h>
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Computes an integer binary logarithm (base two).
+*/
+uint32_t stdlib_base_fast_uint32_log2( const uint32_t x );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_MATH_BASE_SPECIAL_FAST_UINT32_LOG2_H

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/lib/native.js
@@ -46,7 +46,7 @@ var addon = require( './../src/addon.node' );
 * // returns 3
 */
 function log2Uint32( x ) {
-	return Boolean( addon( x ) );
+	return addon( x );
 }
 
 

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/lib/native.js
@@ -1,0 +1,55 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var Boolean = require( '@stdlib/boolean/ctor' );
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Computes an integer binary logarithm (base two).
+*
+* @private
+* @param {uinteger32} x - input value
+* @returns {uinteger32} integer binary logarithm
+*
+* @example
+* var out = log2Uint32( 4 );
+* // returns 2
+*
+* @example
+* var out = log2Uint32( 8 );
+* // returns 3
+*
+* @example
+* var out = log2Uint32( 9 );
+* // returns 3
+*/
+function log2Uint32( x ) {
+	return Boolean( addon( x ) );
+}
+
+
+// EXPORTS //
+
+module.exports = log2Uint32;

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/lib/native.js
@@ -20,7 +20,6 @@
 
 // MODULES //
 
-var Boolean = require( '@stdlib/boolean/ctor' );
 var addon = require( './../src/addon.node' );
 
 

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/manifest.json
@@ -1,0 +1,65 @@
+{
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": []
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": []
+    },
+    {
+      "task": "examples",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": []
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/manifest.json
@@ -36,7 +36,7 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-        "@stdlib/napi/argv_uint32"
+        "@stdlib/napi/argv-uint32"
       ]
     },
     {

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/manifest.json
@@ -35,7 +35,9 @@
       ],
       "libraries": [],
       "libpath": [],
-      "dependencies": []
+      "dependencies": [
+        "@stdlib/napi/argv_uint32"
+      ]
     },
     {
       "task": "benchmark",

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/manifest.json
@@ -36,7 +36,8 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-        "@stdlib/napi/argv-uint32"
+        "@stdlib/napi/argv-uint32",
+        "@stdlib/napi/export"
       ]
     },
     {

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/addon.c
@@ -31,7 +31,7 @@
 * @return       Node-API value
 */
 static napi_value addon( napi_env env, napi_callback_info info ) {
-	// Retrieve add-on callback arguments:
+    // Retrieve add-on callback arguments:
     STDLIB_NAPI_ARGV( env, info, argv, argc, 1 );
 
     // Convert the first argument to a C type:

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/addon.c
@@ -31,19 +31,20 @@
 * @return       Node-API value
 */
 static napi_value addon( napi_env env, napi_callback_info info ) {
+    napi_status status; 
     // Retrieve add-on callback arguments:
     STDLIB_NAPI_ARGV( env, info, argv, argc, 1 );
 
     // Convert the first argument to a C type:
     STDLIB_NAPI_ARGV_UINT32( env, value, argv, 0 );
 
-	uint32_t result = stdlib_base_fast_uint32_log2( value );
+    uint32_t result = stdlib_base_fast_uint32_log2( value );
 
-	napi_value v;
-	status = napi_create_uint32( env, result, &v );
-	assert( status == napi_ok );
+    napi_value v;
+    status = napi_create_uint32( env, result, &v );
+    assert( status == napi_ok );
 
-	return v;
+    return v;
 }
 
 /**

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/addon.c
@@ -1,0 +1,90 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/assert/uint32_log2.h"
+#include <node_api.h>
+#include <stdint.h>
+#include <assert.h>
+
+/**
+* Receives JavaScript callback invocation data.
+*
+* @private
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @return       Node-API value
+*/
+static napi_value addon( napi_env env, napi_callback_info info ) {
+	napi_status status;
+
+	// Get callback arguments:
+	size_t argc = 1;
+	napi_value argv[ 1 ];
+	status = napi_get_cb_info( env, info, &argc, argv, NULL, NULL );
+	assert( status == napi_ok );
+
+	// Check whether we were provided the correct number of arguments:
+	if ( argc < 1 ) {
+		status = napi_throw_error( env, NULL, "invalid invocation. Insufficient arguments." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+	if ( argc > 1 ) {
+		status = napi_throw_error( env, NULL, "invalid invocation. Too many arguments." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	napi_valuetype vtype0;
+	status = napi_typeof( env, argv[ 0 ], &vtype0 );
+	assert( status == napi_ok );
+	if ( vtype0 != napi_number ) {
+		status = napi_throw_type_error( env, NULL, "invalid argument. First argument must be a number." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	uint32_t x;
+	status = napi_get_value_uint32( env, argv[ 0 ], &x );
+	assert( status == napi_ok );
+
+	uint32_t result = stdlib_base_fast_uint32_log2( x );
+
+	napi_value v;
+	status = napi_create_int32( env, (int32_t)result, &v );
+	assert( status == napi_ok );
+
+	return v;
+}
+
+/**
+* Initializes a Node-API module.
+*
+* @private
+* @param env      environment under which the function is invoked
+* @param exports  exports object
+* @return         main export
+*/
+static napi_value init( napi_env env, napi_value exports ) {
+	napi_value fcn;
+	napi_status status = napi_create_function( env, "exports", NAPI_AUTO_LENGTH, addon, NULL, &fcn );
+	assert( status == napi_ok );
+	return fcn;
+}
+
+NAPI_MODULE( NODE_GYP_MODULE_NAME, init )

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/addon.c
@@ -18,6 +18,7 @@
 
 #include "stdlib/math/base/special/fast/uint32_log2.h"
 #include "stdlib/napi/argv_uint32.h"
+#include "stdlib/napi/export.h"
 #include <node_api.h>
 #include <stdint.h>
 #include <assert.h>
@@ -41,19 +42,5 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	return v;
 }
 
-/**
-* Initializes a Node-API module.
-*
-* @private
-* @param env      environment under which the function is invoked
-* @param exports  exports object
-* @return         main export
-*/
-static napi_value init( napi_env env, napi_value exports ) {
-	napi_value fcn;
-	napi_status status = napi_create_function( env, "exports", NAPI_AUTO_LENGTH, addon, NULL, &fcn );
-	assert( status == napi_ok );
-	return fcn;
-}
-
-NAPI_MODULE( NODE_GYP_MODULE_NAME, init )
+// Register a Node-API module:
+STDLIB_NAPI_MODULE_EXPORT_FCN( addon )

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/addon.c
@@ -31,18 +31,11 @@
 * @return       Node-API value
 */
 static napi_value addon( napi_env env, napi_callback_info info ) {
-    napi_status status;
-
-    // Retrieve add-on callback arguments:
-    STDLIB_NAPI_ARGV( env, info, argv, argc, 1 );
-
-    // Convert the first argument to a C type:
-    STDLIB_NAPI_ARGV_UINT32( env, value, argv, 0 );
-
-    uint32_t result = stdlib_base_fast_uint32_log2( value );
+	STDLIB_NAPI_ARGV( env, info, argv, argc, 1 );
+	STDLIB_NAPI_ARGV_UINT32( env, value, argv, 0 );
 
     napi_value v;
-    status = napi_create_uint32( env, result, &v );
+    napi_status status = napi_create_uint32( env, stdlib_base_fast_uint32_log2( value ), &v );
     assert( status == napi_ok );
 
     return v;

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/addon.c
@@ -42,5 +42,4 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	return v;
 }
 
-// Register a Node-API module:
 STDLIB_NAPI_MODULE_EXPORT_FCN( addon )

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/addon.c
@@ -66,7 +66,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	uint32_t result = stdlib_base_fast_uint32_log2( x );
 
 	napi_value v;
-	status = napi_create_int32( env, (int32_t)result, &v );
+	status = napi_create_uint32( env, result, &v );
 	assert( status == napi_ok );
 
 	return v;

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/addon.c
@@ -34,11 +34,11 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV( env, info, argv, argc, 1 );
 	STDLIB_NAPI_ARGV_UINT32( env, value, argv, 0 );
 
-    napi_value v;
-    napi_status status = napi_create_uint32( env, stdlib_base_fast_uint32_log2( value ), &v );
-    assert( status == napi_ok );
+	napi_value v;
+	napi_status status = napi_create_uint32( env, stdlib_base_fast_uint32_log2( value ), &v );
+	assert( status == napi_ok );
 
-    return v;
+	return v;
 }
 
 /**

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/addon.c
@@ -20,7 +20,6 @@
 #include "stdlib/napi/argv_uint32.h"
 #include "stdlib/napi/export.h"
 #include <node_api.h>
-#include <stdint.h>
 #include <assert.h>
 
 /**

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/fast/uint32_log2.h"
+#include "stdlib/napi/argv_uint32.h"
 #include <node_api.h>
 #include <stdint.h>
 #include <assert.h>
@@ -30,40 +31,13 @@
 * @return       Node-API value
 */
 static napi_value addon( napi_env env, napi_callback_info info ) {
-	napi_status status;
+	// Retrieve add-on callback arguments:
+    STDLIB_NAPI_ARGV( env, info, argv, argc, 1 );
 
-	// Get callback arguments:
-	size_t argc = 1;
-	napi_value argv[ 1 ];
-	status = napi_get_cb_info( env, info, &argc, argv, NULL, NULL );
-	assert( status == napi_ok );
+    // Convert the first argument to a C type:
+    STDLIB_NAPI_ARGV_UINT32( env, value, argv, 0 );
 
-	// Check whether we were provided the correct number of arguments:
-	if ( argc < 1 ) {
-		status = napi_throw_error( env, NULL, "invalid invocation. Insufficient arguments." );
-		assert( status == napi_ok );
-		return NULL;
-	}
-	if ( argc > 1 ) {
-		status = napi_throw_error( env, NULL, "invalid invocation. Too many arguments." );
-		assert( status == napi_ok );
-		return NULL;
-	}
-
-	napi_valuetype vtype0;
-	status = napi_typeof( env, argv[ 0 ], &vtype0 );
-	assert( status == napi_ok );
-	if ( vtype0 != napi_number ) {
-		status = napi_throw_type_error( env, NULL, "invalid argument. First argument must be a number." );
-		assert( status == napi_ok );
-		return NULL;
-	}
-
-	uint32_t x;
-	status = napi_get_value_uint32( env, argv[ 0 ], &x );
-	assert( status == napi_ok );
-
-	uint32_t result = stdlib_base_fast_uint32_log2( x );
+	uint32_t result = stdlib_base_fast_uint32_log2( value );
 
 	napi_value v;
 	status = napi_create_uint32( env, result, &v );

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/addon.c
@@ -31,7 +31,8 @@
 * @return       Node-API value
 */
 static napi_value addon( napi_env env, napi_callback_info info ) {
-    napi_status status; 
+    napi_status status;
+
     // Retrieve add-on callback arguments:
     STDLIB_NAPI_ARGV( env, info, argv, argc, 1 );
 

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/addon.c
@@ -16,7 +16,7 @@
 * limitations under the License.
 */
 
-#include "stdlib/math/base/assert/uint32_log2.h"
+#include "stdlib/math/base/special/fast/uint32_log2.h"
 #include <node_api.h>
 #include <stdint.h>
 #include <assert.h>

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/main.c
@@ -1,0 +1,73 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/fast/uint32_log2.h"
+#include <stdint.h>
+
+static const uint32_t B4 = 0xFFFF0000u;
+static const uint32_t B3 = 0xFF00u;
+static const uint32_t B2 = 0xF0u;
+static const uint32_t B1 = 0xCu;
+static const uint32_t B0 = 0x2u;
+static const uint32_t S4 = 16u;
+static const uint32_t S3 = 8u;
+static const uint32_t S2 = 4u;
+static const uint32_t S1 = 2u;
+static const uint32_t S0 = 1u;
+
+/**
+* Computes an integer binary logarithm (base two).
+*
+* @param x    number
+* @returns    integer binary logarithm
+*
+* @example
+* uint32_t out = stdlib_base_fast_uint32_log2( 8 );
+* // returns 3
+*/
+uint32_t stdlib_base_fast_uint32_log2( uint32_t x ) {
+    uint32_t out = 0u;
+    uint32_t y = x;
+
+    // `x >= 65536`:
+    if ( y & B4 ) {
+        y >>= S4;
+        out |= S4;
+    }
+    // `x >= 256`:
+    if ( y & B3 ) {
+        y >>= S3;
+        out |= S3;
+    }
+    // `x >= 16`:
+    if ( y & B2 ) {
+        y >>= S2;
+        out |= S2;
+    }
+    // `x >= 4`:
+    if ( y & B1 ) {
+        y >>= S1;
+        out |= S1;
+    }
+    // `x >= 2`:
+    if ( y & B0 ) {
+        y >>= S0;
+        out |= S0;
+    }
+    return out;
+}

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/main.c
@@ -33,6 +33,26 @@ static const uint32_t S0 = 1u;
 /**
 * Computes an integer binary logarithm (base two).
 *
+* ## Method
+*
+* 1.  Note that the largest unsigned 32-bit integer is `4294967295`, which is `2^{32}-1`. Hence, the integer binary logarithm cannot exceed `31` (i.e., `16 + 8 + 4 + 2 + 1`), which corresponds to the bit sequence
+*
+*     ```binarystring
+*     00000000000000000000000000011111
+*     ```
+*
+* 2.  Initialize a return variable with the value zero.
+*
+* 3.  If at least one of the first sixteen most significant bits of the input 32-bit integer `x` is turned on, we know that the power to which the number `2` must be raised to obtain `x` is at least `16` (i.e., `x > 65536`). Hence, activate the corresponding bit of the return variable. Mutate `x` by shifting sixteen bits to the right, discarding the bits shifted off.
+*
+* 4.  Carry out the following steps with `B` in `[ 8, 4, 2, 1 ]`:
+*
+*     -   If at least one of the next `B` most significant bits of the current `x` is turned on, we know that the power to which the number `2` must be raised to obtain `x` has to be increased by `B`.
+*     -   Activate the bit of the return variable that corresponds to `B`.
+*     -   Mutate `x` by shifting `B` bits to the right, discarding the bits shifted off.
+*
+* 5.  The final value of the return variable is the integer binary logarithm of `x`.
+*
 * @param x    number
 * @returns    integer binary logarithm
 *

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/main.c
@@ -68,7 +68,7 @@ uint32_t stdlib_base_fast_uint32_log2( const uint32_t x ) {
 	}
 	// `xc >= 2`:
 	if ( xc & B0 ) {
-		x >>= S0;
+		xc >>= S0;
 		out |= S0;
 	}
 	return out;

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/main.c
@@ -40,33 +40,36 @@ static const uint32_t S0 = 1u;
 * uint32_t out = stdlib_base_fast_uint32_log2( 8 );
 * // returns 3
 */
-uint32_t stdlib_base_fast_uint32_log2( uint32_t x ) {
-    uint32_t out = 0u;
-
-    // `x >= 65536`:
-    if ( x & B4 ) {
-        x >>= S4;
-        out |= S4;
-    }
-    // `x >= 256`:
-    if ( x & B3 ) {
-        x >>= S3;
-        out |= S3;
-    }
-    // `x >= 16`:
-    if ( x & B2 ) {
-        x >>= S2;
-        out |= S2;
-    }
-    // `x >= 4`:
-    if ( x & B1 ) {
-        x >>= S1;
-        out |= S1;
-    }
-    // `x >= 2`:
-    if ( x & B0 ) {
-        x >>= S0;
-        out |= S0;
-    }
-    return out;
+uint32_t stdlib_base_fast_uint32_log2( const uint32_t x ) {
+	uint32_t out;
+	uint32_t xc;
+	
+	xc = x;
+	out = 0;
+	// `xc >= 65536`:
+	if ( xc & B4 ) {
+		xc >>= S4;
+		out |= S4;
+	}
+	// `xc >= 256`:
+	if ( xc & B3 ) {
+		xc >>= S3;
+		out |= S3;
+	}
+	// `xc >= 16`:
+	if ( xc & B2 ) {
+		xc >>= S2;
+		out |= S2;
+	}
+	// `xc >= 4`:
+	if ( xc & B1 ) {
+		xc >>= S1;
+		out |= S1;
+	}
+	// `xc >= 2`:
+	if ( xc & B0 ) {
+		x >>= S0;
+		out |= S0;
+	}
+	return out;
 }

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/main.c
@@ -42,31 +42,30 @@ static const uint32_t S0 = 1u;
 */
 uint32_t stdlib_base_fast_uint32_log2( uint32_t x ) {
     uint32_t out = 0u;
-    uint32_t y = x;
 
     // `x >= 65536`:
-    if ( y & B4 ) {
-        y >>= S4;
+    if ( x & B4 ) {
+        x >>= S4;
         out |= S4;
     }
     // `x >= 256`:
-    if ( y & B3 ) {
-        y >>= S3;
+    if ( x & B3 ) {
+        x >>= S3;
         out |= S3;
     }
     // `x >= 16`:
-    if ( y & B2 ) {
-        y >>= S2;
+    if ( x & B2 ) {
+        x >>= S2;
         out |= S2;
     }
     // `x >= 4`:
-    if ( y & B1 ) {
-        y >>= S1;
+    if ( x & B1 ) {
+        x >>= S1;
         out |= S1;
     }
     // `x >= 2`:
-    if ( y & B0 ) {
-        y >>= S0;
+    if ( x & B0 ) {
+        x >>= S0;
         out |= S0;
     }
     return out;

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/main.c
@@ -54,7 +54,7 @@ static const uint32_t S0 = 1u;
 * 5.  The final value of the return variable is the integer binary logarithm of `x`.
 *
 * @param x    number
-* @returns    integer binary logarithm
+* @return     integer binary logarithm
 *
 * @example
 * uint32_t out = stdlib_base_fast_uint32_log2( 8 );

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/src/main.c
@@ -68,7 +68,6 @@ uint32_t stdlib_base_fast_uint32_log2( const uint32_t x ) {
 	}
 	// `xc >= 2`:
 	if ( xc & B0 ) {
-		xc >>= S0;
 		out |= S0;
 	}
 	return out;

--- a/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/fast/uint32-log2/test/test.native.js
@@ -1,0 +1,74 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var minstd = require( '@stdlib/random/base/minstd-shuffle' );
+var log2 = require( '@stdlib/math/base/special/log2' );
+var floor = require( '@stdlib/math/base/special/floor' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var log2Uint32 = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( log2Uint32 instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof log2Uint32, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns an approximate binary logarithm (base two) for integer arguments', opts, function test( t ) {
+	var x;
+	var y;
+	var v;
+	var i;
+
+	for ( i = 0; i < 5000; i++ ) {
+		x = minstd() >>> 0;
+		y = log2( x );
+		v = log2Uint32( x );
+		t.strictEqual( v, floor( y ), 'returns an approximate binary logarithm' );
+	}
+	t.end();
+});
+
+tape( 'the function returns the exact binary logarithm (base two) for integer powers of 2', opts, function test( t ) {
+	var x;
+	var y;
+	var i;
+
+	for ( i = 0; i < 32; i++ ) {
+		x = pow( 2, i );
+		y = log2Uint32( x );
+		t.strictEqual( y, i, 'returns binary logarithm' );
+	}
+	t.end();
+});


### PR DESCRIPTION
This commit if applied adds the native C implementation to `@stdlib/math/base/special/fast/uint32-log2`

## Description

> What is the purpose of this pull request?
Add the native C implementation to `@stdlib/math/base/special/fast/uint32-log2` package

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #1931 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
