### PR TITLE
fix: correctly handle signed zeroes in `math/base/special/atanf`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/atanf/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/atanf/lib/main.js
@@ -86,8 +86,8 @@ function atanf( x ) {
 	var y;
 	var z;
 
-	if ( isnanf( x ) ) {
-		return NaN;
+	if ( isnanf( x ) || x === 0.0 ) {
+		return x;
 	}
 	x = float64ToFloat32( x );
 	if ( x < 0.0 ) {

--- a/lib/node_modules/@stdlib/math/base/special/atanf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/atanf/src/main.c
@@ -88,8 +88,8 @@ float stdlib_base_atanf( const float x ) {
 	float y;
 	float z;
 
-	if ( stdlib_base_is_nanf( x ) ) {
-		return 0.0f / 0.0f; // NaN
+	if ( stdlib_base_is_nanf( x ) || x == 0.0f ) {
+		return x;
 	}
 	ax = x;
 	if ( x < 0.0f ) {

--- a/lib/node_modules/@stdlib/math/base/special/atanf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/atanf/test/test.js
@@ -25,6 +25,8 @@ var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var abs = require( '@stdlib/math/base/special/abs' );
 var EPS = require( '@stdlib/constants/float32/eps' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
+var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
 var atanf = require( './../lib' );
 
 
@@ -394,5 +396,23 @@ tape( 'the function computes the arctangent on the interval `[ 1e30, 1e38 ]`', f
 tape( 'the function returns `NaN` if provided `NaN`', function test( t ) {
 	var v = atanf( NaN );
 	t.equal( isnanf( v ), true, 'returns NaN' );
+	t.end();
+});
+
+tape( 'the function returns `-0` if provided `-0`', function test( t ) {
+	var v = atanf( -0.0 );
+	t.equal( isNegativeZerof( v ), true, 'returns -0' );
+	t.end();
+});
+
+tape( 'the function returns `0` if provided +0', function test( t ) {
+	var v;
+
+	v = atanf( 0.0 );
+	t.equal( isPositiveZerof( v ), true, 'returns +0' );
+
+	v = atanf( +0.0 );
+	t.equal( isPositiveZerof( v ), true, 'returns +0' );
+
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/atanf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/atanf/test/test.native.js
@@ -26,6 +26,8 @@ var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var abs = require( '@stdlib/math/base/special/abs' );
 var EPS = require( '@stdlib/constants/float32/eps' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
+var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -403,5 +405,23 @@ tape( 'the function computes the arctangent on the interval `[ 1e30, 1e38 ]`', o
 tape( 'the function returns `NaN` if provided `NaN`', opts, function test( t ) {
 	var v = atanf( NaN );
 	t.equal( isnanf( v ), true, 'returns NaN' );
+	t.end();
+});
+
+tape( 'the function returns `-0` if provided `-0`', opts, function test( t ) {
+	var v = atanf( -0.0 );
+	t.equal( isNegativeZerof( v ), true, 'returns -0' );
+	t.end();
+});
+
+tape( 'the function returns `0` if provided +0', opts, function test( t ) {
+	var v;
+
+	v = atanf( 0.0 );
+	t.equal( isPositiveZerof( v ), true, 'returns +0' );
+
+	v = atanf( +0.0 );
+	t.equal( isPositiveZerof( v ), true, 'returns +0' );
+
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   modifies both C and JavaScript implementations to handle signed zeroes in [`math/base/special/atanf`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/atanf).
-   adds corresponding test for checking results with positive and negative zeroes.

These changes are based on [this](https://github.com/stdlib-js/stdlib/issues/2113#issuecomment-2035283371).

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves a part of #2113.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
