### PR TITLE
fix addon of `blas/ext/base/dcusumors`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dcusumors/manifest.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcusumors/manifest.json
@@ -40,6 +40,7 @@
       "dependencies": [
         "@stdlib/napi/argv",
         "@stdlib/napi/argv-int64",
+        "@stdlib/napi/argv-double",
         "@stdlib/napi/argv-strided-float64array",
         "@stdlib/napi/export"
       ]

--- a/lib/node_modules/@stdlib/blas/ext/base/dcusumors/src/addon.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/dcusumors/src/addon.c
@@ -19,6 +19,7 @@
 #include "stdlib/blas/ext/base/dcusumors.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
+#include "stdlib/napi/argv_double.h"
 #include "stdlib/napi/argv_strided_float64array.h"
 #include "stdlib/napi/export.h"
 
@@ -33,7 +34,7 @@
 static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV( env, info, argv, argc, 6 );
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
-	STDLIB_NAPI_ARGV_INT64( env, sum, argv, 1 );
+	STDLIB_NAPI_ARGV_DOUBLE( env, sum, argv, 1 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 3 );
 	STDLIB_NAPI_ARGV_INT64( env, strideY, argv, 5 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 2 );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-  fixes the data type of `sum` from `int64` to `double` in `src/addon.c` of `blas/ext/base/dcusumors`

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   fixes #2041

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

https://github.com/stdlib-js/stdlib/pull/2041/files#diff-b5fcd80892477ade520b4d9b66e72c4a414a3a4e6acb1e05c9d91d15a4a3fcacL111

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
