### PR TITLE
feat: add `fs/append-file`

### DIFF
--- a/lib/node_modules/@stdlib/fs/append-file/README.md
+++ b/lib/node_modules/@stdlib/fs/append-file/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2018 The Stdlib Authors.
+Copyright (c) 2024 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/fs/append-file/README.md
+++ b/lib/node_modules/@stdlib/fs/append-file/README.md
@@ -140,7 +140,7 @@ var fpath = join( __dirname, 'examples', 'fixtures', 'file.txt' );
 
 // Synchronously append data to a file:
 var error = appendFile.sync( fpath, 'beep boop\n', 'utf8' );
-// function successfully executes and returns null
+// Function successfully executes and returns null
 
 console.log( error instanceof Error );
 // => false

--- a/lib/node_modules/@stdlib/fs/append-file/README.md
+++ b/lib/node_modules/@stdlib/fs/append-file/README.md
@@ -139,13 +139,15 @@ var appendFile = require( '@stdlib/fs/append-file' );
 var fpath = join( __dirname, 'examples', 'fixtures', 'file.txt' );
 
 // Synchronously append data to a file:
+
 var error = appendFile.sync( fpath, 'beep boop\n', 'utf8' );
-// returns null
+// Function successfully executes and returns null
 
 console.log( error instanceof Error );
 // => false
 
 // Asynchronously append data to a file:
+
 appendFile( fpath, 'beep boop\n', onAppend );
 
 function onAppend( error ) {

--- a/lib/node_modules/@stdlib/fs/append-file/README.md
+++ b/lib/node_modules/@stdlib/fs/append-file/README.md
@@ -78,10 +78,9 @@ var join = require( 'path' ).join;
 
 var fpath = join( __dirname, 'examples', 'fixtures', 'file.txt' );
 
-try {
-    appendFile.sync( fpath, 'beep boop\n' );
-} catch ( error ) {
-    console.log( error.message );
+var err = appendFile.sync( fpath, 'beep boop\n' );
+if ( err instanceof Error ) {
+    throw err;
 }
 ```
 
@@ -95,36 +94,33 @@ The function accepts the same `options` and has the same defaults as [`fs.append
 
 ## Notes
 
-<!-- run-disable -->
+-   The difference between this `appendFile.sync` and [`fs.appendFileSync()`][node-fs] is that [`fs.appendFileSync()`][node-fs] will throw if an `error` is encountered (e.g., if given a non-existent directory path) and this API will return an `error`. Hence, the following anti-pattern
 
-```javascript
-var fs = require( 'fs' );
+    <!-- eslint-disable node/no-sync -->
 
-/* eslint-disable node/no-sync */
+    ```javascript
+    var fs = require( 'fs' );
 
-// Check for directory path existence to prevent an error being thrown...
-if ( fs.existsSync( '/path/to' ) ) {
-    fs.appendFileSync( '/path/to/file.txt', 'beep boop\n' );
-}
+    // Check for directory path existence to prevent an error being thrown...
+    if ( fs.existsSync( '/path/to' ) ) {
+        fs.appendFileSync( '/path/to/file.txt', 'beep boop\n' );
+    }
+    ```
 
-/* eslint-enable */
+    can be replaced by an approach which addresses existence via `error` handling.
 
-```
+    <!-- eslint-disable node/no-sync -->
 
-can be replaced by an approach which addresses existence via `error` handling.
+    ```javascript
+    var appendFile = require( '@stdlib/fs/append-file' );
 
-<!-- run-disable -->
-
-```javascript
-var appendFile = require( '@stdlib/fs/append-file' );
-
-// Explicitly handle the error...
-try {
-    appendFile.sync( '/path/to/file.txt', 'beep boop\n' );
-} catch ( error ) {
-    console.log( error.message );
-}
-```
+    // Explicitly handle the error...
+    var err = appendFile.sync( '/path/to/file.txt', 'boop beep\n' );
+    if ( err instanceof Error ) {
+        // You choose what to do...
+        throw err;
+    }
+    ```
 
 </section>
 
@@ -143,13 +139,11 @@ var appendFile = require( '@stdlib/fs/append-file' );
 var fpath = join( __dirname, 'examples', 'fixtures', 'file.txt' );
 
 // Synchronously append data to a file:
-try {
-    appendFile.sync( fpath, 'beep boop\n', 'utf8' );
-    // throws no errors
-} catch ( error ) {
-    console.log( error instanceof Error );
-    // => false
-}
+var error = appendFile.sync( fpath, 'beep boop\n', 'utf8' );
+// returns null
+
+console.log( error instanceof Error );
+// => false
 
 // Asynchronously append data to a file:
 appendFile( fpath, 'beep boop\n', onAppend );
@@ -158,7 +152,7 @@ function onAppend( error ) {
     if ( error ) {
         console.error( 'Error: %s', error.message );
     }
-    console.log( 'Success!' );
+    console.log( 'Success!!!' );
 }
 ```
 
@@ -224,13 +218,6 @@ $ printf 'beep boop\n' | append-file ./examples/fixtures/file.txt
 
 <section class="related">
 
-* * *
-
-## See Also
-
--   <span class="package-name">[`@stdlib/fs/exists`][@stdlib/fs/exists]</span><span class="delimiter">: </span><span class="description">test whether a path exists on the filesystem.</span>
--   <span class="package-name">[`@stdlib/fs/read-file`][@stdlib/fs/read-file]</span><span class="delimiter">: </span><span class="description">read the entire contents of a file.</span>
-
 </section>
 
 <!-- /.related -->
@@ -240,15 +227,10 @@ $ printf 'beep boop\n' | append-file ./examples/fixtures/file.txt
 <section class="links">
 
 [node-fs]: https://nodejs.org/api/fs.html
+
 [@stdlib/buffer/ctor]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/buffer/ctor
+
 [standard-stream]: https://en.wikipedia.org/wiki/Pipeline_%28Unix%29
-
-<!-- <related-links> -->
-
-[@stdlib/fs/exists]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/fs/exists
-[@stdlib/fs/read-file]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/fs/read-file
-
-<!-- </related-links> -->
 
 </section>
 

--- a/lib/node_modules/@stdlib/fs/append-file/README.md
+++ b/lib/node_modules/@stdlib/fs/append-file/README.md
@@ -140,7 +140,7 @@ var fpath = join( __dirname, 'examples', 'fixtures', 'file.txt' );
 
 // Synchronously append data to a file:
 var error = appendFile.sync( fpath, 'beep boop\n', 'utf8' );
-// returns null
+// function successfully executes and returns null
 
 console.log( error instanceof Error );
 // => false

--- a/lib/node_modules/@stdlib/fs/append-file/README.md
+++ b/lib/node_modules/@stdlib/fs/append-file/README.md
@@ -140,7 +140,7 @@ var fpath = join( __dirname, 'examples', 'fixtures', 'file.txt' );
 
 // Synchronously append data to a file:
 var error = appendFile.sync( fpath, 'beep boop\n', 'utf8' );
-// Function successfully executes and returns null
+// returns null
 
 console.log( error instanceof Error );
 // => false

--- a/lib/node_modules/@stdlib/fs/append-file/README.md
+++ b/lib/node_modules/@stdlib/fs/append-file/README.md
@@ -44,7 +44,7 @@ appendFile( fpath, 'beep boop\n', onAppend );
 function onAppend( error ) {
     if ( error ) {
         console.log( error instanceof Error );
-        //false
+        // => false
     }
 }
 ```
@@ -62,7 +62,7 @@ appendFile( fpath, string2buffer( 'beep boop\n' ), onAppend );
 function onAppend( error ) {
     if ( error ) {
         console.log( error instanceof Error );
-        //false
+        // => false
     }
 }
 ```

--- a/lib/node_modules/@stdlib/fs/append-file/README.md
+++ b/lib/node_modules/@stdlib/fs/append-file/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2018 The Stdlib Authors.
+Copyright (c) 2024 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -97,10 +97,12 @@ The function accepts the same `options` and has the same defaults as [`fs.append
 ```javascript
 var fs = require( 'fs' );
 
+/* eslint-disable node/no-sync */
 // Check for directory path existence to prevent an error being thrown...
 if ( fs.existsSync( '/path/to' ) ) {
     fs.appendFileSync( '/path/to/file.txt', 'beep boop\n' );
 }
+/* eslint-enable */
 ```
 
 can be replaced by an approach which addresses existence via `error` handling.
@@ -111,9 +113,9 @@ can be replaced by an approach which addresses existence via `error` handling.
 var appendFile = require( '@stdlib/fs/append-file' );
 
 // Explicitly handle the error...
-try{
+try {
     appendFile.sync( '/path/to/file.txt', 'beep boop\n' );
-} catch( error ) {
+} catch ( error ) {
     console.log( error.message );
 }
 ```
@@ -158,7 +160,7 @@ function onAppend( error ) {
 
 <!-- /.examples -->
 
-***
+* * *
 
 <section class="cli">
 
@@ -216,7 +218,7 @@ $ printf 'beep boop\n' | append-file ./examples/fixtures/file.txt
 
 <section class="related">
 
-***
+* * *
 
 ## See Also
 

--- a/lib/node_modules/@stdlib/fs/append-file/README.md
+++ b/lib/node_modules/@stdlib/fs/append-file/README.md
@@ -43,7 +43,8 @@ appendFile( fpath, 'beep boop\n', onAppend );
 
 function onAppend( error ) {
     if ( error ) {
-        throw error;
+        console.log( error instanceof Error );
+        //false
     }
 }
 ```
@@ -60,7 +61,8 @@ appendFile( fpath, string2buffer( 'beep boop\n' ), onAppend );
 
 function onAppend( error ) {
     if ( error ) {
-        throw error;
+        console.log( error instanceof Error );
+        //false
     }
 }
 ```
@@ -76,9 +78,10 @@ var join = require( 'path' ).join;
 
 var fpath = join( __dirname, 'examples', 'fixtures', 'file.txt' );
 
-var err = appendFile.sync( fpath, 'beep boop\n' );
-if ( err instanceof Error ) {
-    throw err;
+try {
+    appendFile.sync( fpath, 'beep boop\n' );
+} catch ( error ) {
+    console.log( error.message );
 }
 ```
 

--- a/lib/node_modules/@stdlib/fs/append-file/README.md
+++ b/lib/node_modules/@stdlib/fs/append-file/README.md
@@ -98,11 +98,14 @@ The function accepts the same `options` and has the same defaults as [`fs.append
 var fs = require( 'fs' );
 
 /* eslint-disable node/no-sync */
+
 // Check for directory path existence to prevent an error being thrown...
 if ( fs.existsSync( '/path/to' ) ) {
     fs.appendFileSync( '/path/to/file.txt', 'beep boop\n' );
 }
+
 /* eslint-enable */
+
 ```
 
 can be replaced by an approach which addresses existence via `error` handling.

--- a/lib/node_modules/@stdlib/fs/append-file/README.md
+++ b/lib/node_modules/@stdlib/fs/append-file/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2024 The Stdlib Authors.
+Copyright (c) 2018 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -42,9 +42,9 @@ var fpath = join( __dirname, 'examples', 'fixtures', 'file.txt' );
 appendFile( fpath, 'beep boop\n', onAppend );
 
 function onAppend( error ) {
-	if ( error ) {
-		throw error;
-	}
+    if ( error ) {
+        throw error;
+    }
 }
 ```
 
@@ -56,12 +56,12 @@ var string2buffer = require( '@stdlib/buffer/from-string' );
 
 var fpath = join( __dirname, 'examples', 'fixtures', 'file.txt' );
 
-appendFile( fpath, string2buffer('beep boop\n'), onAppend );
+appendFile( fpath, string2buffer( 'beep boop\n' ), onAppend );
 
 function onAppend( error ) {
-	if ( error ) {
-		throw error;
-	}
+    if ( error ) {
+        throw error;
+    }
 }
 ```
 
@@ -78,7 +78,7 @@ var fpath = join( __dirname, 'examples', 'fixtures', 'file.txt' );
 
 var err = appendFile.sync( fpath, 'beep boop\n' );
 if ( err instanceof Error ) {
-	throw err;
+    throw err;
 }
 ```
 
@@ -92,31 +92,31 @@ The function accepts the same `options` and has the same defaults as [`fs.append
 
 ## Notes
 
-    <!-- run-disable -->
+<!-- run-disable -->
 
-    ```javascript
-    var fs = require( 'fs' );
+```javascript
+var fs = require( 'fs' );
 
-    // Check for directory path existence to prevent an error being thrown...
-    if ( fs.existsSync( '/path/to' ) ) {
-        fs.appendFileSync( '/path/to/file.txt', 'beep boop\n' );
-    }
-    ```
+// Check for directory path existence to prevent an error being thrown...
+if ( fs.existsSync( '/path/to' ) ) {
+    fs.appendFileSync( '/path/to/file.txt', 'beep boop\n' );
+}
+```
 
-    can be replaced by an approach which addresses existence via `error` handling.
+can be replaced by an approach which addresses existence via `error` handling.
 
-    <!-- run-disable -->
+<!-- run-disable -->
 
-    ```javascript
-    var appendFile = require( '@stdlib/fs/append-file' );
+```javascript
+var appendFile = require( '@stdlib/fs/append-file' );
 
-    // Explicitly handle the error...
-    try{
-        appendFile.sync( '/path/to/file.txt', 'beep boop\n' );
-    } catch( error ) {
-        throw error
-    }
-    ```
+// Explicitly handle the error...
+try{
+    appendFile.sync( '/path/to/file.txt', 'beep boop\n' );
+} catch( error ) {
+    console.log( error.message );
+}
+```
 
 </section>
 
@@ -136,21 +136,21 @@ var fpath = join( __dirname, 'examples', 'fixtures', 'file.txt' );
 
 // Synchronously append data to a file:
 try {
-	appendFile.sync( fpath, 'beep boop\n', 'utf8' );
-	// throws no errors
+    appendFile.sync( fpath, 'beep boop\n', 'utf8' );
+    // throws no errors
 } catch ( error ) {
-	console.log( error instanceof Error );
-	// => false
+    console.log( error instanceof Error );
+    // => false
 }
 
 // Asynchronously append data to a file:
 appendFile( fpath, 'beep boop\n', onAppend );
 
 function onAppend( error ) {
-	if ( error ) {
-		console.error( 'Error: %s', error.message );
-	}
-	console.log( 'Success!' );
+    if ( error ) {
+        console.error( 'Error: %s', error.message );
+    }
+    console.log( 'Success!' );
 }
 ```
 
@@ -158,7 +158,7 @@ function onAppend( error ) {
 
 <!-- /.examples -->
 
----
+***
 
 <section class="cli">
 
@@ -216,7 +216,7 @@ $ printf 'beep boop\n' | append-file ./examples/fixtures/file.txt
 
 <section class="related">
 
----
+***
 
 ## See Also
 

--- a/lib/node_modules/@stdlib/fs/append-file/README.md
+++ b/lib/node_modules/@stdlib/fs/append-file/README.md
@@ -1,0 +1,247 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2018 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# Append File
+
+> Append data to a file.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var appendFile = require("@stdlib/fs/append-file");
+```
+
+#### appendFile( file, data\[, options], clbk )
+
+Asynchronously appends `data` to a `file`.
+
+```javascript
+var join = require("path").join;
+
+var fpath = join(__dirname, "examples", "fixtures", "file.txt");
+
+appendFile(fpath, "beep boop\n", onAppend);
+
+function onAppend(error) {
+  if (error) {
+    throw error;
+  }
+}
+```
+
+The `data` argument may be either a `string` or a [`Buffer`][@stdlib/buffer/ctor].
+
+```javascript
+var join = require("path").join;
+var string2buffer = require("@stdlib/buffer/from-string");
+
+var fpath = join(__dirname, "examples", "fixtures", "file.txt");
+
+appendFile(fpath, string2buffer("beep boop\n"), onAppend);
+
+function onAppend(error) {
+  if (error) {
+    throw error;
+  }
+}
+```
+
+The function accepts the same `options` and has the same defaults as [`fs.appendFile()`][node-fs].
+
+#### appendFile.sync( file, data\[, options] )
+
+Synchronously appends `data` to a `file`.
+
+```javascript
+var join = require("path").join;
+
+var fpath = join(__dirname, "examples", "fixtures", "file.txt");
+
+var err = appendFile.sync(fpath, "beep boop\n");
+if (err instanceof Error) {
+  throw err;
+}
+```
+
+The function accepts the same `options` and has the same defaults as [`fs.appendFileSync()`][node-fs].
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+    <!-- run-disable -->
+
+    ```javascript
+    var fs = require( 'fs' );
+
+    // Check for directory path existence to prevent an error being thrown...
+    if ( fs.existsSync( '/path/to' ) ) {
+        fs.appendFileSync( '/path/to/file.txt', 'beep boop\n' );
+    }
+    ```
+
+    can be replaced by an approach which addresses existence via `error` handling.
+
+    <!-- run-disable -->
+
+    ```javascript
+    var appendFile = require( '@stdlib/fs/append-file' );
+
+    // Explicitly handle the error...
+    try{
+        appendFile.sync( '/path/to/file.txt', 'beep boop\n' );
+    } catch(err) {
+        throw err
+    }
+    ```
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var join = require("path").join;
+var appendFile = require("@stdlib/fs/append-file");
+
+var fpath = join(__dirname, "examples", "fixtures", "file.txt");
+
+// Synchronously append data to a file:
+try {
+  appendFile.sync(fpath, "beep boop\n", "utf8");
+  // throws no errors
+} catch (err) {
+  console.log(err instanceof Error);
+  // => false
+}
+
+// Asynchronously append data to a file:
+appendFile(fpath, "beep boop\n", onAppend);
+
+function onAppend(error) {
+  if (error) {
+    console.error("Error: %s", error.message);
+  }
+  console.log("Success!");
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+---
+
+<section class="cli">
+
+## CLI
+
+<section class="usage">
+
+### Usage
+
+```text
+Usage: append-file [options] <filepath>
+
+Options:
+
+  -h,    --help                Print this message.
+  -V,    --version             Print the package version.
+  --enc, --encoding encoding   Encoding. Default: 'utf8'.
+         --flag flag           Flag. Default: 'a'.
+         --mode mode           Mode. Default: 0o666.
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+### Notes
+
+- Relative output file paths are resolved relative to the current working directory.
+- Errors are written to `stderr`.
+- File contents should be provided over `stdin` as part of a [standard stream][standard-stream] pipeline.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+### Examples
+
+```bash
+$ printf 'beep boop\n' | append-file ./examples/fixtures/file.txt
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.cli -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+---
+
+## See Also
+
+- <span class="package-name">[`@stdlib/fs/exists`][@stdlib/fs/exists]</span><span class="delimiter">: </span><span class="description">test whether a path exists on the filesystem.</span>
+- <span class="package-name">[`@stdlib/fs/read-file`][@stdlib/fs/read-file]</span><span class="delimiter">: </span><span class="description">read the entire contents of a file.</span>
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[node-fs]: https://nodejs.org/api/fs.html
+[@stdlib/buffer/ctor]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/buffer/ctor
+[standard-stream]: https://en.wikipedia.org/wiki/Pipeline_%28Unix%29
+
+<!-- <related-links> -->
+
+[@stdlib/fs/exists]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/fs/exists
+[@stdlib/fs/read-file]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/fs/read-file
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/fs/append-file/README.md
+++ b/lib/node_modules/@stdlib/fs/append-file/README.md
@@ -27,7 +27,7 @@ limitations under the License.
 ## Usage
 
 ```javascript
-var appendFile = require("@stdlib/fs/append-file");
+var appendFile = require( '@stdlib/fs/append-file' );
 ```
 
 #### appendFile( file, data\[, options], clbk )
@@ -35,33 +35,33 @@ var appendFile = require("@stdlib/fs/append-file");
 Asynchronously appends `data` to a `file`.
 
 ```javascript
-var join = require("path").join;
+var join = require( 'path' ).join;
 
-var fpath = join(__dirname, "examples", "fixtures", "file.txt");
+var fpath = join( __dirname, 'examples', 'fixtures', 'file.txt' );
 
-appendFile(fpath, "beep boop\n", onAppend);
+appendFile( fpath, 'beep boop\n', onAppend );
 
-function onAppend(error) {
-  if (error) {
-    throw error;
-  }
+function onAppend( error ) {
+	if ( error ) {
+		throw error;
+	}
 }
 ```
 
 The `data` argument may be either a `string` or a [`Buffer`][@stdlib/buffer/ctor].
 
 ```javascript
-var join = require("path").join;
-var string2buffer = require("@stdlib/buffer/from-string");
+var join = require( 'path' ).join;
+var string2buffer = require( '@stdlib/buffer/from-string' );
 
-var fpath = join(__dirname, "examples", "fixtures", "file.txt");
+var fpath = join( __dirname, 'examples', 'fixtures', 'file.txt' );
 
-appendFile(fpath, string2buffer("beep boop\n"), onAppend);
+appendFile( fpath, string2buffer('beep boop\n'), onAppend );
 
-function onAppend(error) {
-  if (error) {
-    throw error;
-  }
+function onAppend( error ) {
+	if ( error ) {
+		throw error;
+	}
 }
 ```
 
@@ -72,13 +72,13 @@ The function accepts the same `options` and has the same defaults as [`fs.append
 Synchronously appends `data` to a `file`.
 
 ```javascript
-var join = require("path").join;
+var join = require( 'path' ).join;
 
-var fpath = join(__dirname, "examples", "fixtures", "file.txt");
+var fpath = join( __dirname, 'examples', 'fixtures', 'file.txt' );
 
-var err = appendFile.sync(fpath, "beep boop\n");
-if (err instanceof Error) {
-  throw err;
+var err = appendFile.sync( fpath, 'beep boop\n' );
+if ( err instanceof Error ) {
+	throw err;
 }
 ```
 
@@ -113,8 +113,8 @@ The function accepts the same `options` and has the same defaults as [`fs.append
     // Explicitly handle the error...
     try{
         appendFile.sync( '/path/to/file.txt', 'beep boop\n' );
-    } catch(err) {
-        throw err
+    } catch( error ) {
+        throw error
     }
     ```
 
@@ -129,28 +129,28 @@ The function accepts the same `options` and has the same defaults as [`fs.append
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var join = require("path").join;
-var appendFile = require("@stdlib/fs/append-file");
+var join = require( 'path' ).join;
+var appendFile = require( '@stdlib/fs/append-file' );
 
-var fpath = join(__dirname, "examples", "fixtures", "file.txt");
+var fpath = join( __dirname, 'examples', 'fixtures', 'file.txt' );
 
 // Synchronously append data to a file:
 try {
-  appendFile.sync(fpath, "beep boop\n", "utf8");
-  // throws no errors
-} catch (err) {
-  console.log(err instanceof Error);
-  // => false
+	appendFile.sync( fpath, 'beep boop\n', 'utf8' );
+	// throws no errors
+} catch ( error ) {
+	console.log( error instanceof Error );
+	// => false
 }
 
 // Asynchronously append data to a file:
-appendFile(fpath, "beep boop\n", onAppend);
+appendFile( fpath, 'beep boop\n', onAppend );
 
-function onAppend(error) {
-  if (error) {
-    console.error("Error: %s", error.message);
-  }
-  console.log("Success!");
+function onAppend( error ) {
+	if ( error ) {
+		console.error( 'Error: %s', error.message );
+	}
+	console.log( 'Success!' );
 }
 ```
 
@@ -188,9 +188,9 @@ Options:
 
 ### Notes
 
-- Relative output file paths are resolved relative to the current working directory.
-- Errors are written to `stderr`.
-- File contents should be provided over `stdin` as part of a [standard stream][standard-stream] pipeline.
+-   Relative output file paths are resolved relative to the current working directory.
+-   Errors are written to `stderr`.
+-   File contents should be provided over `stdin` as part of a [standard stream][standard-stream] pipeline.
 
 </section>
 
@@ -220,8 +220,8 @@ $ printf 'beep boop\n' | append-file ./examples/fixtures/file.txt
 
 ## See Also
 
-- <span class="package-name">[`@stdlib/fs/exists`][@stdlib/fs/exists]</span><span class="delimiter">: </span><span class="description">test whether a path exists on the filesystem.</span>
-- <span class="package-name">[`@stdlib/fs/read-file`][@stdlib/fs/read-file]</span><span class="delimiter">: </span><span class="description">read the entire contents of a file.</span>
+-   <span class="package-name">[`@stdlib/fs/exists`][@stdlib/fs/exists]</span><span class="delimiter">: </span><span class="description">test whether a path exists on the filesystem.</span>
+-   <span class="package-name">[`@stdlib/fs/read-file`][@stdlib/fs/read-file]</span><span class="delimiter">: </span><span class="description">read the entire contents of a file.</span>
 
 </section>
 

--- a/lib/node_modules/@stdlib/fs/append-file/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fs/append-file/benchmark/benchmark.js
@@ -24,7 +24,7 @@ var join = require( 'path' ).join;
 var bench = require( '@stdlib/bench' );
 var readFile = require( '@stdlib/fs/read-file' ).sync;
 var pkg = require( '@stdlib/fs/append-file/package.json' ).name;
-var appendFile = require( '@stdlib/fs/append-file/lib' );
+var appendFile = require( './../lib' );
 
 
 // FIXTURES //
@@ -61,7 +61,7 @@ bench( pkg, function benchmark( b ) {
 	}
 });
 
-bench( pkg + ':sync', function benchmark( b ) {
+bench( pkg+':sync', function benchmark( b ) {
 	var out;
 	let i;
 

--- a/lib/node_modules/@stdlib/fs/append-file/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fs/append-file/benchmark/benchmark.js
@@ -63,7 +63,7 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':sync', function benchmark( b ) {
 	var out;
-	let i;
+	var i;
 
 	b.tic();
 	for (i = 0; i < b.iterations; i++) {

--- a/lib/node_modules/@stdlib/fs/append-file/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fs/append-file/benchmark/benchmark.js
@@ -22,15 +22,15 @@
 
 var join = require( 'path' ).join;
 var bench = require( '@stdlib/bench' );
-var readFile = require( '@stdlib/fs/read-file' ).sync;
-var pkg = require( '@stdlib/fs/append-file/package.json' ).name;
+var unlink = require( '@stdlib/fs/unlink' ).sync;
+var pkg = require( './../package.json' ).name;
 var appendFile = require( './../lib' );
 
 
 // FIXTURES //
 
-var FILEPATH = join( __dirname, 'fixtures', 'file.txt' );
-var DATA = readFile( FILEPATH );
+var TMP = join( __dirname, 'fixtures', 'temp.txt' );
+var DATA = 'boop beep\n';
 
 
 // MAIN //
@@ -46,9 +46,10 @@ bench( pkg, function benchmark( b ) {
 	function next() {
 		i += 1;
 		if ( i <= b.iterations ) {
-			return appendFile( FILEPATH, DATA, done );
+			return appendFile( TMP, DATA, done );
 		}
 		b.toc();
+		unlink( TMP );
 		b.pass( 'benchmark finished' );
 		b.end();
 	}
@@ -67,16 +68,16 @@ bench( pkg+':sync', function benchmark( b ) {
 
 	b.tic();
 	for (i = 0; i < b.iterations; i++) {
-		out = appendFile.sync( FILEPATH, DATA );
+		out = appendFile.sync( TMP, DATA );
 		if ( out instanceof Error ) {
 			b.fail( out.message );
 		}
 	}
 	b.toc();
+	unlink( TMP );
 	if ( out instanceof Error ) {
-		b.fail( 'something went wrong' );
-	} else {
-		b.pass( 'benchmark finished' );
+		b.fail( out.message );
 	}
+    b.pass( 'benchmark finished' );
 	b.end();
 });

--- a/lib/node_modules/@stdlib/fs/append-file/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fs/append-file/benchmark/benchmark.js
@@ -78,6 +78,6 @@ bench( pkg+':sync', function benchmark( b ) {
 	if ( out instanceof Error ) {
 		b.fail( out.message );
 	}
-    b.pass( 'benchmark finished' );
+	b.pass( 'benchmark finished' );
 	b.end();
 });

--- a/lib/node_modules/@stdlib/fs/append-file/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fs/append-file/benchmark/benchmark.js
@@ -18,14 +18,13 @@
 
 'use strict';
 
-
 // MODULES //
 
 var join = require( 'path' ).join;
 var bench = require( '@stdlib/bench' );
 var readFile = require( '@stdlib/fs/read-file' ).sync;
-var pkg = require( '../package.json' ).name;
-var appendFile = require( '../lib' );
+var pkg = require( '@stdlib/fs/append-file/package.json' ).name;
+var appendFile = require( '@stdlib/fs/append-file/lib' );
 
 
 // FIXTURES //

--- a/lib/node_modules/@stdlib/fs/append-file/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fs/append-file/benchmark/benchmark.js
@@ -1,80 +1,83 @@
 /**
- * @license Apache-2.0
- *
- * Copyright (c) 2024 The Stdlib Authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
-"use strict";
+'use strict';
+
 
 // MODULES //
 
-var join = require("path").join;
-var bench = require("@stdlib/bench");
-var readFile = require("@stdlib/fs/read-file").sync;
-var pkg = require("./../package.json").name;
-var appendFile = require("./../lib");
+var join = require( 'path' ).join;
+var bench = require( '@stdlib/bench' );
+var readFile = require( '@stdlib/fs/read-file' ).sync;
+var pkg = require( '../package.json' ).name;
+var appendFile = require( '../lib' );
+
 
 // FIXTURES //
 
-var FILEPATH = join(__dirname, "fixtures", "file.txt");
-var DATA = readFile(FILEPATH);
+var FILEPATH = join( __dirname, 'fixtures', 'file.txt' );
+var DATA = readFile( FILEPATH );
+
 
 // MAIN //
 
-bench(pkg, function benchmark(b) {
-  var i;
+bench( pkg, function benchmark( b ) {
+	var i;
 
-  i = 0;
-  b.tic();
+	i = 0;
+	b.tic();
 
-  return next();
+	return next();
 
-  function next() {
-    i += 1;
-    if (i <= b.iterations) {
-      return appendFile(FILEPATH, DATA, done);
-    }
-    b.toc();
-    b.pass("benchmark finished");
-    b.end();
-  }
+	function next() {
+		i += 1;
+		if ( i <= b.iterations ) {
+			return appendFile( FILEPATH, DATA, done );
+		}
+		b.toc();
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
 
-  function done(error) {
-    if (error) {
-      b.fail(error.message);
-    }
-    next();
-  }
+	function done( error ) {
+		if ( error ) {
+			b.fail( error.message );
+		}
+		next();
+	}
 });
 
-bench(pkg + ":sync", function benchmark(b) {
-  var out;
-  let i;
+bench( pkg + ':sync', function benchmark( b ) {
+	var out;
+	let i;
 
-  b.tic();
-  for (i = 0; i < b.iterations; i++) {
-    out = appendFile.sync(FILEPATH, DATA);
-    if (out instanceof Error) {
-      b.fail(out.message);
-    }
-  }
-  b.toc();
-  if (out instanceof Error) {
-    b.fail("something went wrong");
-  } else {
-    b.pass("benchmark finished");
-  }
-  b.end();
+	b.tic();
+	for (i = 0; i < b.iterations; i++) {
+		out = appendFile.sync( FILEPATH, DATA );
+		if ( out instanceof Error ) {
+			b.fail( out.message );
+		}
+	}
+	b.toc();
+	if ( out instanceof Error ) {
+		b.fail( 'something went wrong' );
+	} else {
+		b.pass( 'benchmark finished' );
+	}
+	b.end();
 });

--- a/lib/node_modules/@stdlib/fs/append-file/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fs/append-file/benchmark/benchmark.js
@@ -1,0 +1,80 @@
+/**
+ * @license Apache-2.0
+ *
+ * Copyright (c) 2018 The Stdlib Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+// MODULES //
+
+var join = require("path").join;
+var bench = require("@stdlib/bench");
+var readFile = require("@stdlib/fs/read-file").sync;
+var pkg = require("./../package.json").name;
+var appendFile = require("./../lib");
+
+// FIXTURES //
+
+var FILEPATH = join(__dirname, "fixtures", "file.txt");
+var DATA = readFile(FILEPATH);
+
+// MAIN //
+
+bench(pkg, function benchmark(b) {
+  var i;
+
+  i = 0;
+  b.tic();
+
+  return next();
+
+  function next() {
+    i += 1;
+    if (i <= b.iterations) {
+      return appendFile(FILEPATH, DATA, done);
+    }
+    b.toc();
+    b.pass("benchmark finished");
+    b.end();
+  }
+
+  function done(error) {
+    if (error) {
+      b.fail(error.message);
+    }
+    next();
+  }
+});
+
+bench(pkg + ":sync", function benchmark(b) {
+  var out;
+  let i;
+
+  b.tic();
+  for (i = 0; i < b.iterations; i++) {
+    out = appendFile.sync(FILEPATH, DATA);
+    if (out instanceof Error) {
+      b.fail(out.message);
+    }
+  }
+  b.toc();
+  if (out instanceof Error) {
+    b.fail("something went wrong");
+  } else {
+    b.pass("benchmark finished");
+  }
+  b.end();
+});

--- a/lib/node_modules/@stdlib/fs/append-file/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fs/append-file/benchmark/benchmark.js
@@ -1,7 +1,7 @@
 /**
  * @license Apache-2.0
  *
- * Copyright (c) 2018 The Stdlib Authors.
+ * Copyright (c) 2024 The Stdlib Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/fs/append-file/benchmark/fixtures/file.txt
+++ b/lib/node_modules/@stdlib/fs/append-file/benchmark/fixtures/file.txt
@@ -1,0 +1,1 @@
+boop beep

--- a/lib/node_modules/@stdlib/fs/append-file/benchmark/fixtures/file.txt
+++ b/lib/node_modules/@stdlib/fs/append-file/benchmark/fixtures/file.txt
@@ -1,1 +1,0 @@
-boop beep

--- a/lib/node_modules/@stdlib/fs/append-file/bin/cli
+++ b/lib/node_modules/@stdlib/fs/append-file/bin/cli
@@ -47,8 +47,8 @@ function main() {
 
 	// Create a command-line interface:
 	cli = new CLI({
-		'pkg': require( '@stdlib/fs/append-file/package.json' ),
-		'options': require( '@stdlib/fs/append-file/etc/cli_opts.json' ),
+		'pkg': require( './../package.json' ),
+		'options': require( './../etc/cli_opts.json' ),
 		'help': readFileSync(resolve( __dirname, '..', 'docs', 'usage.txt' ), {
 			'encoding': 'utf8'
 		})
@@ -71,7 +71,7 @@ function main() {
 		opts.flag = flags.flag;
 	}
 	if ( flags.mode ) {
-		opts.mode = parseInt(flags.mode, 8);
+		opts.mode = parseInt( flags.mode, 8 );
 	}
 	fpath = resolve( cwd(), args[0] );
 
@@ -94,7 +94,7 @@ function main() {
 	}
 
 	/**
-	* Callback invoked upon writing a file.
+	* Callback invoked upon appending a file.
 	*
 	* @private
 	* @param {Error} [err] - error object

--- a/lib/node_modules/@stdlib/fs/append-file/bin/cli
+++ b/lib/node_modules/@stdlib/fs/append-file/bin/cli
@@ -27,7 +27,7 @@ var readFileSync = require( '@stdlib/fs/read-file' ).sync;
 var CLI = require( '@stdlib/cli/ctor' );
 var stdin = require( '@stdlib/process/read-stdin' );
 var cwd = require( '@stdlib/process/cwd' );
-var appendFile = require( '@stdlib/fs/append-file/lib' );
+var appendFile = require( './../lib' );
 
 
 // MAIN //
@@ -47,11 +47,11 @@ function main() {
 
 	// Create a command-line interface:
 	cli = new CLI({
-		pkg: require( '@stdlib/fs/append-file/package.json' ),
-		options: require( '@stdlib/fs/append-file/etc/cli_opts.json' ),
-		help: readFileSync(resolve( __dirname, '..', 'docs', 'usage.txt' ), {
-			encoding: 'utf8',
-		}),
+		'pkg': require( '@stdlib/fs/append-file/package.json' ),
+		'options': require( '@stdlib/fs/append-file/etc/cli_opts.json' ),
+		'help': readFileSync(resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+			'encoding': 'utf8'
+		})
 	});
 
 	// Get any provided command-line options:

--- a/lib/node_modules/@stdlib/fs/append-file/bin/cli
+++ b/lib/node_modules/@stdlib/fs/append-file/bin/cli
@@ -3,7 +3,7 @@
 /**
  * @license Apache-2.0
  *
- * Copyright (c) 2018 The Stdlib Authors.
+ * Copyright (c) 2024 The Stdlib Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/fs/append-file/bin/cli
+++ b/lib/node_modules/@stdlib/fs/append-file/bin/cli
@@ -1,109 +1,111 @@
 #!/usr/bin/env node
 
 /**
- * @license Apache-2.0
- *
- * Copyright (c) 2024 The Stdlib Authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
-"use strict";
+'use strict';
+
 
 // MODULES //
 
-var resolve = require("path").resolve;
-var readFileSync = require("@stdlib/fs/read-file").sync;
-var CLI = require("@stdlib/cli/ctor");
-var stdin = require("@stdlib/process/read-stdin");
-var cwd = require("@stdlib/process/cwd");
-var appendFile = require("./../lib");
+var resolve = require( 'path' ).resolve;
+var readFileSync = require( '@stdlib/fs/read-file' ).sync;
+var CLI = require( '@stdlib/cli/ctor' );
+var stdin = require( '@stdlib/process/read-stdin' );
+var cwd = require( '@stdlib/process/cwd' );
+var appendFile = require( '../lib' );
+
 
 // MAIN //
 
 /**
- * Main execution sequence.
- *
- * @private
- * @returns {void}
- */
+* Main execution sequence.
+*
+* @private
+* @returns {void}
+*/
 function main() {
-  var flags;
-  var fpath;
-  var args;
-  var opts;
-  var cli;
+	var flags;
+	var fpath;
+	var args;
+	var opts;
+	var cli;
 
-  // Create a command-line interface:
-  cli = new CLI({
-    pkg: require("./../package.json"),
-    options: require("./../etc/cli_opts.json"),
-    help: readFileSync(resolve(__dirname, "..", "docs", "usage.txt"), {
-      encoding: "utf8",
-    }),
-  });
+	// Create a command-line interface:
+	cli = new CLI({
+		pkg: require( '../package.json' ),
+		options: require( '../etc/cli_opts.json' ),
+		help: readFileSync(resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+			encoding: 'utf8',
+		}),
+	});
 
-  // Get any provided command-line options:
-  flags = cli.flags();
-  if (flags.help || flags.version) {
-    return;
-  }
+	// Get any provided command-line options:
+	flags = cli.flags();
+	if ( flags.help || flags.version ) {
+		return;
+	}
 
-  // Get any provided command-line arguments:
-  args = cli.args();
+	// Get any provided command-line arguments:
+	args = cli.args();
 
-  opts = {};
-  if (flags.encoding) {
-    opts.encoding = flags.encoding;
-  }
-  if (flags.flag) {
-    opts.flag = flags.flag;
-  }
-  if (flags.mode) {
-    opts.mode = parseInt(flags.mode, 8);
-  }
-  fpath = resolve(cwd(), args[0]);
+	opts = {};
+	if ( flags.encoding ) {
+		opts.encoding = flags.encoding;
+	}
+	if ( flags.flag ) {
+		opts.flag = flags.flag;
+	}
+	if ( flags.mode ) {
+		opts.mode = parseInt(flags.mode, 8);
+	}
+	fpath = resolve( cwd(), args[0] );
 
-  // Gather data from `stdin`...
-  stdin(onRead);
+	// Gather data from `stdin`...
+	stdin( onRead );
 
-  /**
-   * Callback invoked upon reading from `stdin`.
-   *
-   * @private
-   * @param {(Error|null)} error - error object
-   * @param {Buffer} data - data
-   * @returns {void}
-   */
-  function onRead(error, data) {
-    if (error) {
-      return cli.error(error);
-    }
-    appendFile(fpath, data, opts, onAppend);
-  }
+	/**
+	* Callback invoked upon reading from `stdin`.
+	*
+	* @private
+	* @param {( Error|null )} error - error object
+	* @param { Buffer } data - data
+	* @returns { void }
+	*/
+	function onRead( error, data ) {
+		if ( error ) {
+			return cli.error( error );
+		}
+		appendFile( fpath, data, opts, onAppend );
+	}
 
-  /**
-   * Callback invoked upon writing a file.
-   *
-   * @private
-   * @param {Error} [err] - error object
-   * @returns {void}
-   */
-  function onAppend(err) {
-    if (err) {
-      return cli.error(err);
-    }
-  }
+	/**
+	* Callback invoked upon writing a file.
+	*
+	* @private
+	* @param { Error } [ err ] - error object
+	* @returns { void }
+	*/
+	function onAppend( err ) {
+		if ( err ) {
+			return cli.error( err );
+		}
+	}
 }
 
 main();

--- a/lib/node_modules/@stdlib/fs/append-file/bin/cli
+++ b/lib/node_modules/@stdlib/fs/append-file/bin/cli
@@ -20,7 +20,6 @@
 
 'use strict';
 
-
 // MODULES //
 
 var resolve = require( 'path' ).resolve;
@@ -28,7 +27,7 @@ var readFileSync = require( '@stdlib/fs/read-file' ).sync;
 var CLI = require( '@stdlib/cli/ctor' );
 var stdin = require( '@stdlib/process/read-stdin' );
 var cwd = require( '@stdlib/process/cwd' );
-var appendFile = require( '../lib' );
+var appendFile = require( '@stdlib/fs/append-file/lib' );
 
 
 // MAIN //
@@ -48,8 +47,8 @@ function main() {
 
 	// Create a command-line interface:
 	cli = new CLI({
-		pkg: require( '../package.json' ),
-		options: require( '../etc/cli_opts.json' ),
+		pkg: require( '@stdlib/fs/append-file/package.json' ),
+		options: require( '@stdlib/fs/append-file/etc/cli_opts.json' ),
 		help: readFileSync(resolve( __dirname, '..', 'docs', 'usage.txt' ), {
 			encoding: 'utf8',
 		}),
@@ -83,9 +82,9 @@ function main() {
 	* Callback invoked upon reading from `stdin`.
 	*
 	* @private
-	* @param {( Error|null )} error - error object
-	* @param { Buffer } data - data
-	* @returns { void }
+	* @param {(Error|null)} error - error object
+	* @param {Buffer} data - data
+	* @returns {void}
 	*/
 	function onRead( error, data ) {
 		if ( error ) {
@@ -98,8 +97,8 @@ function main() {
 	* Callback invoked upon writing a file.
 	*
 	* @private
-	* @param { Error } [ err ] - error object
-	* @returns { void }
+	* @param {Error} [err] - error object
+	* @returns {void}
 	*/
 	function onAppend( err ) {
 		if ( err ) {

--- a/lib/node_modules/@stdlib/fs/append-file/bin/cli
+++ b/lib/node_modules/@stdlib/fs/append-file/bin/cli
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+
+/**
+ * @license Apache-2.0
+ *
+ * Copyright (c) 2018 The Stdlib Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+// MODULES //
+
+var resolve = require("path").resolve;
+var readFileSync = require("@stdlib/fs/read-file").sync;
+var CLI = require("@stdlib/cli/ctor");
+var stdin = require("@stdlib/process/read-stdin");
+var cwd = require("@stdlib/process/cwd");
+var appendFile = require("./../lib");
+
+// MAIN //
+
+/**
+ * Main execution sequence.
+ *
+ * @private
+ * @returns {void}
+ */
+function main() {
+  var flags;
+  var fpath;
+  var args;
+  var opts;
+  var cli;
+
+  // Create a command-line interface:
+  cli = new CLI({
+    pkg: require("./../package.json"),
+    options: require("./../etc/cli_opts.json"),
+    help: readFileSync(resolve(__dirname, "..", "docs", "usage.txt"), {
+      encoding: "utf8",
+    }),
+  });
+
+  // Get any provided command-line options:
+  flags = cli.flags();
+  if (flags.help || flags.version) {
+    return;
+  }
+
+  // Get any provided command-line arguments:
+  args = cli.args();
+
+  opts = {};
+  if (flags.encoding) {
+    opts.encoding = flags.encoding;
+  }
+  if (flags.flag) {
+    opts.flag = flags.flag;
+  }
+  if (flags.mode) {
+    opts.mode = parseInt(flags.mode, 8);
+  }
+  fpath = resolve(cwd(), args[0]);
+
+  // Gather data from `stdin`...
+  stdin(onRead);
+
+  /**
+   * Callback invoked upon reading from `stdin`.
+   *
+   * @private
+   * @param {(Error|null)} error - error object
+   * @param {Buffer} data - data
+   * @returns {void}
+   */
+  function onRead(error, data) {
+    if (error) {
+      return cli.error(error);
+    }
+    appendFile(fpath, data, opts, onAppend);
+  }
+
+  /**
+   * Callback invoked upon writing a file.
+   *
+   * @private
+   * @param {Error} [err] - error object
+   * @returns {void}
+   */
+  function onAppend(err) {
+    if (err) {
+      return cli.error(err);
+    }
+  }
+}
+
+main();

--- a/lib/node_modules/@stdlib/fs/append-file/docs/repl.txt
+++ b/lib/node_modules/@stdlib/fs/append-file/docs/repl.txt
@@ -14,8 +14,7 @@
         Options. If a string, the value is the encoding.
 
     options.encoding: string|null (optional)
-        Encoding. The encoding option is ignored if the data argument is a
-        buffer. Default: 'utf8'.
+        Encoding. Default: 'utf8'.
 
     options.flag: string (optional)
         Flag. Default: 'a'.
@@ -51,8 +50,7 @@
         Options. If a string, the value is the encoding.
 
     options.encoding: string|null (optional)
-        Encoding. The encoding option is ignored if the data argument is a
-        buffer. Default: 'utf8'.
+        Encoding. Default: 'utf8'.
 
     options.flag: string (optional)
         Flag. Default: 'a'.
@@ -60,6 +58,15 @@
     options.mode: integer (optional)
         Mode. Default: 0o666.
 
+    Returns
+    -------
+    err: Error|null
+        Error object or null.
+
+    Examples
+    --------
+    > var err = {{alias}}.sync( './beep/boop.txt', 'beep boop' );
+    
     See Also
     --------
 

--- a/lib/node_modules/@stdlib/fs/append-file/docs/repl.txt
+++ b/lib/node_modules/@stdlib/fs/append-file/docs/repl.txt
@@ -1,0 +1,65 @@
+
+{{alias}}( path, data[, options], clbk )
+    Asynchronously appends data to a file.
+
+    Parameters
+    ----------
+    path: string|Buffer|integer
+        Filename or file descriptor.
+
+    data: string|Buffer
+        Data to append.
+
+    options: Object|string (optional)
+        Options. If a string, the value is the encoding.
+
+    options.encoding: string|null (optional)
+        Encoding. The encoding option is ignored if the data argument is a
+        buffer. Default: 'utf8'.
+
+    options.flag: string (optional)
+        Flag. Default: 'a'.
+
+    options.mode: integer (optional)
+        Mode. Default: 0o666.
+
+    clbk: Function
+        Callback to invoke upon appending data to the file.
+
+    Examples
+    --------
+    > function onAppend( err ) {
+    ...     if ( err ) {
+    ...         console.error( err.message );
+    ...     }
+    ... };
+    > {{alias}}( './beep/boop.txt', 'beep boop', onAppend );
+
+
+{{alias}}.sync( path, data[, options] )
+    Synchronously appends data to a file.
+
+    Parameters
+    ----------
+    path: string|Buffer|integer
+        Filename or file descriptor.
+
+    data: string|Buffer
+        Data to append.
+
+    options: Object|string (optional)
+        Options. If a string, the value is the encoding.
+
+    options.encoding: string|null (optional)
+        Encoding. The encoding option is ignored if the data argument is a
+        buffer. Default: 'utf8'.
+
+    options.flag: string (optional)
+        Flag. Default: 'a'.
+
+    options.mode: integer (optional)
+        Mode. Default: 0o666.
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/fs/append-file/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/fs/append-file/docs/types/index.d.ts
@@ -98,7 +98,7 @@ interface AppendFile {
 	* @param data - data to append
 	* @param options - options (if a string, the value is the encoding)
 	* @returns error object or null
-	* 
+	*
 	* @example
 	* var err = appendFileSync( './beep/boop.txt', 'data to append\n' );
 	* if ( err instanceof Error ) {

--- a/lib/node_modules/@stdlib/fs/append-file/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/fs/append-file/docs/types/index.d.ts
@@ -58,7 +58,7 @@ interface AppendFile {
 	*
 	* @param path - file path or file descriptor
 	* @param data - data to append
-	* @param options - options; if a string, then value is the encoding
+	* @param options - options (if a string, the value is the encoding)
 	* @param clbk - callback to invoke after appending data to a file
 	*
 	* @example
@@ -96,7 +96,7 @@ interface AppendFile {
 	*
 	* @param path - file path or file descriptor
 	* @param data - data to append
-	* @param options - options; if a string, the value is the encoding
+	* @param options - options (if a string, the value is the encoding)
 	* @returns error object or null
 	* 
 	* @example
@@ -113,7 +113,7 @@ interface AppendFile {
 *
 * @param path - file path or file descriptor
 * @param data - data to append
-* @param options - options; if a string, the value is the encoding
+* @param options - options (if a string, the value is the encoding)
 * @param clbk - callback to invoke after appending data to a file
 *
 * @example
@@ -126,6 +126,7 @@ interface AppendFile {
 * appendFile( './beep/boop.txt', 'beep boop\n', onAppend );
 */
 declare var appendFile: AppendFile;
+
 
 // EXPORTS //
 

--- a/lib/node_modules/@stdlib/fs/append-file/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/fs/append-file/docs/types/index.d.ts
@@ -27,7 +27,7 @@ import { Buffer } from 'buffer';
 */
 interface Options {
 	/**
-	* Encoding; ignored if the data argument is a buffer (default: null).
+	* Encoding (default: null).
 	*/
 	encoding?: string | null;
 
@@ -58,7 +58,7 @@ interface AppendFile {
 	*
 	* @param path - file path or file descriptor
 	* @param data - data to append
-	* @param options - options; if a string, the value is the encoding
+	* @param options - options; if a string, then value is the encoding
 	* @param clbk - callback to invoke after appending data to a file
 	*
 	* @example
@@ -97,16 +97,15 @@ interface AppendFile {
 	* @param path - file path or file descriptor
 	* @param data - data to append
 	* @param options - options; if a string, the value is the encoding
-	*
+	* @returns error object or null
+	* 
 	* @example
-	* try {
-	*	appendFileSync('./beep/boop.txt', 'data to append\n');
-	*	console.log('The "data to append" was appended to file!');
-	*  } catch (err) {
-	*	   throw err;
-	*  }
+	* var err = appendFileSync( './beep/boop.txt', 'data to append\n' );
+	* if ( err instanceof Error ) {
+	*     throw err;
+	* }
 	*/
-	sync( path: string | Buffer | number, data: string | Buffer, options?: Options | string ): void;
+	sync( path: string | Buffer | number, data: string | Buffer, options?: Options | string ): Error | null;
 }
 
 /**

--- a/lib/node_modules/@stdlib/fs/append-file/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/fs/append-file/docs/types/index.d.ts
@@ -1,7 +1,7 @@
 /*
  * @license Apache-2.0
  *
- * Copyright (c) 2021 The Stdlib Authors.
+ * Copyright (c) 2024 The Stdlib Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/fs/append-file/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/fs/append-file/docs/types/index.d.ts
@@ -1,140 +1,144 @@
 /*
- * @license Apache-2.0
- *
- * Copyright (c) 2024 The Stdlib Authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
 // TypeScript Version: 4.1
 
-/// <reference types="node"/>
+/// <reference types = 'node'/>
 
-import { Buffer } from "buffer";
+import { Buffer } from 'buffer';
 
 /**
- * Interface defining function options.
- */
+* Interface defining function options.
+*/
 interface Options {
-  /**
-   * Encoding; ignored if the data argument is a buffer (default: null).
-   */
-  encoding?: string | null;
+	/**
+	* Encoding; ignored if the data argument is a buffer (default: null).
+	*/
+	encoding?: string | null;
 
-  /**
-   * Flag (default: 'a').
-   */
-  flag?: string;
+	/**
+	* Flag (default: 'a').
+	*/
+	flag?: string;
 
-  /**
-   * Mode (default: 0o666)
-   */
-  mode?: number;
+	/**
+	* Mode (default: 0o666)
+	*/
+	mode?: number;
 }
 
 /**
- * Callback invoked upon writing data to a file.
- *
- * @param err - error object
- */
-type Callback = (err: Error | null) => void;
+* Callback invoked upon writing data to a file.
+*
+* @param err - error object
+*/
+type Callback = ( err: Error | null ) => void;
 
 /**
- * Interface for appending a file.
- */
+* Interface for appending a file.
+*/
 interface AppendFile {
-  /**
-   * Asynchronously appends data to a file.
-   *
-   * @param path - file path or file descriptor
-   * @param data - data to append
-   * @param options - options; if a string, the value is the encoding
-   * @param clbk - callback to invoke after appending data to a file
-   *
-   * @example
-   * function onAppend( err ) {
-   *     if ( err ) {
-   *         throw err;
-   *     }
-   * }
-   *
-   * var opts = { 'flag': 'r' };
-   * appendFile( './beep/boop.txt', 'beep boop\n', opts, onAppend );
-   */
-  (
-    path: string | Buffer | number,
-    data: string | Buffer,
-    options: Options | string,
-    clbk: Callback
-  ): void;
+	/**
+	* Asynchronously appends data to a file.
+	*
+	* @param path - file path or file descriptor
+	* @param data - data to append
+	* @param options - options; if a string, the value is the encoding
+	* @param clbk - callback to invoke after appending data to a file
+	*
+	* @example
+	* function onAppend( err ) {
+	*     if ( err ) {
+	*         throw err;
+	*     }
+	* }
+	*
+	* var opts = { 'flag': 'r' };
+	* appendFile( './beep/boop.txt', 'beep boop\n', opts, onAppend );
+	*/
+	(
+		path: string | Buffer | number,
+		data: string | Buffer,
+		options: Options | string,
+		clbk: Callback
+	): void;
 
-  /**
-   * Asynchronously appends data to a file.
-   *
-   * @param path - file path or file descriptor
-   * @param data - data to append
-   * @param clbk - callback to invoke after appending data to a file
-   *
-   * @example
-   * function onAppend( err ) {
-   *     if ( err ) {
-   *         throw err;
-   *     }
-   * }
-   *
-   * appendFile( './beep/boop.txt', 'beep boop\n', onAppend );
-   */
-  (path: string | Buffer | number, data: string | Buffer, clbk: Callback): void;
+	/**
+	* Asynchronously appends data to a file.
+	*
+	* @param path - file path or file descriptor
+	* @param data - data to append
+	* @param clbk - callback to invoke after appending data to a file
+	*
+	* @example
+	* function onAppend( err ) {
+	*     if ( err ) {
+	*         throw err;
+	*     }
+	* }
+	*
+	* appendFile( './beep/boop.txt', 'beep boop\n', onAppend );
+	*/
+	(
+		path: string | Buffer | number,
+		data: string | Buffer,
+		clbk: Callback
+	): void;
 
-  /**
-   * Synchronously appends data to a file.
-   *
-   * @param path - file path or file descriptor
-   * @param data - data to append
-   * @param options - options; if a string, the value is the encoding
-   *
-   * @example
-   * try {
-   *	appendFileSync('./beep/boop.txt', 'data to append\n');
-   *	console.log('The "data to append" was appended to file!');
-   *  } catch (err) {
-   *	   throw err;
-   *  }
-   */
-  sync(
-    path: string | Buffer | number,
-    data: string | Buffer,
-    options?: Options | string
-  ): void;
+	/**
+	* Synchronously appends data to a file.
+	*
+	* @param path - file path or file descriptor
+	* @param data - data to append
+	* @param options - options; if a string, the value is the encoding
+	*
+	* @example
+	* try {
+	*	appendFileSync('./beep/boop.txt', 'data to append\n');
+	*	console.log('The "data to append" was appended to file!');
+	*  } catch (err) {
+	*	   throw err;
+	*  }
+	*/
+	sync(
+		path: string | Buffer | number,
+		data: string | Buffer,
+		options?: Options | string
+	): void;
 }
 
 /**
- * Asynchronously appends data to a file.
- *
- * @param path - file path or file descriptor
- * @param data - data to append
- * @param options - options; if a string, the value is the encoding
- * @param clbk - callback to invoke after appending data to a file
- *
- * @example
- * function onAppend( err ) {
- *     if ( err ) {
- *         throw err;
- *     }
- * }
- *
- * appendFile( './beep/boop.txt', 'beep boop\n', onAppend );
- */
+* Asynchronously appends data to a file.
+*
+* @param path - file path or file descriptor
+* @param data - data to append
+* @param options - options; if a string, the value is the encoding
+* @param clbk - callback to invoke after appending data to a file
+*
+* @example
+* function onAppend( err ) {
+*     if ( err ) {
+*         throw err;
+*     }
+* }
+*
+* appendFile( './beep/boop.txt', 'beep boop\n', onAppend );
+*/
 declare var appendFile: AppendFile;
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/fs/append-file/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/fs/append-file/docs/types/index.d.ts
@@ -1,0 +1,142 @@
+/*
+ * @license Apache-2.0
+ *
+ * Copyright (c) 2021 The Stdlib Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TypeScript Version: 4.1
+
+/// <reference types="node"/>
+
+import { Buffer } from "buffer";
+
+/**
+ * Interface defining function options.
+ */
+interface Options {
+  /**
+   * Encoding; ignored if the data argument is a buffer (default: null).
+   */
+  encoding?: string | null;
+
+  /**
+   * Flag (default: 'a').
+   */
+  flag?: string;
+
+  /**
+   * Mode (default: 0o666)
+   */
+  mode?: number;
+}
+
+/**
+ * Callback invoked upon writing data to a file.
+ *
+ * @param err - error object
+ */
+type Callback = (err: Error | null) => void;
+
+/**
+ * Interface for appending a file.
+ */
+interface AppendFile {
+  /**
+   * Asynchronously appends data to a file.
+   *
+   * @param path - file path or file descriptor
+   * @param data - data to append
+   * @param options - options; if a string, the value is the encoding
+   * @param clbk - callback to invoke after appending data to a file
+   *
+   * @example
+   * function onAppend( err ) {
+   *     if ( err ) {
+   *         throw err;
+   *     }
+   * }
+   *
+   * var opts = { 'flag': 'r' };
+   * appendFile( './beep/boop.txt', 'beep boop\n', opts, onAppend );
+   */
+  (
+    path: string | Buffer | number,
+    data: string | Buffer,
+    options: Options | string,
+    clbk: Callback
+  ): void;
+
+  /**
+   * Asynchronously appends data to a file.
+   *
+   * @param path - file path or file descriptor
+   * @param data - data to append
+   * @param clbk - callback to invoke after appending data to a file
+   *
+   * @example
+   * function onAppend( err ) {
+   *     if ( err ) {
+   *         throw err;
+   *     }
+   * }
+   *
+   * appendFile( './beep/boop.txt', 'beep boop\n', onAppend );
+   */
+  (path: string | Buffer | number, data: string | Buffer, clbk: Callback): void;
+
+  /**
+   * Synchronously appends data to a file.
+   *
+   * @param path - file path or file descriptor
+   * @param data - data to append
+   * @param options - options; if a string, the value is the encoding
+   *
+   * @example
+   * try {
+   *	appendFileSync('./beep/boop.txt', 'data to append\n');
+   *	console.log('The "data to append" was appended to file!');
+   *  } catch (err) {
+   *	   throw err;
+   *  }
+   */
+  sync(
+    path: string | Buffer | number,
+    data: string | Buffer,
+    options?: Options | string
+  ): void;
+}
+
+/**
+ * Asynchronously appends data to a file.
+ *
+ * @param path - file path or file descriptor
+ * @param data - data to append
+ * @param options - options; if a string, the value is the encoding
+ * @param clbk - callback to invoke after appending data to a file
+ *
+ * @example
+ * function onAppend( err ) {
+ *     if ( err ) {
+ *         throw err;
+ *     }
+ * }
+ *
+ * appendFile( './beep/boop.txt', 'beep boop\n', onAppend );
+ */
+declare var appendFile: AppendFile;
+
+// EXPORTS //
+
+export = appendFile;

--- a/lib/node_modules/@stdlib/fs/append-file/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/fs/append-file/docs/types/index.d.ts
@@ -64,19 +64,14 @@ interface AppendFile {
 	* @example
 	* function onAppend( err ) {
 	*     if ( err ) {
-	*         throw err;
+	*         console.log( err.message );
 	*     }
 	* }
 	*
 	* var opts = { 'flag': 'r' };
 	* appendFile( './beep/boop.txt', 'beep boop\n', opts, onAppend );
 	*/
-	(
-		path: string | Buffer | number,
-		data: string | Buffer,
-		options: Options | string,
-		clbk: Callback
-	): void;
+	( path: string | Buffer | number, data: string | Buffer, options: Options | string, clbk: Callback ): void;
 
 	/**
 	* Asynchronously appends data to a file.
@@ -88,17 +83,13 @@ interface AppendFile {
 	* @example
 	* function onAppend( err ) {
 	*     if ( err ) {
-	*         throw err;
+	*         console.log( err.message );
 	*     }
 	* }
 	*
 	* appendFile( './beep/boop.txt', 'beep boop\n', onAppend );
 	*/
-	(
-		path: string | Buffer | number,
-		data: string | Buffer,
-		clbk: Callback
-	): void;
+	( path: string | Buffer | number, data: string | Buffer, clbk: Callback ): void;
 
 	/**
 	* Synchronously appends data to a file.
@@ -115,11 +106,7 @@ interface AppendFile {
 	*	   throw err;
 	*  }
 	*/
-	sync(
-		path: string | Buffer | number,
-		data: string | Buffer,
-		options?: Options | string
-	): void;
+	sync( path: string | Buffer | number, data: string | Buffer, options?: Options | string ): void;
 }
 
 /**
@@ -133,7 +120,7 @@ interface AppendFile {
 * @example
 * function onAppend( err ) {
 *     if ( err ) {
-*         throw err;
+*         console.log( err.message );
 *     }
 * }
 *

--- a/lib/node_modules/@stdlib/fs/append-file/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/fs/append-file/docs/types/test.ts
@@ -75,59 +75,39 @@ const onAppend = ( err: Error | null ): void => {
 	appendFile( '/path/to/beepboop', 'beepboop', undefined, onAppend ); // $ExpectError
 	appendFile( '/path/to/beepboop', 'beepboop', 123, onAppend ); // $ExpectError
 	appendFile( '/path/to/beepboop', 'beepboop', [], onAppend ); // $ExpectError
-	appendFile( 
-		'/path/to/beepboop',
-		'beepboop',
-		( x: number ): number => x,
-		onAppend
-	); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', ( x: number ): number => x, onAppend ); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided an `encoding` option which is not a string or null...
 {
-	appendFile( '/path/to/beepboop', 'beepboop', { encoding: 123 }, onAppend ); // $ExpectError
-	appendFile( '/path/to/beepboop', 'beepboop', { encoding: true }, onAppend ); // $ExpectError
-	appendFile( '/path/to/beepboop', 'beepboop', { encoding: false }, onAppend ); // $ExpectError
-	appendFile( '/path/to/beepboop', 'beepboop', { encoding: [] }, onAppend ); // $ExpectError
-	appendFile( '/path/to/beepboop', 'beepboop', { encoding: {} }, onAppend ); // $ExpectError
-	appendFile(
-		'/path/to/beepboop',
-		'beepboop',
-		{ encoding: ( x: number ): number => x },
-		onAppend
-	); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { 'encoding': 123 }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { 'encoding': true }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { 'encoding': false }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { 'encoding': [] }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { 'encoding': {} }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { 'encoding': ( x: number ): number => x }, onAppend ); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided a `flag` option which is not a string...
 {
-	appendFile( '/path/to/beepboop', 'beepboop', { flag: 123 }, onAppend ); // $ExpectError
-	appendFile( '/path/to/beepboop', 'beepboop', { flag: true }, onAppend ); // $ExpectError
-	appendFile( '/path/to/beepboop', 'beepboop', { flag: false }, onAppend ); // $ExpectError
-	appendFile( '/path/to/beepboop', 'beepboop', { flag: null }, onAppend ); // $ExpectError
-	appendFile( '/path/to/beepboop', 'beepboop', { flag: [] }, onAppend ); // $ExpectError
-	appendFile( '/path/to/beepboop', 'beepboop', { flag: {} }, onAppend ); // $ExpectError
-	appendFile(
-		'/path/to/beepboop',
-		'beepboop',
-		{ flag: ( x: number ): number => x },
-		onAppend
-	); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { 'flag': 123 }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { 'flag': true }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { 'flag': false }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { 'flag': null }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { 'flag': [] }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { 'flag': {} }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { 'flag': ( x: number ): number => x },onAppend ); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided a `mode` option which is not a number...
 {
-	appendFile( '/path/to/beepboop', 'beepboop', { mode: 'abc' }, onAppend ); // $ExpectError
-	appendFile( '/path/to/beepboop', 'beepboop', { mode: true }, onAppend ); // $ExpectError
-	appendFile( '/path/to/beepboop', 'beepboop', { mode: false }, onAppend ); // $ExpectError
-	appendFile( '/path/to/beepboop', 'beepboop', { mode: null }, onAppend ); // $ExpectError
-	appendFile( '/path/to/beepboop', 'beepboop', { mode: [] }, onAppend ); // $ExpectError
-	appendFile( '/path/to/beepboop', 'beepboop', { mode: {} }, onAppend ); // $ExpectError
-	appendFile(
-		'/path/to/beepboop',
-		'beepboop',
-		{ mode: ( x: number ): number => x },
-		onAppend
-	); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { 'mode': 'abc' }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { 'mode': true }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { 'mode': false }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { 'mode': null }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { 'mode': [] }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { 'mode': {} }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { 'mode': ( x: number ): number => x }, onAppend ); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided an unsupported number of arguments...
@@ -176,40 +156,34 @@ const onAppend = ( err: Error | null ): void => {
 
 // The compiler throws an error if the `sync` method is provided an `encoding` option which is not a string or null...
 {
-	appendFile.sync( '/path/to/beepboop', 'beepboop', { encoding: 123 } ); // $ExpectError
-	appendFile.sync( '/path/to/beepboop', 'beepboop', { encoding: true } ); // $ExpectError
-	appendFile.sync( '/path/to/beepboop', 'beepboop', { encoding: false } ); // $ExpectError
-	appendFile.sync( '/path/to/beepboop', 'beepboop', { encoding: [] } ); // $ExpectError
-	appendFile.sync( '/path/to/beepboop', 'beepboop', { encoding: {} } ); // $ExpectError
-	appendFile.sync( '/path/to/beepboop', 'beepboop', {
-		encoding: ( x: number ): number => x,
-	} ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { 'encoding': 123 } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { 'encoding': true } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { 'encoding': false } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { 'encoding': [] } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { 'encoding': {} } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { 'encoding': ( x: number ): number => x } ); // $ExpectError
 }
 
 // The compiler throws an error if the `sync` method is provided a `flag` option which is not a string...
 {
-	appendFile.sync( '/path/to/beepboop', 'beepboop', { flag: 123 } ); // $ExpectError
-	appendFile.sync( '/path/to/beepboop', 'beepboop', { flag: true } ); // $ExpectError
-	appendFile.sync( '/path/to/beepboop', 'beepboop', { flag: false } ); // $ExpectError
-	appendFile.sync( '/path/to/beepboop', 'beepboop', { flag: null } ); // $ExpectError
-	appendFile.sync( '/path/to/beepboop', 'beepboop', { flag: [] } ); // $ExpectError
-	appendFile.sync( '/path/to/beepboop', 'beepboop', { flag: {} } ); // $ExpectError
-	appendFile.sync( '/path/to/beepboop', 'beepboop', {
-		flag: (x: number): number => x,
-	} ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { 'flag': 123 } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { 'flag': true } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { 'flag': false } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { 'flag': null } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { 'flag': [] } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { 'flag': {} } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { 'flag': ( x: number ): number => x } ); // $ExpectError
 }
 
 // The compiler throws an error if the `sync` method is provided a `mode` option which is not a number...
 {
-	appendFile.sync( '/path/to/beepboop', 'beepboop', { mode: 'abc' } ); // $ExpectError
-	appendFile.sync( '/path/to/beepboop', 'beepboop', { mode: true } ); // $ExpectError
-	appendFile.sync( '/path/to/beepboop', 'beepboop', { mode: false } ); // $ExpectError
-	appendFile.sync( '/path/to/beepboop', 'beepboop', { mode: null } ); // $ExpectError
-	appendFile.sync( '/path/to/beepboop', 'beepboop', { mode: [] } ); // $ExpectError
-	appendFile.sync( '/path/to/beepboop', 'beepboop', { mode: {} } ); // $ExpectError
-	appendFile.sync( '/path/to/beepboop', 'beepboop', {
-		mode: ( x: number ): number => x,
-	} ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { 'mode': 'abc' } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { 'mode': true } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { 'mode': false } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { 'mode': null } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { 'mode': [] } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { 'mode': {} } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { 'mode': ( x: number ): number => x } ); // $ExpectError
 }
 
 // The compiler throws an error if the `sync` method is provided an unsupported number of arguments...

--- a/lib/node_modules/@stdlib/fs/append-file/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/fs/append-file/docs/types/test.ts
@@ -1,218 +1,219 @@
 /*
- * @license Apache-2.0
- *
- * Copyright (c) 2024 The Stdlib Authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
-import appendFile = require("./index");
+import appendFile = require( './index' );
 
-const onAppend = (err: Error | null): void => {
-  if (err) {
-    throw err;
-  }
+const onAppend = ( err: Error | null ): void => {
+	if ( err ) {
+		throw err;
+	}
 };
+
 
 // TESTS //
 
 // The function does not have a return value...
 {
-  appendFile("./beep/boop.txt", "beepboop", onAppend); // $ExpectType void
+	appendFile( './beep/boop.txt', 'beepboop', onAppend ); // $ExpectType void
 }
 
 // The compiler throws an error if the function is provided a first argument which is not a string, buffer, or file descriptor...
 {
-  appendFile(false, "beepboop", onAppend); // $ExpectError
-  appendFile(true, "beepboop", onAppend); // $ExpectError
-  appendFile(null, "beepboop", onAppend); // $ExpectError
-  appendFile(undefined, "beepboop", onAppend); // $ExpectError
-  appendFile([], "beepboop", onAppend); // $ExpectError
-  appendFile({}, "beepboop", onAppend); // $ExpectError
-  appendFile((x: number): number => x, "beepboop", onAppend); // $ExpectError
+	appendFile( false, 'beepboop', onAppend ); // $ExpectError
+	appendFile( true, 'beepboop', onAppend ); // $ExpectError
+	appendFile( null, 'beepboop', onAppend ); // $ExpectError
+	appendFile( undefined, 'beepboop', onAppend ); // $ExpectError
+	appendFile( [], 'beepboop', onAppend ); // $ExpectError
+	appendFile( {}, 'beepboop', onAppend ); // $ExpectError
+	appendFile( ( x: number ): number => x, 'beepboop', onAppend ); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided a second argument which is not a string or buffer...
 {
-  appendFile("./beep/boop.txt", false, onAppend); // $ExpectError
-  appendFile("./beep/boop.txt", true, onAppend); // $ExpectError
-  appendFile("./beep/boop.txt", null, onAppend); // $ExpectError
-  appendFile("./beep/boop.txt", undefined, onAppend); // $ExpectError
-  appendFile("./beep/boop.txt", [], onAppend); // $ExpectError
-  appendFile("./beep/boop.txt", {}, onAppend); // $ExpectError
-  appendFile("./beep/boop.txt", (x: number): number => x, onAppend); // $ExpectError
+	appendFile( './beep/boop.txt', false, onAppend ); // $ExpectError
+	appendFile( './beep/boop.txt', true, onAppend ); // $ExpectError
+	appendFile( './beep/boop.txt', null, onAppend ); // $ExpectError
+	appendFile( './beep/boop.txt', undefined, onAppend ); // $ExpectError
+	appendFile( './beep/boop.txt', [], onAppend ); // $ExpectError
+	appendFile( './beep/boop.txt', {}, onAppend ); // $ExpectError
+	appendFile( './beep/boop.txt', ( x: number ): number => x, onAppend ); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided a callback argument which is not a function with the expected signature...
 {
-  appendFile("/path/to/beepboop", "beepboop", "abc"); // $ExpectError
-  appendFile("/path/to/beepboop", "beepboop", 1); // $ExpectError
-  appendFile("/path/to/beepboop", "beepboop", false); // $ExpectError
-  appendFile("/path/to/beepboop", "beepboop", true); // $ExpectError
-  appendFile("/path/to/beepboop", "beepboop", null); // $ExpectError
-  appendFile("/path/to/beepboop", "beepboop", undefined); // $ExpectError
-  appendFile("/path/to/beepboop", "beepboop", []); // $ExpectError
-  appendFile("/path/to/beepboop", "beepboop", {}); // $ExpectError
-  appendFile("/path/to/beepboop", "beepboop", (x: number): number => x); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', 'abc' ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', 1 ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', false ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', true ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', null ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', undefined ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', [] ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', {} ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', ( x: number ): number => x ); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided an options argument which is not an object or string...
 {
-  appendFile("/path/to/beepboop", "beepboop", false, onAppend); // $ExpectError
-  appendFile("/path/to/beepboop", "beepboop", true, onAppend); // $ExpectError
-  appendFile("/path/to/beepboop", "beepboop", null, onAppend); // $ExpectError
-  appendFile("/path/to/beepboop", "beepboop", undefined, onAppend); // $ExpectError
-  appendFile("/path/to/beepboop", "beepboop", 123, onAppend); // $ExpectError
-  appendFile("/path/to/beepboop", "beepboop", [], onAppend); // $ExpectError
-  appendFile(
-    "/path/to/beepboop",
-    "beepboop",
-    (x: number): number => x,
-    onAppend
-  ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', false, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', true, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', null, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', undefined, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', 123, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', [], onAppend ); // $ExpectError
+	appendFile( 
+		'/path/to/beepboop',
+		'beepboop',
+		( x: number ): number => x,
+		onAppend
+	); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided an `encoding` option which is not a string or null...
 {
-  appendFile("/path/to/beepboop", "beepboop", { encoding: 123 }, onAppend); // $ExpectError
-  appendFile("/path/to/beepboop", "beepboop", { encoding: true }, onAppend); // $ExpectError
-  appendFile("/path/to/beepboop", "beepboop", { encoding: false }, onAppend); // $ExpectError
-  appendFile("/path/to/beepboop", "beepboop", { encoding: [] }, onAppend); // $ExpectError
-  appendFile("/path/to/beepboop", "beepboop", { encoding: {} }, onAppend); // $ExpectError
-  appendFile(
-    "/path/to/beepboop",
-    "beepboop",
-    { encoding: (x: number): number => x },
-    onAppend
-  ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { encoding: 123 }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { encoding: true }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { encoding: false }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { encoding: [] }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { encoding: {} }, onAppend ); // $ExpectError
+	appendFile(
+		'/path/to/beepboop',
+		'beepboop',
+		{ encoding: ( x: number ): number => x },
+		onAppend
+	); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided a `flag` option which is not a string...
 {
-  appendFile("/path/to/beepboop", "beepboop", { flag: 123 }, onAppend); // $ExpectError
-  appendFile("/path/to/beepboop", "beepboop", { flag: true }, onAppend); // $ExpectError
-  appendFile("/path/to/beepboop", "beepboop", { flag: false }, onAppend); // $ExpectError
-  appendFile("/path/to/beepboop", "beepboop", { flag: null }, onAppend); // $ExpectError
-  appendFile("/path/to/beepboop", "beepboop", { flag: [] }, onAppend); // $ExpectError
-  appendFile("/path/to/beepboop", "beepboop", { flag: {} }, onAppend); // $ExpectError
-  appendFile(
-    "/path/to/beepboop",
-    "beepboop",
-    { flag: (x: number): number => x },
-    onAppend
-  ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { flag: 123 }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { flag: true }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { flag: false }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { flag: null }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { flag: [] }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { flag: {} }, onAppend ); // $ExpectError
+	appendFile(
+		'/path/to/beepboop',
+		'beepboop',
+		{ flag: ( x: number ): number => x },
+		onAppend
+	); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided a `mode` option which is not a number...
 {
-  appendFile("/path/to/beepboop", "beepboop", { mode: "abc" }, onAppend); // $ExpectError
-  appendFile("/path/to/beepboop", "beepboop", { mode: true }, onAppend); // $ExpectError
-  appendFile("/path/to/beepboop", "beepboop", { mode: false }, onAppend); // $ExpectError
-  appendFile("/path/to/beepboop", "beepboop", { mode: null }, onAppend); // $ExpectError
-  appendFile("/path/to/beepboop", "beepboop", { mode: [] }, onAppend); // $ExpectError
-  appendFile("/path/to/beepboop", "beepboop", { mode: {} }, onAppend); // $ExpectError
-  appendFile(
-    "/path/to/beepboop",
-    "beepboop",
-    { mode: (x: number): number => x },
-    onAppend
-  ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { mode: 'abc' }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { mode: true }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { mode: false }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { mode: null }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { mode: [] }, onAppend ); // $ExpectError
+	appendFile( '/path/to/beepboop', 'beepboop', { mode: {} }, onAppend ); // $ExpectError
+	appendFile(
+		'/path/to/beepboop',
+		'beepboop',
+		{ mode: ( x: number ): number => x },
+		onAppend
+	); // $ExpectError
 }
 
 // The compiler throws an error if the function is provided an unsupported number of arguments...
 {
-  appendFile(); // $ExpectError
-  appendFile("C:\\foo\\bar\\baz\\beepboop"); // $ExpectError
-  appendFile("C:\\foo\\bar\\baz\\beepboop", "beepboop"); // $ExpectError
+	appendFile(); // $ExpectError
+	appendFile( 'C:\\foo\\bar\\baz\\beepboop' ); // $ExpectError
+	appendFile( 'C:\\foo\\bar\\baz\\beepboop', 'beepboop' ); // $ExpectError
 }
 
 // Attached to main export is a `sync` method which returns an error or null...
 {
-  appendFile.sync("/path/to/beepboop", "beepboop"); // $ExpectType Error | null
+	appendFile.sync( '/path/to/beepboop', 'beepboop' ); // $ExpectType Error | null
 }
 
 // The compiler throws an error if the `sync` method is provided a first argument which is not a string, buffer, or file descriptor...
 {
-  appendFile.sync(false, "beepboop"); // $ExpectError
-  appendFile.sync(true, "beepboop"); // $ExpectError
-  appendFile.sync(null, "beepboop"); // $ExpectError
-  appendFile.sync(undefined, "beepboop"); // $ExpectError
-  appendFile.sync([], "beepboop"); // $ExpectError
-  appendFile.sync({}, "beepboop"); // $ExpectError
-  appendFile.sync((x: number): number => x, "beepboop"); // $ExpectError
+	appendFile.sync( false, 'beepboop' ); // $ExpectError
+	appendFile.sync( true, 'beepboop' ); // $ExpectError
+	appendFile.sync( null, 'beepboop' ); // $ExpectError
+	appendFile.sync( undefined, 'beepboop' ); // $ExpectError
+	appendFile.sync( [], 'beepboop' ); // $ExpectError
+	appendFile.sync( {}, 'beepboop' ); // $ExpectError
+	appendFile.sync( ( x: number ): number => x, 'beepboop' ); // $ExpectError
 }
 
 // The compiler throws an error if the `sync` method is provided a second argument which is not a string or buffer...
 {
-  appendFile.sync("/path/to/beepboop", false); // $ExpectError
-  appendFile.sync("/path/to/beepboop", true); // $ExpectError
-  appendFile.sync("/path/to/beepboop", null); // $ExpectError
-  appendFile.sync("/path/to/beepboop", undefined); // $ExpectError
-  appendFile.sync("/path/to/beepboop", []); // $ExpectError
-  appendFile.sync("/path/to/beepboop", {}); // $ExpectError
-  appendFile.sync("/path/to/beepboop", (x: number): number => x); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', false ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', true ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', null ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', undefined ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', [] ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', {} ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', ( x: number ): number => x ); // $ExpectError
 }
 
 // The compiler throws an error if the `sync` method is provided an options argument which is not an object or string...
 {
-  appendFile.sync("/path/to/beepboop", "beepboop", null); // $ExpectError
-  appendFile.sync("/path/to/beepboop", "beepboop", true); // $ExpectError
-  appendFile.sync("/path/to/beepboop", "beepboop", false); // $ExpectError
-  appendFile.sync("/path/to/beepboop", "beepboop", 123); // $ExpectError
-  appendFile.sync("/path/to/beepboop", "beepboop", []); // $ExpectError
-  appendFile.sync("/path/to/beepboop", "beepboop", (x: number): number => x); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', null ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', true ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', false ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', 123 ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', [] ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', ( x: number ): number => x ); // $ExpectError
 }
 
 // The compiler throws an error if the `sync` method is provided an `encoding` option which is not a string or null...
 {
-  appendFile.sync("/path/to/beepboop", "beepboop", { encoding: 123 }); // $ExpectError
-  appendFile.sync("/path/to/beepboop", "beepboop", { encoding: true }); // $ExpectError
-  appendFile.sync("/path/to/beepboop", "beepboop", { encoding: false }); // $ExpectError
-  appendFile.sync("/path/to/beepboop", "beepboop", { encoding: [] }); // $ExpectError
-  appendFile.sync("/path/to/beepboop", "beepboop", { encoding: {} }); // $ExpectError
-  appendFile.sync("/path/to/beepboop", "beepboop", {
-    encoding: (x: number): number => x,
-  }); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { encoding: 123 } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { encoding: true } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { encoding: false } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { encoding: [] } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { encoding: {} } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', {
+		encoding: ( x: number ): number => x,
+	} ); // $ExpectError
 }
 
 // The compiler throws an error if the `sync` method is provided a `flag` option which is not a string...
 {
-  appendFile.sync("/path/to/beepboop", "beepboop", { flag: 123 }); // $ExpectError
-  appendFile.sync("/path/to/beepboop", "beepboop", { flag: true }); // $ExpectError
-  appendFile.sync("/path/to/beepboop", "beepboop", { flag: false }); // $ExpectError
-  appendFile.sync("/path/to/beepboop", "beepboop", { flag: null }); // $ExpectError
-  appendFile.sync("/path/to/beepboop", "beepboop", { flag: [] }); // $ExpectError
-  appendFile.sync("/path/to/beepboop", "beepboop", { flag: {} }); // $ExpectError
-  appendFile.sync("/path/to/beepboop", "beepboop", {
-    flag: (x: number): number => x,
-  }); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { flag: 123 } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { flag: true } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { flag: false } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { flag: null } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { flag: [] } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { flag: {} } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', {
+		flag: (x: number): number => x,
+	} ); // $ExpectError
 }
 
 // The compiler throws an error if the `sync` method is provided a `mode` option which is not a number...
 {
-  appendFile.sync("/path/to/beepboop", "beepboop", { mode: "abc" }); // $ExpectError
-  appendFile.sync("/path/to/beepboop", "beepboop", { mode: true }); // $ExpectError
-  appendFile.sync("/path/to/beepboop", "beepboop", { mode: false }); // $ExpectError
-  appendFile.sync("/path/to/beepboop", "beepboop", { mode: null }); // $ExpectError
-  appendFile.sync("/path/to/beepboop", "beepboop", { mode: [] }); // $ExpectError
-  appendFile.sync("/path/to/beepboop", "beepboop", { mode: {} }); // $ExpectError
-  appendFile.sync("/path/to/beepboop", "beepboop", {
-    mode: (x: number): number => x,
-  }); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { mode: 'abc' } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { mode: true } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { mode: false } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { mode: null } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { mode: [] } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', { mode: {} } ); // $ExpectError
+	appendFile.sync( '/path/to/beepboop', 'beepboop', {
+		mode: ( x: number ): number => x,
+	} ); // $ExpectError
 }
 
 // The compiler throws an error if the `sync` method is provided an unsupported number of arguments...
 {
-  appendFile.sync(); // $ExpectError
-  appendFile.sync("/path/to/beepboop"); // $ExpectError
+	appendFile.sync(); // $ExpectError
+	appendFile.sync( '/path/to/beepboop' ); // $ExpectError
 }

--- a/lib/node_modules/@stdlib/fs/append-file/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/fs/append-file/docs/types/test.ts
@@ -1,0 +1,218 @@
+/*
+ * @license Apache-2.0
+ *
+ * Copyright (c) 2021 The Stdlib Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import appendFile = require("./index");
+
+const onAppend = (err: Error | null): void => {
+  if (err) {
+    throw err;
+  }
+};
+
+// TESTS //
+
+// The function does not have a return value...
+{
+  appendFile("./beep/boop.txt", "beepboop", onAppend); // $ExpectType void
+}
+
+// The compiler throws an error if the function is provided a first argument which is not a string, buffer, or file descriptor...
+{
+  appendFile(false, "beepboop", onAppend); // $ExpectError
+  appendFile(true, "beepboop", onAppend); // $ExpectError
+  appendFile(null, "beepboop", onAppend); // $ExpectError
+  appendFile(undefined, "beepboop", onAppend); // $ExpectError
+  appendFile([], "beepboop", onAppend); // $ExpectError
+  appendFile({}, "beepboop", onAppend); // $ExpectError
+  appendFile((x: number): number => x, "beepboop", onAppend); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument which is not a string or buffer...
+{
+  appendFile("./beep/boop.txt", false, onAppend); // $ExpectError
+  appendFile("./beep/boop.txt", true, onAppend); // $ExpectError
+  appendFile("./beep/boop.txt", null, onAppend); // $ExpectError
+  appendFile("./beep/boop.txt", undefined, onAppend); // $ExpectError
+  appendFile("./beep/boop.txt", [], onAppend); // $ExpectError
+  appendFile("./beep/boop.txt", {}, onAppend); // $ExpectError
+  appendFile("./beep/boop.txt", (x: number): number => x, onAppend); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a callback argument which is not a function with the expected signature...
+{
+  appendFile("/path/to/beepboop", "beepboop", "abc"); // $ExpectError
+  appendFile("/path/to/beepboop", "beepboop", 1); // $ExpectError
+  appendFile("/path/to/beepboop", "beepboop", false); // $ExpectError
+  appendFile("/path/to/beepboop", "beepboop", true); // $ExpectError
+  appendFile("/path/to/beepboop", "beepboop", null); // $ExpectError
+  appendFile("/path/to/beepboop", "beepboop", undefined); // $ExpectError
+  appendFile("/path/to/beepboop", "beepboop", []); // $ExpectError
+  appendFile("/path/to/beepboop", "beepboop", {}); // $ExpectError
+  appendFile("/path/to/beepboop", "beepboop", (x: number): number => x); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an options argument which is not an object or string...
+{
+  appendFile("/path/to/beepboop", "beepboop", false, onAppend); // $ExpectError
+  appendFile("/path/to/beepboop", "beepboop", true, onAppend); // $ExpectError
+  appendFile("/path/to/beepboop", "beepboop", null, onAppend); // $ExpectError
+  appendFile("/path/to/beepboop", "beepboop", undefined, onAppend); // $ExpectError
+  appendFile("/path/to/beepboop", "beepboop", 123, onAppend); // $ExpectError
+  appendFile("/path/to/beepboop", "beepboop", [], onAppend); // $ExpectError
+  appendFile(
+    "/path/to/beepboop",
+    "beepboop",
+    (x: number): number => x,
+    onAppend
+  ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an `encoding` option which is not a string or null...
+{
+  appendFile("/path/to/beepboop", "beepboop", { encoding: 123 }, onAppend); // $ExpectError
+  appendFile("/path/to/beepboop", "beepboop", { encoding: true }, onAppend); // $ExpectError
+  appendFile("/path/to/beepboop", "beepboop", { encoding: false }, onAppend); // $ExpectError
+  appendFile("/path/to/beepboop", "beepboop", { encoding: [] }, onAppend); // $ExpectError
+  appendFile("/path/to/beepboop", "beepboop", { encoding: {} }, onAppend); // $ExpectError
+  appendFile(
+    "/path/to/beepboop",
+    "beepboop",
+    { encoding: (x: number): number => x },
+    onAppend
+  ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a `flag` option which is not a string...
+{
+  appendFile("/path/to/beepboop", "beepboop", { flag: 123 }, onAppend); // $ExpectError
+  appendFile("/path/to/beepboop", "beepboop", { flag: true }, onAppend); // $ExpectError
+  appendFile("/path/to/beepboop", "beepboop", { flag: false }, onAppend); // $ExpectError
+  appendFile("/path/to/beepboop", "beepboop", { flag: null }, onAppend); // $ExpectError
+  appendFile("/path/to/beepboop", "beepboop", { flag: [] }, onAppend); // $ExpectError
+  appendFile("/path/to/beepboop", "beepboop", { flag: {} }, onAppend); // $ExpectError
+  appendFile(
+    "/path/to/beepboop",
+    "beepboop",
+    { flag: (x: number): number => x },
+    onAppend
+  ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a `mode` option which is not a number...
+{
+  appendFile("/path/to/beepboop", "beepboop", { mode: "abc" }, onAppend); // $ExpectError
+  appendFile("/path/to/beepboop", "beepboop", { mode: true }, onAppend); // $ExpectError
+  appendFile("/path/to/beepboop", "beepboop", { mode: false }, onAppend); // $ExpectError
+  appendFile("/path/to/beepboop", "beepboop", { mode: null }, onAppend); // $ExpectError
+  appendFile("/path/to/beepboop", "beepboop", { mode: [] }, onAppend); // $ExpectError
+  appendFile("/path/to/beepboop", "beepboop", { mode: {} }, onAppend); // $ExpectError
+  appendFile(
+    "/path/to/beepboop",
+    "beepboop",
+    { mode: (x: number): number => x },
+    onAppend
+  ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+  appendFile(); // $ExpectError
+  appendFile("C:\\foo\\bar\\baz\\beepboop"); // $ExpectError
+  appendFile("C:\\foo\\bar\\baz\\beepboop", "beepboop"); // $ExpectError
+}
+
+// Attached to main export is a `sync` method which returns an error or null...
+{
+  appendFile.sync("/path/to/beepboop", "beepboop"); // $ExpectType Error | null
+}
+
+// The compiler throws an error if the `sync` method is provided a first argument which is not a string, buffer, or file descriptor...
+{
+  appendFile.sync(false, "beepboop"); // $ExpectError
+  appendFile.sync(true, "beepboop"); // $ExpectError
+  appendFile.sync(null, "beepboop"); // $ExpectError
+  appendFile.sync(undefined, "beepboop"); // $ExpectError
+  appendFile.sync([], "beepboop"); // $ExpectError
+  appendFile.sync({}, "beepboop"); // $ExpectError
+  appendFile.sync((x: number): number => x, "beepboop"); // $ExpectError
+}
+
+// The compiler throws an error if the `sync` method is provided a second argument which is not a string or buffer...
+{
+  appendFile.sync("/path/to/beepboop", false); // $ExpectError
+  appendFile.sync("/path/to/beepboop", true); // $ExpectError
+  appendFile.sync("/path/to/beepboop", null); // $ExpectError
+  appendFile.sync("/path/to/beepboop", undefined); // $ExpectError
+  appendFile.sync("/path/to/beepboop", []); // $ExpectError
+  appendFile.sync("/path/to/beepboop", {}); // $ExpectError
+  appendFile.sync("/path/to/beepboop", (x: number): number => x); // $ExpectError
+}
+
+// The compiler throws an error if the `sync` method is provided an options argument which is not an object or string...
+{
+  appendFile.sync("/path/to/beepboop", "beepboop", null); // $ExpectError
+  appendFile.sync("/path/to/beepboop", "beepboop", true); // $ExpectError
+  appendFile.sync("/path/to/beepboop", "beepboop", false); // $ExpectError
+  appendFile.sync("/path/to/beepboop", "beepboop", 123); // $ExpectError
+  appendFile.sync("/path/to/beepboop", "beepboop", []); // $ExpectError
+  appendFile.sync("/path/to/beepboop", "beepboop", (x: number): number => x); // $ExpectError
+}
+
+// The compiler throws an error if the `sync` method is provided an `encoding` option which is not a string or null...
+{
+  appendFile.sync("/path/to/beepboop", "beepboop", { encoding: 123 }); // $ExpectError
+  appendFile.sync("/path/to/beepboop", "beepboop", { encoding: true }); // $ExpectError
+  appendFile.sync("/path/to/beepboop", "beepboop", { encoding: false }); // $ExpectError
+  appendFile.sync("/path/to/beepboop", "beepboop", { encoding: [] }); // $ExpectError
+  appendFile.sync("/path/to/beepboop", "beepboop", { encoding: {} }); // $ExpectError
+  appendFile.sync("/path/to/beepboop", "beepboop", {
+    encoding: (x: number): number => x,
+  }); // $ExpectError
+}
+
+// The compiler throws an error if the `sync` method is provided a `flag` option which is not a string...
+{
+  appendFile.sync("/path/to/beepboop", "beepboop", { flag: 123 }); // $ExpectError
+  appendFile.sync("/path/to/beepboop", "beepboop", { flag: true }); // $ExpectError
+  appendFile.sync("/path/to/beepboop", "beepboop", { flag: false }); // $ExpectError
+  appendFile.sync("/path/to/beepboop", "beepboop", { flag: null }); // $ExpectError
+  appendFile.sync("/path/to/beepboop", "beepboop", { flag: [] }); // $ExpectError
+  appendFile.sync("/path/to/beepboop", "beepboop", { flag: {} }); // $ExpectError
+  appendFile.sync("/path/to/beepboop", "beepboop", {
+    flag: (x: number): number => x,
+  }); // $ExpectError
+}
+
+// The compiler throws an error if the `sync` method is provided a `mode` option which is not a number...
+{
+  appendFile.sync("/path/to/beepboop", "beepboop", { mode: "abc" }); // $ExpectError
+  appendFile.sync("/path/to/beepboop", "beepboop", { mode: true }); // $ExpectError
+  appendFile.sync("/path/to/beepboop", "beepboop", { mode: false }); // $ExpectError
+  appendFile.sync("/path/to/beepboop", "beepboop", { mode: null }); // $ExpectError
+  appendFile.sync("/path/to/beepboop", "beepboop", { mode: [] }); // $ExpectError
+  appendFile.sync("/path/to/beepboop", "beepboop", { mode: {} }); // $ExpectError
+  appendFile.sync("/path/to/beepboop", "beepboop", {
+    mode: (x: number): number => x,
+  }); // $ExpectError
+}
+
+// The compiler throws an error if the `sync` method is provided an unsupported number of arguments...
+{
+  appendFile.sync(); // $ExpectError
+  appendFile.sync("/path/to/beepboop"); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/fs/append-file/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/fs/append-file/docs/types/test.ts
@@ -1,7 +1,7 @@
 /*
  * @license Apache-2.0
  *
- * Copyright (c) 2021 The Stdlib Authors.
+ * Copyright (c) 2024 The Stdlib Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/fs/append-file/docs/usage.txt
+++ b/lib/node_modules/@stdlib/fs/append-file/docs/usage.txt
@@ -1,0 +1,10 @@
+
+Usage: append-file [options] <filepath>
+
+Options:
+
+  -h,    --help                Print this message.
+  -V,    --version             Print the package version.
+  --enc, --encoding encoding   Encoding. Default: 'utf8'.
+         --flag flag           Flag. Default: 'a'.
+         --mode mode           Mode. Default: 0o666.

--- a/lib/node_modules/@stdlib/fs/append-file/etc/cli_opts.json
+++ b/lib/node_modules/@stdlib/fs/append-file/etc/cli_opts.json
@@ -1,22 +1,22 @@
 {
-  "string": [
-    "encoding",
-    "flag",
-    "mode"
-  ],
-  "boolean": [
-    "help",
-    "version"
-  ],
-  "alias": {
-    "help": [
-      "h"
-    ],
-    "version": [
-      "V"
-    ],
-    "encoding": [
-      "enc"
-    ]
-  }
+	"string": [
+		"encoding",
+		"flag",
+		"mode"
+	],
+	"boolean": [
+		"help",
+		"version"
+	],
+	"alias": {
+		"help": [
+			"h"
+		],
+		"version": [
+			"V"
+		],
+		"encoding": [
+			"enc"
+		]
+	}
 }

--- a/lib/node_modules/@stdlib/fs/append-file/etc/cli_opts.json
+++ b/lib/node_modules/@stdlib/fs/append-file/etc/cli_opts.json
@@ -1,0 +1,22 @@
+{
+  "string": [
+    "encoding",
+    "flag",
+    "mode"
+  ],
+  "boolean": [
+    "help",
+    "version"
+  ],
+  "alias": {
+    "help": [
+      "h"
+    ],
+    "version": [
+      "V"
+    ],
+    "encoding": [
+      "enc"
+    ]
+  }
+}

--- a/lib/node_modules/@stdlib/fs/append-file/examples/index.js
+++ b/lib/node_modules/@stdlib/fs/append-file/examples/index.js
@@ -23,15 +23,16 @@ var appendFile = require( './../lib' );
 
 var fpath = join( __dirname, 'fixtures', 'file.txt' );
 
-// Synchronously append data to a file:
-try {
-	appendFile.sync( fpath, 'beep boop\n', 'utf8' );
-} catch ( err ) {
-	console.log( err.message );
-	// => false
-}
+// Synchronously appends data to a file:
+
+var err = appendFile.sync( fpath, 'beep boop\n', 'utf8' );
+// returns null
+
+console.log( err instanceof Error );
+// => false
 
 // Asynchronously append data to a file:
+
 appendFile( fpath, 'appended something\n', onAppend );
 
 function onAppend( err ) {

--- a/lib/node_modules/@stdlib/fs/append-file/examples/index.js
+++ b/lib/node_modules/@stdlib/fs/append-file/examples/index.js
@@ -1,7 +1,7 @@
 /**
  * @license Apache-2.0
  *
- * Copyright (c) 2018 The Stdlib Authors.
+ * Copyright (c) 2024 The Stdlib Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/fs/append-file/examples/index.js
+++ b/lib/node_modules/@stdlib/fs/append-file/examples/index.js
@@ -1,42 +1,42 @@
 /**
- * @license Apache-2.0
- *
- * Copyright (c) 2024 The Stdlib Authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
-"use strict";
+'use strict';
 
-var join = require("path").join;
-var appendFile = require("./../lib");
+var join = require( 'path' ).join;
+var appendFile = require( './../lib' );
 
-var fpath = join(__dirname, "fixtures", "file.txt");
+var fpath = join( __dirname, 'fixtures', 'file.txt' );
 
 // Synchronously append data to a file:
 try {
-  appendFile.sync(fpath, "beep boop\n", "utf8");
-} catch (err) {
-  console.log(err.message);
-  // => false
+	appendFile.sync( fpath, 'beep boop\n', 'utf8' );
+} catch ( err ) {
+	console.log( err.message );
+	// => false
 }
 
 // Asynchronously append data to a file:
-appendFile(fpath, "appended something\n", onAppend);
+appendFile( fpath, 'appended something\n', onAppend );
 
-function onAppend(err) {
-  if (err) {
-    console.error("Error: %s", err.message);
-  }
-  console.log("Success!");
+function onAppend( err ) {
+	if ( err ) {
+		console.error( 'Error: %s', err.message );
+	}
+	console.log( 'Success!' );
 }

--- a/lib/node_modules/@stdlib/fs/append-file/examples/index.js
+++ b/lib/node_modules/@stdlib/fs/append-file/examples/index.js
@@ -1,0 +1,42 @@
+/**
+ * @license Apache-2.0
+ *
+ * Copyright (c) 2018 The Stdlib Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+var join = require("path").join;
+var appendFile = require("./../lib");
+
+var fpath = join(__dirname, "fixtures", "file.txt");
+
+// Synchronously append data to a file:
+try {
+  appendFile.sync(fpath, "beep boop\n", "utf8");
+} catch (err) {
+  console.log(err.message);
+  // => false
+}
+
+// Asynchronously append data to a file:
+appendFile(fpath, "appended something\n", onAppend);
+
+function onAppend(err) {
+  if (err) {
+    console.error("Error: %s", err.message);
+  }
+  console.log("Success!");
+}

--- a/lib/node_modules/@stdlib/fs/append-file/lib/async.js
+++ b/lib/node_modules/@stdlib/fs/append-file/lib/async.js
@@ -1,0 +1,56 @@
+/**
+ * @license Apache-2.0
+ *
+ * Copyright (c) 2018 The Stdlib Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+// MODULES //
+
+var append = require("fs").appendFile;
+
+// MAIN //
+
+/**
+ * Asynchronously append data to a file, creating the file if it does not yet exist.
+ *
+ * @param {(string|Buffer|integer)} path - file path or file descriptor
+ * @param {(string|Buffer)} data - data to append
+ * @param {(Object|string)} [options] - options
+ * @param {Function} clbk - callback to invoke after appending data to the file
+ *
+ * @example
+ * function onAppend( err ) {
+ *     if ( err ) {
+ *         throw err;
+ *     }
+ * }
+ *
+ * appendFile( './beep/boop.txt', 'appended something\n', onAppend );
+ */
+function appendFile() {
+  var args;
+  var i;
+  args = [];
+  for (i = 0; i < arguments.length; i++) {
+    args.push(arguments[i]);
+  }
+  append.apply(null, args);
+}
+
+// EXPORTS //
+
+module.exports = appendFile;

--- a/lib/node_modules/@stdlib/fs/append-file/lib/async.js
+++ b/lib/node_modules/@stdlib/fs/append-file/lib/async.js
@@ -18,7 +18,6 @@
 
 'use strict';
 
-
 // MODULES //
 
 var append = require( 'fs' ).appendFile;
@@ -29,15 +28,15 @@ var append = require( 'fs' ).appendFile;
 /**
 * Asynchronously append data to a file, creating the file if it does not yet exist.
 *
-* @param {( string|Buffer|integer )} path - file path or file descriptor
-* @param {( string|Buffer )} data - data to append
-* @param {( Object|string )} [options] - options
-* @param { Function } clbk - callback to invoke after appending data to the file
+* @param {(string|Buffer|integer)} path - file path or file descriptor
+* @param {(string|Buffer)} data - data to append
+* @param {(Object|string)} [options] - options
+* @param {Function} clbk - callback to invoke after appending data to the file
 *
 * @example
 * function onAppend( err ) {
 *     if ( err ) {
-*         throw err;
+*         console.log( err.message );
 *     }
 * }
 *

--- a/lib/node_modules/@stdlib/fs/append-file/lib/async.js
+++ b/lib/node_modules/@stdlib/fs/append-file/lib/async.js
@@ -1,55 +1,58 @@
 /**
- * @license Apache-2.0
- *
- * Copyright (c) 2024 The Stdlib Authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
-"use strict";
+'use strict';
+
 
 // MODULES //
 
-var append = require("fs").appendFile;
+var append = require( 'fs' ).appendFile;
+
 
 // MAIN //
 
 /**
- * Asynchronously append data to a file, creating the file if it does not yet exist.
- *
- * @param {(string|Buffer|integer)} path - file path or file descriptor
- * @param {(string|Buffer)} data - data to append
- * @param {(Object|string)} [options] - options
- * @param {Function} clbk - callback to invoke after appending data to the file
- *
- * @example
- * function onAppend( err ) {
- *     if ( err ) {
- *         throw err;
- *     }
- * }
- *
- * appendFile( './beep/boop.txt', 'appended something\n', onAppend );
- */
+* Asynchronously append data to a file, creating the file if it does not yet exist.
+*
+* @param {( string|Buffer|integer )} path - file path or file descriptor
+* @param {( string|Buffer )} data - data to append
+* @param {( Object|string )} [options] - options
+* @param { Function } clbk - callback to invoke after appending data to the file
+*
+* @example
+* function onAppend( err ) {
+*     if ( err ) {
+*         throw err;
+*     }
+* }
+*
+* appendFile( './beep/boop.txt', 'appended something\n', onAppend );
+*/
 function appendFile() {
-  var args;
-  var i;
-  args = [];
-  for (i = 0; i < arguments.length; i++) {
-    args.push(arguments[i]);
-  }
-  append.apply(null, args);
+	var args;
+	var i;
+	args = [];
+	for (i = 0; i < arguments.length; i++) {
+		args.push( arguments[i] );
+	}
+	append.apply( null, args );
 }
+
 
 // EXPORTS //
 

--- a/lib/node_modules/@stdlib/fs/append-file/lib/async.js
+++ b/lib/node_modules/@stdlib/fs/append-file/lib/async.js
@@ -1,7 +1,7 @@
 /**
  * @license Apache-2.0
  *
- * Copyright (c) 2018 The Stdlib Authors.
+ * Copyright (c) 2024 The Stdlib Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/fs/append-file/lib/index.js
+++ b/lib/node_modules/@stdlib/fs/append-file/lib/index.js
@@ -37,12 +37,10 @@
 * @example
 * var appendFileSync = require( '@stdlib/fs/append-file' ).sync;
 *
-* try {
-*	appendFileSync('./beep/boop.txt', 'data to append\n');
-*	console.log('The "data to append" was appended to file!');
-*  } catch (err) {
-*	   throw err;
-*  }
+* var err = appendFileSync( './beep/boop.txt', 'data to append\n' );
+* if ( err instanceof Error ) {
+*     throw err;
+* }
 */
 
 

--- a/lib/node_modules/@stdlib/fs/append-file/lib/index.js
+++ b/lib/node_modules/@stdlib/fs/append-file/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Appends data to a file.
+* Append data to a file.
 *
 * @module @stdlib/fs/append-file
 *

--- a/lib/node_modules/@stdlib/fs/append-file/lib/index.js
+++ b/lib/node_modules/@stdlib/fs/append-file/lib/index.js
@@ -1,59 +1,62 @@
 /**
- * @license Apache-2.0
- *
- * Copyright (c) 2024 The Stdlib Authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
-"use strict";
+'use strict';
 
 /**
- * Appends data to a file.
- *
- * @module @stdlib/fs/append-file
- *
- * @example
- * var appendFile = require( '@stdlib/fs/append-file' );
- *
- * function onAppend( err ) {
- *     if ( err ) {
- *         throw err;
- *     }
- * }
- *
- * appendFile( './beep/boop.txt', 'appended something\n', onAppend );
- *
- * @example
- * var appendFileSync = require( '@stdlib/fs/append-file' ).sync;
- *
- * try {
- *	appendFileSync('./beep/boop.txt', 'data to append\n');
- *	console.log('The "data to append" was appended to file!');
- *  } catch (err) {
- *	   throw err;
- *  }
- */
+* Appends data to a file.
+*
+* @module @stdlib/fs/append-file
+*
+* @example
+* var appendFile = require( '@stdlib/fs/append-file' );
+*
+* function onAppend( err ) {
+*     if ( err ) {
+*         throw err;
+*     }
+* }
+*
+* appendFile( './beep/boop.txt', 'appended something\n', onAppend );
+*
+* @example
+* var appendFileSync = require( '@stdlib/fs/append-file' ).sync;
+*
+* try {
+*	appendFileSync('./beep/boop.txt', 'data to append\n');
+*	console.log('The "data to append" was appended to file!');
+*  } catch (err) {
+*	   throw err;
+*  }
+*/
+
 
 // MODULES //
 
-var setReadOnly = require("@stdlib/utils/define-nonenumerable-read-only-property");
-var async = require("./async.js");
-var sync = require("./sync.js");
+var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
+var async = require( './async.js' );
+var sync = require( './sync.js' );
+
 
 // MAIN //
 
-setReadOnly(async, "sync", sync);
+setReadOnly( async, 'sync', sync );
+
 
 // EXPORTS //
 

--- a/lib/node_modules/@stdlib/fs/append-file/lib/index.js
+++ b/lib/node_modules/@stdlib/fs/append-file/lib/index.js
@@ -28,7 +28,7 @@
 *
 * function onAppend( err ) {
 *     if ( err ) {
-*         throw err;
+*         console.log( err.message );
 *     }
 * }
 *

--- a/lib/node_modules/@stdlib/fs/append-file/lib/index.js
+++ b/lib/node_modules/@stdlib/fs/append-file/lib/index.js
@@ -1,0 +1,60 @@
+/**
+ * @license Apache-2.0
+ *
+ * Copyright (c) 2018 The Stdlib Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+/**
+ * Appends data to a file.
+ *
+ * @module @stdlib/fs/append-file
+ *
+ * @example
+ * var appendFile = require( '@stdlib/fs/append-file' );
+ *
+ * function onAppend( err ) {
+ *     if ( err ) {
+ *         throw err;
+ *     }
+ * }
+ *
+ * appendFile( './beep/boop.txt', 'appended something\n', onAppend );
+ *
+ * @example
+ * var appendFileSync = require( '@stdlib/fs/append-file' ).sync;
+ *
+ * try {
+ *	appendFileSync('./beep/boop.txt', 'data to append\n');
+ *	console.log('The "data to append" was appended to file!');
+ *  } catch (err) {
+ *	   throw err;
+ *  }
+ */
+
+// MODULES //
+
+var setReadOnly = require("@stdlib/utils/define-nonenumerable-read-only-property");
+var async = require("./async.js");
+var sync = require("./sync.js");
+
+// MAIN //
+
+setReadOnly(async, "sync", sync);
+
+// EXPORTS //
+
+module.exports = async;

--- a/lib/node_modules/@stdlib/fs/append-file/lib/index.js
+++ b/lib/node_modules/@stdlib/fs/append-file/lib/index.js
@@ -1,7 +1,7 @@
 /**
  * @license Apache-2.0
  *
- * Copyright (c) 2018 The Stdlib Authors.
+ * Copyright (c) 2024 The Stdlib Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/fs/append-file/lib/sync.js
+++ b/lib/node_modules/@stdlib/fs/append-file/lib/sync.js
@@ -31,13 +31,12 @@ var appendFile = require( 'fs' ).appendFileSync; // eslint-disable-line node/no-
 * @param {(string|Buffer|integer)} path - file path or file descriptor
 * @param {(string|Buffer)} data - data to append
 * @param {(Object|string)} [options] - options
+* @returns {(Error|null)} error object or null
 *
 * @example
-* try {
-*	appendFileSync('./beep/boop.txt', 'data to append\n');
-*	console.log('The "data to append" was appended to file!');
-* } catch (err) {
-*	throw err;
+* var err = appendFileSync( './beep/boop.txt', 'data to append\n' );
+* if ( err instanceof Error ) {
+*     throw err;
 * }
 */
 function appendFileSync( path, data, options ) {
@@ -48,9 +47,9 @@ function appendFileSync( path, data, options ) {
 			appendFile( path, data );
 		}
 	} catch ( err ) {
-		console.log( err.message );
-		throw err;
+		return err;
 	}
+	return null;
 }
 
 

--- a/lib/node_modules/@stdlib/fs/append-file/lib/sync.js
+++ b/lib/node_modules/@stdlib/fs/append-file/lib/sync.js
@@ -30,7 +30,7 @@ var appendFile = require( 'fs' ).appendFileSync; // eslint-disable-line node/no-
 *
 * @param {(string|Buffer|integer)} path - file path or file descriptor
 * @param {(string|Buffer)} data - data to append
-* @param {(Object|string)} [ options ] - options
+* @param {(Object|string)} [options] - options
 *
 * @example
 * try {

--- a/lib/node_modules/@stdlib/fs/append-file/lib/sync.js
+++ b/lib/node_modules/@stdlib/fs/append-file/lib/sync.js
@@ -31,6 +31,7 @@ var appendFile = require( 'fs' ).appendFileSync; // eslint-disable-line node/no-
 * @param {(string|Buffer|integer)} path - file path or file descriptor
 * @param {(string|Buffer)} data - data to append
 * @param {(Object|string)} [options] - options
+* @returns {(void)} void
 *
 * @example
 * try {
@@ -51,7 +52,6 @@ function appendFileSync( path, data, options ) {
 		console.log( err.message );
 		throw err;
 	}
-	return null;
 }
 
 

--- a/lib/node_modules/@stdlib/fs/append-file/lib/sync.js
+++ b/lib/node_modules/@stdlib/fs/append-file/lib/sync.js
@@ -1,57 +1,60 @@
 /**
- * @license Apache-2.0
- *
- * Copyright (c) 2024 The Stdlib Authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
-"use strict";
+'use strict';
+
 
 // MODULES //
 
-var appendFile = require("fs").appendFileSync; // eslint-disable-line node/no-sync
+var appendFile = require( 'fs' ).appendFileSync; // eslint-disable-line node/no-sync
+
 
 // MAIN //
 
 /**
- * Synchronously append data to a file, creating the file if it does not yet exist.
- *
- * @param {(string|Buffer|integer)} path - file path or file descriptor
- * @param {(string|Buffer)} data - data to append
- * @param {(Object|string)} [options] - options
- *
- * @example
- * try {
- *	appendFileSync('./beep/boop.txt', 'data to append\n');
- *	console.log('The "data to append" was appended to file!');
- *  } catch (err) {
- *	   throw err;
- *  }
- */
+* Synchronously append data to a file, creating the file if it does not yet exist.
+*
+* @param {( string|Buffer|integer )} path - file path or file descriptor
+* @param {( string|Buffer )} data - data to append
+* @param {( Object|string )} [ options ] - options
+*
+* @example
+* try {
+*	appendFileSync('./beep/boop.txt', 'data to append\n');
+*	console.log('The "data to append" was appended to file!');
+*  } catch (err) {
+*	   throw err;
+*  }
+*/
 
-function appendFileSync(path, data, options) {
-  try {
-    if (arguments.length > 2) {
-      appendFile(path, data, options);
-    } else {
-      appendFile(path, data);
-    }
-  } catch (err) {
-    throw err;
-  }
-  return null;
+function appendFileSync( path, data, options ) {
+	try {
+		if ( arguments.length > 2 ) {
+			appendFile( path, data, options );
+		} else {
+			appendFile( path, data );
+		}
+	} catch ( err ) {
+		throw err;
+	}
+	return null;
 }
+
 
 // EXPORTS //
 

--- a/lib/node_modules/@stdlib/fs/append-file/lib/sync.js
+++ b/lib/node_modules/@stdlib/fs/append-file/lib/sync.js
@@ -40,7 +40,6 @@ var appendFile = require( 'fs' ).appendFileSync; // eslint-disable-line node/no-
 *	   throw err;
 *  }
 */
-
 function appendFileSync( path, data, options ) {
 	try {
 		if ( arguments.length > 2 ) {
@@ -49,6 +48,7 @@ function appendFileSync( path, data, options ) {
 			appendFile( path, data );
 		}
 	} catch ( err ) {
+		console.log( err.message );
 		throw err;
 	}
 	return null;

--- a/lib/node_modules/@stdlib/fs/append-file/lib/sync.js
+++ b/lib/node_modules/@stdlib/fs/append-file/lib/sync.js
@@ -1,7 +1,7 @@
 /**
  * @license Apache-2.0
  *
- * Copyright (c) 2018 The Stdlib Authors.
+ * Copyright (c) 2024 The Stdlib Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/fs/append-file/lib/sync.js
+++ b/lib/node_modules/@stdlib/fs/append-file/lib/sync.js
@@ -31,7 +31,6 @@ var appendFile = require( 'fs' ).appendFileSync; // eslint-disable-line node/no-
 * @param {(string|Buffer|integer)} path - file path or file descriptor
 * @param {(string|Buffer)} data - data to append
 * @param {(Object|string)} [options] - options
-* @returns {(void)} void
 *
 * @example
 * try {

--- a/lib/node_modules/@stdlib/fs/append-file/lib/sync.js
+++ b/lib/node_modules/@stdlib/fs/append-file/lib/sync.js
@@ -18,7 +18,6 @@
 
 'use strict';
 
-
 // MODULES //
 
 var appendFile = require( 'fs' ).appendFileSync; // eslint-disable-line node/no-sync
@@ -29,9 +28,9 @@ var appendFile = require( 'fs' ).appendFileSync; // eslint-disable-line node/no-
 /**
 * Synchronously append data to a file, creating the file if it does not yet exist.
 *
-* @param {( string|Buffer|integer )} path - file path or file descriptor
-* @param {( string|Buffer )} data - data to append
-* @param {( Object|string )} [ options ] - options
+* @param {(string|Buffer|integer)} path - file path or file descriptor
+* @param {(string|Buffer)} data - data to append
+* @param {(Object|string)} [ options ] - options
 *
 * @example
 * try {

--- a/lib/node_modules/@stdlib/fs/append-file/lib/sync.js
+++ b/lib/node_modules/@stdlib/fs/append-file/lib/sync.js
@@ -36,9 +36,9 @@ var appendFile = require( 'fs' ).appendFileSync; // eslint-disable-line node/no-
 * try {
 *	appendFileSync('./beep/boop.txt', 'data to append\n');
 *	console.log('The "data to append" was appended to file!');
-*  } catch (err) {
-*	   throw err;
-*  }
+* } catch (err) {
+*	throw err;
+* }
 */
 function appendFileSync( path, data, options ) {
 	try {

--- a/lib/node_modules/@stdlib/fs/append-file/lib/sync.js
+++ b/lib/node_modules/@stdlib/fs/append-file/lib/sync.js
@@ -1,0 +1,58 @@
+/**
+ * @license Apache-2.0
+ *
+ * Copyright (c) 2018 The Stdlib Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+// MODULES //
+
+var appendFile = require("fs").appendFileSync; // eslint-disable-line node/no-sync
+
+// MAIN //
+
+/**
+ * Synchronously append data to a file, creating the file if it does not yet exist.
+ *
+ * @param {(string|Buffer|integer)} path - file path or file descriptor
+ * @param {(string|Buffer)} data - data to append
+ * @param {(Object|string)} [options] - options
+ *
+ * @example
+ * try {
+ *	appendFileSync('./beep/boop.txt', 'data to append\n');
+ *	console.log('The "data to append" was appended to file!');
+ *  } catch (err) {
+ *	   throw err;
+ *  }
+ */
+
+function appendFileSync(path, data, options) {
+  try {
+    if (arguments.length > 2) {
+      appendFile(path, data, options);
+    } else {
+      appendFile(path, data);
+    }
+  } catch (err) {
+    throw err;
+  }
+  return null;
+}
+
+// EXPORTS //
+
+module.exports = appendFileSync;

--- a/lib/node_modules/@stdlib/fs/append-file/package.json
+++ b/lib/node_modules/@stdlib/fs/append-file/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/fs/append-file",
   "version": "0.0.0",
-  "description": "Appends data to a file.",
+  "description": "Append data to a file.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/fs/append-file/package.json
+++ b/lib/node_modules/@stdlib/fs/append-file/package.json
@@ -34,7 +34,6 @@
   "bugs": {
     "url": "https://github.com/stdlib-js/stdlib/issues"
   },
-  "dependencies": {},
   "devDependencies": {},
   "engines": {
     "node": ">=0.10.0",

--- a/lib/node_modules/@stdlib/fs/append-file/package.json
+++ b/lib/node_modules/@stdlib/fs/append-file/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@stdlib/fs/append-file",
+  "version": "0.0.0",
+  "description": "Appends data to a file.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "bin": {
+    "append-file": "./bin/cli"
+  },
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdfs",
+    "fs",
+    "appendfile",
+    "appendfilesync",
+    "path",
+    "async",
+    "sync",
+    "file",
+    "append",
+    "appends",
+    "open",
+    "filesystem"
+  ]
+}

--- a/lib/node_modules/@stdlib/fs/append-file/package.json
+++ b/lib/node_modules/@stdlib/fs/append-file/package.json
@@ -34,6 +34,7 @@
   "bugs": {
     "url": "https://github.com/stdlib-js/stdlib/issues"
   },
+  "dependencies": {},
   "devDependencies": {},
   "engines": {
     "node": ">=0.10.0",

--- a/lib/node_modules/@stdlib/fs/append-file/test/fixtures/stdin_error.js.txt
+++ b/lib/node_modules/@stdlib/fs/append-file/test/fixtures/stdin_error.js.txt
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/fs/append-file/test/fixtures/stdin_error.js.txt
+++ b/lib/node_modules/@stdlib/fs/append-file/test/fixtures/stdin_error.js.txt
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2018 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -16,26 +16,19 @@
 * limitations under the License.
 */
 
-'use strict';
+var proc = require( 'process' );
+var resolve = require( 'path' ).resolve;
+var proxyquire = require( 'proxyquire' );
 
-// MODULES //
+var fpath = resolve( __dirname, '..', 'bin', 'cli' );
 
-var tape = require( 'tape' );
-var appendFile = require( '@stdlib/fs/append-file/lib' );
+proc.stdin.isTTY = false;
+proc.argv[ 2 ] = resolve( __dirname, 'fixtures', 'file.txt' );
 
+proxyquire( fpath, {
+	'@stdlib/process/read-stdin': stdin
+});
 
-// TESTS //
-
-tape( 'main export is a function', function test( t ) {
-	t.ok( true, __filename );
-	t.strictEqual( typeof appendFile, 'function', 'main export is a function' );
-	t.end();
-} );
-
-tape(
-	'attached to the main export is a method that synchronously appends data to a file',
-	function test( t ) {
-		t.strictEqual( typeof appendFile.sync, 'function', 'has method' );
-		t.end();
-	}
-);
+function stdin( clbk ) {
+	clbk( new Error( 'beep' ) );
+}

--- a/lib/node_modules/@stdlib/fs/append-file/test/fixtures/write_error.js.txt
+++ b/lib/node_modules/@stdlib/fs/append-file/test/fixtures/write_error.js.txt
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/fs/append-file/test/fixtures/write_error.js.txt
+++ b/lib/node_modules/@stdlib/fs/append-file/test/fixtures/write_error.js.txt
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+var proc = require( 'process' );
+var resolve = require( 'path' ).resolve;
+var proxyquire = require( 'proxyquire' );
+
+var fpath = resolve( __dirname, '..', 'bin', 'cli' );
+
+proc.stdin.isTTY = false;
+proc.argv[ 2 ] = resolve( __dirname, 'fixtures', 'file.txt' );
+
+proxyquire( fpath, {
+	'@stdlib/process/read-stdin': stdin,
+	'./../lib': appendFile
+});
+
+function stdin( clbk ) {
+	clbk( null, 'beep boop foo' );
+}
+
+function appendFile() {
+	var clbk = arguments[ arguments.length-1 ];
+	setTimeout( onTimeout, 0 );
+	function onTimeout() {
+		clbk( new Error( 'beep' ) );
+	}
+}

--- a/lib/node_modules/@stdlib/fs/append-file/test/test.async.js
+++ b/lib/node_modules/@stdlib/fs/append-file/test/test.async.js
@@ -26,7 +26,7 @@ var readFile = require( '@stdlib/fs/read-file' ).sync;
 var writeFileSync = require( '@stdlib/fs/write-file' ).sync;
 var IS_BROWSER = require( '@stdlib/assert/is-browser' );
 var string2buffer = require( '@stdlib/buffer/from-string' );
-var appendFile = require( './../lib/async' );
+var appendFile = require( './../lib/async.js' );
 
 
 // VARIABLES //

--- a/lib/node_modules/@stdlib/fs/append-file/test/test.async.js
+++ b/lib/node_modules/@stdlib/fs/append-file/test/test.async.js
@@ -26,14 +26,14 @@ var readFile = require( '@stdlib/fs/read-file' ).sync;
 var writeFileSync = require( '@stdlib/fs/write-file' ).sync;
 var IS_BROWSER = require( '@stdlib/assert/is-browser' );
 var string2buffer = require( '@stdlib/buffer/from-string' );
-var appendFile = require( '@stdlib/fs/append-file/lib/async.js' );
+var appendFile = require( './../lib/async' );
 
 
 // VARIABLES //
 
 // Don't run tests in the browser...for now...
 var opts = {
-	skip: IS_BROWSER, // FIXME
+	'skip': IS_BROWSER // FIXME
 };
 var fpath = join( __dirname, 'fixtures', 'file.txt' );
 var DATA = readFile( fpath, 'utf8' );
@@ -61,7 +61,7 @@ tape( 'main export is a function', function test( t ) {
 	t.ok( true, __filename );
 	t.strictEqual( typeof appendFile, 'function', 'main export is a function' );
 	t.end();
-} );
+});
 
 tape( 'the function appends data to a file (string)', opts, function test( t ) {
 	var expected = 'beep boop 1';
@@ -78,7 +78,7 @@ tape( 'the function appends data to a file (string)', opts, function test( t ) {
 		restore();
 		t.end();
 	}
-} );
+});
 
 tape( 'the function appends data to a file (buffer)', opts, function test( t ) {
 	var expected = 'beep boop 2';
@@ -95,128 +95,107 @@ tape( 'the function appends data to a file (buffer)', opts, function test( t ) {
 		restore();
 		t.end();
 	}
-} );
+});
 
-tape(
-	'the function appends data to a file using provided options (option string)',
-	opts,
-	function test( t ) {
-		var expected = 'beep boop 3';
-		appendFile( fpath, 'beep boop 3', 'utf8', onAppend );
+tape( 'the function appends data to a file using provided options (option string)', opts, function test( t ) {
+	var expected = 'beep boop 3';
+	appendFile( fpath, 'beep boop 3', 'utf8', onAppend );
 
-		function onAppend( error ) {
-			var actual;
-			if ( error ) {
-				t.fail( error.message );
-			}
-			actual = readFile( fpath, 'utf8' );
-			t.strictEqual( actual, expected, 'file contains expected contents' );
-
-			restore();
-			t.end();
+	function onAppend( error ) {
+		var actual;
+		if ( error ) {
+			t.fail( error.message );
 		}
-	}
-);
+		actual = readFile( fpath, 'utf8' );
+		t.strictEqual( actual, expected, 'file contains expected contents' );
 
-tape(
-	'the function appends data to a file using provided options (option object)',
-	opts,
-	function test( t ) {
+		restore();
+		t.end();
+	}
+});
+
+tape( 'the function appends data to a file using provided options (option object)', opts, function test( t ) {
+	var expected;
+	var opts;
+
+	expected = 'beep boop 4';
+	opts = {
+		'encoding': 'utf8'
+	};
+	appendFile( fpath, 'beep boop 4', opts, onAppend );
+
+	function onAppend( error ) {
+		var actual;
+		if ( error ) {
+			t.fail( error.message );
+		}
+		actual = readFile( fpath, 'utf8' );
+		t.strictEqual( actual, expected, 'file contains expected contents' );
+
+		restore();
+		t.end();
+	}
+});
+
+tape( 'if the function encounters an error, the function returns the error', opts, function test( t ) {
+	var file = 'beepboopbapbop/dkfjldjfaklsjf/bdlfalfas/bkldflakfjas/travashHRD'; // non-existent directory path
+	appendFile( file, 'beepboopbapbop', onAppend );
+
+	function onAppend( error ) {
 		var expected;
-		var opts;
+		var actual;
 
-		expected = 'beep boop 4';
-		opts = {
-			encoding: 'utf8',
-		};
-		appendFile( fpath, 'beep boop 4', opts, onAppend );
+		t.strictEqual( error instanceof Error, true, error.message );
 
-		function onAppend( error ) {
-			var actual;
-			if ( error ) {
-				t.fail( error.message );
-			}
-			actual = readFile( fpath, 'utf8' );
-			t.strictEqual( actual, expected, 'file contains expected contents' );
+		expected = DATA;
+		actual = readFile( fpath, 'utf8' );
+		t.strictEqual( actual, expected, 'file contains expected contents' );
 
-			restore();
-			t.end();
-		}
+		restore();
+		t.end();
 	}
-);
+});
 
-tape(
-	'if the function encounters an error, the function returns the error',
-	opts,
-	function test( t ) {
-		var file =
-			'beepboopbapbop/dkfjldjfaklsjf/bdlfalfas/bkldflakfjas/travashHRD'; // non-existent directory path
-		appendFile( file, 'beepboopbapbop', onAppend );
+tape( 'if the function encounters an error, the function returns the error (option string)', opts, function test( t ) {
+	var file = 'beepboopbapbop/dkfjldjfaklsjf/bdlfalfas/bkldflakfjas'; // non-existent directory path
+	appendFile( file, 'beepboopbapbop', 'utf8', onAppend );
 
-		function onAppend( error ) {
-			var expected;
-			var actual;
+	function onAppend( error ) {
+		var expected;
+		var actual;
 
-			t.strictEqual( error instanceof Error, true, error.message );
+		t.strictEqual( error instanceof Error, true, error.message );
 
-			expected = DATA;
-			actual = readFile( fpath, 'utf8' );
-			t.strictEqual( actual, expected, 'file contains expected contents' );
+		expected = DATA;
+		actual = readFile( fpath, 'utf8' );
+		t.strictEqual( actual, expected, 'file contains expected contents' );
 
-			restore();
-			t.end();
-		}
+		restore();
+		t.end();
 	}
-);
+});
 
-tape(
-	'if the function encounters an error, the function returns the error (option string)',
-	opts,
-	function test( t ) {
-		var file = 'beepboopbapbop/dkfjldjfaklsjf/bdlfalfas/bkldflakfjas'; // non-existent directory path
-		appendFile( file, 'beepboopbapbop', 'utf8', onAppend );
+tape( 'if the function encounters an error, the function returns the error (option object)', opts, function test( t ) {
+	var file;
+	var opts;
 
-		function onAppend( error ) {
-			var expected;
-			var actual;
+	file = 'beepboopbapbop/dkfjldjfaklsjf/bdlfalftisas/bkldflHRDakfjas'; // non-existent directory path
+	opts = {
+		'encoding': 'utf8'
+	};
+	appendFile( file, 'beepboopbapbop', opts, onAppend );
 
-			t.strictEqual( error instanceof Error, true, error.message );
+	function onAppend( error ) {
+		var expected;
+		var actual;
 
-			expected = DATA;
-			actual = readFile( fpath, 'utf8' );
-			t.strictEqual( actual, expected, 'file contains expected contents' );
+		t.strictEqual( error instanceof Error, true, error.message );
 
-			restore();
-			t.end();
-		}
+		expected = DATA;
+		actual = readFile( fpath, 'utf8' );
+		t.strictEqual( actual, expected, 'file contains expected contents' );
+
+		restore();
+		t.end();
 	}
-);
-
-tape(
-	'if the function encounters an error, the function returns the error (option object)',
-	opts,
-	function test( t ) {
-		var file;
-		var opts;
-
-		file = 'beepboopbapbop/dkfjldjfaklsjf/bdlfalftisas/bkldflHRDakfjas'; // non-existent directory path
-		opts = {
-			encoding: 'utf8',
-		};
-		appendFile( file, 'beepboopbapbop', opts, onAppend );
-
-		function onAppend( error ) {
-			var expected;
-			var actual;
-
-			t.strictEqual( error instanceof Error, true, error.message );
-
-			expected = DATA;
-			actual = readFile( fpath, 'utf8' );
-			t.strictEqual( actual, expected, 'file contains expected contents' );
-
-			restore();
-			t.end();
-		}
-	}
-);
+});

--- a/lib/node_modules/@stdlib/fs/append-file/test/test.async.js
+++ b/lib/node_modules/@stdlib/fs/append-file/test/test.async.js
@@ -1,0 +1,219 @@
+/**
+ * @license Apache-2.0
+ *
+ * Copyright (c) 2018 The Stdlib Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+// MODULES //
+
+var join = require("path").join;
+var tape = require("tape");
+var readFile = require("@stdlib/fs/read-file").sync;
+var IS_BROWSER = require("@stdlib/assert/is-browser");
+var string2buffer = require("@stdlib/buffer/from-string");
+var appendFileSync = require("../lib/sync.js");
+var appendFile = require("../lib/async.js");
+
+// VARIABLES //
+
+// Don't run tests in the browser...for now...
+var opts = {
+  skip: IS_BROWSER, // FIXME
+};
+var fpath = join(__dirname, "fixtures", "file.txt");
+var DATA = readFile(fpath, "utf8");
+
+// FUNCTIONS //
+
+/**
+ * Restores a fixture file.
+ *
+ * ## Notes
+ *
+ * -   Every function which has the **potential** to affect the fixture file should invoke this function immediately before calling `t.end()`.
+ *
+ * @private
+ */
+function restore() {
+  appendFileSync(fpath, DATA);
+}
+
+// TESTS //
+
+tape("main export is a function", function test(t) {
+  t.ok(true, __filename);
+  t.strictEqual(typeof appendFile, "function", "main export is a function");
+  t.end();
+});
+
+tape("the function appends data to a file (string)", opts, function test(t) {
+  var expected = "beep boop 1";
+  appendFile(fpath, "beep boop 1", onAppend);
+
+  function onAppend(error) {
+    var actual;
+    if (error) {
+      t.fail(error.message);
+    }
+    actual = readFile(fpath, "utf8");
+    t.strictEqual(actual, expected, "file contains expected contents");
+
+    restore();
+    t.end();
+  }
+});
+
+tape("the function appends data to a file (buffer)", opts, function test(t) {
+  var expected = "beep boop 2";
+  appendFile(fpath, string2buffer("beep boop 2"), onAppend);
+
+  function onAppend(error) {
+    var actual;
+    if (error) {
+      t.fail(error.message);
+    }
+    actual = readFile(fpath, "utf8");
+    t.strictEqual(actual, expected, "file contains expected contents");
+
+    restore();
+    t.end();
+  }
+});
+
+tape(
+  "the function appends data to a file using provided options (option string)",
+  opts,
+  function test(t) {
+    var expected = "beep boop 3";
+    appendFile(fpath, "beep boop 3", "utf8", onAppend);
+
+    function onAppend(error) {
+      var actual;
+      if (error) {
+        t.fail(error.message);
+      }
+      actual = readFile(fpath, "utf8");
+      t.strictEqual(actual, expected, "file contains expected contents");
+
+      restore();
+      t.end();
+    }
+  }
+);
+
+tape(
+  "the function appends data to a file using provided options (option object)",
+  opts,
+  function test(t) {
+    var expected;
+    var opts;
+
+    expected = "beep boop 4";
+    opts = {
+      encoding: "utf8",
+    };
+    appendFile(fpath, "beep boop 4", opts, onAppend);
+
+    function onAppend(error) {
+      var actual;
+      if (error) {
+        t.fail(error.message);
+      }
+      actual = readFile(fpath, "utf8");
+      t.strictEqual(actual, expected, "file contains expected contents");
+
+      restore();
+      t.end();
+    }
+  }
+);
+
+tape(
+  "if the function encounters an error, the function returns the error",
+  opts,
+  function test(t) {
+    var file =
+      "beepboopbapbop/dkfjldjfaklsjf/bdlfalfas/bkldflakfjas/travashHRD"; // non-existent directory path
+    appendFile(file, "beepboopbapbop", onAppend);
+
+    function onAppend(error) {
+      var expected;
+      var actual;
+
+      t.strictEqual(error instanceof Error, true, error.message);
+
+      expected = DATA;
+      actual = readFile(fpath, "utf8");
+      t.strictEqual(actual, expected, "file contains expected contents");
+
+      restore();
+      t.end();
+    }
+  }
+);
+
+tape(
+  "if the function encounters an error, the function returns the error (option string)",
+  opts,
+  function test(t) {
+    var file = "beepboopbapbop/dkfjldjfaklsjf/bdlfalfas/bkldflakfjas"; // non-existent directory path
+    appendFile(file, "beepboopbapbop", "utf8", onAppend);
+
+    function onAppend(error) {
+      var expected;
+      var actual;
+
+      t.strictEqual(error instanceof Error, true, error.message);
+
+      expected = DATA;
+      actual = readFile(fpath, "utf8");
+      t.strictEqual(actual, expected, "file contains expected contents");
+
+      restore();
+      t.end();
+    }
+  }
+);
+
+tape(
+  "if the function encounters an error, the function returns the error (option object)",
+  opts,
+  function test(t) {
+    var file;
+    var opts;
+
+    file = "beepboopbapbop/dkfjldjfaklsjf/bdlfalftisas/bkldflHRDakfjas"; // non-existent directory path
+    opts = {
+      encoding: "utf8",
+    };
+    appendFile(file, "beepboopbapbop", opts, onAppend);
+
+    function onAppend(error) {
+      var expected;
+      var actual;
+
+      t.strictEqual(error instanceof Error, true, error.message);
+
+      expected = DATA;
+      actual = readFile(fpath, "utf8");
+      t.strictEqual(actual, expected, "file contains expected contents");
+
+      restore();
+      t.end();
+    }
+  }
+);

--- a/lib/node_modules/@stdlib/fs/append-file/test/test.async.js
+++ b/lib/node_modules/@stdlib/fs/append-file/test/test.async.js
@@ -18,7 +18,6 @@
 
 'use strict';
 
-
 // MODULES //
 
 var join = require( 'path' ).join;
@@ -27,7 +26,7 @@ var readFile = require( '@stdlib/fs/read-file' ).sync;
 var writeFileSync = require( '@stdlib/fs/write-file' ).sync;
 var IS_BROWSER = require( '@stdlib/assert/is-browser' );
 var string2buffer = require( '@stdlib/buffer/from-string' );
-var appendFile = require( '../lib/async.js' );
+var appendFile = require( '@stdlib/fs/append-file/lib/async.js' );
 
 
 // VARIABLES //

--- a/lib/node_modules/@stdlib/fs/append-file/test/test.async.js
+++ b/lib/node_modules/@stdlib/fs/append-file/test/test.async.js
@@ -1,219 +1,223 @@
 /**
- * @license Apache-2.0
- *
- * Copyright (c) 2024 The Stdlib Authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
-"use strict";
+'use strict';
+
 
 // MODULES //
 
-var join = require("path").join;
-var tape = require("tape");
-var readFile = require("@stdlib/fs/read-file").sync;
-var writeFileSync = require("@stdlib/fs/write-file").sync;
-var IS_BROWSER = require("@stdlib/assert/is-browser");
-var string2buffer = require("@stdlib/buffer/from-string");
-var appendFile = require("../lib/async.js");
+var join = require( 'path' ).join;
+var tape = require( 'tape' );
+var readFile = require( '@stdlib/fs/read-file' ).sync;
+var writeFileSync = require( '@stdlib/fs/write-file' ).sync;
+var IS_BROWSER = require( '@stdlib/assert/is-browser' );
+var string2buffer = require( '@stdlib/buffer/from-string' );
+var appendFile = require( '../lib/async.js' );
+
 
 // VARIABLES //
 
 // Don't run tests in the browser...for now...
 var opts = {
-  skip: IS_BROWSER, // FIXME
+	skip: IS_BROWSER, // FIXME
 };
-var fpath = join(__dirname, "fixtures", "file.txt");
-var DATA = readFile(fpath, "utf8");
+var fpath = join( __dirname, 'fixtures', 'file.txt' );
+var DATA = readFile( fpath, 'utf8' );
+
 
 // FUNCTIONS //
 
 /**
- * Restores a fixture file.
- *
- * ## Notes
- *
- * -   Every function which has the **potential** to affect the fixture file should invoke this function immediately before calling `t.end()`.
- *
- * @private
- */
+* Restores a fixture file.
+*
+* ## Notes
+*
+* -   Every function which has the **potential** to affect the fixture file should invoke this function immediately before calling `t.end()`.
+*
+* @private
+*/
 function restore() {
-  writeFileSync(fpath, DATA);
+	writeFileSync( fpath, DATA );
 }
+
 
 // TESTS //
 
-tape("main export is a function", function test(t) {
-  t.ok(true, __filename);
-  t.strictEqual(typeof appendFile, "function", "main export is a function");
-  t.end();
-});
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof appendFile, 'function', 'main export is a function' );
+	t.end();
+} );
 
-tape("the function appends data to a file (string)", opts, function test(t) {
-  var expected = "beep boop 1";
-  appendFile(fpath, "beep boop 1", onAppend);
+tape( 'the function appends data to a file (string)', opts, function test( t ) {
+	var expected = 'beep boop 1';
+	appendFile( fpath, 'beep boop 1', onAppend );
 
-  function onAppend(error) {
-    var actual;
-    if (error) {
-      t.fail(error.message);
-    }
-    actual = readFile(fpath, "utf8");
-    t.strictEqual(actual, expected, "file contains expected contents");
+	function onAppend( error ) {
+		var actual;
+		if ( error ) {
+			t.fail( error.message );
+		}
+		actual = readFile( fpath, 'utf8' );
+		t.strictEqual( actual, expected, 'file contains expected contents' );
 
-    restore();
-    t.end();
-  }
-});
+		restore();
+		t.end();
+	}
+} );
 
-tape("the function appends data to a file (buffer)", opts, function test(t) {
-  var expected = "beep boop 2";
-  appendFile(fpath, string2buffer("beep boop 2"), onAppend);
+tape( 'the function appends data to a file (buffer)', opts, function test( t ) {
+	var expected = 'beep boop 2';
+	appendFile( fpath, string2buffer('beep boop 2'), onAppend );
 
-  function onAppend(error) {
-    var actual;
-    if (error) {
-      t.fail(error.message);
-    }
-    actual = readFile(fpath, "utf8");
-    t.strictEqual(actual, expected, "file contains expected contents");
+	function onAppend( error ) {
+		var actual;
+		if ( error ) {
+			t.fail( error.message );
+		}
+		actual = readFile( fpath, 'utf8' );
+		t.strictEqual( actual, expected, 'file contains expected contents' );
 
-    restore();
-    t.end();
-  }
-});
+		restore();
+		t.end();
+	}
+} );
 
 tape(
-  "the function appends data to a file using provided options (option string)",
-  opts,
-  function test(t) {
-    var expected = "beep boop 3";
-    appendFile(fpath, "beep boop 3", "utf8", onAppend);
+	'the function appends data to a file using provided options (option string)',
+	opts,
+	function test( t ) {
+		var expected = 'beep boop 3';
+		appendFile( fpath, 'beep boop 3', 'utf8', onAppend );
 
-    function onAppend(error) {
-      var actual;
-      if (error) {
-        t.fail(error.message);
-      }
-      actual = readFile(fpath, "utf8");
-      t.strictEqual(actual, expected, "file contains expected contents");
+		function onAppend( error ) {
+			var actual;
+			if ( error ) {
+				t.fail( error.message );
+			}
+			actual = readFile( fpath, 'utf8' );
+			t.strictEqual( actual, expected, 'file contains expected contents' );
 
-      restore();
-      t.end();
-    }
-  }
+			restore();
+			t.end();
+		}
+	}
 );
 
 tape(
-  "the function appends data to a file using provided options (option object)",
-  opts,
-  function test(t) {
-    var expected;
-    var opts;
+	'the function appends data to a file using provided options (option object)',
+	opts,
+	function test( t ) {
+		var expected;
+		var opts;
 
-    expected = "beep boop 4";
-    opts = {
-      encoding: "utf8",
-    };
-    appendFile(fpath, "beep boop 4", opts, onAppend);
+		expected = 'beep boop 4';
+		opts = {
+			encoding: 'utf8',
+		};
+		appendFile( fpath, 'beep boop 4', opts, onAppend );
 
-    function onAppend(error) {
-      var actual;
-      if (error) {
-        t.fail(error.message);
-      }
-      actual = readFile(fpath, "utf8");
-      t.strictEqual(actual, expected, "file contains expected contents");
+		function onAppend( error ) {
+			var actual;
+			if ( error ) {
+				t.fail( error.message );
+			}
+			actual = readFile( fpath, 'utf8' );
+			t.strictEqual( actual, expected, 'file contains expected contents' );
 
-      restore();
-      t.end();
-    }
-  }
+			restore();
+			t.end();
+		}
+	}
 );
 
 tape(
-  "if the function encounters an error, the function returns the error",
-  opts,
-  function test(t) {
-    var file =
-      "beepboopbapbop/dkfjldjfaklsjf/bdlfalfas/bkldflakfjas/travashHRD"; // non-existent directory path
-    appendFile(file, "beepboopbapbop", onAppend);
+	'if the function encounters an error, the function returns the error',
+	opts,
+	function test( t ) {
+		var file =
+			'beepboopbapbop/dkfjldjfaklsjf/bdlfalfas/bkldflakfjas/travashHRD'; // non-existent directory path
+		appendFile( file, 'beepboopbapbop', onAppend );
 
-    function onAppend(error) {
-      var expected;
-      var actual;
+		function onAppend( error ) {
+			var expected;
+			var actual;
 
-      t.strictEqual(error instanceof Error, true, error.message);
+			t.strictEqual( error instanceof Error, true, error.message );
 
-      expected = DATA;
-      actual = readFile(fpath, "utf8");
-      t.strictEqual(actual, expected, "file contains expected contents");
+			expected = DATA;
+			actual = readFile( fpath, 'utf8' );
+			t.strictEqual( actual, expected, 'file contains expected contents' );
 
-      restore();
-      t.end();
-    }
-  }
+			restore();
+			t.end();
+		}
+	}
 );
 
 tape(
-  "if the function encounters an error, the function returns the error (option string)",
-  opts,
-  function test(t) {
-    var file = "beepboopbapbop/dkfjldjfaklsjf/bdlfalfas/bkldflakfjas"; // non-existent directory path
-    appendFile(file, "beepboopbapbop", "utf8", onAppend);
+	'if the function encounters an error, the function returns the error (option string)',
+	opts,
+	function test( t ) {
+		var file = 'beepboopbapbop/dkfjldjfaklsjf/bdlfalfas/bkldflakfjas'; // non-existent directory path
+		appendFile( file, 'beepboopbapbop', 'utf8', onAppend );
 
-    function onAppend(error) {
-      var expected;
-      var actual;
+		function onAppend( error ) {
+			var expected;
+			var actual;
 
-      t.strictEqual(error instanceof Error, true, error.message);
+			t.strictEqual( error instanceof Error, true, error.message );
 
-      expected = DATA;
-      actual = readFile(fpath, "utf8");
-      t.strictEqual(actual, expected, "file contains expected contents");
+			expected = DATA;
+			actual = readFile( fpath, 'utf8' );
+			t.strictEqual( actual, expected, 'file contains expected contents' );
 
-      restore();
-      t.end();
-    }
-  }
+			restore();
+			t.end();
+		}
+	}
 );
 
 tape(
-  "if the function encounters an error, the function returns the error (option object)",
-  opts,
-  function test(t) {
-    var file;
-    var opts;
+	'if the function encounters an error, the function returns the error (option object)',
+	opts,
+	function test( t ) {
+		var file;
+		var opts;
 
-    file = "beepboopbapbop/dkfjldjfaklsjf/bdlfalftisas/bkldflHRDakfjas"; // non-existent directory path
-    opts = {
-      encoding: "utf8",
-    };
-    appendFile(file, "beepboopbapbop", opts, onAppend);
+		file = 'beepboopbapbop/dkfjldjfaklsjf/bdlfalftisas/bkldflHRDakfjas'; // non-existent directory path
+		opts = {
+			encoding: 'utf8',
+		};
+		appendFile( file, 'beepboopbapbop', opts, onAppend );
 
-    function onAppend(error) {
-      var expected;
-      var actual;
+		function onAppend( error ) {
+			var expected;
+			var actual;
 
-      t.strictEqual(error instanceof Error, true, error.message);
+			t.strictEqual( error instanceof Error, true, error.message );
 
-      expected = DATA;
-      actual = readFile(fpath, "utf8");
-      t.strictEqual(actual, expected, "file contains expected contents");
+			expected = DATA;
+			actual = readFile( fpath, 'utf8' );
+			t.strictEqual( actual, expected, 'file contains expected contents' );
 
-      restore();
-      t.end();
-    }
-  }
+			restore();
+			t.end();
+		}
+	}
 );

--- a/lib/node_modules/@stdlib/fs/append-file/test/test.async.js
+++ b/lib/node_modules/@stdlib/fs/append-file/test/test.async.js
@@ -1,7 +1,7 @@
 /**
  * @license Apache-2.0
  *
- * Copyright (c) 2018 The Stdlib Authors.
+ * Copyright (c) 2024 The Stdlib Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/fs/append-file/test/test.async.js
+++ b/lib/node_modules/@stdlib/fs/append-file/test/test.async.js
@@ -23,9 +23,9 @@
 var join = require("path").join;
 var tape = require("tape");
 var readFile = require("@stdlib/fs/read-file").sync;
+var writeFileSync = require("@stdlib/fs/write-file").sync;
 var IS_BROWSER = require("@stdlib/assert/is-browser");
 var string2buffer = require("@stdlib/buffer/from-string");
-var appendFileSync = require("../lib/sync.js");
 var appendFile = require("../lib/async.js");
 
 // VARIABLES //
@@ -49,7 +49,7 @@ var DATA = readFile(fpath, "utf8");
  * @private
  */
 function restore() {
-  appendFileSync(fpath, DATA);
+  writeFileSync(fpath, DATA);
 }
 
 // TESTS //

--- a/lib/node_modules/@stdlib/fs/append-file/test/test.cli.js
+++ b/lib/node_modules/@stdlib/fs/append-file/test/test.cli.js
@@ -36,7 +36,7 @@ var writeFileSync = require( '@stdlib/fs/write-file' ).sync;
 
 var fpath = resolve( __dirname, '..', 'bin', 'cli' );
 var opts = {
-	skip: IS_BROWSER || IS_WINDOWS,
+	'skip': IS_BROWSER || IS_WINDOWS
 };
 var FILE = join( __dirname, 'fixtures', 'file.txt' );
 var DATA = readFileSync( FILE );
@@ -68,247 +68,203 @@ function restore() {
 tape( 'command-line interface', function test( t ) {
 	t.ok( true, __filename );
 	t.end();
-} );
+});
 
-tape(
-	'when invoked with a `--help` flag, the command-line interface prints the help text to `stderr`',
-	opts,
-	function test( t ) {
-		var expected;
-		var cmd;
+tape( 'when invoked with a `--help` flag, the command-line interface prints the help text to `stderr`', opts, function test( t ) {
+	var expected;
+	var cmd;
 
-		expected = readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
-			encoding: 'utf8',
-		} );
-		cmd = [ EXEC_PATH, fpath, '--help' ];
+	expected = readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+		'encoding': 'utf8'
+	});
+	cmd = [
+		EXEC_PATH,
+		fpath,
+		'--help'
+	];
 
-		exec( cmd.join(' '), done );
+	exec( cmd.join(' '), done );
 
-		function done( error, stdout, stderr ) {
-			if ( error ) {
-				t.fail( error.message );
-			} else {
-				t.strictEqual(
-					stdout.toString(),
-					'',
-					'does not print to `stdout`'
-				);
-				t.strictEqual(
-					stderr.toString(),
-					expected + '\n',
-					'expected value'
-				);
-			}
-			t.end();
-		}
-	}
-);
-
-tape(
-	'when invoked with a `-h` flag, the command-line interface prints the help text to `stderr`',
-	opts,
-	function test( t ) {
-		var expected;
-		var cmd;
-
-		expected = readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
-			encoding: 'utf8',
-		} );
-		cmd = [ EXEC_PATH, fpath, '-h' ];
-
-		exec( cmd.join(' '), done );
-
-		function done( error, stdout, stderr ) {
-			if ( error ) {
-				t.fail( error.message );
-			} else {
-				t.strictEqual(
-					stdout.toString(),
-					'',
-					'does not print to `stdout`'
-				);
-				t.strictEqual(
-					stderr.toString(),
-					expected + '\n',
-					'expected value'
-				);
-			}
-			t.end();
-		}
-	}
-);
-
-tape(
-	'when invoked with a `--version` flag, the command-line interface prints the version to `stderr`',
-	opts,
-	function test( t ) {
-		var cmd = [ EXEC_PATH, fpath, '--version' ];
-
-		exec( cmd.join(' '), done );
-
-		function done( error, stdout, stderr ) {
-			if ( error ) {
-				t.fail( error.message );
-			} else {
-				t.strictEqual(
-					stdout.toString(),
-					'',
-					'does not print to `stdout`'
-				);
-				t.strictEqual(
-					stderr.toString(),
-					PKG_VERSION + '\n',
-					'expected value'
-				);
-			}
-			t.end();
-		}
-	}
-);
-
-tape(
-	'when invoked with a `-V` flag, the command-line interface prints the version to `stderr`',
-	opts,
-	function test( t ) {
-		var cmd = [ EXEC_PATH, fpath, '-V' ];
-
-		exec( cmd.join(' '), done );
-
-		function done( error, stdout, stderr ) {
-			if ( error ) {
-				t.fail( error.message );
-			} else {
-				t.strictEqual(
-					stdout.toString(),
-					'',
-					'does not print to `stdout`'
-				);
-				t.strictEqual(
-					stderr.toString(),
-					PKG_VERSION + '\n',
-					'expected value'
-				);
-			}
-			t.end();
-		}
-	}
-);
-
-tape(
-	'the command-line interface appends data received from `stdin` to a file',
-	opts,
-	function test( t ) {
-		var expected;
-		var opts;
-		var cmd;
-
-		cmd = [ 'printf "beep boop 1"', '|', EXEC_PATH, fpath, FILE ];
-		opts = {};
-
-		expected = 'beep boop 1';
-		exec( cmd.join( ' ' ), opts, done );
-
-		function done( error, stdout, stderr ) {
-			var actual;
-			if ( error ) {
-				t.fail( error.message );
-			} else {
-				t.strictEqual(
-					stdout.toString(),
-					'',
-					'does not print to `stdout`'
-				);
-				t.strictEqual(
-					stderr.toString(),
-					'',
-					'does not print to `stderr`'
-				);
-			}
-			actual = readFileSync( FILE, 'utf8' );
-			t.strictEqual(actual, expected, 'file contains expected contents');
-
-			restore();
-			t.end();
-		}
-	}
-);
-
-tape(
-	'if an error is encountered when reading from `stdin`, the command-line interface prints an error and sets a non-zero exit code',
-	opts,
-	function test( t ) {
-		var script;
-		var opts;
-		var cmd;
-
-		script = readFileSync(
-			resolve( __dirname, 'fixtures', 'stdin_error.js.txt' ),
-			{
-				encoding: 'utf8',
-			}
-		);
-
-		// Replace single quotes with double quotes:
-		script = replace( script, "'", '"' );
-
-		cmd = [ EXEC_PATH, '-e', "'" + script + "'" ];
-
-		opts = {
-			cwd: __dirname,
-		};
-
-		exec( cmd.join( ' ' ), opts, done );
-
-		function done( error, stdout, stderr ) {
-			if ( error ) {
-				t.pass( error.message );
-				t.strictEqual( error.code, 1, 'expected exit code' );
-			}
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
 			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
-			t.strictEqual( stderr.toString(), 'Error: beep\n', 'expected value' );
-
-			restore();
-			t.end();
+			t.strictEqual( stderr.toString(), expected + '\n', 'expected value' );
 		}
+		t.end();
 	}
-);
+});
 
-tape(
-	'if an error is encountered when appending to file, the command-line interface prints an error and sets a non-zero exit code',
-	opts,
-	function test( t ) {
-		var script;
-		var opts;
-		var cmd;
+tape( 'when invoked with a `-h` flag, the command-line interface prints the help text to `stderr`', opts, function test( t ) {
+	var expected;
+	var cmd;
 
-		script = readFileSync(
-			resolve( __dirname, 'fixtures', 'write_error.js.txt' ),
-			{
-				encoding: 'utf8',
-			}
-		);
+	expected = readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+		'encoding': 'utf8'
+	});
+	cmd = [
+		EXEC_PATH,
+		fpath,
+		'-h'
+	];
 
-		// Replace single quotes with double quotes:
-		script = replace( script, "'", '"' );
+	exec( cmd.join(' '), done );
 
-		cmd = [ EXEC_PATH, '-e', "'" + script + "'" ];
-
-		opts = {
-			cwd: __dirname,
-		};
-
-		exec( cmd.join( ' ' ), opts, done );
-
-		function done( error, stdout, stderr ) {
-			if ( error ) {
-				t.pass( error.message );
-				t.strictEqual( error.code, 1, 'expected exit code' );
-			}
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
 			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
-			t.strictEqual( stderr.toString(), 'Error: beep\n', 'expected value' );
-
-			restore();
-			t.end();
+			t.strictEqual( stderr.toString(), expected + '\n', 'expected value' );
 		}
+		t.end();
 	}
-);
+});
+
+tape( 'when invoked with a `--version` flag, the command-line interface prints the version to `stderr`', opts, function test( t ) {
+	var cmd = [
+		EXEC_PATH,
+		fpath,
+		'--version'
+	];
+
+	exec( cmd.join(' '), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), PKG_VERSION + '\n', 'expected value' );
+		}
+		t.end();
+	}
+});
+
+tape( 'when invoked with a `-V` flag, the command-line interface prints the version to `stderr`', opts, function test( t ) {
+	var cmd = [
+		EXEC_PATH,
+		fpath,
+		'-V'
+	];
+
+	exec( cmd.join(' '), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), PKG_VERSION + '\n', 'expected value' );
+		}
+		t.end();
+	}
+});
+
+tape( 'the command-line interface appends data received from `stdin` to a file', opts, function test( t ) {
+	var expected;
+	var opts;
+	var cmd;
+
+	cmd = [
+		'printf "beep boop 1"',
+		'|',
+		EXEC_PATH,
+		fpath,
+		FILE
+	];
+	opts = {};
+
+	expected = 'beep boop 1';
+	exec( cmd.join( ' ' ), opts, done );
+
+	function done( error, stdout, stderr ) {
+		var actual;
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), '', 'does not print to `stderr`' );
+		}
+		actual = readFileSync( FILE, 'utf8' );
+		t.strictEqual(actual, expected, 'file contains expected contents');
+
+		restore();
+		t.end();
+	}
+});
+
+tape( 'if an error is encountered when reading from `stdin`, the command-line interface prints an error and sets a non-zero exit code', opts, function test( t ) {
+	var script;
+	var opts;
+	var cmd;
+
+	script = readFileSync( resolve( __dirname, 'fixtures', 'stdin_error.js.txt' ), {
+		'encoding': 'utf8'
+	});
+
+	// Replace single quotes with double quotes:
+	script = replace( script, "'", '"' );
+
+	cmd = [
+		EXEC_PATH,
+		'-e',
+		"'" + script + "'"
+	];
+
+	opts = {
+		'cwd': __dirname
+	};
+
+	exec( cmd.join( ' ' ), opts, done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.pass( error.message );
+			t.strictEqual( error.code, 1, 'expected exit code' );
+		}
+		t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+		t.strictEqual( stderr.toString(), 'Error: beep\n', 'expected value' );
+
+		restore();
+		t.end();
+	}
+});
+
+tape( 'if an error is encountered when appending to file, the command-line interface prints an error and sets a non-zero exit code', opts, function test( t ) {
+	var script;
+	var opts;
+	var cmd;
+
+	script = readFileSync( resolve( __dirname, 'fixtures', 'write_error.js.txt' ), {
+		'encoding': 'utf8'
+	});
+
+	// Replace single quotes with double quotes:
+	script = replace( script, "'", '"' );
+
+	cmd = [
+		EXEC_PATH,
+		'-e',
+		"'" + script + "'"
+	];
+
+	opts = {
+		'cwd': __dirname
+	};
+
+	exec( cmd.join( ' ' ), opts, done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.pass( error.message );
+			t.strictEqual( error.code, 1, 'expected exit code' );
+		}
+		t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+		t.strictEqual( stderr.toString(), 'Error: beep\n', 'expected value' );
+
+		restore();
+		t.end();
+	}
+});

--- a/lib/node_modules/@stdlib/fs/append-file/test/test.cli.js
+++ b/lib/node_modules/@stdlib/fs/append-file/test/test.cli.js
@@ -1,0 +1,270 @@
+/**
+ * @license Apache-2.0
+ *
+ * Copyright (c) 2018 The Stdlib Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+// MODULES //
+
+var resolve = require("path").resolve;
+var join = require("path").join;
+var exec = require("child_process").exec;
+var tape = require("tape");
+var IS_BROWSER = require("@stdlib/assert/is-browser");
+var IS_WINDOWS = require("@stdlib/assert/is-windows");
+var EXEC_PATH = require("@stdlib/process/exec-path");
+var replace = require("@stdlib/string/replace");
+var readFileSync = require("@stdlib/fs/read-file").sync;
+var appendFileSync = require("../lib/sync.js");
+
+// VARIABLES //
+
+var fpath = resolve(__dirname, "..", "bin", "cli");
+var opts = {
+  skip: IS_BROWSER || IS_WINDOWS,
+};
+var FILE = join(__dirname, "fixtures", "file.txt");
+var DATA = readFileSync(FILE);
+
+// FIXTURES //
+
+var PKG_VERSION = require("./../package.json").version;
+
+// FUNCTIONS //
+
+/**
+ * Restores a fixture file.
+ *
+ * ## Notes
+ *
+ * -   Every function which has the **potential** to affect the fixture file should invoke this function immediately before calling `t.end()`.
+ *
+ * @private
+ */
+function restore() {
+  appendFileSync(FILE, DATA);
+}
+
+// TESTS //
+
+tape("command-line interface", function test(t) {
+  t.ok(true, __filename);
+  t.end();
+});
+
+tape(
+  "when invoked with a `--help` flag, the command-line interface prints the help text to `stderr`",
+  opts,
+  function test(t) {
+    var expected;
+    var cmd;
+
+    expected = readFileSync(resolve(__dirname, "..", "docs", "usage.txt"), {
+      encoding: "utf8",
+    });
+    cmd = [EXEC_PATH, fpath, "--help"];
+
+    exec(cmd.join(" "), done);
+
+    function done(error, stdout, stderr) {
+      if (error) {
+        t.fail(error.message);
+      } else {
+        t.strictEqual(stdout.toString(), "", "does not print to `stdout`");
+        t.strictEqual(stderr.toString(), expected + "\n", "expected value");
+      }
+      t.end();
+    }
+  }
+);
+
+tape(
+  "when invoked with a `-h` flag, the command-line interface prints the help text to `stderr`",
+  opts,
+  function test(t) {
+    var expected;
+    var cmd;
+
+    expected = readFileSync(resolve(__dirname, "..", "docs", "usage.txt"), {
+      encoding: "utf8",
+    });
+    cmd = [EXEC_PATH, fpath, "-h"];
+
+    exec(cmd.join(" "), done);
+
+    function done(error, stdout, stderr) {
+      if (error) {
+        t.fail(error.message);
+      } else {
+        t.strictEqual(stdout.toString(), "", "does not print to `stdout`");
+        t.strictEqual(stderr.toString(), expected + "\n", "expected value");
+      }
+      t.end();
+    }
+  }
+);
+
+tape(
+  "when invoked with a `--version` flag, the command-line interface prints the version to `stderr`",
+  opts,
+  function test(t) {
+    var cmd = [EXEC_PATH, fpath, "--version"];
+
+    exec(cmd.join(" "), done);
+
+    function done(error, stdout, stderr) {
+      if (error) {
+        t.fail(error.message);
+      } else {
+        t.strictEqual(stdout.toString(), "", "does not print to `stdout`");
+        t.strictEqual(stderr.toString(), PKG_VERSION + "\n", "expected value");
+      }
+      t.end();
+    }
+  }
+);
+
+tape(
+  "when invoked with a `-V` flag, the command-line interface prints the version to `stderr`",
+  opts,
+  function test(t) {
+    var cmd = [EXEC_PATH, fpath, "-V"];
+
+    exec(cmd.join(" "), done);
+
+    function done(error, stdout, stderr) {
+      if (error) {
+        t.fail(error.message);
+      } else {
+        t.strictEqual(stdout.toString(), "", "does not print to `stdout`");
+        t.strictEqual(stderr.toString(), PKG_VERSION + "\n", "expected value");
+      }
+      t.end();
+    }
+  }
+);
+
+tape(
+  "the command-line interface appends data received from `stdin` to a file",
+  opts,
+  function test(t) {
+    var expected;
+    var opts;
+    var cmd;
+
+    cmd = ['printf "beep boop 1"', "|", EXEC_PATH, fpath, FILE];
+    opts = {};
+
+    expected = "beep boop 1";
+    exec(cmd.join(" "), opts, done);
+
+    function done(error, stdout, stderr) {
+      var actual;
+      if (error) {
+        t.fail(error.message);
+      } else {
+        t.strictEqual(stdout.toString(), "", "does not print to `stdout`");
+        t.strictEqual(stderr.toString(), "", "does not print to `stderr`");
+      }
+      actual = readFileSync(FILE, "utf8");
+      t.strictEqual(actual, expected, "file contains expected contents");
+
+      restore();
+      t.end();
+    }
+  }
+);
+
+tape(
+  "if an error is encountered when reading from `stdin`, the command-line interface prints an error and sets a non-zero exit code",
+  opts,
+  function test(t) {
+    var script;
+    var opts;
+    var cmd;
+
+    script = readFileSync(
+      resolve(__dirname, "fixtures", "stdin_error.js.txt"),
+      {
+        encoding: "utf8",
+      }
+    );
+
+    // Replace single quotes with double quotes:
+    script = replace(script, "'", '"');
+
+    cmd = [EXEC_PATH, "-e", "'" + script + "'"];
+
+    opts = {
+      cwd: __dirname,
+    };
+
+    exec(cmd.join(" "), opts, done);
+
+    function done(error, stdout, stderr) {
+      if (error) {
+        t.pass(error.message);
+        t.strictEqual(error.code, 1, "expected exit code");
+      }
+      t.strictEqual(stdout.toString(), "", "does not print to `stdout`");
+      t.strictEqual(stderr.toString(), "Error: beep\n", "expected value");
+
+      restore();
+      t.end();
+    }
+  }
+);
+
+tape(
+  "if an error is encountered when appending to file, the command-line interface prints an error and sets a non-zero exit code",
+  opts,
+  function test(t) {
+    var script;
+    var opts;
+    var cmd;
+
+    script = readFileSync(
+      resolve(__dirname, "fixtures", "write_error.js.txt"),
+      {
+        encoding: "utf8",
+      }
+    );
+
+    // Replace single quotes with double quotes:
+    script = replace(script, "'", '"');
+
+    cmd = [EXEC_PATH, "-e", "'" + script + "'"];
+
+    opts = {
+      cwd: __dirname,
+    };
+
+    exec(cmd.join(" "), opts, done);
+
+    function done(error, stdout, stderr) {
+      if (error) {
+        t.pass(error.message);
+        t.strictEqual(error.code, 1, "expected exit code");
+      }
+      t.strictEqual(stdout.toString(), "", "does not print to `stdout`");
+      t.strictEqual(stderr.toString(), "Error: beep\n", "expected value");
+
+      restore();
+      t.end();
+    }
+  }
+);

--- a/lib/node_modules/@stdlib/fs/append-file/test/test.cli.js
+++ b/lib/node_modules/@stdlib/fs/append-file/test/test.cli.js
@@ -18,7 +18,6 @@
 
 'use strict';
 
-
 // MODULES //
 
 var resolve = require( 'path' ).resolve;
@@ -45,7 +44,7 @@ var DATA = readFileSync( FILE );
 
 // FIXTURES //
 
-var PKG_VERSION = require( './../package.json' ).version;
+var PKG_VERSION = require( '@stdlib/fs/append-file/package.json' ).version;
 
 
 // FUNCTIONS //

--- a/lib/node_modules/@stdlib/fs/append-file/test/test.cli.js
+++ b/lib/node_modules/@stdlib/fs/append-file/test/test.cli.js
@@ -1,270 +1,315 @@
 /**
- * @license Apache-2.0
- *
- * Copyright (c) 2024 The Stdlib Authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
-"use strict";
+'use strict';
+
 
 // MODULES //
 
-var resolve = require("path").resolve;
-var join = require("path").join;
-var exec = require("child_process").exec;
-var tape = require("tape");
-var IS_BROWSER = require("@stdlib/assert/is-browser");
-var IS_WINDOWS = require("@stdlib/assert/is-windows");
-var EXEC_PATH = require("@stdlib/process/exec-path");
-var replace = require("@stdlib/string/replace");
-var readFileSync = require("@stdlib/fs/read-file").sync;
-var appendFileSync = require("../lib/sync.js");
+var resolve = require( 'path' ).resolve;
+var join = require( 'path' ).join;
+var exec = require( 'child_process' ).exec;
+var tape = require( 'tape' );
+var IS_BROWSER = require( '@stdlib/assert/is-browser' );
+var IS_WINDOWS = require( '@stdlib/assert/is-windows' );
+var EXEC_PATH = require( '@stdlib/process/exec-path' );
+var replace = require( '@stdlib/string/replace' );
+var readFileSync = require( '@stdlib/fs/read-file' ).sync;
+var writeFileSync = require( '@stdlib/fs/write-file' ).sync;
+
 
 // VARIABLES //
 
-var fpath = resolve(__dirname, "..", "bin", "cli");
+var fpath = resolve( __dirname, '..', 'bin', 'cli' );
 var opts = {
-  skip: IS_BROWSER || IS_WINDOWS,
+	skip: IS_BROWSER || IS_WINDOWS,
 };
-var FILE = join(__dirname, "fixtures", "file.txt");
-var DATA = readFileSync(FILE);
+var FILE = join( __dirname, 'fixtures', 'file.txt' );
+var DATA = readFileSync( FILE );
+
 
 // FIXTURES //
 
-var PKG_VERSION = require("./../package.json").version;
+var PKG_VERSION = require( './../package.json' ).version;
+
 
 // FUNCTIONS //
 
 /**
- * Restores a fixture file.
- *
- * ## Notes
- *
- * -   Every function which has the **potential** to affect the fixture file should invoke this function immediately before calling `t.end()`.
- *
- * @private
- */
+* Restores a fixture file.
+*
+* ## Notes
+*
+* -   Every function which has the **potential** to affect the fixture file should invoke this function immediately before calling `t.end()`.
+*
+* @private
+*/
 function restore() {
-  appendFileSync(FILE, DATA);
+	writeFileSync( FILE, DATA );
 }
+
 
 // TESTS //
 
-tape("command-line interface", function test(t) {
-  t.ok(true, __filename);
-  t.end();
-});
+tape( 'command-line interface', function test( t ) {
+	t.ok( true, __filename );
+	t.end();
+} );
 
 tape(
-  "when invoked with a `--help` flag, the command-line interface prints the help text to `stderr`",
-  opts,
-  function test(t) {
-    var expected;
-    var cmd;
+	'when invoked with a `--help` flag, the command-line interface prints the help text to `stderr`',
+	opts,
+	function test( t ) {
+		var expected;
+		var cmd;
 
-    expected = readFileSync(resolve(__dirname, "..", "docs", "usage.txt"), {
-      encoding: "utf8",
-    });
-    cmd = [EXEC_PATH, fpath, "--help"];
+		expected = readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+			encoding: 'utf8',
+		} );
+		cmd = [ EXEC_PATH, fpath, '--help' ];
 
-    exec(cmd.join(" "), done);
+		exec( cmd.join(' '), done );
 
-    function done(error, stdout, stderr) {
-      if (error) {
-        t.fail(error.message);
-      } else {
-        t.strictEqual(stdout.toString(), "", "does not print to `stdout`");
-        t.strictEqual(stderr.toString(), expected + "\n", "expected value");
-      }
-      t.end();
-    }
-  }
+		function done( error, stdout, stderr ) {
+			if ( error ) {
+				t.fail( error.message );
+			} else {
+				t.strictEqual(
+					stdout.toString(),
+					'',
+					'does not print to `stdout`'
+				);
+				t.strictEqual(
+					stderr.toString(),
+					expected + '\n',
+					'expected value'
+				);
+			}
+			t.end();
+		}
+	}
 );
 
 tape(
-  "when invoked with a `-h` flag, the command-line interface prints the help text to `stderr`",
-  opts,
-  function test(t) {
-    var expected;
-    var cmd;
+	'when invoked with a `-h` flag, the command-line interface prints the help text to `stderr`',
+	opts,
+	function test( t ) {
+		var expected;
+		var cmd;
 
-    expected = readFileSync(resolve(__dirname, "..", "docs", "usage.txt"), {
-      encoding: "utf8",
-    });
-    cmd = [EXEC_PATH, fpath, "-h"];
+		expected = readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+			encoding: 'utf8',
+		} );
+		cmd = [ EXEC_PATH, fpath, '-h' ];
 
-    exec(cmd.join(" "), done);
+		exec( cmd.join(' '), done );
 
-    function done(error, stdout, stderr) {
-      if (error) {
-        t.fail(error.message);
-      } else {
-        t.strictEqual(stdout.toString(), "", "does not print to `stdout`");
-        t.strictEqual(stderr.toString(), expected + "\n", "expected value");
-      }
-      t.end();
-    }
-  }
+		function done( error, stdout, stderr ) {
+			if ( error ) {
+				t.fail( error.message );
+			} else {
+				t.strictEqual(
+					stdout.toString(),
+					'',
+					'does not print to `stdout`'
+				);
+				t.strictEqual(
+					stderr.toString(),
+					expected + '\n',
+					'expected value'
+				);
+			}
+			t.end();
+		}
+	}
 );
 
 tape(
-  "when invoked with a `--version` flag, the command-line interface prints the version to `stderr`",
-  opts,
-  function test(t) {
-    var cmd = [EXEC_PATH, fpath, "--version"];
+	'when invoked with a `--version` flag, the command-line interface prints the version to `stderr`',
+	opts,
+	function test( t ) {
+		var cmd = [ EXEC_PATH, fpath, '--version' ];
 
-    exec(cmd.join(" "), done);
+		exec( cmd.join(' '), done );
 
-    function done(error, stdout, stderr) {
-      if (error) {
-        t.fail(error.message);
-      } else {
-        t.strictEqual(stdout.toString(), "", "does not print to `stdout`");
-        t.strictEqual(stderr.toString(), PKG_VERSION + "\n", "expected value");
-      }
-      t.end();
-    }
-  }
+		function done( error, stdout, stderr ) {
+			if ( error ) {
+				t.fail( error.message );
+			} else {
+				t.strictEqual(
+					stdout.toString(),
+					'',
+					'does not print to `stdout`'
+				);
+				t.strictEqual(
+					stderr.toString(),
+					PKG_VERSION + '\n',
+					'expected value'
+				);
+			}
+			t.end();
+		}
+	}
 );
 
 tape(
-  "when invoked with a `-V` flag, the command-line interface prints the version to `stderr`",
-  opts,
-  function test(t) {
-    var cmd = [EXEC_PATH, fpath, "-V"];
+	'when invoked with a `-V` flag, the command-line interface prints the version to `stderr`',
+	opts,
+	function test( t ) {
+		var cmd = [ EXEC_PATH, fpath, '-V' ];
 
-    exec(cmd.join(" "), done);
+		exec( cmd.join(' '), done );
 
-    function done(error, stdout, stderr) {
-      if (error) {
-        t.fail(error.message);
-      } else {
-        t.strictEqual(stdout.toString(), "", "does not print to `stdout`");
-        t.strictEqual(stderr.toString(), PKG_VERSION + "\n", "expected value");
-      }
-      t.end();
-    }
-  }
+		function done( error, stdout, stderr ) {
+			if ( error ) {
+				t.fail( error.message );
+			} else {
+				t.strictEqual(
+					stdout.toString(),
+					'',
+					'does not print to `stdout`'
+				);
+				t.strictEqual(
+					stderr.toString(),
+					PKG_VERSION + '\n',
+					'expected value'
+				);
+			}
+			t.end();
+		}
+	}
 );
 
 tape(
-  "the command-line interface appends data received from `stdin` to a file",
-  opts,
-  function test(t) {
-    var expected;
-    var opts;
-    var cmd;
+	'the command-line interface appends data received from `stdin` to a file',
+	opts,
+	function test( t ) {
+		var expected;
+		var opts;
+		var cmd;
 
-    cmd = ['printf "beep boop 1"', "|", EXEC_PATH, fpath, FILE];
-    opts = {};
+		cmd = [ 'printf "beep boop 1"', '|', EXEC_PATH, fpath, FILE ];
+		opts = {};
 
-    expected = "beep boop 1";
-    exec(cmd.join(" "), opts, done);
+		expected = 'beep boop 1';
+		exec( cmd.join( ' ' ), opts, done );
 
-    function done(error, stdout, stderr) {
-      var actual;
-      if (error) {
-        t.fail(error.message);
-      } else {
-        t.strictEqual(stdout.toString(), "", "does not print to `stdout`");
-        t.strictEqual(stderr.toString(), "", "does not print to `stderr`");
-      }
-      actual = readFileSync(FILE, "utf8");
-      t.strictEqual(actual, expected, "file contains expected contents");
+		function done( error, stdout, stderr ) {
+			var actual;
+			if ( error ) {
+				t.fail( error.message );
+			} else {
+				t.strictEqual(
+					stdout.toString(),
+					'',
+					'does not print to `stdout`'
+				);
+				t.strictEqual(
+					stderr.toString(),
+					'',
+					'does not print to `stderr`'
+				);
+			}
+			actual = readFileSync( FILE, 'utf8' );
+			t.strictEqual(actual, expected, 'file contains expected contents');
 
-      restore();
-      t.end();
-    }
-  }
+			restore();
+			t.end();
+		}
+	}
 );
 
 tape(
-  "if an error is encountered when reading from `stdin`, the command-line interface prints an error and sets a non-zero exit code",
-  opts,
-  function test(t) {
-    var script;
-    var opts;
-    var cmd;
+	'if an error is encountered when reading from `stdin`, the command-line interface prints an error and sets a non-zero exit code',
+	opts,
+	function test( t ) {
+		var script;
+		var opts;
+		var cmd;
 
-    script = readFileSync(
-      resolve(__dirname, "fixtures", "stdin_error.js.txt"),
-      {
-        encoding: "utf8",
-      }
-    );
+		script = readFileSync(
+			resolve( __dirname, 'fixtures', 'stdin_error.js.txt' ),
+			{
+				encoding: 'utf8',
+			}
+		);
 
-    // Replace single quotes with double quotes:
-    script = replace(script, "'", '"');
+		// Replace single quotes with double quotes:
+		script = replace( script, "'", '"' );
 
-    cmd = [EXEC_PATH, "-e", "'" + script + "'"];
+		cmd = [ EXEC_PATH, '-e', "'" + script + "'" ];
 
-    opts = {
-      cwd: __dirname,
-    };
+		opts = {
+			cwd: __dirname,
+		};
 
-    exec(cmd.join(" "), opts, done);
+		exec( cmd.join( ' ' ), opts, done );
 
-    function done(error, stdout, stderr) {
-      if (error) {
-        t.pass(error.message);
-        t.strictEqual(error.code, 1, "expected exit code");
-      }
-      t.strictEqual(stdout.toString(), "", "does not print to `stdout`");
-      t.strictEqual(stderr.toString(), "Error: beep\n", "expected value");
+		function done( error, stdout, stderr ) {
+			if ( error ) {
+				t.pass( error.message );
+				t.strictEqual( error.code, 1, 'expected exit code' );
+			}
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), 'Error: beep\n', 'expected value' );
 
-      restore();
-      t.end();
-    }
-  }
+			restore();
+			t.end();
+		}
+	}
 );
 
 tape(
-  "if an error is encountered when appending to file, the command-line interface prints an error and sets a non-zero exit code",
-  opts,
-  function test(t) {
-    var script;
-    var opts;
-    var cmd;
+	'if an error is encountered when appending to file, the command-line interface prints an error and sets a non-zero exit code',
+	opts,
+	function test( t ) {
+		var script;
+		var opts;
+		var cmd;
 
-    script = readFileSync(
-      resolve(__dirname, "fixtures", "write_error.js.txt"),
-      {
-        encoding: "utf8",
-      }
-    );
+		script = readFileSync(
+			resolve( __dirname, 'fixtures', 'write_error.js.txt' ),
+			{
+				encoding: 'utf8',
+			}
+		);
 
-    // Replace single quotes with double quotes:
-    script = replace(script, "'", '"');
+		// Replace single quotes with double quotes:
+		script = replace( script, "'", '"' );
 
-    cmd = [EXEC_PATH, "-e", "'" + script + "'"];
+		cmd = [ EXEC_PATH, '-e', "'" + script + "'" ];
 
-    opts = {
-      cwd: __dirname,
-    };
+		opts = {
+			cwd: __dirname,
+		};
 
-    exec(cmd.join(" "), opts, done);
+		exec( cmd.join( ' ' ), opts, done );
 
-    function done(error, stdout, stderr) {
-      if (error) {
-        t.pass(error.message);
-        t.strictEqual(error.code, 1, "expected exit code");
-      }
-      t.strictEqual(stdout.toString(), "", "does not print to `stdout`");
-      t.strictEqual(stderr.toString(), "Error: beep\n", "expected value");
+		function done( error, stdout, stderr ) {
+			if ( error ) {
+				t.pass( error.message );
+				t.strictEqual( error.code, 1, 'expected exit code' );
+			}
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), 'Error: beep\n', 'expected value' );
 
-      restore();
-      t.end();
-    }
-  }
+			restore();
+			t.end();
+		}
+	}
 );

--- a/lib/node_modules/@stdlib/fs/append-file/test/test.cli.js
+++ b/lib/node_modules/@stdlib/fs/append-file/test/test.cli.js
@@ -1,7 +1,7 @@
 /**
  * @license Apache-2.0
  *
- * Copyright (c) 2018 The Stdlib Authors.
+ * Copyright (c) 2024 The Stdlib Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/fs/append-file/test/test.js
+++ b/lib/node_modules/@stdlib/fs/append-file/test/test.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var appendFile = require( '@stdlib/fs/append-file/lib' );
+var appendFile = require( './../lib' );
 
 
 // TESTS //
@@ -30,12 +30,9 @@ tape( 'main export is a function', function test( t ) {
 	t.ok( true, __filename );
 	t.strictEqual( typeof appendFile, 'function', 'main export is a function' );
 	t.end();
-} );
+});
 
-tape(
-	'attached to the main export is a method that synchronously appends data to a file',
-	function test( t ) {
-		t.strictEqual( typeof appendFile.sync, 'function', 'has method' );
-		t.end();
-	}
-);
+tape( 'attached to the main export is a method that synchronously appends data to a file', function test( t ) {
+	t.strictEqual( typeof appendFile.sync, 'function', 'has method' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/fs/append-file/test/test.js
+++ b/lib/node_modules/@stdlib/fs/append-file/test/test.js
@@ -1,0 +1,40 @@
+/**
+ * @license Apache-2.0
+ *
+ * Copyright (c) 2018 The Stdlib Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+// MODULES //
+
+var tape = require("tape");
+var appendFile = require("../lib");
+
+// TESTS //
+
+tape("main export is a function", function test(t) {
+  t.ok(true, __filename);
+  t.strictEqual(typeof writeFile, "function", "main export is a function");
+  t.end();
+});
+
+tape(
+  "attached to the main export is a method that synchronously appends data to a file",
+  function test(t) {
+    t.strictEqual(typeof writeFile.sync, "function", "has method");
+    t.end();
+  }
+);

--- a/lib/node_modules/@stdlib/fs/append-file/test/test.js
+++ b/lib/node_modules/@stdlib/fs/append-file/test/test.js
@@ -27,14 +27,14 @@ var appendFile = require("../lib");
 
 tape("main export is a function", function test(t) {
   t.ok(true, __filename);
-  t.strictEqual(typeof writeFile, "function", "main export is a function");
+  t.strictEqual(typeof appendFile, "function", "main export is a function");
   t.end();
 });
 
 tape(
   "attached to the main export is a method that synchronously appends data to a file",
   function test(t) {
-    t.strictEqual(typeof writeFile.sync, "function", "has method");
+    t.strictEqual(typeof appendFile.sync, "function", "has method");
     t.end();
   }
 );

--- a/lib/node_modules/@stdlib/fs/append-file/test/test.js
+++ b/lib/node_modules/@stdlib/fs/append-file/test/test.js
@@ -1,7 +1,7 @@
 /**
  * @license Apache-2.0
  *
- * Copyright (c) 2018 The Stdlib Authors.
+ * Copyright (c) 2024 The Stdlib Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/fs/append-file/test/test.js
+++ b/lib/node_modules/@stdlib/fs/append-file/test/test.js
@@ -1,40 +1,42 @@
 /**
- * @license Apache-2.0
- *
- * Copyright (c) 2024 The Stdlib Authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
-"use strict";
+'use strict';
+
 
 // MODULES //
 
-var tape = require("tape");
-var appendFile = require("../lib");
+var tape = require( 'tape' );
+var appendFile = require( '../lib' );
+
 
 // TESTS //
 
-tape("main export is a function", function test(t) {
-  t.ok(true, __filename);
-  t.strictEqual(typeof appendFile, "function", "main export is a function");
-  t.end();
-});
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof appendFile, 'function', 'main export is a function' );
+	t.end();
+} );
 
 tape(
-  "attached to the main export is a method that synchronously appends data to a file",
-  function test(t) {
-    t.strictEqual(typeof appendFile.sync, "function", "has method");
-    t.end();
-  }
+	'attached to the main export is a method that synchronously appends data to a file',
+	function test( t ) {
+		t.strictEqual( typeof appendFile.sync, 'function', 'has method' );
+		t.end();
+	}
 );

--- a/lib/node_modules/@stdlib/fs/append-file/test/test.sync.js
+++ b/lib/node_modules/@stdlib/fs/append-file/test/test.sync.js
@@ -127,19 +127,14 @@ tape( 'the function appends data to a file using provided options (object)', opt
 	t.end();
 });
 
-tape( 'if the function encounters an error, the function throws the error', opts, function test( t ) {
+tape( 'if the function encounters an error, the function returns the error', opts, function test( t ) {
 	var expected;
 	var actual;
 	var file;
 	var err;
 
 	file = 'beepboopbapbop/dkfjldjfaklsjf/bdlfalfas/bkldflakfjas'; // non-existent directory path
-
-	try {
-		appendFile( file, 'beepboopbapbop' );
-	} catch ( error ) {
-		err = error;
-	}
+	err = appendFile( file, 'beepboopbapbop' );
 
 	t.strictEqual( err instanceof Error, true, err.message );
 
@@ -158,12 +153,7 @@ tape( 'if the function encounters an error, the function throws the error (optio
 	var err;
 
 	file = 'beepboopbapbop/dkfjldjfaklsjf/bdlfalfas/bkldflakfjas'; // non-existent directory path
-
-	try {
-		appendFile( file, 'beepboopbapbop', 'utf8' );
-	} catch ( error ) {
-		err = error;
-	}
+	err = appendFile( file, 'beepboopbapbop', 'utf8' );
 
 	t.strictEqual( err instanceof Error, true, err.message );
 
@@ -188,11 +178,7 @@ tape( 'if the function encounters an error, the function throws the error (optio
 		'encoding': 'utf8'
 	};
 
-	try {
-		appendFile( file, 'beepboopbapbop', opts );
-	} catch ( error ) {
-		err = error;
-	}
+	err = appendFile( file, 'beepboopbapbop', opts );
 
 	t.strictEqual( err instanceof Error, true, err.message );
 

--- a/lib/node_modules/@stdlib/fs/append-file/test/test.sync.js
+++ b/lib/node_modules/@stdlib/fs/append-file/test/test.sync.js
@@ -26,7 +26,7 @@ var readFile = require( '@stdlib/fs/read-file' ).sync;
 var writeFile = require( '@stdlib/fs/write-file' ).sync;
 var IS_BROWSER = require( '@stdlib/assert/is-browser' );
 var string2buffer = require( '@stdlib/buffer/from-string' );
-var appendFile = require( './../lib/sync' );
+var appendFile = require( './../lib/sync.js' );
 
 
 // VARIABLES //

--- a/lib/node_modules/@stdlib/fs/append-file/test/test.sync.js
+++ b/lib/node_modules/@stdlib/fs/append-file/test/test.sync.js
@@ -26,14 +26,14 @@ var readFile = require( '@stdlib/fs/read-file' ).sync;
 var writeFile = require( '@stdlib/fs/write-file' ).sync;
 var IS_BROWSER = require( '@stdlib/assert/is-browser' );
 var string2buffer = require( '@stdlib/buffer/from-string' );
-var appendFile = require( '@stdlib/fs/append-file/lib/sync.js' );
+var appendFile = require( './../lib/sync' );
 
 
 // VARIABLES //
 
 // Don't run tests in the browser...for now...
 var opts = {
-	skip: IS_BROWSER, // FIXME
+	'skip': IS_BROWSER // FIXME
 };
 var fpath = join( __dirname, 'fixtures', 'file.txt' );
 var DATA = readFile( fpath, 'utf8' );
@@ -61,7 +61,7 @@ tape( 'main export is a function', function test( t ) {
 	t.ok( true, __filename );
 	t.strictEqual( typeof appendFile, 'function', 'main export is a function' );
 	t.end();
-} );
+});
 
 tape( 'the function appends data to a file (string)', opts, function test( t ) {
 	var expected;
@@ -76,7 +76,7 @@ tape( 'the function appends data to a file (string)', opts, function test( t ) {
 
 	restore();
 	t.end();
-} );
+});
 
 tape( 'the function appends data to a file (buffer)', opts, function test( t ) {
 	var expected;
@@ -91,135 +91,115 @@ tape( 'the function appends data to a file (buffer)', opts, function test( t ) {
 
 	restore();
 	t.end();
-} );
+});
 
-tape(
-	'the function appends data to a file using provided options (string)',
-	opts,
-	function test( t ) {
-		var expected;
-		var actual;
+tape( 'the function appends data to a file using provided options (string)', opts, function test( t ) {
+	var expected;
+	var actual;
 
-		expected = 'beep boop 3';
+	expected = 'beep boop 3';
 
-		appendFile( fpath, 'beep boop 3', 'utf8' );
-		actual = readFile( fpath, 'utf8' );
+	appendFile( fpath, 'beep boop 3', 'utf8' );
+	actual = readFile( fpath, 'utf8' );
 
-		t.strictEqual( actual, expected, 'file contains expected data' );
+	t.strictEqual( actual, expected, 'file contains expected data' );
 
-		restore();
-		t.end();
+	restore();
+	t.end();
+});
+
+tape( 'the function appends data to a file using provided options (object)', opts, function test( t ) {
+	var expected;
+	var actual;
+	var opts;
+
+	expected = 'beep boop 4';
+
+	opts = {
+		'encoding': 'utf8'
+	};
+	appendFile( fpath, 'beep boop 4', opts );
+	actual = readFile( fpath, 'utf8' );
+
+	t.strictEqual( actual, expected, 'file contains expected data' );
+
+	restore();
+	t.end();
+});
+
+tape( 'if the function encounters an error, the function throws the error', opts, function test( t ) {
+	var expected;
+	var actual;
+	var file;
+	var err;
+
+	file = 'beepboopbapbop/dkfjldjfaklsjf/bdlfalfas/bkldflakfjas'; // non-existent directory path
+
+	try {
+		appendFile( file, 'beepboopbapbop' );
+	} catch ( error ) {
+		err = error;
 	}
-);
 
-tape(
-	'the function appends data to a file using provided options (object)',
-	opts,
-	function test( t ) {
-		var expected;
-		var actual;
-		var opts;
+	t.strictEqual( err instanceof Error, true, err.message );
 
-		expected = 'beep boop 4';
+	expected = DATA;
+	actual = readFile( fpath, 'utf8' );
+	t.strictEqual( actual, expected, 'file contains expected contents' );
 
-		opts = {
-			encoding: 'utf8',
-		};
-		appendFile( fpath, 'beep boop 4', opts );
-		actual = readFile( fpath, 'utf8' );
+	restore();
+	t.end();
+});
 
-		t.strictEqual( actual, expected, 'file contains expected data' );
+tape( 'if the function encounters an error, the function throws the error (option string)', opts, function test( t ) {
+	var expected;
+	var actual;
+	var file;
+	var err;
 
-		restore();
-		t.end();
+	file = 'beepboopbapbop/dkfjldjfaklsjf/bdlfalfas/bkldflakfjas'; // non-existent directory path
+
+	try {
+		appendFile( file, 'beepboopbapbop', 'utf8' );
+	} catch ( error ) {
+		err = error;
 	}
-);
 
-tape(
-	'if the function encounters an error, the function throws the error',
-	opts,
-	function test( t ) {
-		var expected;
-		var actual;
-		var file;
-		var err;
+	t.strictEqual( err instanceof Error, true, err.message );
 
-		file = 'beepboopbapbop/dkfjldjfaklsjf/bdlfalfas/bkldflakfjas'; // non-existent directory path
+	expected = DATA;
+	actual = readFile( fpath, 'utf8' );
+	t.strictEqual( actual, expected, 'file contains expected contents' );
 
-		try {
-			appendFile( file, 'beepboopbapbop' );
-		} catch ( error ) {
-			err = error;
-		}
+	restore();
+	t.end();
+});
 
-		t.strictEqual( err instanceof Error, true, err.message );
+tape( 'if the function encounters an error, the function throws the error (option object)', opts, function test( t ) {
+	var expected;
+	var actual;
+	var file;
+	var opts;
+	var err;
 
-		expected = DATA;
-		actual = readFile( fpath, 'utf8' );
-		t.strictEqual( actual, expected, 'file contains expected contents' );
+	file = 'beepboopbapbop/dkfjldjfaklsjf/bdlfalfas/bkldflakfjas'; // non-existent directory path
 
-		restore();
-		t.end();
+	opts = {
+		'encoding': 'utf8'
+	};
+
+	try {
+		appendFile( file, 'beepboopbapbop', opts );
+	} catch ( error ) {
+		err = error;
 	}
-);
 
-tape(
-	'if the function encounters an error, the function throws the error (option string)',
-	opts,
-	function test( t ) {
-		var expected;
-		var actual;
-		var file;
-		var err;
+	t.strictEqual( err instanceof Error, true, err.message );
 
-		file = 'beepboopbapbop/dkfjldjfaklsjf/bdlfalfas/bkldflakfjas'; // non-existent directory path
+	expected = DATA;
+	actual = readFile( fpath, 'utf8' );
+	t.strictEqual( actual, expected, 'file contains expected contents' );
 
-		try {
-			appendFile( file, 'beepboopbapbop', 'utf8' );
-		} catch ( error ) {
-			err = error;
-		}
-
-		t.strictEqual( err instanceof Error, true, err.message );
-
-		expected = DATA;
-		actual = readFile( fpath, 'utf8' );
-		t.strictEqual( actual, expected, 'file contains expected contents' );
-
-		restore();
-		t.end();
-	}
-);
-
-tape(
-	'if the function encounters an error, the function throws the error (option object)',
-	opts,
-	function test( t ) {
-		var expected;
-		var actual;
-		var file;
-		var opts;
-		var err;
-
-		file = 'beepboopbapbop/dkfjldjfaklsjf/bdlfalfas/bkldflakfjas'; // non-existent directory path
-
-		opts = {
-			encoding: 'utf8',
-		};
-
-		try {
-			appendFile( file, 'beepboopbapbop', opts );
-		} catch ( error ) {
-			err = error;
-		}
-
-		t.strictEqual( err instanceof Error, true, err.message );
-
-		expected = DATA;
-		actual = readFile( fpath, 'utf8' );
-		t.strictEqual( actual, expected, 'file contains expected contents' );
-
-		restore();
-		t.end();
-	}
-);
+	restore();
+	t.end();
+});

--- a/lib/node_modules/@stdlib/fs/append-file/test/test.sync.js
+++ b/lib/node_modules/@stdlib/fs/append-file/test/test.sync.js
@@ -1,0 +1,221 @@
+/**
+ * @license Apache-2.0
+ *
+ * Copyright (c) 2018 The Stdlib Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+// MODULES //
+
+var join = require("path").join;
+var tape = require("tape");
+var readFile = require("@stdlib/fs/read-file").sync;
+var IS_BROWSER = require("@stdlib/assert/is-browser");
+var string2buffer = require("@stdlib/buffer/from-string");
+var appendFile = require("../lib/sync.js");
+
+// VARIABLES //
+
+// Don't run tests in the browser...for now...
+var opts = {
+  skip: IS_BROWSER, // FIXME
+};
+var fpath = join(__dirname, "fixtures", "file.txt");
+var DATA = readFile(fpath, "utf8");
+
+// FUNCTIONS //
+
+/**
+ * Restores a fixture file.
+ *
+ * ## Notes
+ *
+ * -   Every function which has the **potential** to affect the fixture file should invoke this function immediately before calling `t.end()`.
+ *
+ * @private
+ */
+function restore() {
+  appendFile(fpath, DATA);
+}
+
+// TESTS //
+
+tape("main export is a function", function test(t) {
+  t.ok(true, __filename);
+  t.strictEqual(typeof appendFile, "function", "main export is a function");
+  t.end();
+});
+
+tape("the function appends data to a file (string)", opts, function test(t) {
+  var expected;
+  var actual;
+
+  expected = "beep boop 1";
+
+  appendFile(fpath, "beep boop 1");
+  actual = readFile(fpath, "utf8");
+
+  t.strictEqual(actual, expected, "file contains expected data");
+
+  restore();
+  t.end();
+});
+
+tape("the function appends data to a file (buffer)", opts, function test(t) {
+  var expected;
+  var actual;
+
+  expected = "beep boop 2";
+
+  appendFile(fpath, string2buffer("beep boop 2"));
+  actual = readFile(fpath, "utf8");
+
+  t.strictEqual(actual, expected, "file contains expected data");
+
+  restore();
+  t.end();
+});
+
+tape(
+  "the function appends data to a file using provided options (string)",
+  opts,
+  function test(t) {
+    var expected;
+    var actual;
+
+    expected = "beep boop 3";
+
+    appendFile(fpath, "beep boop 3", "utf8");
+    actual = readFile(fpath, "utf8");
+
+    t.strictEqual(actual, expected, "file contains expected data");
+
+    restore();
+    t.end();
+  }
+);
+
+tape(
+  "the function appends data to a file using provided options (object)",
+  opts,
+  function test(t) {
+    var expected;
+    var actual;
+    var opts;
+
+    expected = "beep boop 4";
+
+    opts = {
+      encoding: "utf8",
+    };
+    appendFile(fpath, "beep boop 4", opts);
+    actual = readFile(fpath, "utf8");
+
+    t.strictEqual(actual, expected, "file contains expected data");
+
+    restore();
+    t.end();
+  }
+);
+
+tape(
+  "if the function encounters an error, the function throws the error",
+  opts,
+  function test(t) {
+    var expected;
+    var actual;
+    var file;
+    var err;
+
+    file = "beepboopbapbop/dkfjldjfaklsjf/bdlfalfas/bkldflakfjas"; // non-existent directory path
+
+    try {
+      appendFile(file, "beepboopbapbop");
+    } catch (error) {
+      err = error;
+    }
+
+    t.strictEqual(err instanceof Error, true, err.message);
+
+    expected = DATA;
+    actual = readFile(fpath, "utf8");
+    t.strictEqual(actual, expected, "file contains expected contents");
+
+    restore();
+    t.end();
+  }
+);
+
+tape(
+  "if the function encounters an error, the function throws the error (option string)",
+  opts,
+  function test(t) {
+    var expected;
+    var actual;
+    var file;
+    var err;
+
+    file = "beepboopbapbop/dkfjldjfaklsjf/bdlfalfas/bkldflakfjas"; // non-existent directory path
+
+    try {
+      appendFile(file, "beepboopbapbop", "utf8");
+    } catch (error) {
+      err = error;
+    }
+
+    t.strictEqual(err instanceof Error, true, err.message);
+
+    expected = DATA;
+    actual = readFile(fpath, "utf8");
+    t.strictEqual(actual, expected, "file contains expected contents");
+
+    restore();
+    t.end();
+  }
+);
+
+tape(
+  "if the function encounters an error, the function throws the error (option object)",
+  opts,
+  function test(t) {
+    var expected;
+    var actual;
+    var file;
+    var opts;
+    var err;
+
+    file = "beepboopbapbop/dkfjldjfaklsjf/bdlfalfas/bkldflakfjas"; // non-existent directory path
+
+    opts = {
+      encoding: "utf8",
+    };
+
+    try {
+      appendFile(file, "beepboopbapbop", opts);
+    } catch (error) {
+      err = error;
+    }
+
+    t.strictEqual(err instanceof Error, true, err.message);
+
+    expected = DATA;
+    actual = readFile(fpath, "utf8");
+    t.strictEqual(actual, expected, "file contains expected contents");
+
+    restore();
+    t.end();
+  }
+);

--- a/lib/node_modules/@stdlib/fs/append-file/test/test.sync.js
+++ b/lib/node_modules/@stdlib/fs/append-file/test/test.sync.js
@@ -18,7 +18,6 @@
 
 'use strict';
 
-
 // MODULES //
 
 var join = require( 'path' ).join;
@@ -27,7 +26,7 @@ var readFile = require( '@stdlib/fs/read-file' ).sync;
 var writeFile = require( '@stdlib/fs/write-file' ).sync;
 var IS_BROWSER = require( '@stdlib/assert/is-browser' );
 var string2buffer = require( '@stdlib/buffer/from-string' );
-var appendFile = require( '../lib/sync.js' );
+var appendFile = require( '@stdlib/fs/append-file/lib/sync.js' );
 
 
 // VARIABLES //

--- a/lib/node_modules/@stdlib/fs/append-file/test/test.sync.js
+++ b/lib/node_modules/@stdlib/fs/append-file/test/test.sync.js
@@ -1,222 +1,226 @@
 /**
- * @license Apache-2.0
- *
- * Copyright (c) 2024 The Stdlib Authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
-"use strict";
+'use strict';
+
 
 // MODULES //
 
-var join = require("path").join;
-var tape = require("tape");
-var readFile = require("@stdlib/fs/read-file").sync;
-var writeFile = require("@stdlib/fs/write-file").sync;
-var IS_BROWSER = require("@stdlib/assert/is-browser");
-var string2buffer = require("@stdlib/buffer/from-string");
-var appendFile = require("../lib/sync.js");
+var join = require( 'path' ).join;
+var tape = require( 'tape' );
+var readFile = require( '@stdlib/fs/read-file' ).sync;
+var writeFile = require( '@stdlib/fs/write-file' ).sync;
+var IS_BROWSER = require( '@stdlib/assert/is-browser' );
+var string2buffer = require( '@stdlib/buffer/from-string' );
+var appendFile = require( '../lib/sync.js' );
+
 
 // VARIABLES //
 
 // Don't run tests in the browser...for now...
 var opts = {
-  skip: IS_BROWSER, // FIXME
+	skip: IS_BROWSER, // FIXME
 };
-var fpath = join(__dirname, "fixtures", "file.txt");
-var DATA = readFile(fpath, "utf8");
+var fpath = join( __dirname, 'fixtures', 'file.txt' );
+var DATA = readFile( fpath, 'utf8' );
+
 
 // FUNCTIONS //
 
 /**
- * Restores a fixture file.
- *
- * ## Notes
- *
- * -   Every function which has the **potential** to affect the fixture file should invoke this function immediately before calling `t.end()`.
- *
- * @private
- */
+* Restores a fixture file.
+*
+* ## Notes
+*
+* -   Every function which has the **potential** to affect the fixture file should invoke this function immediately before calling `t.end()`.
+*
+* @private
+*/
 function restore() {
-  writeFile(fpath, DATA);
+	writeFile( fpath, DATA );
 }
+
 
 // TESTS //
 
-tape("main export is a function", function test(t) {
-  t.ok(true, __filename);
-  t.strictEqual(typeof appendFile, "function", "main export is a function");
-  t.end();
-});
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof appendFile, 'function', 'main export is a function' );
+	t.end();
+} );
 
-tape("the function appends data to a file (string)", opts, function test(t) {
-  var expected;
-  var actual;
+tape( 'the function appends data to a file (string)', opts, function test( t ) {
+	var expected;
+	var actual;
 
-  expected = "beep boop 1";
+	expected = 'beep boop 1';
 
-  appendFile(fpath, "beep boop 1");
-  actual = readFile(fpath, "utf8");
+	appendFile( fpath, 'beep boop 1' );
+	actual = readFile( fpath, 'utf8' );
 
-  t.strictEqual(actual, expected, "file contains expected data");
+	t.strictEqual( actual, expected, 'file contains expected data' );
 
-  restore();
-  t.end();
-});
+	restore();
+	t.end();
+} );
 
-tape("the function appends data to a file (buffer)", opts, function test(t) {
-  var expected;
-  var actual;
+tape( 'the function appends data to a file (buffer)', opts, function test( t ) {
+	var expected;
+	var actual;
 
-  expected = "beep boop 2";
+	expected = 'beep boop 2';
 
-  appendFile(fpath, string2buffer("beep boop 2"));
-  actual = readFile(fpath, "utf8");
+	appendFile( fpath, string2buffer( 'beep boop 2' ) );
+	actual = readFile( fpath, 'utf8' );
 
-  t.strictEqual(actual, expected, "file contains expected data");
+	t.strictEqual( actual, expected, 'file contains expected data' );
 
-  restore();
-  t.end();
-});
+	restore();
+	t.end();
+} );
 
 tape(
-  "the function appends data to a file using provided options (string)",
-  opts,
-  function test(t) {
-    var expected;
-    var actual;
+	'the function appends data to a file using provided options (string)',
+	opts,
+	function test( t ) {
+		var expected;
+		var actual;
 
-    expected = "beep boop 3";
+		expected = 'beep boop 3';
 
-    appendFile(fpath, "beep boop 3", "utf8");
-    actual = readFile(fpath, "utf8");
+		appendFile( fpath, 'beep boop 3', 'utf8' );
+		actual = readFile( fpath, 'utf8' );
 
-    t.strictEqual(actual, expected, "file contains expected data");
+		t.strictEqual( actual, expected, 'file contains expected data' );
 
-    restore();
-    t.end();
-  }
+		restore();
+		t.end();
+	}
 );
 
 tape(
-  "the function appends data to a file using provided options (object)",
-  opts,
-  function test(t) {
-    var expected;
-    var actual;
-    var opts;
+	'the function appends data to a file using provided options (object)',
+	opts,
+	function test( t ) {
+		var expected;
+		var actual;
+		var opts;
 
-    expected = "beep boop 4";
+		expected = 'beep boop 4';
 
-    opts = {
-      encoding: "utf8",
-    };
-    appendFile(fpath, "beep boop 4", opts);
-    actual = readFile(fpath, "utf8");
+		opts = {
+			encoding: 'utf8',
+		};
+		appendFile( fpath, 'beep boop 4', opts );
+		actual = readFile( fpath, 'utf8' );
 
-    t.strictEqual(actual, expected, "file contains expected data");
+		t.strictEqual( actual, expected, 'file contains expected data' );
 
-    restore();
-    t.end();
-  }
+		restore();
+		t.end();
+	}
 );
 
 tape(
-  "if the function encounters an error, the function throws the error",
-  opts,
-  function test(t) {
-    var expected;
-    var actual;
-    var file;
-    var err;
+	'if the function encounters an error, the function throws the error',
+	opts,
+	function test( t ) {
+		var expected;
+		var actual;
+		var file;
+		var err;
 
-    file = "beepboopbapbop/dkfjldjfaklsjf/bdlfalfas/bkldflakfjas"; // non-existent directory path
+		file = 'beepboopbapbop/dkfjldjfaklsjf/bdlfalfas/bkldflakfjas'; // non-existent directory path
 
-    try {
-      appendFile(file, "beepboopbapbop");
-    } catch (error) {
-      err = error;
-    }
+		try {
+			appendFile( file, 'beepboopbapbop' );
+		} catch ( error ) {
+			err = error;
+		}
 
-    t.strictEqual(err instanceof Error, true, err.message);
+		t.strictEqual( err instanceof Error, true, err.message );
 
-    expected = DATA;
-    actual = readFile(fpath, "utf8");
-    t.strictEqual(actual, expected, "file contains expected contents");
+		expected = DATA;
+		actual = readFile( fpath, 'utf8' );
+		t.strictEqual( actual, expected, 'file contains expected contents' );
 
-    restore();
-    t.end();
-  }
+		restore();
+		t.end();
+	}
 );
 
 tape(
-  "if the function encounters an error, the function throws the error (option string)",
-  opts,
-  function test(t) {
-    var expected;
-    var actual;
-    var file;
-    var err;
+	'if the function encounters an error, the function throws the error (option string)',
+	opts,
+	function test( t ) {
+		var expected;
+		var actual;
+		var file;
+		var err;
 
-    file = "beepboopbapbop/dkfjldjfaklsjf/bdlfalfas/bkldflakfjas"; // non-existent directory path
+		file = 'beepboopbapbop/dkfjldjfaklsjf/bdlfalfas/bkldflakfjas'; // non-existent directory path
 
-    try {
-      appendFile(file, "beepboopbapbop", "utf8");
-    } catch (error) {
-      err = error;
-    }
+		try {
+			appendFile( file, 'beepboopbapbop', 'utf8' );
+		} catch ( error ) {
+			err = error;
+		}
 
-    t.strictEqual(err instanceof Error, true, err.message);
+		t.strictEqual( err instanceof Error, true, err.message );
 
-    expected = DATA;
-    actual = readFile(fpath, "utf8");
-    t.strictEqual(actual, expected, "file contains expected contents");
+		expected = DATA;
+		actual = readFile( fpath, 'utf8' );
+		t.strictEqual( actual, expected, 'file contains expected contents' );
 
-    restore();
-    t.end();
-  }
+		restore();
+		t.end();
+	}
 );
 
 tape(
-  "if the function encounters an error, the function throws the error (option object)",
-  opts,
-  function test(t) {
-    var expected;
-    var actual;
-    var file;
-    var opts;
-    var err;
+	'if the function encounters an error, the function throws the error (option object)',
+	opts,
+	function test( t ) {
+		var expected;
+		var actual;
+		var file;
+		var opts;
+		var err;
 
-    file = "beepboopbapbop/dkfjldjfaklsjf/bdlfalfas/bkldflakfjas"; // non-existent directory path
+		file = 'beepboopbapbop/dkfjldjfaklsjf/bdlfalfas/bkldflakfjas'; // non-existent directory path
 
-    opts = {
-      encoding: "utf8",
-    };
+		opts = {
+			encoding: 'utf8',
+		};
 
-    try {
-      appendFile(file, "beepboopbapbop", opts);
-    } catch (error) {
-      err = error;
-    }
+		try {
+			appendFile( file, 'beepboopbapbop', opts );
+		} catch ( error ) {
+			err = error;
+		}
 
-    t.strictEqual(err instanceof Error, true, err.message);
+		t.strictEqual( err instanceof Error, true, err.message );
 
-    expected = DATA;
-    actual = readFile(fpath, "utf8");
-    t.strictEqual(actual, expected, "file contains expected contents");
+		expected = DATA;
+		actual = readFile( fpath, 'utf8' );
+		t.strictEqual( actual, expected, 'file contains expected contents' );
 
-    restore();
-    t.end();
-  }
+		restore();
+		t.end();
+	}
 );

--- a/lib/node_modules/@stdlib/fs/append-file/test/test.sync.js
+++ b/lib/node_modules/@stdlib/fs/append-file/test/test.sync.js
@@ -1,7 +1,7 @@
 /**
  * @license Apache-2.0
  *
- * Copyright (c) 2018 The Stdlib Authors.
+ * Copyright (c) 2024 The Stdlib Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/fs/append-file/test/test.sync.js
+++ b/lib/node_modules/@stdlib/fs/append-file/test/test.sync.js
@@ -23,6 +23,7 @@
 var join = require("path").join;
 var tape = require("tape");
 var readFile = require("@stdlib/fs/read-file").sync;
+var writeFile = require("@stdlib/fs/write-file").sync;
 var IS_BROWSER = require("@stdlib/assert/is-browser");
 var string2buffer = require("@stdlib/buffer/from-string");
 var appendFile = require("../lib/sync.js");
@@ -48,7 +49,7 @@ var DATA = readFile(fpath, "utf8");
  * @private
  */
 function restore() {
-  appendFile(fpath, DATA);
+  writeFile(fpath, DATA);
 }
 
 // TESTS //


### PR DESCRIPTION
adds file system append file utility to Stdlib

## Description

> What is the purpose of this pull request?
This pull request brings the node js file system append-file utility to Stdlib

This pull request:

is aligned with the purpose of achievinng feature parity with Node.js fs package. It Brings file system's powerful append file utility to Stdlib expanding its existing fs utilities.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Implementation details

-- async version
```
var join = require("path").join;

var fpath = join(__dirname, "examples", "fixtures", "file.txt");

appendFile(fpath, "beep boop\n", onAppend);

function onAppend(error) {
  if (error) {
    throw error;
  }
}
```

-- sync version
```
var appendFile = require( '@stdlib/fs/append-file' );

// Explicitly handle the error...
var err = appendFile( './beep/boop.txt', 'data to append\n' );
if ( err instanceof Error ) {
     throw err;
}
```

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
