### PR TITLE
fix: missing headers in `math/base/special/fast/pow-int` and `math/base/special/bernoulli`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/bernoulli/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/bernoulli/examples/c/example.c
@@ -18,6 +18,7 @@
 
 #include "stdlib/math/base/special/bernoulli.h"
 #include <stdio.h>
+#include <stdint.h>
 
 int main( void ) {
 	int32_t i;

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/README.md
@@ -207,6 +207,7 @@ double stdlib_base_fast_pow( const double x, const int32_t y );
 #include "stdlib/math/base/special/fast/pow.h"
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdint.h>
 
 int main( void ) {
     const double x[] = { 3.14, 2.0, 2.0, 0.0 };

--- a/lib/node_modules/@stdlib/math/base/special/fast/pow-int/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/fast/pow-int/examples/c/example.c
@@ -18,6 +18,7 @@
 
 #include "stdlib/math/base/special/fast/pow.h"
 #include <stdio.h>
+#include <stdint.h>
 
 int main( void ) {
 	const double x[] = { 3.14, 2.0, 2.0, 0.0 };


### PR DESCRIPTION
This commit adds the missing headers in the respective packages.

## Description

> What is the purpose of this pull request?

This very short PR adds the necessary headers so that the compiler recognizes the types correctly without behaving unexpectedly for any cases

## Related Issues

> Does this pull request have any related issues?

N/A

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
