### PR TITLE
feat: add `blas/base/grot`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/grot/README.md
+++ b/lib/node_modules/@stdlib/blas/base/grot/README.md
@@ -1,0 +1,201 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# grot
+
+> Apply a plane rotation.
+
+<section class="intro">
+
+This BLAS level 1 routine applies a real plane rotation to real double-precision floating-point vectors. The plane rotation is applied to `N` points, where the points to be rotated are contained in vectors `x` and `y` and where the cosine and sine of the angle of rotation are `c` and `s`, respectively. The operation is as follows:
+
+<!-- <equation class="equation" label="eq:grot" align="center" raw="\begin{bmatrix}x_i \\ y_i\end{bmatrix} = \begin{bmatrix} c & s \\ -s & c\end{bmatrix}\begin{bmatrix} x_i \\ y_i \end{bmatrix}" alt="Plane rotation"> -->
+
+<!-- </equation> -->
+
+where `x_i` and `y_i` are the individual elements on which the rotation is applied.
+
+</section>
+
+<!-- /.intro -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var grot = require( '@stdlib/blas/base/grot' );
+```
+
+#### grot( N, x, strideX, y, strideY, c, s )
+
+Applies a plane rotation.
+
+```javascript
+var x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
+var y = [ 6.0, 7.0, 8.0, 9.0, 10.0 ];
+
+grot( x.length, x, 1, y, 1, 0.8, 0.6 );
+// x => [ ~4.4, ~5.8, 7.2, 8.6, 10.0 ]
+// y => [ ~4.2, 4.4, 4.6, 4.8, 5.0 ]
+```
+
+The function has the following parameters:
+
+-   **N**: number of indexed elements.
+-   **x**: first input [`Array`][mdn-array] or [`typed array`][mdn-typed-array].
+-   **strideX**: index increment for `x`.
+-   **y**: second input [`Array`][mdn-array] or [`typed array`][mdn-typed-array].
+-   **strideY**: index increment for `y`.
+-   **c**: cosine of the angle of rotation.
+-   **s**: sine of the angle of rotation.
+
+The `N` and stride parameters determine how values in the strided arrays are accessed at runtime. For example, to apply a plane rotation to every other element,
+
+```javascript
+var x = [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ];
+var y = [ 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 ];
+
+grot( 3, x, 2, y, 2, 0.8, 0.6 );
+// x => [ 5.0, 2.0, 7.8, 4.0, 10.6, 6.0 ]
+// y => [ ~5.0, 8.0, 5.4, 10.0, ~5.8, 12.0 ]
+```
+
+Note that indexing is relative to the first index. To introduce an offset, use [`typed array`][mdn-typed-array] views.
+
+<!-- eslint-disable stdlib/capitalized-comments -->
+
+```javascript
+var Float64Array = require( '@stdlib/array/float64' );
+
+// Initial arrays...
+var x0 = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+var y0 = new Float64Array( [ 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 ] );
+
+// Create offset views...
+var x1 = new Float64Array( x0.buffer, x0.BYTES_PER_ELEMENT*1 ); // start at 2nd element
+var y1 = new Float64Array( y0.buffer, y0.BYTES_PER_ELEMENT*3 ); // start at 4th element
+
+grot( 3, x1, 1, y1, 1, 0.8, 0.6 );
+// x0 => <Float64Array>[ 1.0, 7.6, 9.0, ~10.4, 5.0, 6.0 ]
+// y0 => <Float64Array>[ 7.0, 8.0, 9.0, 6.8, ~7.0, ~7.2 ]
+```
+
+#### grot.ndarray( N, x, strideX, offsetX, y, strideY, offsetY, c, s )
+
+Applies a plane rotation using alternative indexing semantics.
+
+```javascript
+var x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
+var y = [ 6.0, 7.0, 8.0, 9.0, 10.0 ];
+
+grot.ndarray( 4, x, 1, 1, y, 1, 1, 0.8, 0.6 );
+// x => [ 1.0, ~5.8, 7.2, 8.6, 10.0 ]
+// y => [ 6.0, 4.4, ~4.6, ~4.8, 5.0 ]
+```
+
+The function has the following additional parameters:
+
+-   **offsetX**: starting index for `x`.
+-   **offsetY**: starting index for `y`.
+
+While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying buffer, the offset parameters support indexing semantics based on starting indices. For example, to apply a plane rotation to every other element starting from the second element,
+
+```javascript
+var x = [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ];
+var y = [ 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 ];
+
+grot.ndarray( 3, x, 2, 1, y, 2, 1, 0.8, 0.6 );
+// x => [ 1.0, 6.4, 3.0, 9.2, 5.0, 12.0 ]
+// y => [ 7.0, 5.2, 9.0, 5.6, 11.0, ~6.0 ]
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   If `N <= 0`, both functions leave `x` and `y` unchanged.
+-   Both functions support array-like objects having getter and setter accessors for array element access (e.g., @stdlib/array/complex64). 
+-   `grot()` corresponds to the [BLAS][blas] level 1 function [`drot`][drot] with the exception that this implementation works with any array type, not just Float64Arrays. Depending on the environment, the typed versions ([`drot`][@stdlib/blas/base/drot], [`srot`][@stdlib/blas/base/srot], etc.) are likely to be significantly more performant.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var grot = require( '@stdlib/blas/base/grot' );
+
+var opts = {
+    'dtype': 'float64'
+};
+var x = discreteUniform( 10, 0, 500, opts );
+console.log( x );
+
+var y = discreteUniform( x.length, 0, 255, opts );
+console.log( y );
+
+// Apply a plane rotation:
+grot( x.length, x, 1, y, 1, 0.8, 0.6 );
+console.log( x );
+console.log( y );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[blas]: http://www.netlib.org/blas
+
+[drot]: https://www.netlib.org/lapack/explore-html/d1/d45/group__rot_gae48ef017306866ac2d5a8c5a52617858.html#gae48ef017306866ac2d5a8c5a5261785
+
+[mdn-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array
+
+[mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
+
+[@stdlib/blas/base/drot]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/blas/base/drot
+
+[@stdlib/blas/base/srot]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/blas/base/srot
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/blas/base/grot/README.md
+++ b/lib/node_modules/@stdlib/blas/base/grot/README.md
@@ -136,7 +136,7 @@ grot.ndarray( 3, x, 2, 1, y, 2, 1, 0.8, 0.6 );
 ## Notes
 
 -   If `N <= 0`, both functions leave `x` and `y` unchanged.
--   Both functions support array-like objects having getter and setter accessors for array element access (e.g., @stdlib/array/complex64). 
+-   Both functions support array-like objects having getter and setter accessors for array element access (e.g., [`@stdlib/array/complex64`][@stdlib/array/complex64]). 
 -   `grot()` corresponds to the [BLAS][blas] level 1 function [`drot`][drot] with the exception that this implementation works with any array type, not just Float64Arrays. Depending on the environment, the typed versions ([`drot`][@stdlib/blas/base/drot], [`srot`][@stdlib/blas/base/srot], etc.) are likely to be significantly more performant.
 
 </section>
@@ -195,6 +195,8 @@ console.log( y );
 [@stdlib/blas/base/drot]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/blas/base/drot
 
 [@stdlib/blas/base/srot]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/blas/base/srot
+
+[@stdlib/array/complex64]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/complex64
 
 </section>
 

--- a/lib/node_modules/@stdlib/blas/base/grot/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/grot/benchmark/benchmark.js
@@ -1,0 +1,103 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var pkg = require( './../package.json' ).name;
+var grot = require( './../lib/' );
+
+
+// VARIABLES //
+
+var options = {
+	'dtype': 'generic'
+};
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var z;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			z = grot( len, x, 1, y, 1, 0.707, 0.707 );
+			if ( isnan( z[ i%x.length ] ) ) {
+				b.fail( 'something went wrong' );
+			}
+		}
+		b.toc();
+		if ( isnan( z[ i%x.length ] ) ) {
+			b.fail( 'something went wrong' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/blas/base/grot/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/grot/benchmark/benchmark.js
@@ -63,12 +63,12 @@ function createBenchmark( len ) {
 		for ( i = 0; i < b.iterations; i++ ) {
 			z = grot( len, x, 1, y, 1, 0.707, 0.707 );
 			if ( isnan( z[ i%x.length ] ) ) {
-				b.fail( 'something went wrong' );
+				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
 		if ( isnan( z[ i%x.length ] ) ) {
-			b.fail( 'something went wrong' );
+			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );
 		b.end();

--- a/lib/node_modules/@stdlib/blas/base/grot/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/grot/benchmark/benchmark.ndarray.js
@@ -1,0 +1,103 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var pkg = require( './../package.json' ).name;
+var grot = require( './../lib' ).ndarray;
+
+
+// VARIABLES //
+
+var options = {
+	'dtype': 'generic'
+};
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = uniform( len, -100.0, 100.0, options );
+	var y = uniform( len, -100.0, 100.0, options );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var z;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			z = grot( len, x, 1, 0, y, 1, 0, 0.707, 0.707 );
+			if ( isnan( z[ i%x.length ] ) ) {
+				b.fail( 'something went wrong' );
+			}
+		}
+		b.toc();
+		if ( isnan( z[ i%x.length ] ) ) {
+			b.fail( 'something went wrong' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':ndarray:len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/blas/base/grot/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/grot/benchmark/benchmark.ndarray.js
@@ -63,12 +63,12 @@ function createBenchmark( len ) {
 		for ( i = 0; i < b.iterations; i++ ) {
 			z = grot( len, x, 1, 0, y, 1, 0, 0.707, 0.707 );
 			if ( isnan( z[ i%x.length ] ) ) {
-				b.fail( 'something went wrong' );
+				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
 		if ( isnan( z[ i%x.length ] ) ) {
-			b.fail( 'something went wrong' );
+			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );
 		b.end();

--- a/lib/node_modules/@stdlib/blas/base/grot/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/base/grot/docs/repl.txt
@@ -8,7 +8,7 @@
     Indexing is relative to the first index. To introduce an offset, use typed
     array views.
 
-    If `N` is less than or equal to `0`, the vectors are unchanged.
+    If `N` is less than or equal to `0`, the arrays are left unchanged.
 
     Parameters
     ----------

--- a/lib/node_modules/@stdlib/blas/base/grot/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/base/grot/docs/repl.txt
@@ -1,0 +1,135 @@
+
+{{alias}}( N, x, strideX, y, strideY, c, s )
+    Applies a plane rotation.
+
+    The `N` and stride parameters determine how values in the strided arrays are
+    accessed at runtime.
+
+    Indexing is relative to the first index. To introduce an offset, use typed
+    array views.
+
+    If `N` is less than or equal to `0`, the vectors are unchanged.
+
+    Parameters
+    ----------
+    N: integer
+        Number of indexed elements.
+
+    x: Array<number>|TypedArray
+        First input array.
+
+    strideX: integer
+        Index increment for `x`.
+
+    y: Array<number>|TypedArray
+        Second input array.
+
+    strideY: integer
+        Index increment for `y`.
+
+    c: number
+        Cosine of the angle of rotation.
+
+    s: number
+        Sine of the angle of rotation.
+
+    Returns
+    -------
+    y: Array<number>|TypedArray
+        Second input array.
+
+    Examples
+    --------
+    // Standard Usage:
+    > var x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
+    > var y = [ 6.0, 7.0, 8.0, 9.0, 10.0 ];
+    > {{alias}}( x.length, x, 1, y, 1, 0.8, 0.6 );
+    > x
+    [ ~4.4, ~5.8, 7.2, 8.6, 10.0 ]
+    > y
+    [ ~4.2, 4.4, 4.6, 4.8, 5.0 ]
+
+    // Advanced Indexing:
+    > x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
+    > y = [ 6.0, 7.0, 8.0, 9.0, 10.0 ];
+    > {{alias}}( 2, x, -1, y, 2, 0.707, 0.707 );
+    > x
+    [ ~6.36, ~5.66, 3.0, 4.0, 5.0 ]
+    > y
+    [ ~2.83, 7.0, ~4.95, 9.0, 10.0 ]
+
+    // Using typed array views:
+    > var x0 = new {{alias:@stdlib/array/float64}}( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+    > var y0 = new {{alias:@stdlib/array/float64}}( [ 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 ] );
+    > var x1 = new {{alias:@stdlib/array/float64}}( x0.buffer, x0.BYTES_PER_ELEMENT*1 );
+    > var y1 = new {{alias:@stdlib/array/float64}}( y0.buffer, y0.BYTES_PER_ELEMENT*3 );
+    > {{alias}}( 3, x1, 1, y1, 1, 0.8, 0.6 );
+    > x0
+    <Float64Array>[ 1.0, 7.6, 9.0, ~10.4, 5.0, 6.0 ]
+    > y0
+    <Float64Array>[ 7.0, 8.0, 9.0, 6.8, ~7.0, ~7.2 ]
+
+
+{{alias}}.ndarray( N, x, strideX, offsetX, y, strideY, offsetY, c, s )
+    Applies a plane rotation using alternative indexing semantics.
+
+    While typed array views mandate a view offset based on the underlying
+    buffer, the offset parameters support indexing semantics based on starting
+    indices.
+
+    Parameters
+    ----------
+    N: integer
+        Number of indexed elements.
+
+    x: Array<number>|TypedArray
+        First input array.
+
+    strideX: integer
+        Index increment for `x`.
+
+    offsetX: integer
+        Starting index for `x`.
+
+    y: Array<number>|TypedArray
+        Second input array.
+
+    strideY: integer
+        Index increment for `y`.
+
+    offsetY: integer
+        Starting index for `y`.
+
+    c: number
+        Cosine of the angle of rotation.
+
+    s: number
+        Sine of the angle of rotation.
+
+    Returns
+    -------
+    y: Array<number>|TypedArray
+        Second input array.
+
+    Examples
+    --------
+    // Standard Usage:
+    > var x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
+    > var y = [ 6.0, 7.0, 8.0, 9.0, 10.0 ];
+    > {{alias}}.ndarray( 4, x, 1, 1, y, 1, 1, 0.8, 0.6 );
+    > x
+    [ 1.0, ~5.8, 7.2, 8.6, 10.0 ]
+    > y
+    [ 6.0, 4.4, ~4.6, ~4.8, 5.0 ]
+
+    // Advanced Indexing:
+    > x = [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ];
+    > y = [ 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 ];
+    > {{alias}}.ndarray( 3, x, 2, 1, y, 2, 1, 0.8, 0.6 );
+    > x
+    [ 1.0, 6.4, 3.0, 9.2, 5.0, 12.0 ]
+    > y
+    [ 7.0, 5.2, 9.0, 5.6, 11.0, ~6.0 ]
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/blas/base/grot/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/base/grot/docs/types/index.d.ts
@@ -1,0 +1,109 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { NumericArray } from '@stdlib/types/array';
+
+/**
+* Interface describing `grot`.
+*/
+interface Routine {
+	/**
+	* Applies a plane rotation.
+	*
+	* @param N - number of indexed elements
+	* @param x - first input array
+	* @param strideX - `x` stride length
+	* @param y - second input array
+	* @param strideY - `y` stride length
+	* @param c - cosine of the angle of rotation
+	* @param s - sine of the angle of rotation
+	* @returns `y`
+	*
+	* @example
+	* var x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
+	* var y = [ 6.0, 7.0, 8.0, 9.0, 10.0 ];
+	*
+	* grot( x.length, x, 1, y, 1, 0.8, 0.6 );
+	* // x => [ ~4.4, ~5.8, 7.2, 8.6, 10.0 ]
+	* // y => [ ~4.2, 4.4, 4.6, 4.8, 5.0 ]
+	*/
+	( N: number, x: NumericArray, strideX: number, y: NumericArray, strideY: number, c: number, s: number ): NumericArray;
+
+	/**
+	* Applies a plane rotation using alternative indexing semantics.
+	*
+	* @param N - number of indexed elements
+	* @param x - first input array
+	* @param strideX - `x` stride length
+	* @param offsetX - starting index for `x`
+	* @param y - second input array
+	* @param strideY - `y` stride length
+	* @param offsetY - starting index for `y`
+	* @param c - cosine of the angle of rotation
+	* @param s - sine of the angle of rotation
+	* @returns `y`
+	*
+	* @example
+	* var x = [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+	* var y = [ 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 ] );
+	*
+	* grot.ndarray( 3, x, 2, 1, y, 2, 1, 0.8, 0.6 );
+	* // x => [ 1.0, 6.4, 3.0, 9.2, 5.0, 12.0 ]
+	* // y => [ 7.0, 5.2, 9.0, 5.6, 11.0, ~6.0 ]
+	*/
+	ndarray( N: number, x: NumericArray, strideX: number, offsetX: number, y: NumericArray, strideY: number, offsetY: number, c: number, s: number ): NumericArray;
+}
+
+/**
+* Applies a plane rotation.
+*
+* @param N - number of indexed elements
+* @param x - first input array
+* @param strideX - `x` stride length
+* @param y - second input array
+* @param strideY - `y` stride length
+* @param c - cosine of the angle of rotation
+* @param s - sine of the angle of rotation
+* @returns `y`
+*
+* @example
+* var x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
+* var y = [ 6.0, 7.0, 8.0, 9.0, 10.0 ];
+*
+* grot( x.length, x, 1, y, 1, 0.8, 0.6 );
+* // x => [ ~4.4, ~5.8, 7.2, 8.6, 10.0 ]
+* // y => [ ~4.2, 4.4, ~4.6, ~4.8, 5.0 ]
+*
+* @example
+* var x = [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ];
+* var y = [ 7.0, 8.0, 9.0, 10.0, 11.0, 12.0 ];
+*
+* grot.ndarray( 3, x, 2, 1, y, 2, 1, 0.8, 0.6 );
+* // x => [ 1.0, 6.4, 3.0, 9.2, 5.0, 12.0 ]
+* // y => [ 7.0, 5.2, 9.0, 5.6, 11.0, ~6.0 ]
+*/
+declare var grot: Routine;
+
+
+// EXPORTS //
+
+export = grot;

--- a/lib/node_modules/@stdlib/blas/base/grot/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/base/grot/docs/types/test.ts
@@ -1,0 +1,309 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import grot = require( './index' );
+
+
+// TESTS //
+
+// The function returns a numeric array...
+{
+	const x = new Float64Array( 10 );
+	const y = new Float64Array( 10 );
+
+	grot( x.length, x, 1, y, 1, 1.0, 0.0 ); // $ExpectType NumericArray
+}
+
+// The compiler throws an error if the function is provided a first argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+	const y = new Float64Array( 10 );
+
+	grot( '10', x, 1, y, 1, 1.0, 0.0 ); // $ExpectError
+	grot( true, x, 1, y, 1, 1.0, 0.0 ); // $ExpectError
+	grot( false, x, 1, y, 1, 1.0, 0.0 ); // $ExpectError
+	grot( null, x, 1, y, 1, 1.0, 0.0 ); // $ExpectError
+	grot( undefined, x, 1, y, 1, 1.0, 0.0 ); // $ExpectError
+	grot( [], x, 1, y, 1, 1.0, 0.0 ); // $ExpectError
+	grot( {}, x, 1, y, 1, 1.0, 0.0 ); // $ExpectError
+	grot( ( x: number ): number => x, x, 1, y, 1, 1.0, 0.0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument which is not a numeric array...
+{
+	const x = new Float64Array( 10 );
+	const y = new Float64Array( 10 );
+
+	grot( x.length, 10, 1, y, 1, 1.0, 0.0 ); // $ExpectError
+	grot( x.length, '10', 1, y, 1, 1.0, 0.0 ); // $ExpectError
+	grot( x.length, true, 1, y, 1, 1.0, 0.0 ); // $ExpectError
+	grot( x.length, false, 1, y, 1, 1.0, 0.0 ); // $ExpectError
+	grot( x.length, null, 1, y, 1, 1.0, 0.0 ); // $ExpectError
+	grot( x.length, undefined, 1, y, 1, 1.0, 0.0 ); // $ExpectError
+	grot( x.length, [ '1' ], 1, y, 1, 1.0, 0.0 ); // $ExpectError
+	grot( x.length, {}, 1, y, 1, 1.0, 0.0 ); // $ExpectError
+	grot( x.length, ( x: number ): number => x, 1, y, 1, 1.0, 0.0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a third argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+	const y = new Float64Array( 10 );
+
+	grot( x.length, x, '10', y, 1, 1.0, 0.0 ); // $ExpectError
+	grot( x.length, x, true, y, 1, 1.0, 0.0 ); // $ExpectError
+	grot( x.length, x, false, y, 1, 1.0, 0.0 ); // $ExpectError
+	grot( x.length, x, null, y, 1, 1.0, 0.0 ); // $ExpectError
+	grot( x.length, x, undefined, y, 1, 1.0, 0.0 ); // $ExpectError
+	grot( x.length, x, [], y, 1, 1.0, 0.0 ); // $ExpectError
+	grot( x.length, x, {}, y, 1, 1.0, 0.0 ); // $ExpectError
+	grot( x.length, x, ( x: number ): number => x, y, 1, 1.0, 0.0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a fourth argument which is not a numeric array...
+{
+	const x = new Float64Array( 10 );
+
+	grot( x.length, x, 1, 10, 1, 1.0, 0.0 ); // $ExpectError
+	grot( x.length, x, 1, '10', 1, 1.0, 0.0 ); // $ExpectError
+	grot( x.length, x, 1, true, 1, 1.0, 0.0 ); // $ExpectError
+	grot( x.length, x, 1, false, 1, 1.0, 0.0 ); // $ExpectError
+	grot( x.length, x, 1, null, 1, 1.0, 0.0 ); // $ExpectError
+	grot( x.length, x, 1, undefined, 1, 1.0, 0.0 ); // $ExpectError
+	grot( x.length, x, 1, [ '1' ], 1, 1.0, 0.0 ); // $ExpectError
+	grot( x.length, x, 1, {}, 1, 1.0, 0.0 ); // $ExpectError
+	grot( x.length, x, 1, ( x: number ): number => x, 1, 1.0, 0.0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a fifth argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+	const y = new Float64Array( 10 );
+
+	grot( x.length, x, 1, y, '10', 1.0, 0.0 ); // $ExpectError
+	grot( x.length, x, 1, y, true, 1.0, 0.0 ); // $ExpectError
+	grot( x.length, x, 1, y, false, 1.0, 0.0 ); // $ExpectError
+	grot( x.length, x, 1, y, null, 1.0, 0.0 ); // $ExpectError
+	grot( x.length, x, 1, y, undefined, 1.0, 0.0 ); // $ExpectError
+	grot( x.length, x, 1, y, [], 1.0, 0.0 ); // $ExpectError
+	grot( x.length, x, 1, y, {}, 1.0, 0.0 ); // $ExpectError
+	grot( x.length, x, 1, y, ( x: number ): number => x, 1.0, 0.0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a sixth argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+	const y = new Float64Array( 10 );
+
+	grot( x.length, x, 1, y, 1, '10', 0.0 ); // $ExpectError
+	grot( x.length, x, 1, y, 1, true, 0.0 ); // $ExpectError
+	grot( x.length, x, 1, y, 1, false, 0.0 ); // $ExpectError
+	grot( x.length, x, 1, y, 1, null, 0.0 ); // $ExpectError
+	grot( x.length, x, 1, y, 1, undefined, 0.0 ); // $ExpectError
+	grot( x.length, x, 1, y, 1, [], 0.0 ); // $ExpectError
+	grot( x.length, x, 1, y, 1, {}, 0.0 ); // $ExpectError
+	grot( x.length, x, 1, y, 1, ( x: number ): number => x, 0.0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a seventh argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+	const y = new Float64Array( 10 );
+
+	grot( x.length, x, 1, y, 1, 1.0, '10' ); // $ExpectError
+	grot( x.length, x, 1, y, 1, 1.0, true ); // $ExpectError
+	grot( x.length, x, 1, y, 1, 1.0, false ); // $ExpectError
+	grot( x.length, x, 1, y, 1, 1.0, null ); // $ExpectError
+	grot( x.length, x, 1, y, 1, 1.0, undefined ); // $ExpectError
+	grot( x.length, x, 1, y, 1, 1.0, [] ); // $ExpectError
+	grot( x.length, x, 1, y, 1, 1.0, {} ); // $ExpectError
+	grot( x.length, x, 1, y, 1, 1.0, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	const x = new Float64Array( 10 );
+	const y = new Float64Array( 10 );
+
+	grot(); // $ExpectError
+	grot( x.length ); // $ExpectError
+	grot( x.length, x ); // $ExpectError
+	grot( x.length, x, 1 ); // $ExpectError
+	grot( x.length, x, 1, y ); // $ExpectError
+	grot( x.length, x, 1, y, 1, 1.0 ); // $ExpectError
+	grot( x.length, x, 1, y, 1, 1.0, 0.0, 10 ); // $ExpectError
+}
+
+// Attached to main export is an `ndarray` method which returns a numeric array...
+{
+	const x = new Float64Array( 10 );
+	const y = new Float64Array( 10 );
+
+	grot.ndarray( x.length, x, 1, 0, y, 1, 0, 1.0, 0.0 ); // $ExpectType NumericArray
+}
+
+// The compiler throws an error if the `ndarray` method is provided a first argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+	const y = new Float64Array( 10 );
+
+	grot.ndarray( '10', x, 1, 0, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( true, x, 1, 0, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( false, x, 1, 0, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( null, x, 1, 0, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( undefined, x, 1, 0, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( [], x, 1, 0, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( {}, x, 1, 0, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( ( x: number ): number => x, x, 1, 0, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a second argument which is not a numeric array...
+{
+	const x = new Float64Array( 10 );
+	const y = new Float64Array( 10 );
+
+	grot.ndarray( x.length, 10, 1, 0, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, '10', 1, 0, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, true, 1, 0, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, false, 1, 0, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, null, 1, 0, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, undefined, 1, 0, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, [ '1' ], 1, 0, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, {}, 1, 0, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, ( x: number ): number => x, 1, 0, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a third argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+	const y = new Float64Array( 10 );
+
+	grot.ndarray( x.length, x, '10', 0, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, true, 0, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, false, 0, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, null, 0, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, undefined, 0, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, [], 0, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, {}, 0, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, ( x: number ): number => x, 0, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a fourth argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+	const y = new Float64Array( 10 );
+
+	grot.ndarray( x.length, x, 1, '10', y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, true, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, false, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, null, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, undefined, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, [], y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, {}, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, ( x: number ): number => x, y, 1, 0, 1.0, 0.0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a fifth argument which is not a numeric array...
+{
+	const x = new Float64Array( 10 );
+
+	grot.ndarray( x.length, x, 1, 0, 10, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, '10', 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, true, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, false, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, null, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, undefined, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, [ '1' ], 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, {}, 1, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, ( x: number ): number => x, 1, 0, 1.0, 0.0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a sixth argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+	const y = new Float64Array( 10 );
+
+	grot.ndarray( x.length, x, 1, 0, y, '10', 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, true, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, false, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, null, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, undefined, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, [], 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, {}, 0, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, ( x: number ): number => x, 0, 1.0, 0.0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a seventh argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+	const y = new Float64Array( 10 );
+
+	grot.ndarray( x.length, x, 1, 0, y, 1, '10', 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, 1, true, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, 1, false, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, 1, null, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, 1, undefined, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, 1, [], 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, 1, {}, 1.0, 0.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, 1, ( x: number ): number => x, 1.0, 0.0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a eighth argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+	const y = new Float64Array( 10 );
+
+	grot.ndarray( x.length, x, 1, 0, y, 1, 0, '10', 1.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, 1, 0, true, 1.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, 1, 0, false, 1.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, 1, 0, null, 1.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, 1, 0, undefined, 1.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, 1, 0, [], 1.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, 1, 0, {}, 1.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, 1, 0, ( x: number ): number => x, 1.0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided a ninth argument which is not a number...
+{
+	const x = new Float64Array( 10 );
+	const y = new Float64Array( 10 );
+
+	grot.ndarray( x.length, x, 1, 0, y, 1, 0, 1.0, '1.0' ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, 1, 0, 1.0, true ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, 1, 0, 1.0, false ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, 1, 0, 1.0, null ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, 1, 0, 1.0, undefined ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, 1, 0, 1.0, [] ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, 1, 0, 1.0, {} ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, 1, 0, 1.0, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided an unsupported number of arguments...
+{
+	const x = new Float64Array( 10 );
+	const y = new Float64Array( 10 );
+
+	grot.ndarray(); // $ExpectError
+	grot.ndarray( x.length ); // $ExpectError
+	grot.ndarray( x.length, x ); // $ExpectError
+	grot.ndarray( x.length, x, 1 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, 1.0 ); // $ExpectError
+	grot.ndarray( x.length, x, 1, 0, y, 1.0, 0.0, 10 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/blas/base/grot/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/base/grot/examples/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
-var grot = require( './../lib' ).ndarray;
+var grot = require( './../lib' );
 
 var opts = {
 	'dtype': 'float64'
@@ -30,6 +30,6 @@ console.log( x );
 var y = discreteUniform( x.length, 0, 255, opts );
 console.log( y );
 
-grot( x.length, x, 1, 0, y, 1, 0, 0.8, 0.6 );
+grot( x.length, x, 1, y, 1, 0.8, 0.6 );
 console.log( x );
 console.log( y );

--- a/lib/node_modules/@stdlib/blas/base/grot/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/base/grot/examples/index.js
@@ -1,0 +1,35 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var grot = require( './../lib' ).ndarray;
+
+var opts = {
+	'dtype': 'float64'
+};
+var x = discreteUniform( 10, 0, 500, opts );
+console.log( x );
+
+var y = discreteUniform( x.length, 0, 255, opts );
+console.log( y );
+
+grot( x.length, x, 1, 0, y, 1, 0, 0.8, 0.6 );
+console.log( x );
+console.log( y );

--- a/lib/node_modules/@stdlib/blas/base/grot/lib/accessors.js
+++ b/lib/node_modules/@stdlib/blas/base/grot/lib/accessors.js
@@ -1,0 +1,123 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MAIN //
+
+var real = require( '@stdlib/complex/real' );
+var imag = require( '@stdlib/complex/imag' );
+var isComplexTypedArray = require( '@stdlib/array/base/assert/is-complex-typed-array' );
+var complex = require( '@stdlib/complex/cmplx' );
+var dtype = require( '@stdlib/complex/dtype' );
+/**
+* Applies a plane rotation.
+*
+* @private
+* @param {PositiveInteger} N - number of indexed elements
+* @param {Object} x - first input array object
+* @param {Collection} x.data - first input array data
+* @param {Array<Function>} x.accessors - array element accessors
+* @param {integer} strideX - `x` stride length
+* @param {NonNegativeInteger} offsetX - starting `x` index
+* @param {Object} y - second input array object
+* @param {Collection} y.data - second input array array
+* @param {Array<Function>} y.accessors - array element accessors
+* @param {integer} strideY - `y` stride length
+* @param {NonNegativeInteger} offsetY - starting `y` index
+* @param {number} c - cosine of the angle of rotation
+* @param {number} s - sine of the angle of rotation
+* @returns {Object} `y`
+*
+* @example
+* var Complex64Array = require( '@stdlib/array/complex64' );
+* var Complex64 = require( '@stdlib/complex/float32' );
+* var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
+*
+* function setter( data, idx, value ) {
+*     data.set( value, idx );
+* }
+*
+* function getter( data, idx ) {
+*     return data.get( idx );
+* }
+*
+* var x = {
+*     'data': new Complex64Array( [ 1.0, 2.0, 3.0, 4.0 ] ),
+*     'accessors': [ getter, setter ]
+* };
+*
+* var y = {
+*     'data': new Complex64Array( [ 5.0, 6.0, 7.0, 8.0 ] ),
+*     'accessors': [ getter, setter ]
+* };
+*
+* grot( x.data.length, x, 1, 0, y, 1, 0, 0.8, 0.6 );
+*
+* var viewX = reinterpret64( x.data, 0 );
+* // viewX => <Float32Array>[ ~3.8, ~5.2, ~6.6, 8.0 ]
+*
+* var viewY = reinterpret64( y.data, 0 );
+* // viewY => <Float32Array>[ ~3.4, ~3.6, ~3.8, 4.0 ]
+*/
+function grot( N, x, strideX, offsetX, y, strideY, offsetY, c, s ) {
+	var xbuf;
+	var ybuf;
+	var set;
+	var get;
+	var tmp;
+	var ix;
+	var iy;
+	var dt;
+	var i;
+
+	// Cache references to array data:
+	xbuf = x.data;
+	ybuf = y.data;
+
+	// Cache a reference to the element accessors:
+	get = x.accessors[ 0 ];
+	set = y.accessors[ 1 ];
+
+	ix = offsetX;
+	iy = offsetY;
+	for ( i = 0; i < N; i++ ) {
+		if ( isComplexTypedArray( x.data ) ) {
+			if ( dtype( x.data.get( 0 ) ) === 'complex128' ) {
+				dt = 'float64';
+			}
+			else if ( dtype( x.data.get( 0 ) ) === 'complex64' ) {
+				dt = 'float32';
+			}
+			tmp = complex( ( ( c * real( get( xbuf, ix ) ) ) + ( s * real( get( ybuf, iy ) ) ) ), ( ( c * imag( get( xbuf, ix ) ) ) + ( s * imag( get( ybuf, iy ) ) ) ), dt ); // eslint-disable-line max-len
+			set( ybuf, iy, complex( ( ( c * real( get( ybuf, iy ) ) ) - ( s * real( get( xbuf, ix ) ) ) ), ( ( c * imag( get( ybuf, iy ) ) ) - ( s * imag( get( xbuf, ix ) ) ) ), dt ) ); // eslint-disable-line max-len
+		} else {
+			tmp = ( c * get( xbuf, ix ) ) + ( s * get( ybuf, iy ) );
+			set( ybuf, iy, ( c * get( ybuf, iy ) ) - ( s * get( xbuf, ix ) ) );
+		}
+		set( xbuf, ix, tmp );
+		ix += strideX;
+		iy += strideY;
+	}
+	return y;
+}
+
+
+// EXPORTS //
+
+module.exports = grot;

--- a/lib/node_modules/@stdlib/blas/base/grot/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/base/grot/lib/index.js
@@ -1,0 +1,61 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* BLAS level 1 routine to apply a plane rotation.
+*
+* @module @stdlib/blas/base/grot
+*
+* @example
+* var grot = require( '@stdlib/blas/base/grot' );
+*
+* var x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
+* var y = [ 6.0, 7.0, 8.0, 9.0, 10.0 ];
+*
+* grot( x.length, x, 1, y, 1, 0.8, 0.6 );
+* // x => [ ~4.4, ~5.8, 7.2, 8.6, 10.0 ]
+* // y => [ ~4.2, 4.4, 4.6, 4.8, 5.0 ]
+*
+* @example
+* var grot = require( '@stdlib/blas/base/grot' );
+*
+* var x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
+* var y = [ 6.0, 7.0, 8.0, 9.0, 10.0 ];
+*
+* grot.ndarray( 4, x, 1, 1, y, 1, 1, 0.8, 0.6 );
+* // x => [ 1.0, ~5.8, 7.2, 8.6, 10.0 ]
+* // y => [ 6.0, 4.4, ~4.6, ~4.8, 5.0 ]
+*/
+
+// MODULES //
+
+var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
+var main = require( './main.js' );
+var ndarray = require( './ndarray.js' );
+
+
+// MAIN //
+
+setReadOnly( main, 'ndarray', ndarray );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/blas/base/grot/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/base/grot/lib/main.js
@@ -1,0 +1,121 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var arraylike2object = require( '@stdlib/array/base/arraylike2object' );
+var isComplexTypedArray = require( '@stdlib/array/base/assert/is-complex-typed-array' );
+var isAccessorArray = require( '@stdlib/array/base/assert/is-accessor-array' );
+var accessors = require( './accessors.js' );
+
+
+// MAIN //
+
+/**
+* Applies a plane rotation.
+*
+* @param {PositiveInteger} N - number of indexed elements
+* @param {Collection} x - first input array
+* @param {integer} strideX - `x` stride length
+* @param {Collection} y - second input array
+* @param {integer} strideY - `y` stride length
+* @param {number} c - cosine of the angle of rotation
+* @param {number} s - sine of the angle of rotation
+* @returns {Collection} `y`
+*
+* @example
+* var x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
+* var y = [ 6.0, 7.0, 8.0, 9.0, 10.0 ];
+*
+* grot( x.length, x, 1, y, 1, 0.8, 0.6 );
+* // x => [ ~4.4, ~5.8, 7.2, 8.6, 10.0 ]
+* // y => [ ~4.2, 4.4, 4.6, 4.8, 5.0 ]
+*/
+function grot( N, x, strideX, y, strideY, c, s ) {
+	var tmp;
+	var out;
+	var ox;
+	var oy;
+	var ix;
+	var iy;
+	var i;
+
+	if ( N <= 0 ) {
+		if ( isAccessorArray( y ) ) {
+			if ( isComplexTypedArray( y ) ) {
+				return y;
+			}
+			return y._buffer; // eslint-disable-line no-underscore-dangle
+		}
+		return y;
+	}
+	ox = arraylike2object( x );
+	oy = arraylike2object( y );
+	if ( ox.accessorProtocol || oy.accessorProtocol ) {
+		if ( strideX < 0 ) {
+			ix = ( 1 - N ) * strideX;
+		} else {
+			ix = 0;
+		}
+		if ( strideY < 0 ) {
+			iy = ( 1 - N ) * strideY;
+		} else {
+			iy = 0;
+		}
+		out = accessors( N, ox, strideX, ix, oy, strideY, iy, c, s );
+		if ( isComplexTypedArray( y ) ) {
+			return out.data;
+		}
+		return out.data._buffer; // eslint-disable-line no-underscore-dangle
+	}
+	// If both strides are equal to `1`...
+	if ( strideX === 1 && strideY === 1 ) {
+		for ( i = 0; i < N; i++ ) {
+			tmp = ( c * x[ i ] ) + ( s * y[ i ] );
+			y[ i ] = ( c * y[ i ] ) - ( s * x[ i ] );
+			x[ i ] = tmp;
+		}
+		return y;
+	}
+	// If both strides are not equal to `1`...
+	if ( strideX < 0 ) {
+		ix = ( 1 - N ) * strideX;
+	} else {
+		ix = 0;
+	}
+	if ( strideY < 0 ) {
+		iy = ( 1 - N ) * strideY;
+	} else {
+		iy = 0;
+	}
+	for ( i = 0; i < N; i++ ) {
+		tmp = ( c * x[ ix ] ) + ( s * y[ iy ] );
+		y[ iy ] = ( c * y[ iy ] ) - ( s * x[ ix ] );
+		x[ ix ] = tmp;
+		ix += strideX;
+		iy += strideY;
+	}
+	return y;
+}
+
+
+// EXPORTS //
+
+module.exports = grot;

--- a/lib/node_modules/@stdlib/blas/base/grot/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/grot/lib/ndarray.js
@@ -1,0 +1,96 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var arraylike2object = require( '@stdlib/array/base/arraylike2object' );
+var isComplexTypedArray = require( '@stdlib/array/base/assert/is-complex-typed-array' );
+var isAccessorArray = require( '@stdlib/array/base/assert/is-accessor-array' );
+var accessors = require( './accessors.js' );
+
+
+// MAIN //
+
+/**
+* Applies a plane rotation.
+*
+* @param {PositiveInteger} N - number of indexed elements
+* @param {Collection} x - first input array
+* @param {integer} strideX - `x` stride length
+* @param {NonNegativeInteger} offsetX - starting `x` index
+* @param {Collection} y - second input array
+* @param {integer} strideY - `y` stride length
+* @param {NonNegativeInteger} offsetY - starting `y` index
+* @param {number} c - cosine of the angle of rotation
+* @param {number} s - sine of the angle of rotation
+* @returns {Collection} `y`
+*
+* @example
+* var x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
+* var y = [ 6.0, 7.0, 8.0, 9.0, 10.0 ];
+*
+* grot( 4, x, 1, 1, y, 1, 1, 0.8, 0.6 );
+* // x => [ 1.0, ~5.8, 7.2, 8.6, 10.0 ]
+* // y => [ 6.0, 4.4, ~4.6, ~4.8, 5.0 ]
+*/
+function grot( N, x, strideX, offsetX, y, strideY, offsetY, c, s ) {
+	var tmp;
+	var out;
+	var ox;
+	var oy;
+	var ix;
+	var iy;
+	var i;
+
+	if ( N <= 0 ) {
+		if ( isAccessorArray( y ) ) {
+			if ( isComplexTypedArray( y ) ) {
+				return y;
+			}
+			return y._buffer; // eslint-disable-line no-underscore-dangle
+		}
+		return y;
+	}
+	ox = arraylike2object( x );
+	oy = arraylike2object( y );
+	if ( ox.accessorProtocol || oy.accessorProtocol ) {
+		out = accessors( N, ox, strideX, offsetX, oy, strideY, offsetY, c, s );
+		if ( isComplexTypedArray( y ) ) {
+			return out.data;
+		}
+		return out.data._buffer; // eslint-disable-line no-underscore-dangle
+	}
+	ix = offsetX;
+	iy = offsetY;
+
+	for ( i = 0; i < N; i++ ) {
+		tmp = ( c * x[ ix ] ) + ( s * y[ iy ] );
+		y[ iy ] = ( c * y[ iy ] ) - ( s * x[ ix ] );
+		x[ ix ] = tmp;
+		ix += strideX;
+		iy += strideY;
+	}
+	return y;
+}
+
+
+// EXPORTS //
+
+module.exports = grot;

--- a/lib/node_modules/@stdlib/blas/base/grot/package.json
+++ b/lib/node_modules/@stdlib/blas/base/grot/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@stdlib/blas/base/grot",
+  "version": "0.0.0",
+  "description": "Apply a plane rotation.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
+    "blas",
+    "level 1",
+    "linear",
+    "algebra",
+    "subroutines",
+    "drot",
+    "srot",
+    "rotation",
+    "vector",
+    "array",
+    "ndarray"
+  ]
+}

--- a/lib/node_modules/@stdlib/blas/base/grot/test/test.js
+++ b/lib/node_modules/@stdlib/blas/base/grot/test/test.js
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var grot = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof grot, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the main export is a method providing an ndarray interface', function test( t ) {
+	t.strictEqual( typeof grot.ndarray, 'function', 'method is a function' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/blas/base/grot/test/test.main.js
+++ b/lib/node_modules/@stdlib/blas/base/grot/test/test.main.js
@@ -1,0 +1,919 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var dcopy = require( '@stdlib/blas/base/dcopy' );
+var EPS = require( '@stdlib/constants/float64/eps' );
+var Complex128Array = require( '@stdlib/array/complex128' );
+var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
+var toAccessorArray = require( '@stdlib/array/base/to-accessor-array' );
+var abs = require( '@stdlib/math/base/special/abs' );
+var grot = require( './../lib/main.js' );
+
+
+// FUNCTIONS //
+
+/**
+* Tests for element-wise approximate equality.
+*
+* @private
+* @param {Object} t - test object
+* @param {Collection} actual - actual values
+* @param {Collection} expected - expected values
+* @param {number} rtol - relative tolerance
+*/
+function isApprox( t, actual, expected, rtol ) {
+	var delta;
+	var tol;
+	var i;
+
+	t.strictEqual( actual.length, expected.length, 'returns expected value' );
+	for ( i = 0; i < expected.length; i++ ) {
+		if ( actual[ i ] === expected[ i ] ) {
+			t.strictEqual( actual[ i ], expected[ i ], 'returns expected value' );
+		} else {
+			delta = abs( actual[ i ] - expected[ i ] );
+			tol = rtol * EPS * abs( expected[ i ] );
+			t.ok( delta <= tol, 'within tolerance. actual: '+actual[ i ]+'. expected: '+expected[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
+		}
+	}
+}
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof grot, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 7', function test( t ) {
+	t.strictEqual( grot.length, 7, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function applies a plane rotation (sx=1, sy=1)', function test( t ) {
+	var xbuf;
+	var ybuf;
+	var out;
+	var xe;
+	var ye;
+	var N;
+	var x;
+	var y;
+	var i;
+
+	N = [ 0, 1, 2, 4 ];
+
+	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
+	ybuf = [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ];
+
+	xe = [
+		[ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, -0.46, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, -0.46, -0.22, 1.06, 0.9, -0.3, -0.4 ]
+	];
+	ye = [
+		[ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.78, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.78, 0.54, 0.08, -0.6, 0.2, 0.8 ]
+	];
+
+	for ( i = 0; i < N.length; i++ ) {
+		x = xbuf.slice();
+		y = ybuf.slice();
+		out = grot( N[ i ], x, 1, y, 1, 0.8, 0.6 );
+		isApprox( t, x, xe[ i ], 6.0 );
+		isApprox( t, y, ye[ i ], 6.0 );
+		t.strictEqual( out, y, 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function applies a plane rotation (sx=1, sy=1) (accessors - complex)', function test( t ) {
+	var xbuf;
+	var ybuf;
+	var out;
+	var xe;
+	var ye;
+	var N;
+	var x;
+	var y;
+	var i;
+
+	N = [ 0, 1, 2 ];
+
+	xbuf = new Complex128Array( [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3 ] );
+	ybuf = new Complex128Array( [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2 ] );
+
+	xe = [
+		new Complex128Array( [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3 ] ),
+		new Complex128Array( [ 0.78, -0.46, -0.5, 0.8, 0.9, -0.3 ] ),
+		new Complex128Array( [ 0.78, -0.46, -0.22, 1.06, 0.9, -0.3 ] )
+	];
+	ye = [
+		new Complex128Array( [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2 ] ),
+		new Complex128Array( [ 0.04, -0.78, 0.3, 0.7, -0.6, 0.2 ] ),
+		new Complex128Array( [ 0.04, -0.78, 0.54, 0.08, -0.6, 0.2 ] )
+	];
+
+	for ( i = 0; i < N.length; i++ ) {
+		x = new Complex128Array( xbuf );
+		y = new Complex128Array( ybuf );
+		out = grot( N[ i ], x, 1, y, 1, 0.8, 0.6 );
+		isApprox( t, reinterpret128( x, 0 ), reinterpret128( xe[ i ], 0 ), 6.0 ); // eslint-disable-line max-len
+		isApprox( t, reinterpret128( out, 0 ), reinterpret128( ye[ i ], 0 ), 6.0 ); // eslint-disable-line max-len
+		isApprox(t, reinterpret128( out, 0 ), reinterpret128( y, 0 ), 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function applies a plane rotation (sx=1, sy=1) (accessors - real)', function test( t ) {
+	var xbuf;
+	var ybuf;
+	var out;
+	var xe;
+	var ye;
+	var N;
+	var x;
+	var y;
+	var i;
+
+	N = [ 0, 1, 2, 4 ];
+
+	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
+	ybuf = [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ];
+
+	xe = [
+		[ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, -0.46, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, -0.46, -0.22, 1.06, 0.9, -0.3, -0.4 ]
+	];
+	ye = [
+		[ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.78, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.78, 0.54, 0.08, -0.6, 0.2, 0.8 ]
+	];
+
+	for ( i = 0; i < N.length; i++ ) {
+		x = xbuf.slice();
+		y = ybuf.slice();
+		out = grot( N[ i ], toAccessorArray( x ), 1, toAccessorArray( y ), 1, 0.8, 0.6 ); // eslint-disable-line max-len
+		isApprox( t, x, xe[ i ], 6.0 );
+		isApprox( t, y, ye[ i ], 6.0 );
+		t.strictEqual( out, y, 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function applies a plane rotation (sx=2, sy=-2)', function test( t ) {
+	var xbuf;
+	var ybuf;
+	var out;
+	var xe;
+	var ye;
+	var N;
+	var x;
+	var y;
+	var i;
+
+	N = [ 0, 1, 2, 4 ];
+
+	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
+	ybuf = [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ];
+
+	xe = [
+		[ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.66, 0.1, -0.1, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.96, 0.1, -0.76, 0.8, 0.9, -0.3, -0.02 ]
+	];
+	ye = [
+		[ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.7, -0.9, -0.12, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.64, -0.9, -0.3, 0.7, -0.18, 0.2, 0.28 ]
+	];
+
+	for ( i = 0; i < N.length; i++ ) {
+		x = xbuf.slice();
+		y = ybuf.slice();
+		out = grot( N[ i ], x, 2, y, -2, 0.8, 0.6 );
+		isApprox( t, x, xe[ i ], 20.0 );
+		isApprox( t, y, ye[ i ], 20.0 );
+		t.strictEqual( out, y, 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function applies a plane rotation (sx=2, sy=-2) (accessors - complex)', function test( t ) {
+	var xbuf;
+	var ybuf;
+	var out;
+	var xe;
+	var ye;
+	var N;
+	var x;
+	var y;
+	var i;
+
+	N = [ 0, 1 ];
+
+	xbuf = new Complex128Array( [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3 ] );
+	ybuf = new Complex128Array( [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2 ] );
+
+	xe = [
+		new Complex128Array( [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3 ] ),
+		new Complex128Array( [ 0.78, -0.46, -0.5, 0.8, 0.9, -0.3 ] )
+	];
+	ye = [
+		new Complex128Array( [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2 ] ),
+		new Complex128Array( [ 0.04, -0.78, 0.3, 0.7, -0.6, 0.2 ] )
+	];
+
+	for ( i = 0; i < N.length; i++ ) {
+		x = new Complex128Array( xbuf );
+		y = new Complex128Array( ybuf );
+		out = grot( N[ i ], x, 2, y, -2, 0.8, 0.6 );
+		isApprox( t, reinterpret128( x, 0 ), reinterpret128( xe[ i ], 0 ), 20.0 ); // eslint-disable-line max-len
+		isApprox( t, reinterpret128( out, 0 ), reinterpret128( ye[ i ], 0 ), 20.0 ); // eslint-disable-line max-len
+		isApprox( t, reinterpret128( out, 0 ), reinterpret128( y, 0 ), 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function applies a plane rotation (sx=2, sy=-2) (accessors - real)', function test( t ) {
+	var xbuf;
+	var ybuf;
+	var out;
+	var xe;
+	var ye;
+	var N;
+	var x;
+	var y;
+	var i;
+
+	N = [ 0, 1, 2, 4 ];
+
+	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
+	ybuf = [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ];
+
+	xe = [
+		[ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.66, 0.1, -0.1, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.96, 0.1, -0.76, 0.8, 0.9, -0.3, -0.02 ]
+	];
+	ye = [
+		[ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.7, -0.9, -0.12, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.64, -0.9, -0.3, 0.7, -0.18, 0.2, 0.28 ]
+	];
+
+	for ( i = 0; i < N.length; i++ ) {
+		x = xbuf.slice();
+		y = ybuf.slice();
+		out = grot( N[ i ], toAccessorArray( x ), 2, toAccessorArray( y ), -2, 0.8, 0.6 ); // eslint-disable-line max-len
+		isApprox( t, x, xe[ i ], 20.0 );
+		isApprox( t, y, ye[ i ], 20.0 );
+		t.strictEqual( out, y, 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function applies a plane rotation (sx=-2, sy=1)', function test( t ) {
+	var xbuf;
+	var ybuf;
+	var out;
+	var xe;
+	var ye;
+	var N;
+	var x;
+	var y;
+	var i;
+
+	N = [ 0, 1, 2, 4 ];
+
+	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
+	ybuf = [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ];
+
+	xe = [
+		[ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ -0.06, 0.1, -0.1, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.9, 0.1, -0.22, 0.8, 0.18, -0.3, -0.02 ]
+	];
+	ye = [
+		[ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.7, -1.08, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.64, -1.26, 0.54, 0.2, -0.6, 0.2, 0.8 ]
+	];
+
+	for ( i = 0; i < N.length; i++ ) {
+		x = xbuf.slice();
+		y = ybuf.slice();
+		out = grot( N[ i ], x, -2, y, 1, 0.8, 0.6 );
+		isApprox( t, x, xe[ i ], 20.0 );
+		isApprox( t, y, ye[ i ], 20.0 );
+		t.strictEqual( out, y, 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function applies a plane rotation (sx=-2, sy=1) (accessors - complex)', function test( t ) {
+	var xbuf;
+	var ybuf;
+	var out;
+	var xe;
+	var ye;
+	var N;
+	var x;
+	var y;
+	var i;
+
+	N = [ 0, 1 ];
+
+	xbuf = new Complex128Array( [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3 ] );
+	ybuf = new Complex128Array( [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2 ] );
+
+	xe = [
+		new Complex128Array( [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3 ] ),
+		new Complex128Array( [ 0.78, -0.46, -0.5, 0.8, 0.9, -0.3 ] )
+	];
+	ye = [
+		new Complex128Array( [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2 ] ),
+		new Complex128Array( [ 0.04, -0.78, 0.3, 0.7, -0.6, 0.2 ] )
+	];
+
+	for ( i = 0; i < N.length; i++ ) {
+		x = new Complex128Array( xbuf );
+		y = new Complex128Array( ybuf );
+		out = grot( N[ i ], x, -2, y, 1, 0.8, 0.6 );
+		isApprox( t, reinterpret128( x, 0 ), reinterpret128( xe[ i ], 0 ), 20.0 ); // eslint-disable-line max-len
+		isApprox( t, reinterpret128( out, 0 ), reinterpret128( ye[ i ], 0 ), 20.0 ); // eslint-disable-line max-len
+		isApprox( t, reinterpret128( out, 0 ), reinterpret128( y, 0 ), 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function applies a plane rotation (sx=-2, sy=1) (accessors - real)', function test( t ) {
+	var xbuf;
+	var ybuf;
+	var out;
+	var xe;
+	var ye;
+	var N;
+	var x;
+	var y;
+	var i;
+
+	N = [ 0, 1, 2, 4 ];
+
+	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
+	ybuf = [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ];
+
+	xe = [
+		[ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ -0.06, 0.1, -0.1, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.9, 0.1, -0.22, 0.8, 0.18, -0.3, -0.02 ]
+	];
+	ye = [
+		[ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.7, -1.08, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.64, -1.26, 0.54, 0.2, -0.6, 0.2, 0.8 ]
+	];
+
+	for ( i = 0; i < N.length; i++ ) {
+		x = xbuf.slice();
+		y = ybuf.slice();
+		out = grot( N[ i ], toAccessorArray( x ), -2, toAccessorArray( y ), 1, 0.8, 0.6 ); // eslint-disable-line max-len
+		isApprox( t, x, xe[ i ], 20.0 );
+		isApprox( t, y, ye[ i ], 20.0 );
+		t.strictEqual( out, y, 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function applies a plane rotation (sx=-1, sy=-2)', function test( t ) {
+	var xbuf;
+	var ybuf;
+	var out;
+	var xe;
+	var ye;
+	var N;
+	var x;
+	var y;
+	var i;
+
+	N = [ 0, 1, 2, 4 ];
+
+	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
+	ybuf = [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ];
+
+	xe = [
+		[ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, 0.26, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, 0.26, -0.76, 1.12, 0.9, -0.3, -0.4 ]
+	];
+	ye = [
+		[ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.9, 0.18, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.9, 0.18, 0.7, -0.18, 0.2, 0.16 ]
+	];
+
+	for ( i = 0; i < N.length; i++ ) {
+		x = xbuf.slice();
+		y = ybuf.slice();
+		out = grot( N[ i ], x, -1, y, -2, 0.8, 0.6 );
+		isApprox( t, x, xe[ i ], 4.0 );
+		isApprox( t, y, ye[ i ], 4.0 );
+		t.strictEqual( out, y, 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function applies a plane rotation (sx=-1, sy=-2) (accessors - complex)', function test( t ) {
+	var xbuf;
+	var ybuf;
+	var out;
+	var xe;
+	var ye;
+	var N;
+	var x;
+	var y;
+	var i;
+
+	N = [ 0, 1, 2 ];
+
+	xbuf = new Complex128Array( [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3 ] );
+	ybuf = new Complex128Array( [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2 ] );
+
+	xe = [
+		new Complex128Array( [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3 ] ),
+		new Complex128Array( [ 0.78, -0.46, -0.5, 0.8, 0.9, -0.3 ] ),
+		new Complex128Array( [ 0.78, -0.46, -0.76, 0.76, 0.9, -0.3 ] )
+	];
+	ye = [
+		new Complex128Array( [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2 ] ),
+		new Complex128Array( [ 0.04, -0.78, 0.3, 0.7, -0.6, 0.2 ] ),
+		new Complex128Array( [ 0.04, -0.78, 0.3, 0.7, -0.18, -0.32 ] )
+	];
+
+	for ( i = 0; i < N.length; i++ ) {
+		x = new Complex128Array( xbuf );
+		y = new Complex128Array( ybuf );
+		out = grot( N[ i ], x, -1, y, -2, 0.8, 0.6 );
+		isApprox( t, reinterpret128( x, 0 ), reinterpret128( xe[ i ], 0 ), 4.0 ); // eslint-disable-line max-len
+		isApprox( t, reinterpret128( out, 0 ), reinterpret128( ye[ i ], 0 ), 4.0 ); // eslint-disable-line max-len
+		isApprox( t, reinterpret128( out, 0 ), reinterpret128( y, 0 ), 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function applies a plane rotation (sx=-1, sy=-2) (accessors - real)', function test( t ) {
+	var xbuf;
+	var ybuf;
+	var out;
+	var xe;
+	var ye;
+	var N;
+	var x;
+	var y;
+	var i;
+
+	N = [ 0, 1, 2, 4 ];
+
+	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
+	ybuf = [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ];
+
+	xe = [
+		[ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, 0.26, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, 0.26, -0.76, 1.12, 0.9, -0.3, -0.4 ]
+	];
+	ye = [
+		[ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.9, 0.18, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.9, 0.18, 0.7, -0.18, 0.2, 0.16 ]
+	];
+
+	for ( i = 0; i < N.length; i++ ) {
+		x = xbuf.slice();
+		y = ybuf.slice();
+		out = grot( N[ i ], toAccessorArray( x ), -1, toAccessorArray( y ), -2, 0.8, 0.6 ); // eslint-disable-line max-len
+		isApprox( t, x, xe[ i ], 4.0 );
+		isApprox( t, y, ye[ i ], 4.0 );
+		t.strictEqual( out, y, 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function supports an `x` stride', function test( t ) {
+	var xe;
+	var ye;
+	var x;
+	var y;
+
+	x = [
+		1.0, // 0
+		2.0,
+		3.0, // 1
+		4.0,
+		5.0
+	];
+	y = [
+		6.0, // 0
+		7.0, // 1
+		8.0,
+		9.0,
+		10.0
+	];
+
+	grot( 2, x, 2, y, 1, 0.8, 0.6 );
+
+	xe = [ 4.4, 2.0, 6.6, 4.0, 5.0 ];
+	ye = [ 4.2, 3.8, 8.0, 9.0, 10.0 ];
+
+	isApprox( t, x, xe, 2.0 );
+	isApprox( t, y, ye, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function supports an `x` stride (accessors - complex)', function test( t ) {
+	var xe;
+	var ye;
+	var x;
+	var y;
+
+	x = new Complex128Array([
+		1.0, // 0
+		2.0,
+		3.0,
+		4.0,
+		5.0, // 1
+		6.0
+	]);
+	y = new Complex128Array([
+		7.0, // 0
+		8.0,
+		9.0, // 1
+		10.0,
+		11.0,
+		12.0
+	]);
+
+	grot( 2, x, 2, y, 1, 0.8, 0.6 );
+
+	xe = new Complex128Array( [ 5, 6.4, 3.0, 4.0, 9.4, 10.8 ] );
+	ye = new Complex128Array( [ 5.0, 5.2, 4.2, 4.4, 11.0, 12.0 ] );
+
+	isApprox( t, reinterpret128( x, 0 ), reinterpret128( xe, 0 ), 2.0 );
+	isApprox( t, reinterpret128( y, 0 ), reinterpret128( ye, 0 ), 2.0 );
+
+	t.end();
+});
+
+tape( 'the function supports an `x` stride (accessors - real)', function test( t ) {
+	var xe;
+	var ye;
+	var x;
+	var y;
+
+	x = [
+		1.0, // 0
+		2.0,
+		3.0, // 1
+		4.0,
+		5.0
+	];
+	y = [
+		6.0, // 0
+		7.0, // 1
+		8.0,
+		9.0,
+		10.0
+	];
+
+	grot( 2, toAccessorArray( x ), 2, toAccessorArray( y ), 1, 0.8, 0.6 );
+
+	xe = [ 4.4, 2.0, 6.6, 4.0, 5.0 ];
+	ye = [ 4.2, 3.8, 8.0, 9.0, 10.0 ];
+
+	isApprox( t, x, xe, 2.0 );
+	isApprox( t, y, ye, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function supports a `y` stride', function test( t ) {
+	var xe;
+	var ye;
+	var x;
+	var y;
+
+	x = [
+		1.0, // 0
+		2.0, // 1
+		3.0, // 2
+		4.0,
+		5.0
+	];
+	y = [
+		1.0, // 0
+		2.0,
+		3.0, // 1
+		4.0,
+		5.0  // 2
+	];
+
+	grot( 3, x, 1, y, 2, 0.0, -1.0 );
+
+	xe = [ -1.0, -3.0, -5.0, 4.0, 5.0 ];
+	ye = [ 1.0, 2.0, 2.0, 4.0, 3.0 ];
+
+	t.deepEqual( x, xe, 'returns expected value' );
+	t.deepEqual( y, ye, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a `y` stride (accessors - complex)', function test( t ) {
+	var xe;
+	var ye;
+	var x;
+	var y;
+
+	x = new Complex128Array([
+		1.0, // 0
+		2.0,
+		3.0, // 1
+		4.0,
+		5.0,
+		6.0
+	]);
+	y = new Complex128Array([
+		1.0,  // 0
+		2.0,
+		3.0,
+		4.0,
+		5.0,  // 1
+		6.0
+	]);
+
+	grot( 2, x, 1, y, 2, 0.0, -1.0 );
+
+	xe = new Complex128Array( [ -1.0, -2.0, -5.0, -6.0, 5.0, 6.0 ] );
+	ye = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 3.0, 4.0 ] );
+
+	isApprox( t, reinterpret128( x, 0 ), reinterpret128( xe, 0 ), 2.0 );
+	isApprox( t, reinterpret128( y, 0 ), reinterpret128( ye, 0 ), 2.0 );
+
+	t.end();
+});
+
+tape( 'the function supports a `y` stride (accessors - real)', function test( t ) {
+	var xe;
+	var ye;
+	var x;
+	var y;
+
+	x = [
+		1.0, // 0
+		2.0, // 1
+		3.0, // 2
+		4.0,
+		5.0
+	];
+	y = [
+		1.0, // 0
+		2.0,
+		3.0, // 1
+		4.0,
+		5.0  // 2
+	];
+
+	grot( 3, toAccessorArray( x ), 1, toAccessorArray( y ), 2, 0.0, -1.0 );
+
+	xe = [ -1.0, -3.0, -5.0, 4.0, 5.0 ];
+	ye = [ 1.0, 2.0, 2.0, 4.0, 3.0 ];
+
+	t.deepEqual( x, xe, 'returns expected value' );
+	t.deepEqual( y, ye, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a reference to the second input array', function test( t ) {
+	var out;
+	var x;
+	var y;
+
+	x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
+	y = [ 6.0, 7.0, 8.0, 9.0, 10.0 ];
+
+	out = grot( x.length, x, 1, y, 1, 1, 0 );
+
+	t.strictEqual( out, y, 'returns expected value' );
+	t.end();
+});
+
+tape( 'if provided an `N` parameter less than or equal to `0`, the function leaves both input arrays unchanged', function test( t ) {
+	var xe;
+	var ye;
+	var x;
+	var y;
+
+	x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
+	y = [ 6.0, 7.0, 8.0, 9.0, 10.0 ];
+
+	xe = x.slice();
+	dcopy( x.length, x, 1, xe, 1 );
+
+	ye = y.slice();
+	dcopy( y.length, y, 1, ye, 1 );
+
+	grot( -1, x, 1, y, 1, 0.8, 0.6 );
+	t.deepEqual( x, xe, 'returns expected value' );
+	t.deepEqual( y, ye, 'returns expected value' );
+
+	grot( 0, x, 1, y, 1, 0.8, 0.6 );
+	t.deepEqual( x, xe, 'returns expected value' );
+	t.deepEqual( y, ye, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports negative strides', function test( t ) {
+	var xe;
+	var ye;
+	var x;
+	var y;
+
+	x = [
+		0.6,  // 3
+		0.1,
+		-0.5, // 2
+		0.8,
+		0.9,  // 1
+		-0.3,
+		-0.4  // 0
+	];
+	y = [
+		0.5,  // 0
+		-0.9, // 1
+		0.3,  // 2
+		0.7,  // 3
+		-0.6,
+		0.2,
+		0.8
+	];
+
+	grot( 4, x, -2, y, 1, 0.8, 0.6 );
+
+	xe = [ 0.9, 0.1, -0.22, 0.8, 0.18, -0.3, -0.02 ];
+	ye = [ 0.64, -1.26, 0.54, 0.2, -0.6, 0.2, 0.8 ];
+
+	isApprox( t, x, xe, 20.0 );
+	isApprox( t, y, ye, 20.0 );
+
+	t.end();
+});
+
+tape( 'the function supports negative strides (accessors - complex)', function test( t ) {
+	var xe;
+	var ye;
+	var x;
+	var y;
+
+	x = new Complex128Array([
+		0.6,  // 1
+		0.1,
+		-0.5,
+		0.8,
+		0.9,  // 0
+		-0.4
+	]);
+	y = new Complex128Array([
+		0.5,  // 0
+		-0.9,
+		0.3,  // 1
+		0.7,
+		-0.6,
+		0.2
+	]);
+
+	grot( 2, x, -2, y, 1, 0.8, 0.6 );
+
+	xe = new Complex128Array( [ 0.66, 0.5, -0.5, 0.8, 1.02, -0.86 ] );
+	ye = new Complex128Array( [ -0.14, -0.48, -0.12, 0.50, -0.6, 0.2 ] );
+
+	isApprox( t, reinterpret128( x, 0 ), reinterpret128( xe, 0 ), 2.0 );
+	isApprox( t, reinterpret128( y, 0 ), reinterpret128( ye, 0 ), 2.0 );
+
+	t.end();
+});
+
+tape( 'the function supports negative strides (accessors - real)', function test( t ) {
+	var xe;
+	var ye;
+	var x;
+	var y;
+
+	x = [
+		0.6,  // 3
+		0.1,
+		-0.5, // 2
+		0.8,
+		0.9,  // 1
+		-0.3,
+		-0.4  // 0
+	];
+	y = [
+		0.5,  // 0
+		-0.9, // 1
+		0.3,  // 2
+		0.7,  // 3
+		-0.6,
+		0.2,
+		0.8
+	];
+
+	grot( 4, toAccessorArray( x ), -2, toAccessorArray( y ), 1, 0.8, 0.6 );
+
+	xe = [ 0.9, 0.1, -0.22, 0.8, 0.18, -0.3, -0.02 ];
+	ye = [ 0.64, -1.26, 0.54, 0.2, -0.6, 0.2, 0.8 ];
+
+	isApprox( t, x, xe, 20.0 );
+	isApprox( t, y, ye, 20.0 );
+
+	t.end();
+});
+
+tape( 'the function supports complex access patterns', function test( t ) {
+	var xe;
+	var ye;
+	var x;
+	var y;
+
+	x = [
+		0.6,  // 1
+		0.1,  // 0
+		-0.5,
+		0.8,
+		0.9,
+		-0.3,
+		-0.4
+	];
+	y = [
+		0.5,  // 1
+		-0.9,
+		0.3,  // 0
+		0.7,
+		-0.6,
+		0.2,
+		0.8
+	];
+
+	grot( 2, x, -1, y, -2, 0.8, 0.6 );
+
+	xe = [ 0.78, 0.26, -0.5, 0.8, 0.9, -0.3, -0.4 ];
+	ye = [ 0.04, -0.9, 0.18, 0.7, -0.6, 0.2, 0.8 ];
+
+	isApprox( t, x, xe, 5.0 );
+	isApprox( t, y, ye, 5.0 );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/blas/base/grot/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/grot/test/test.ndarray.js
@@ -1,0 +1,1173 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var dcopy = require( '@stdlib/blas/base/dcopy' ).ndarray;
+var Complex128Array = require( '@stdlib/array/complex128' );
+var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
+var toAccessorArray = require( '@stdlib/array/base/to-accessor-array' );
+var EPS = require( '@stdlib/constants/float64/eps' );
+var abs = require( '@stdlib/math/base/special/abs' );
+var grot = require( './../lib/ndarray.js' );
+
+
+// FUNCTIONS //
+
+/**
+* Tests for element-wise approximate equality.
+*
+* @private
+* @param {Object} t - test object
+* @param {Collection} actual - actual values
+* @param {Collection} expected - expected values
+* @param {number} rtol - relative tolerance
+*/
+function isApprox( t, actual, expected, rtol ) {
+	var delta;
+	var tol;
+	var i;
+
+	t.strictEqual( actual.length, expected.length, 'returns expected value' );
+	for ( i = 0; i < expected.length; i++ ) {
+		if ( actual[ i ] === expected[ i ] ) {
+			t.strictEqual( actual[ i ], expected[ i ], 'returns expected value' );
+		} else {
+			delta = abs( actual[ i ] - expected[ i ] );
+			tol = rtol * EPS * abs( expected[ i ] );
+			t.ok( delta <= tol, 'within tolerance. actual: '+actual[ i ]+'. expected: '+expected[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
+		}
+	}
+}
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof grot, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 9', function test( t ) {
+	t.strictEqual( grot.length, 9, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function applies a plane rotation (sx=1, sy=1)', function test( t ) {
+	var xbuf;
+	var ybuf;
+	var out;
+	var xe;
+	var ye;
+	var ox;
+	var oy;
+	var N;
+	var x;
+	var y;
+	var i;
+
+	N = [ 0, 1, 2, 4 ];
+
+	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
+	ybuf = [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ];
+
+	ox = [ 0, 0, 0, 0 ];
+	oy = [ 0, 0, 0, 0 ];
+
+	xe = [
+		[ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, -0.46, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, -0.46, -0.22, 1.06, 0.9, -0.3, -0.4 ]
+	];
+	ye = [
+		[ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.78, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.78, 0.54, 0.08, -0.6, 0.2, 0.8 ]
+	];
+
+	for ( i = 0; i < N.length; i++ ) {
+		x = xbuf.slice();
+		y = ybuf.slice();
+		out = grot( N[ i ], x, 1, ox[ i ], y, 1, oy[ i ], 0.8, 0.6 );
+		isApprox( t, x, xe[ i ], 6.0 );
+		isApprox( t, y, ye[ i ], 6.0 );
+		t.strictEqual( out, y, 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function applies a plane rotation (sx=1, sy=1) (accessors - complex)', function test( t ) {
+	var xbuf;
+	var ybuf;
+	var out;
+	var xe;
+	var ye;
+	var ox;
+	var oy;
+	var N;
+	var x;
+	var y;
+	var i;
+
+	N = [ 0, 1, 2 ];
+
+	xbuf = new Complex128Array( [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3 ] );
+	ybuf = new Complex128Array( [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2 ] );
+
+	ox = [ 0, 0, 0 ];
+	oy = [ 0, 0, 0 ];
+
+	xe = [
+		new Complex128Array( [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3 ] ),
+		new Complex128Array( [ 0.78, -0.46, -0.5, 0.8, 0.9, -0.3 ] ),
+		new Complex128Array( [ 0.78, -0.46, -0.22, 1.06, 0.9, -0.3 ] )
+	];
+	ye = [
+		new Complex128Array( [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2 ] ),
+		new Complex128Array( [ 0.04, -0.78, 0.3, 0.7, -0.6, 0.2 ] ),
+		new Complex128Array( [ 0.04, -0.78, 0.54, 0.08, -0.6, 0.2 ] )
+	];
+
+	for ( i = 0; i < N.length; i++ ) {
+		x = new Complex128Array( xbuf );
+		y = new Complex128Array( ybuf );
+		out = grot( N[ i ], x, 1, ox[ i ], y, 1, oy[ i ], 0.8, 0.6 );
+		isApprox( t, reinterpret128( x, 0 ), reinterpret128( xe[ i ], 0 ), 6.0 ); // eslint-disable-line max-len
+		isApprox( t, reinterpret128( out, 0 ), reinterpret128( ye[ i ], 0 ), 6.0 ); // eslint-disable-line max-len
+		isApprox( t, reinterpret128( out, 0 ), reinterpret128( y, 0 ), 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function applies a plane rotation (sx=1, sy=1) (accessors - real)', function test( t ) {
+	var xbuf;
+	var ybuf;
+	var out;
+	var xe;
+	var ye;
+	var ox;
+	var oy;
+	var N;
+	var x;
+	var y;
+	var i;
+
+	N = [ 0, 1, 2, 4 ];
+
+	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
+	ybuf = [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ];
+
+	ox = [ 0, 0, 0, 0 ];
+	oy = [ 0, 0, 0, 0 ];
+
+	xe = [
+		[ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, -0.46, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, -0.46, -0.22, 1.06, 0.9, -0.3, -0.4 ]
+	];
+	ye = [
+		[ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.78, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.78, 0.54, 0.08, -0.6, 0.2, 0.8 ]
+	];
+
+	for ( i = 0; i < N.length; i++ ) {
+		x = xbuf.slice();
+		y = ybuf.slice();
+		out = grot( N[ i ], x, 1, ox[ i ], y, 1, oy[ i ], 0.8, 0.6 );
+		isApprox( t, x, xe[ i ], 6.0 );
+		isApprox( t, y, ye[ i ], 6.0 );
+		t.strictEqual( out, y, 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function applies a plane rotation (sx=2, sy=-2)', function test( t ) {
+	var xbuf;
+	var ybuf;
+	var out;
+	var xe;
+	var ye;
+	var ox;
+	var oy;
+	var N;
+	var x;
+	var y;
+	var i;
+
+	N = [ 0, 1, 2, 4 ];
+
+	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
+	ybuf = [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ];
+
+	ox = [ 0, 0, 0, 0 ];
+	oy = [ 0, 0, 2, 6 ];
+
+	xe = [
+		[ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.66, 0.1, -0.1, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.96, 0.1, -0.76, 0.8, 0.9, -0.3, -0.02 ]
+	];
+	ye = [
+		[ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.7, -0.9, -0.12, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.64, -0.9, -0.3, 0.7, -0.18, 0.2, 0.28 ]
+	];
+
+	for ( i = 0; i < N.length; i++ ) {
+		x = xbuf.slice();
+		y = ybuf.slice();
+		out = grot( N[ i ], x, 2, ox[ i ], y, -2, oy[ i ], 0.8, 0.6 );
+		isApprox( t, x, xe[ i ], 20.0 );
+		isApprox( t, y, ye[ i ], 20.0 );
+		t.strictEqual( out, y, 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function applies a plane rotation (sx=2, sy=-2) (accessors - complex)', function test( t ) {
+	var xbuf;
+	var ybuf;
+	var out;
+	var xe;
+	var ye;
+	var ox;
+	var oy;
+	var N;
+	var x;
+	var y;
+	var i;
+
+	N = [ 0, 1 ];
+
+	xbuf = new Complex128Array( [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3 ] );
+	ybuf = new Complex128Array( [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2 ] );
+
+	ox = [ 0, 0 ];
+	oy = [ 0, 0 ];
+
+	xe = [
+		new Complex128Array( [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3 ] ),
+		new Complex128Array( [ 0.78, -0.46, -0.5, 0.8, 0.9, -0.3 ] )
+	];
+	ye = [
+		new Complex128Array( [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2 ] ),
+		new Complex128Array( [ 0.040000000000000036, -0.78, 0.3, 0.7, -0.6, 0.2 ] ) // eslint-disable-line max-len
+	];
+
+	for ( i = 0; i < N.length; i++ ) {
+		x = new Complex128Array( xbuf );
+		y = new Complex128Array( ybuf );
+		out = grot( N[ i ], x, 2, ox[ i ], y, -2, oy[ i ], 0.8, 0.6 );
+		isApprox( t, reinterpret128( x, 0 ), reinterpret128( xe[ i ], 0 ), 20.0 ); // eslint-disable-line max-len
+		isApprox( t, reinterpret128( out, 0 ), reinterpret128( ye[ i ], 0 ), 20.0 ); // eslint-disable-line max-len
+		isApprox( t, reinterpret128( out, 0 ), reinterpret128( y, 0 ), 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function applies a plane rotation (sx=2, sy=-2) (accessors - real)', function test( t ) {
+	var xbuf;
+	var ybuf;
+	var out;
+	var xe;
+	var ye;
+	var ox;
+	var oy;
+	var N;
+	var x;
+	var y;
+	var i;
+
+	N = [ 0, 1, 2, 4 ];
+
+	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
+	ybuf = [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ];
+
+	ox = [ 0, 0, 0, 0 ];
+	oy = [ 0, 0, 2, 6 ];
+
+	xe = [
+		[ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.66, 0.1, -0.1, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.96, 0.1, -0.76, 0.8, 0.9, -0.3, -0.02 ]
+	];
+	ye = [
+		[ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.7, -0.9, -0.12, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.64, -0.9, -0.3, 0.7, -0.18, 0.2, 0.28 ]
+	];
+
+	for ( i = 0; i < N.length; i++ ) {
+		x = xbuf.slice();
+		y = ybuf.slice();
+		out = grot( N[ i ], toAccessorArray( x ), 2, ox[ i ], toAccessorArray( y ), -2, oy[ i ], 0.8, 0.6 ); // eslint-disable-line max-len
+		isApprox( t, x, xe[ i ], 20.0 );
+		isApprox( t, y, ye[ i ], 20.0 );
+		t.strictEqual( out, y, 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function applies a plane rotation (sx=-2, sy=1)', function test( t ) {
+	var xbuf;
+	var ybuf;
+	var out;
+	var xe;
+	var ye;
+	var ox;
+	var oy;
+	var N;
+	var x;
+	var y;
+	var i;
+
+	N = [ 0, 1, 2, 4 ];
+
+	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
+	ybuf = [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ];
+
+	ox = [ 0, 0, 2, 6 ];
+	oy = [ 0, 0, 0, 0 ];
+
+	xe = [
+		[ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ -0.06, 0.1, -0.1, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.9, 0.1, -0.22, 0.8, 0.18, -0.3, -0.02 ]
+	];
+	ye = [
+		[ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.7, -1.08, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.64, -1.26, 0.54, 0.2, -0.6, 0.2, 0.8 ]
+	];
+	for ( i = 0; i < N.length; i++ ) {
+		x = xbuf.slice();
+		y = ybuf.slice();
+		out = grot( N[ i ], x, -2, ox[ i ], y, 1, oy[ i ], 0.8, 0.6 );
+		isApprox( t, x, xe[ i ], 20.0 );
+		isApprox( t, y, ye[ i ], 20.0 );
+		t.strictEqual( out, y, 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function applies a plane rotation (sx=-2, sy=1) (accessors - complex)', function test( t ) {
+	var xbuf;
+	var ybuf;
+	var out;
+	var xe;
+	var ye;
+	var ox;
+	var oy;
+	var N;
+	var x;
+	var y;
+	var i;
+
+	N = [ 0, 1 ];
+
+	ox = [ 0, 0 ];
+	oy = [ 0, 0 ];
+
+	xbuf = new Complex128Array( [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3 ] );
+	ybuf = new Complex128Array( [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2 ] );
+
+	xe = [
+		new Complex128Array( [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3 ] ),
+		new Complex128Array( [ 0.78, -0.46, -0.5, 0.8, 0.9, -0.3 ] )
+	];
+	ye = [
+		new Complex128Array( [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2 ] ),
+		new Complex128Array( [ 0.04, -0.78, 0.3, 0.7, -0.6, 0.2 ] )
+	];
+
+	for ( i = 0; i < N.length; i++ ) {
+		x = new Complex128Array( xbuf );
+		y = new Complex128Array( ybuf );
+		out = grot( N[ i ], x, -2, ox[ i ], y, 1, oy[ i ], 0.8, 0.6 );
+		isApprox( t, reinterpret128( x, 0 ), reinterpret128( xe[ i ], 0 ), 20.0 ); // eslint-disable-line max-len
+		isApprox( t, reinterpret128( out, 0 ), reinterpret128( ye[ i ], 0 ), 20.0 ); // eslint-disable-line max-len
+		isApprox( t, reinterpret128( out, 0 ), reinterpret128( y, 0 ), 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function applies a plane rotation (sx=-2, sy=1) (accessors - real)', function test( t ) {
+	var xbuf;
+	var ybuf;
+	var out;
+	var xe;
+	var ye;
+	var ox;
+	var oy;
+	var N;
+	var x;
+	var y;
+	var i;
+
+	N = [ 0, 1, 2, 4 ];
+
+	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
+	ybuf = [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ];
+
+	ox = [ 0, 0, 2, 6 ];
+	oy = [ 0, 0, 0, 0 ];
+
+	xe = [
+		[ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ -0.06, 0.1, -0.1, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.9, 0.1, -0.22, 0.8, 0.18, -0.3, -0.02 ]
+	];
+	ye = [
+		[ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.7, -1.08, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.64, -1.26, 0.54, 0.2, -0.6, 0.2, 0.8 ]
+	];
+	for ( i = 0; i < N.length; i++ ) {
+		x = xbuf.slice();
+		y = ybuf.slice();
+		out = grot( N[ i ], toAccessorArray( x ), -2, ox[ i ], toAccessorArray( y ), 1, oy[ i ], 0.8, 0.6 ); // eslint-disable-line max-len
+		isApprox( t, x, xe[ i ], 20.0 );
+		isApprox( t, y, ye[ i ], 20.0 );
+		t.strictEqual( out, y, 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function applies a plane rotation (sx=-1, sy=-2)', function test( t ) {
+	var xbuf;
+	var ybuf;
+	var out;
+	var xe;
+	var ye;
+	var ox;
+	var oy;
+	var N;
+	var x;
+	var y;
+	var i;
+
+	N = [ 0, 1, 2, 4 ];
+
+	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
+	ybuf = [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ];
+
+	ox = [ 0, 0, 1, 3 ];
+	oy = [ 0, 0, 2, 6 ];
+
+	xe = [
+		[ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, 0.26, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, 0.26, -0.76, 1.12, 0.9, -0.3, -0.4 ]
+	];
+	ye = [
+		[ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.9, 0.18, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.9, 0.18, 0.7, -0.18, 0.2, 0.16 ]
+	];
+
+	for ( i = 0; i < N.length; i++ ) {
+		x = xbuf.slice();
+		y = ybuf.slice();
+		out = grot( N[ i ], x, -1, ox[ i ], y, -2, oy[ i ], 0.8, 0.6 );
+		isApprox( t, x, xe[ i ], 4.0 );
+		isApprox( t, y, ye[ i ], 4.0 );
+		t.strictEqual( out, y, 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function applies a plane rotation (sx=-1, sy=-2) (accessors - complex)', function test( t ) {
+	var xbuf;
+	var ybuf;
+	var out;
+	var xe;
+	var ye;
+	var ox;
+	var oy;
+	var N;
+	var x;
+	var y;
+	var i;
+
+	N = [ 0, 1, 2 ];
+
+	xbuf = new Complex128Array( [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3 ] );
+	ybuf = new Complex128Array( [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2 ] );
+
+	ox = [ 0, 0, 1 ];
+	oy = [ 0, 0, 2 ];
+
+	xe = [
+		new Complex128Array( [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3 ] ),
+		new Complex128Array( [ 0.78, -0.46, -0.5, 0.8, 0.9, -0.3 ] ),
+		new Complex128Array( [ 0.78, -0.46, -0.76, 0.76, 0.9, -0.3 ] )
+	];
+	ye = [
+		new Complex128Array( [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2 ] ),
+		new Complex128Array( [ 0.04, -0.78, 0.3, 0.7, -0.6, 0.2 ] ),
+		new Complex128Array( [ 0.04, -0.78, 0.3, 0.7, -0.18, -0.32 ] )
+	];
+
+	for ( i = 0; i < N.length; i++ ) {
+		x = new Complex128Array( xbuf );
+		y = new Complex128Array( ybuf );
+		out = grot( N[ i ], x, -1, ox[ i ], y, -2, oy[ i ], 0.8, 0.6 );
+		isApprox( t, reinterpret128( x, 0 ), reinterpret128( xe[ i ], 0 ), 4.0 ); // eslint-disable-line max-len
+		isApprox( t, reinterpret128( out, 0 ), reinterpret128( ye[ i ], 0 ), 4.0 ); // eslint-disable-line max-len
+		isApprox( t, reinterpret128( out, 0 ), reinterpret128( y, 0 ), 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function applies a plane rotation (sx=-1, sy=-2) (accessors - real)', function test( t ) {
+	var xbuf;
+	var ybuf;
+	var out;
+	var xe;
+	var ye;
+	var ox;
+	var oy;
+	var N;
+	var x;
+	var y;
+	var i;
+
+	N = [ 0, 1, 2, 4 ];
+
+	xbuf = [ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ];
+	ybuf = [ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ];
+
+	ox = [ 0, 0, 1, 3 ];
+	oy = [ 0, 0, 2, 6 ];
+
+	xe = [
+		[ 0.6, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, 0.1, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, 0.26, -0.5, 0.8, 0.9, -0.3, -0.4 ],
+		[ 0.78, 0.26, -0.76, 1.12, 0.9, -0.3, -0.4 ]
+	];
+	ye = [
+		[ 0.5, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.9, 0.3, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.9, 0.18, 0.7, -0.6, 0.2, 0.8 ],
+		[ 0.04, -0.9, 0.18, 0.7, -0.18, 0.2, 0.16 ]
+	];
+
+	for ( i = 0; i < N.length; i++ ) {
+		x = xbuf.slice();
+		y = ybuf.slice();
+		out = grot( N[ i ], toAccessorArray( x ), -1, ox[ i ], toAccessorArray( y ), -2, oy[ i ], 0.8, 0.6 ); // eslint-disable-line max-len
+		isApprox( t, x, xe[ i ], 4.0 );
+		isApprox( t, y, ye[ i ], 4.0 );
+		t.strictEqual( out, y, 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function supports an `x` stride', function test( t ) {
+	var xe;
+	var ye;
+	var x;
+	var y;
+
+	x = [
+		1.0, // 0
+		2.0,
+		3.0, // 1
+		4.0,
+		5.0
+	];
+	y = [
+		6.0, // 0
+		7.0, // 1
+		8.0,
+		9.0,
+		10.0
+	];
+
+	grot( 2, x, 2, 0, y, 1, 0, 0.8, 0.6 );
+
+	xe = [ 4.4, 2.0, 6.6, 4.0, 5.0 ];
+	ye = [ 4.2, 3.8, 8.0, 9.0, 10.0 ];
+
+	isApprox( t, x, xe, 2.0 );
+	isApprox( t, y, ye, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function supports an `x` stride (accessors - complex)', function test( t ) {
+	var xe;
+	var ye;
+	var x;
+	var y;
+
+	x = new Complex128Array([
+		1.0, // 0
+		2.0,
+		3.0,
+		4.0,
+		5.0, // 1
+		6.0
+	]);
+	y = new Complex128Array([
+		7.0, // 0
+		8.0,
+		9.0, // 1
+		10.0,
+		11.0,
+		12.0
+	]);
+
+	grot( 2, x, 2, 0, y, 1, 0, 0.8, 0.6 );
+
+	xe = new Complex128Array( [ 5, 6.4, 3.0, 4.0, 9.4, 10.8 ] );
+	ye = new Complex128Array( [ 5.0, 5.2, 4.2, 4.4, 11.0, 12.0 ] );
+
+	isApprox( t, reinterpret128( x, 0 ), reinterpret128( xe, 0 ), 2.0 );
+	isApprox( t, reinterpret128( y, 0 ), reinterpret128( ye, 0 ), 2.0 );
+
+	t.end();
+});
+
+tape( 'the function supports an `x` stride (accessors - real)', function test( t ) {
+	var xe;
+	var ye;
+	var x;
+	var y;
+
+	x = [
+		1.0, // 0
+		2.0,
+		3.0, // 1
+		4.0,
+		5.0
+	];
+	y = [
+		6.0, // 0
+		7.0, // 1
+		8.0,
+		9.0,
+		10.0
+	];
+
+	grot( 2, toAccessorArray( x ), 2, 0, toAccessorArray( y ), 1, 0, 0.8, 0.6 );
+
+	xe = [ 4.4, 2.0, 6.6, 4.0, 5.0 ];
+	ye = [ 4.2, 3.8, 8.0, 9.0, 10.0 ];
+
+	isApprox( t, x, xe, 2.0 );
+	isApprox( t, y, ye, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function supports an `x` offset', function test( t ) {
+	var xe;
+	var ye;
+	var x;
+	var y;
+
+	x = [
+		1.0,
+		2.0, // 0
+		3.0, // 1
+		4.0,
+		5.0
+	];
+	y = [
+		6.0, // 0
+		7.0, // 1
+		8.0,
+		9.0,
+		10.0
+	];
+
+	grot( 2, x, 1, 1, y, 1, 0, 0.8, 0.6 );
+
+	xe = [ 1.0, 5.2, 6.6, 4.0, 5.0 ];
+	ye = [ 3.6, 3.8, 8.0, 9.0, 10.0 ];
+
+	isApprox( t, x, xe, 2.0 );
+	isApprox( t, y, ye, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function supports an `x` offset (accessors - complex)', function test( t ) {
+	var xe;
+	var ye;
+	var x;
+	var y;
+
+	x = new Complex128Array([
+		1.0,
+		2.0,
+		3.0, // 0
+		4.0,
+		5.0, // 1
+		6.0
+	]);
+	y = new Complex128Array([
+		7.0, // 0
+		8.0,
+		9.0, // 1
+		10.0,
+		11.0,
+		12.0
+	]);
+
+	grot( 2, x, 1, 1, y, 1, 0, 0.8, 0.6 );
+
+	xe = new Complex128Array( [ 1.0, 2.0, 6.6, 8, 9.4, 10.8 ] );
+	ye = new Complex128Array( [ 3.8, 4, 4.2, 4.4, 11.0, 12.0 ] );
+
+	isApprox( t, reinterpret128( x, 0 ), reinterpret128( xe, 0 ), 2.0 );
+	isApprox( t, reinterpret128( y, 0 ), reinterpret128( ye, 0 ), 2.0 );
+
+	t.end();
+});
+
+tape( 'the function supports an `x` offset (accessors - real)', function test( t ) {
+	var xe;
+	var ye;
+	var x;
+	var y;
+
+	x = [
+		1.0,
+		2.0, // 0
+		3.0, // 1
+		4.0,
+		5.0
+	];
+	y = [
+		6.0, // 0
+		7.0, // 1
+		8.0,
+		9.0,
+		10.0
+	];
+
+	grot( 2, toAccessorArray( x ), 1, 1, toAccessorArray( y ), 1, 0, 0.8, 0.6 );
+
+	xe = [ 1.0, 5.2, 6.6, 4.0, 5.0 ];
+	ye = [ 3.6, 3.8, 8.0, 9.0, 10.0 ];
+
+	isApprox( t, x, xe, 2.0 );
+	isApprox( t, y, ye, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function supports a `y` stride', function test( t ) {
+	var xe;
+	var ye;
+	var x;
+	var y;
+
+	x = [
+		1.0, // 0
+		2.0, // 1
+		3.0, // 2
+		4.0,
+		5.0
+	];
+	y = [
+		1.0, // 0
+		2.0,
+		3.0, // 1
+		4.0,
+		5.0  // 2
+	];
+
+	grot( 3, x, 1, 0, y, 2, 0, 0.0, -1.0 );
+
+	xe = [ -1.0, -3.0, -5.0, 4.0, 5.0 ];
+	ye = [ 1.0, 2.0, 2.0, 4.0, 3.0 ];
+
+	isApprox( t, x, xe, 1.0 );
+	isApprox( t, y, ye, 1.0 );
+
+	t.end();
+});
+
+tape( 'the function supports a `y` stride (accessors - complex)', function test( t ) {
+	var xe;
+	var ye;
+	var x;
+	var y;
+
+	x = new Complex128Array([
+		1.0, // 0
+		2.0,
+		3.0, // 1
+		4.0,
+		5.0,
+		6.0
+	]);
+	y = new Complex128Array([
+		1.0, // 0
+		2.0,
+		3.0,
+		4.0,
+		5.0, // 1
+		6.0
+	]);
+
+	grot( 2, x, 1, 0, y, 2, 0, 0.0, -1.0 );
+
+	xe = new Complex128Array( [ -1.0, -2.0, -5.0, -6.0, 5.0, 6.0 ] );
+	ye = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 3.0, 4.0 ] );
+
+	isApprox( t, reinterpret128( x, 0 ), reinterpret128( xe, 0 ), 2.0 );
+	isApprox( t, reinterpret128( y, 0 ), reinterpret128( ye, 0 ), 2.0 );
+
+	t.end();
+});
+
+tape( 'the function supports a `y` stride (accessors - real)', function test( t ) {
+	var xe;
+	var ye;
+	var x;
+	var y;
+
+	x = [
+		1.0, // 0
+		2.0, // 1
+		3.0, // 2
+		4.0,
+		5.0
+	];
+	y = [
+		1.0, // 0
+		2.0,
+		3.0, // 1
+		4.0,
+		5.0  // 2
+	];
+
+	grot( 3, toAccessorArray( x ), 1, 0, toAccessorArray( y ), 2, 0, 0.0, -1.0 ); // eslint-disable-line max-len
+
+	xe = [ -1.0, -3.0, -5.0, 4.0, 5.0 ];
+	ye = [ 1.0, 2.0, 2.0, 4.0, 3.0 ];
+
+	isApprox( t, x, xe, 1.0 );
+	isApprox( t, y, ye, 1.0 );
+
+	t.end();
+});
+
+tape( 'the function supports a `y` offset', function test( t ) {
+	var xe;
+	var ye;
+	var x;
+	var y;
+
+	x = [
+		1.0, // 0
+		2.0, // 1
+		3.0,
+		4.0,
+		5.0
+	];
+	y = [
+		6.0,
+		7.0,
+		8.0, // 0
+		9.0, // 1
+		10.0
+	];
+
+	grot( 2, x, 1, 0, y, 1, 2, 0.8, 0.6 );
+
+	xe = [ 5.6, 7.0, 3.0, 4.0, 5.0 ];
+	ye = [ 6.0, 7.0, 5.8, 6.0, 10.0 ];
+
+	isApprox( t, x, xe, 1.0 );
+	isApprox( t, y, ye, 1.0 );
+
+	t.end();
+});
+
+tape( 'the function supports a `y` offset (accessors - complex)', function test( t ) {
+	var xe;
+	var ye;
+	var x;
+	var y;
+
+	x = new Complex128Array([
+		1.0, // 0
+		2.0,
+		3.0, // 1
+		4.0,
+		5.0,
+		6.0
+	]);
+	y = new Complex128Array([
+		7.0,
+		8.0,
+		9.0,  // 0
+		10.0,
+		11.0, // 1
+		12.0
+	]);
+
+	grot( 2, x, 1, 0, y, 1, 1, 0.8, 0.6 );
+
+	xe = new Complex128Array( [ 6.2, 7.6, 9, 10.4, 5.0, 6.0 ] );
+	ye = new Complex128Array( [ 7.0, 8.0, 6.6, 6.8, 7.0, 7.2 ] );
+
+	isApprox( t, reinterpret128( x, 0 ), reinterpret128( xe, 0 ), 2.0 );
+	isApprox( t, reinterpret128( y, 0 ), reinterpret128( ye, 0 ), 2.0 );
+
+	t.end();
+});
+
+tape( 'the function supports a `y` offset (accessors - real)', function test( t ) {
+	var xe;
+	var ye;
+	var x;
+	var y;
+
+	x = [
+		1.0, // 0
+		2.0, // 1
+		3.0,
+		4.0,
+		5.0
+	];
+	y = [
+		6.0,
+		7.0,
+		8.0, // 0
+		9.0, // 1
+		10.0
+	];
+
+	grot( 2, toAccessorArray( x ), 1, 0, toAccessorArray( y ), 1, 2, 0.8, 0.6 );
+
+	xe = [ 5.6, 7.0, 3.0, 4.0, 5.0 ];
+	ye = [ 6.0, 7.0, 5.8, 6.0, 10.0 ];
+
+	isApprox( t, x, xe, 1.0 );
+	isApprox( t, y, ye, 1.0 );
+
+	t.end();
+});
+
+tape( 'the function returns a reference to the second input array', function test( t ) {
+	var out;
+	var x;
+	var y;
+
+	x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
+	y = [ 6.0, 7.0, 8.0, 9.0, 10.0 ];
+
+	out = grot( x.length, x, 1, 0, y, 1, 0, 1, 0 );
+
+	t.strictEqual( out, y, 'returns expected value' );
+	t.end();
+});
+
+tape( 'if provided an `N` parameter less than or equal to `0`, the function leaves both input arrays unchanged', function test( t ) {
+	var xe;
+	var ye;
+	var x;
+	var y;
+
+	x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
+	y = [ 6.0, 7.0, 8.0, 9.0, 10.0 ];
+
+	xe = x.slice();
+	dcopy( x.length, x, 1, 0, xe, 1, 0 );
+
+	ye = y.slice();
+	dcopy( y.length, y, 1, 0, ye, 1, 0 );
+
+	grot( 0, x, 1, 0, y, 1, 0, 0.8, 0.6 );
+	t.deepEqual( x, xe, 'returns expected value' );
+	t.deepEqual( y, ye, 'returns expected value' );
+
+	grot( 0, x, 1, y, 1, 0.8, 0.6 );
+	t.deepEqual( x, xe, 'returns expected value' );
+	t.deepEqual( y, ye, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports negative strides', function test( t ) {
+	var xe;
+	var ye;
+	var x;
+	var y;
+
+	x = [
+		0.6,  // 3
+		0.1,
+		-0.5, // 2
+		0.8,
+		0.9,  // 1
+		-0.3,
+		-0.4  // 0
+	];
+	y = [
+		0.5,  // 0
+		-0.9, // 1
+		0.3,  // 2
+		0.7,  // 3
+		-0.6,
+		0.2,
+		0.8
+	];
+
+	grot( 4, x, -2, 6, y, 1, 0, 0.8, 0.6 );
+
+	xe = [ 0.9, 0.1, -0.22, 0.8, 0.18, -0.3, -0.02 ];
+	ye = [ 0.64, -1.26, 0.54, 0.2, -0.6, 0.2, 0.8 ];
+
+	isApprox( t, x, xe, 20.0 );
+	isApprox( t, y, ye, 20.0 );
+
+	t.end();
+});
+
+tape( 'the function supports negative strides (accessors - complex)', function test( t ) {
+	var xe;
+	var ye;
+	var x;
+	var y;
+
+	x = new Complex128Array([
+		0.6,
+		0.1,  // 1
+		-0.5,
+		0.8,
+		0.9,
+		-0.4  // 0
+	]);
+	y = new Complex128Array([
+		0.5,  // 0
+		-0.9,
+		0.3,  // 1
+		0.7,
+		-0.6,
+		0.2
+	]);
+
+	grot( 2, x, -2, 2, y, 1, 0, 0.8, 0.6 );
+
+	xe = new Complex128Array( [ 0.66, 0.5, -0.5, 0.8, 1.02, -0.86 ] );
+	ye = new Complex128Array( [ -0.14, -0.48, -0.12, 0.50, -0.6, 0.2 ] );
+
+	isApprox( t, reinterpret128( x, 0 ), reinterpret128( xe, 0 ), 2.0 );
+	isApprox( t, reinterpret128( y, 0 ), reinterpret128( ye, 0 ), 2.0 );
+
+	t.end();
+});
+
+tape( 'the function supports negative strides (accessors - real)', function test( t ) {
+	var xe;
+	var ye;
+	var x;
+	var y;
+
+	x = [
+		0.6,  // 3
+		0.1,
+		-0.5, // 2
+		0.8,
+		0.9,  // 1
+		-0.3,
+		-0.4  // 0
+	];
+	y = [
+		0.5,  // 0
+		-0.9, // 1
+		0.3,  // 2
+		0.7,  // 3
+		-0.6,
+		0.2,
+		0.8
+	];
+
+	grot( 4, toAccessorArray( x ), -2, 6, toAccessorArray( y ), 1, 0, 0.8, 0.6 ); // eslint-disable-line max-len
+
+	xe = [ 0.9, 0.1, -0.22, 0.8, 0.18, -0.3, -0.02 ];
+	ye = [ 0.64, -1.26, 0.54, 0.2, -0.6, 0.2, 0.8 ];
+
+	isApprox( t, x, xe, 20.0 );
+	isApprox( t, y, ye, 20.0 );
+
+	t.end();
+});
+
+tape( 'the function supports complex access patterns', function test( t ) {
+	var xe;
+	var ye;
+	var x;
+	var y;
+
+	x = [
+		0.6,  // 1
+		0.1,  // 0
+		-0.5,
+		0.8,
+		0.9,
+		-0.3,
+		-0.4
+	];
+	y = [
+		0.5,  // 1
+		-0.9,
+		0.3,  // 0
+		0.7,
+		-0.6,
+		0.2,
+		0.8
+	];
+
+	grot( 2, x, -1, 1, y, -2, 2, 0.8, 0.6 );
+
+	xe = [ 0.78, 0.26, -0.5, 0.8, 0.9, -0.3, -0.4 ];
+	ye = [ 0.04, -0.9, 0.18, 0.7, -0.6, 0.2, 0.8 ];
+
+	isApprox( t, x, xe, 5.0 );
+	isApprox( t, y, ye, 5.0 );
+
+	t.end();
+});


### PR DESCRIPTION
If applied, this commit will add the package `blas/base/grot`


## Description

> What is the purpose of this pull request?

Add the package, `blas/base/grot` which serves as a generic JavaScript interface to handle array types such as numeric arrays and accessor arrays.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #2190 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

1. Use of `eslint-disable-line no-underscore-dangle`: This is used since we return the data buffer in case of an input accessor array.

2. We are typecasting input arrays to accessor arrays while passing it to the grot function e.g.
```javascript
x = xbuf.slice();
y = ybuf.slice();
out = grot( N[ i ], toAccessorArray( x ), 1, toAccessorArray( y ), 1, 0.8, 0.6 ); // eslint-disable-line max-len
```
Please do let me know in case it is preferred to cast it before it is passed as an argument e.g.

```javascript
x = toAccessorArray( xbuf.slice() );
y = toAccessorArray( ybuf.slice() );
out = grot( N[ i ], x, 1, y, 1, 0.8, 0.6 ); // eslint-disable-line max-len
```

3. In accessor array implementation, we're using `@stdlib/complex/dtype` to find out the dtype of the input arrays and then conditionally setting it as a param for `@stdlib/complex/cmplx`.

4. Also, accessor array implementation works on one index at a time from each array similar to numeric array implementation but the complex array implementation works on 2 indexes from each array at a time since they're stored in pairs.

5. Tests pertaining to accessor arrays are bifurcated to numeric array tests, accessor array (complex) tests, and accessor array (real) tests. 

6. Also, tests pertaining to accessor arrays testing if it applies plane rotation correctly have headings like :
`tape( '...(sx=1, sy=1) (accessors - complex)', ....`. I'm not sure whether using parenthesis after parenthesis is the correct way.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
