### PR TITLE
fix: Bug with skin tone emojis when using prevGraphemeClusterBreak package

### DIFF
--- a/lib/node_modules/@stdlib/string/prev-grapheme-cluster-break/lib/main.js
+++ b/lib/node_modules/@stdlib/string/prev-grapheme-cluster-break/lib/main.js
@@ -63,6 +63,8 @@ var emojiProperty = grapheme.emojiProperty;
 * // returns -1
 */
 function prevGraphemeClusterBreak( str, fromIndex ) {
+	var regexEmojiMatching;
+	var regexEmoji;
 	var breaks;
 	var emoji;
 	var ans;
@@ -71,15 +73,20 @@ function prevGraphemeClusterBreak( str, fromIndex ) {
 	var cp;
 	var i;
 
-	var regexEmoji = new RegExp("\\p{Extended_Pictographic}", "ug");
-	var regexEmojiMatching = str.match(regexEmoji)
-	if (regexEmoji.test(str) && regexEmojiMatching && regexEmojiMatching.length === 1) {
-		str = regexEmojiMatching[0];
-	}
-
 	if ( !isString( str ) ) {
 		throw new TypeError( format( 'invalid argument. First argument must be a string. Value: `%s`.', str ) );
 	}
+
+	regexEmoji = /\p{Extended_Pictographic}/u;
+	regexEmojiMatching = str.match(regexEmoji);
+	if (
+		regexEmoji.test(str) && 
+	  	regexEmojiMatching && 
+    	regexEmojiMatching.length === 1
+	) {
+		str = regexEmojiMatching[0];
+	}
+
 	len = str.length;
 	if ( arguments.length > 1 ) {
 		if ( !isInteger( fromIndex ) ) {

--- a/lib/node_modules/@stdlib/string/prev-grapheme-cluster-break/lib/main.js
+++ b/lib/node_modules/@stdlib/string/prev-grapheme-cluster-break/lib/main.js
@@ -71,9 +71,10 @@ function prevGraphemeClusterBreak( str, fromIndex ) {
 	var cp;
 	var i;
 
-	const regexEmoji = /\p{Extended_Pictographic}/ug;
-	if (regexEmoji.test(str) && str.match(regexEmoji).length === 1) {
-		str = str.match(regexEmoji)?.[0];
+	var regexEmoji = new RegExp("\\p{Extended_Pictographic}", "ug");
+	var regexEmojiMatching = str.match(regexEmoji)
+	if (regexEmoji.test(str) && regexEmojiMatching && regexEmojiMatching.length === 1) {
+		str = regexEmojiMatching[0];
 	}
 
 	if ( !isString( str ) ) {

--- a/lib/node_modules/@stdlib/string/prev-grapheme-cluster-break/lib/main.js
+++ b/lib/node_modules/@stdlib/string/prev-grapheme-cluster-break/lib/main.js
@@ -71,6 +71,11 @@ function prevGraphemeClusterBreak( str, fromIndex ) {
 	var cp;
 	var i;
 
+	const regexEmoji = /\p{Extended_Pictographic}/ug;
+	if (regexEmoji.test(str) && str.match(regexEmoji).length === 1) {
+		str = str.match(regexEmoji)?.[0];
+	}
+
 	if ( !isString( str ) ) {
 		throw new TypeError( format( 'invalid argument. First argument must be a string. Value: `%s`.', str ) );
 	}

--- a/lib/node_modules/@stdlib/string/prev-grapheme-cluster-break/test/test.js
+++ b/lib/node_modules/@stdlib/string/prev-grapheme-cluster-break/test/test.js
@@ -245,3 +245,12 @@ tape( 'the function returns -1 if provided an empty string', function test( t ) 
 
 	t.end();
 });
+
+tape( 'the function returns -1 if provided a skin tone emoji', function test( t ) {
+	var out;
+
+	out = prevGraphemeClusterBreak( '👉🏿' );
+	t.strictEqual( out, -1, 'returns expected value' );
+
+	t.end();
+});


### PR DESCRIPTION
Resolves #1092 

## Description

> What is the purpose of this pull request?

There's an issue with prevGraphemeClusterBreak package, if I compare the results with nextGraphemeClusterBreak for a single skin tone emoji it doesn't return the same values,
```javascript
prevGraphemeClusterBreak( '👉🏿' ) // returns 1
nextGraphemeClusterBreak( '👉🏿' ) // returns -1
``` 

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #1092 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
