### PR TITLE
docs: fix example return value in `math/base/special/rcbrt`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/rcbrt/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/rcbrt/docs/types/index.d.ts
@@ -42,7 +42,7 @@
 *
 * @example
 * var v = rcbrt( -8.0 );
-* // returns -2.0
+* // returns -0.5
 *
 * @example
 * var v = rcbrt( NaN );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   changes the output of an example to display correct value.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

```
In [18]: rcbrt(-8.0)
Out[18]: -0.5
```

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
