### PR TITLE
feat: add `constants/float32/two-pi`

### DIFF
--- a/lib/node_modules/@stdlib/constants/float32/two-pi/README.md
+++ b/lib/node_modules/@stdlib/constants/float32/two-pi/README.md
@@ -1,0 +1,123 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# FLOAT32_TWO_PI
+
+> The mathematical constant [π][@stdlib/constants/float32/pi] times 2.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var FLOAT32_TWO_PI = require( '@stdlib/constants/float32/two-pi' );
+```
+
+#### FLOAT32_TWO_PI
+
+The mathematical constant [π][@stdlib/constants/float32/pi] times 2.
+
+```javascript
+var bool = ( FLOAT32_TWO_PI === 6.2831854820251465 );
+// returns true
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- TODO: better example -->
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var FLOAT32_TWO_PI = require( '@stdlib/constants/float32/two-pi' );
+
+console.log( FLOAT32_TWO_PI );
+// => 6.2831854820251465
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/constants/float32/half_pi.h"
+```
+
+#### STDLIB_CONSTANT_FLOAT32_TWO_PI
+
+Macro for The mathematical constant [π][@stdlib/constants/float32/pi] times 2.
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[@stdlib/constants/float32/pi]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/constants/float32/pi
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/constants/float32/two-pi/docs/repl.txt
+++ b/lib/node_modules/@stdlib/constants/float32/two-pi/docs/repl.txt
@@ -1,0 +1,12 @@
+
+{{alias}}
+    The mathematical constant `π` times `2`.
+
+    Examples
+    --------
+    > {{alias}}
+    6.2831854820251465
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/constants/float32/two-pi/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/constants/float32/two-pi/docs/types/index.d.ts
@@ -1,0 +1,33 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* The mathematical constant `π` times `2`.
+*
+* @example
+* var val = FLOAT32_TWO_PI;
+* // returns 6.2831854820251465
+*/
+declare const FLOAT32_TWO_PI: number;
+
+
+// EXPORTS //
+
+export = FLOAT32_TWO_PI;

--- a/lib/node_modules/@stdlib/constants/float32/two-pi/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/constants/float32/two-pi/docs/types/test.ts
@@ -1,0 +1,28 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import FLOAT32_TWO_PI = require( './index' );
+
+
+// TESTS //
+
+// The export is a number...
+{
+	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+	FLOAT32_TWO_PI; // $ExpectType number
+}

--- a/lib/node_modules/@stdlib/constants/float32/two-pi/examples/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/two-pi/examples/index.js
@@ -1,0 +1,24 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var FLOAT32_TWO_PI = require( './../lib' );
+
+console.log( FLOAT32_TWO_PI );
+// => 6.2831854820251465

--- a/lib/node_modules/@stdlib/constants/float32/two-pi/include/stdlib/constants/float32/two_pi.h
+++ b/lib/node_modules/@stdlib/constants/float32/two-pi/include/stdlib/constants/float32/two_pi.h
@@ -1,0 +1,27 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_CONSTANTS_FLOAT32_TWO_PI_H
+#define STDLIB_CONSTANTS_FLOAT32_TWO_PI_H
+
+/**
+* Macro for 2π.
+*/
+#define STDLIB_CONSTANT_FLOAT32_TWO_PI 6.283185307179586f
+
+#endif // !STDLIB_CONSTANTS_FLOAT32_TWO_PI_H

--- a/lib/node_modules/@stdlib/constants/float32/two-pi/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/two-pi/lib/index.js
@@ -1,0 +1,52 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* The mathematical constant `π` times `2`.
+*
+* @module @stdlib/constants/float32/two-pi
+* @type {number}
+*
+* @example
+* var FLOAT32_TWO_PI = require( '@stdlib/constants/float32/two-pi' );
+* // returns 6.2831854820251465
+*/
+
+// MODULES //
+
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+
+
+// MAIN //
+
+/**
+* The mathematical constant `π` times `2`.
+*
+* @constant
+* @type {number}
+* @default 6.2831854820251465
+* @see [Wikipedia]{@link https://en.wikipedia.org/wiki/Pi}
+*/
+var FLOAT32_TWO_PI = float64ToFloat32( 6.283185307179586 );
+
+
+// EXPORTS //
+
+module.exports = FLOAT32_TWO_PI;

--- a/lib/node_modules/@stdlib/constants/float32/two-pi/manifest.json
+++ b/lib/node_modules/@stdlib/constants/float32/two-pi/manifest.json
@@ -1,0 +1,36 @@
+{
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": []
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float32/two-pi/package.json
+++ b/lib/node_modules/@stdlib/constants/float32/two-pi/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@stdlib/constants/float32/two-pi",
+  "version": "0.0.0",
+  "description": "2π.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "constant",
+    "const",
+    "mathematics",
+    "math",
+    "pi",
+    "2pi",
+    "ieee754",
+    "float",
+    "precision",
+    "floating-point",
+    "float32"
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float32/two-pi/test/test.js
+++ b/lib/node_modules/@stdlib/constants/float32/two-pi/test/test.js
@@ -1,0 +1,39 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var FLOAT32_TWO_PI = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a number', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof FLOAT32_TWO_PI, 'number', 'main export is a number' );
+	t.end();
+});
+
+tape( 'export is a single-precision floating-point number equal to 6.2831854820251465', function test( t ) {
+	t.equal( FLOAT32_TWO_PI, float64ToFloat32( 6.283185307179586 ), 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds `constants/float32/two-pi`, which would be the single precision variant of [`constants/float64/two-pi`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/constants/float64/two-pi).
-   is a pre-requisite for #2124.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves a part of #2124.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

- Code coverage report:
   
<img width="1710" alt="Screenshot 2024-04-05 at 22 50 21" src="https://github.com/stdlib-js/stdlib/assets/67432819/04bd0cfe-20a2-4d65-9a97-3c71aed40d08">

- I have followed the function descriptions used in [`constants/float64/two-pi`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/constants/float64/two-pi).

- Values for reference:
   ```
    In [7]: var float64ToFloat32 = require("@stdlib/number/float64/base/to-float32");

    In [8]: console.log(float64ToFloat32(6.283185307179586))
    6.2831854820251465
   ```
    `repl` was really useful here.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
