### PR TITLE
docs: improve example code of `stats/base/dists/triangular` namespace

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/README.md
@@ -97,8 +97,6 @@ var y = dist.quantile( 0.5 );
 
 y = dist.quantile( 1.9 );
 // returns NaN
-
-
 ```
 
 </section>
@@ -109,42 +107,62 @@ y = dist.quantile( 1.9 );
 
 ## Examples
 
-<!-- TODO: better examples -->
-
-
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var objectKeys = require( '@stdlib/utils/keys' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var triangular = require( '@stdlib/stats/base/dists/triangular' );
 
-console.log( objectKeys( triangular ) );
+// Scenario: Modeling completion time for a software development task
 
+// Define the distribution parameters (in hours):
+var a = 1.5; // Minimum time (best-case scenario)
+var b = 4.5; // Maximum time (worst-case scenario)
+var c = discreteUniform( 2, 4 ); // Most likely time (mode)
+console.log( 'a: %d, b: %d, c: %d', a, b, c );
 
-// Basic Usage: Calculate and print the mean, median, and mode
-console.log('Mean:', dist.mean()); 
-  // returns Mean: 3.0
+// Expected (mean) completion time:
+var mean = triangular.mean( a, b, c );
+console.log( '\nExpected completion time: %d hours', mean );
 
-console.log('Median:', dist.median());
- // returns Median: 3.0
+// Median completion time:
+var median = triangular.median( a, b, c );
+console.log( 'Median completion time: %d hours', median );
 
-console.log('Mode:', dist.mode());  
- // returns Mode: 3.0
+// Variance in completion time:
+var variance = triangular.variance( a, b, c );
+console.log( 'Variance in completion time: %d hours^2', variance );
 
-// Probability Density Function (PDF): Calculate the PDF at x=3.5
-var pdfValue = dist.pdf(3.5);
-console.log('PDF at x=3.5:', pdfValue); 
-// returns  PDF at x=3.5: 0.4
+// Probability of completing the task within 3 hours:
+var x = 3.0;
+var prob = triangular.cdf( x, a, b, c );
+console.log( '\nProbability of completing within %d hours: %d', x, prob );
 
-// Cumulative Distribution Function (CDF): Calculate the CDF at x=3.5
-var cdfValue = dist.cdf(3.5);
-console.log('CDF at x=3.5:', cdfValue); 
-// returns CDF at x=3.5: 0.5
+// 90th percentile of completion time:
+var p = 0.9;
+var percentile = triangular.quantile( p, a, b, c );
+console.log( '90% of tasks will be completed within %d hours', percentile );
 
-// Quantile Function: Find the quantile for p=0.5
-var quantileValue = dist.quantile(0.5);
-console.log('Quantile for p=0.5:', quantileValue);
- // returns Quantile for p=0.5: 3.0
+// Relative likelihood of completing the task in exactly 2.5 hours:
+x = 2.5;
+var likelihood = triangular.pdf( x, a, b, c );
+console.log( '\nRelative likelihood of completing in exactly %d hours: %d', x, likelihood );
+
+// Skewness to understand the distribution's shape:
+var skewness = triangular.skewness( a, b, c );
+console.log( '\nSkewness of completion times: %d', skewness );
+if ( skewness > 0 ) {
+    console.log( 'The distribution is right-skewed, suggesting occasional longer completion times.' );
+} else if ( skewness < 0 ) {
+    console.log( 'The distribution is left-skewed, suggesting occasional shorter completion times.' );
+} else {
+    console.log( 'The distribution is symmetric.' );
+}
+
+// Entropy as a measure of uncertainty in the estimate:
+var entropy = triangular.entropy( a, b, c );
+console.log( '\nEntropy of the distribution: %d nats', entropy );
+console.log( 'Higher entropy indicates more uncertainty in completion times.' );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/README.md
@@ -97,6 +97,8 @@ var y = dist.quantile( 0.5 );
 
 y = dist.quantile( 1.9 );
 // returns NaN
+
+
 ```
 
 </section>
@@ -109,6 +111,7 @@ y = dist.quantile( 1.9 );
 
 <!-- TODO: better examples -->
 
+
 <!-- eslint no-undef: "error" -->
 
 ```javascript
@@ -116,6 +119,32 @@ var objectKeys = require( '@stdlib/utils/keys' );
 var triangular = require( '@stdlib/stats/base/dists/triangular' );
 
 console.log( objectKeys( triangular ) );
+
+
+// Basic Usage: Calculate and print the mean, median, and mode
+console.log('Mean:', dist.mean()); 
+  // returns Mean: 3.0
+
+console.log('Median:', dist.median());
+ // returns Median: 3.0
+
+console.log('Mode:', dist.mode());  
+ // returns Mode: 3.0
+
+// Probability Density Function (PDF): Calculate the PDF at x=3.5
+var pdfValue = dist.pdf(3.5);
+console.log('PDF at x=3.5:', pdfValue); 
+// returns  PDF at x=3.5: 0.4
+
+// Cumulative Distribution Function (CDF): Calculate the CDF at x=3.5
+var cdfValue = dist.cdf(3.5);
+console.log('CDF at x=3.5:', cdfValue); 
+// returns CDF at x=3.5: 0.5
+
+// Quantile Function: Find the quantile for p=0.5
+var quantileValue = dist.quantile(0.5);
+console.log('Quantile for p=0.5:', quantileValue);
+ // returns Quantile for p=0.5: 3.0
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/examples/index.js
@@ -18,7 +18,56 @@
 
 'use strict';
 
-var objectKeys = require( '@stdlib/utils/keys' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var triangular = require( './../lib' );
 
-console.log( objectKeys( triangular ) );
+// Scenario: Modeling completion time for a software development task
+
+// Define the distribution parameters (in hours):
+var a = 1.5; // Minimum time (best-case scenario)
+var b = 4.5; // Maximum time (worst-case scenario)
+var c = discreteUniform( 2, 4 ); // Most likely time (mode)
+console.log( 'a: %d, b: %d, c: %d', a, b, c );
+
+// Expected (mean) completion time:
+var mean = triangular.mean( a, b, c );
+console.log( '\nExpected completion time: %d hours', mean );
+
+// Median completion time:
+var median = triangular.median( a, b, c );
+console.log( 'Median completion time: %d hours', median );
+
+// Variance in completion time:
+var variance = triangular.variance( a, b, c );
+console.log( 'Variance in completion time: %d hours^2', variance );
+
+// Probability of completing the task within 3 hours:
+var x = 3.0;
+var prob = triangular.cdf( x, a, b, c );
+console.log( '\nProbability of completing within %d hours: %d', x, prob );
+
+// 90th percentile of completion time:
+var p = 0.9;
+var percentile = triangular.quantile( p, a, b, c );
+console.log( '90% of tasks will be completed within %d hours', percentile );
+
+// Relative likelihood of completing the task in exactly 2.5 hours:
+x = 2.5;
+var likelihood = triangular.pdf( x, a, b, c );
+console.log( '\nRelative likelihood of completing in exactly %d hours: %d', x, likelihood );
+
+// Skewness to understand the distribution's shape:
+var skewness = triangular.skewness( a, b, c );
+console.log( '\nSkewness of completion times: %d', skewness );
+if ( skewness > 0 ) {
+	console.log( 'The distribution is right-skewed, suggesting occasional longer completion times.' );
+} else if ( skewness < 0 ) {
+	console.log( 'The distribution is left-skewed, suggesting occasional shorter completion times.' );
+} else {
+	console.log( 'The distribution is symmetric.' );
+}
+
+// Entropy as a measure of uncertainty in the estimate:
+var entropy = triangular.entropy( a, b, c );
+console.log( '\nEntropy of the distribution: %d nats', entropy );
+console.log( 'Higher entropy indicates more uncertainty in completion times.' );


### PR DESCRIPTION
Resolves # .

## Description
This pull request:

Add examples of the functions present in stats/base/dists/triangular namespace
adds example demonstration using mean ,mode, median functions in the README.

## Related Issues

resolve improve README examples of stats/base/dists/triangular namespace https://github.com/stdlib-js/stdlib/issues/1646

This pull request:

-   resolves #1646
 

## Questions

>Sir the changes are correct??

 

 

## Checklist

 

-   [X] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
