### PR TITLE
feat: add `constants/float32/fourth-pi`

### DIFF
--- a/lib/node_modules/@stdlib/constants/float32/fourth-pi/README.md
+++ b/lib/node_modules/@stdlib/constants/float32/fourth-pi/README.md
@@ -1,0 +1,123 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# FLOAT32_FOURTH_PI
+
+> One fourth times the mathematical constant [π][pi].
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var FLOAT32_FOURTH_PI = require( '@stdlib/constants/float32/fourth-pi' );
+```
+
+#### FLOAT32_FOURTH_PI
+
+One fourth times the mathematical constant [π][pi].
+
+```javascript
+var bool = ( FLOAT32_FOURTH_PI === 7.853981852531433e-1 );
+// returns true
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- TODO: better example -->
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var FLOAT32_FOURTH_PI = require( '@stdlib/constants/float32/fourth-pi' );
+
+console.log( FLOAT32_FOURTH_PI );
+// => 7.853981852531433e-1
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/constants/float32/fourth_pi.h"
+```
+
+#### STDLIB_CONSTANT_FLOAT32_FOURTH_PI
+
+Macro for one fourth times the mathematical constant [π][pi].
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[pi]: https://en.wikipedia.org/wiki/Pi
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/constants/float32/fourth-pi/docs/repl.txt
+++ b/lib/node_modules/@stdlib/constants/float32/fourth-pi/docs/repl.txt
@@ -1,0 +1,12 @@
+
+{{alias}}
+    One fourth times the mathematical constant `π`.
+
+    Examples
+    --------
+    > {{alias}}
+    7.853981852531433e-1
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/constants/float32/fourth-pi/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/constants/float32/fourth-pi/docs/types/index.d.ts
@@ -1,0 +1,33 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* One fourth times the mathematical constant `π`.
+*
+* @example
+* var val = FLOAT32_FOURTH_PI;
+* // returns 7.853981852531433e-1
+*/
+declare const FLOAT32_FOURTH_PI: number;
+
+
+// EXPORTS //
+
+export = FLOAT32_FOURTH_PI;

--- a/lib/node_modules/@stdlib/constants/float32/fourth-pi/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/constants/float32/fourth-pi/docs/types/test.ts
@@ -1,0 +1,28 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import FLOAT32_FOURTH_PI = require( './index' );
+
+
+// TESTS //
+
+// The export is a number...
+{
+	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+	FLOAT32_FOURTH_PI; // $ExpectType number
+}

--- a/lib/node_modules/@stdlib/constants/float32/fourth-pi/examples/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/fourth-pi/examples/index.js
@@ -1,0 +1,24 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var FLOAT32_FOURTH_PI = require( './../lib' );
+
+console.log( FLOAT32_FOURTH_PI );
+// => 7.853981852531433e-1

--- a/lib/node_modules/@stdlib/constants/float32/fourth-pi/include/stdlib/constants/float32/fourth_pi.h
+++ b/lib/node_modules/@stdlib/constants/float32/fourth-pi/include/stdlib/constants/float32/fourth_pi.h
@@ -1,0 +1,27 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_CONSTANTS_FLOAT32_FOURTH_PI_H
+#define STDLIB_CONSTANTS_FLOAT32_FOURTH_PI_H
+
+/**
+* Macro for one fourth times the mathematical constant π.
+*/
+#define STDLIB_CONSTANT_FLOAT32_FOURTH_PI 7.85398163397448309616e-1f
+
+#endif // !STDLIB_CONSTANTS_FLOAT32_FOURTH_PI_H

--- a/lib/node_modules/@stdlib/constants/float32/fourth-pi/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/fourth-pi/lib/index.js
@@ -1,0 +1,52 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* One fourth times the mathematical constant `π`.
+*
+* @module @stdlib/constants/float32/fourth-pi
+* @type {number}
+*
+* @example
+* var FLOAT32_FOURTH_PI = require( '@stdlib/constants/float32/fourth-pi' );
+* // returns 7.853981852531433e-1
+*/
+
+// MODULES //
+
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+
+
+// MAIN //
+
+/**
+* One fourth times the mathematical constant `π`.
+*
+* @constant
+* @type {number}
+* @default 7.853981852531433e-1
+* @see [Wikipedia]{@link https://en.wikipedia.org/wiki/Pi}
+*/
+var FLOAT32_FOURTH_PI = float64ToFloat32( 7.85398163397448309616e-1 );
+
+
+// EXPORTS //
+
+module.exports = FLOAT32_FOURTH_PI;

--- a/lib/node_modules/@stdlib/constants/float32/fourth-pi/manifest.json
+++ b/lib/node_modules/@stdlib/constants/float32/fourth-pi/manifest.json
@@ -1,0 +1,36 @@
+{
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": []
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float32/fourth-pi/package.json
+++ b/lib/node_modules/@stdlib/constants/float32/fourth-pi/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@stdlib/constants/float32/fourth-pi",
+  "version": "0.0.0",
+  "description": "1/4 times π.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "constant",
+    "const",
+    "mathematics",
+    "math",
+    "fourth",
+    "pi",
+    "ieee754",
+    "float",
+    "floating-point",
+    "float32"
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float32/fourth-pi/test/test.js
+++ b/lib/node_modules/@stdlib/constants/float32/fourth-pi/test/test.js
@@ -1,0 +1,39 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var FLOAT32_FOURTH_PI = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a number', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof FLOAT32_FOURTH_PI, 'number', 'main export is a number' );
+	t.end();
+});
+
+tape( 'export is a single-precision floating-point number equal to 7.853981852531433e-1', function test( t ) {
+	t.equal( FLOAT32_FOURTH_PI, float64ToFloat32( 7.85398163397448309616e-1 ), 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds `constants/float32/fourth-pi`, which is the single precision equivalent for [`constants/float64/fourth-pi`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/constants/float64/fourth-pi)

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves a part of #2035.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
