### PR TITLE
feat: add a stdlib ASCII art in REPL's default welcome message

### DIFF
--- a/lib/node_modules/@stdlib/repl/lib/welcome_text.js
+++ b/lib/node_modules/@stdlib/repl/lib/welcome_text.js
@@ -21,8 +21,12 @@
 // MAIN //
 
 var MSG = [
+	'     _      _ _ _ _',
+	' ___| |_ __| | (_) |__    |  A better REPL for JavaScript and Node.js.',
+	'/ __| __/ _` | | | \'_ \\   |',
+	'\\__ \\ || (_| | | | |_) |  |  For more info about stdlib, see the source repository:',
+	'|___/\\__\\__,_|_|_|_.__/   |  https://github.com/stdlib-js/stdlib',
 	'',
-	'A better REPL for JavaScript and Node.js.',
 
 	// TODO: include platform, copyright, version (see Julia, R, and Python for inspiration)
 	'',
@@ -38,10 +42,6 @@ var MSG = [
 	'',
 	'    license()               Print license information.',
 	'    copyright()             Print copyright information.',
-	'',
-	'For more info about stdlib, see the source repository:',
-	'',
-	'  https://github.com/stdlib-js/stdlib',
 	'',
 	''
 ].join( '\n' );

--- a/lib/node_modules/@stdlib/repl/lib/welcome_text.js
+++ b/lib/node_modules/@stdlib/repl/lib/welcome_text.js
@@ -24,7 +24,7 @@ var MSG = [
 	'     _      _ _ _ _',
 	' ___| |_ __| | (_) |__    |  A better REPL for JavaScript and Node.js.',
 	'/ __| __/ _` | | | \'_ \\   |',
-	'\\__ \\ || (_| | | | |_) |  |  For more info about stdlib, see the source repository:',
+	'\\__ \\ || (_| | | | |_) |  |  For more info, see the source repository:',
 	'|___/\\__\\__,_|_|_|_.__/   |  https://github.com/stdlib-js/stdlib',
 	'',
 


### PR DESCRIPTION
Resolves #2175

## Description

> What is the purpose of this pull request?

This pull request adds a stdlib ASCII art in the default welcome message of the REPL.

Some design combinations I tried are attached below:

- ### Julia type partitioning

  - **Current implementation**:
![julia_std](https://github.com/stdlib-js/stdlib/assets/130062020/ecc80214-ea5e-4fd1-832f-73530ad5a697)
  
  - We can add/remove more spaces to make it more spread-out/compact:
![julia_std_nospace](https://github.com/stdlib-js/stdlib/assets/130062020/7f5a762c-b498-44fc-a751-c9e1324fade5)
![julia_std_spacetop](https://github.com/stdlib-js/stdlib/assets/130062020/f36b9b3b-b8bf-43ee-b5ab-b5276a65eaf1)

  - A Tall typeface:
![julia_tall](https://github.com/stdlib-js/stdlib/assets/130062020/b3c41020-a7ea-4da3-9bb5-d7ce2f8a0c41)

- ### Simple design

  ![simple_nospace](https://github.com/stdlib-js/stdlib/assets/130062020/e3532340-6f99-402d-9802-5f0b7ab8dfb0)

- ### A dramatic design I made myself (personally, not a fan)

  ![dramatic_1](https://github.com/stdlib-js/stdlib/assets/130062020/fbbddcc3-3fdc-45a7-aaa9-19fe6d5a9c3e)
  ![dramatic_2](https://github.com/stdlib-js/stdlib/assets/130062020/b0577ad1-c74e-4b8f-9005-fe0e84a5346d)

@kgryte all yours to choose... I prefer the current implementation or a more compact version of it

There are various other fonts available [here](https://patorjk.com/software/taag/#p=display&f=BlurVision%20ASCII&t=stdlib) too, although most are a bit too dramatic for a REPL application IMO...
If we are looking for even smaller arts, [*rectangles*](https://patorjk.com/software/taag/#p=display&f=Rectangles&t=stdlib), [*small*](https://patorjk.com/software/taag/#p=display&f=Small&t=stdlib) etc are some of the good fonts 

We can also explore incorporating some colors into our welcome message, now or in the future...

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #2175

## Questions

> Any questions for reviewers of this pull request?

Can we shorten the text `'For more info about stdlib, see the source repository:'` to just `'For more info, see the source repository:'` or `'see the source repository:'`? It better aligns with the rest of the block giving us a fixed width as attached below:

![image](https://github.com/stdlib-js/stdlib/assets/130062020/6755fc63-131b-43ff-8284-9cc396e02b7d)

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
