### PR TITLE
feat: add `fs/mkdir`

### DIFF
--- a/lib/node_modules/@stdlib/fs/mkdir/README.md
+++ b/lib/node_modules/@stdlib/fs/mkdir/README.md
@@ -1,0 +1,244 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# Create Directory
+
+> Create a directory and any necessary subdirectories.
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+
+<!-- run-disable -->
+
+```javascript
+var mkdir = require( '@stdlib/fs/mkdir' );
+```
+
+#### mkdir( path\[, options], clbk )
+
+Asynchronously creates a directory and any necessary subdirectories.
+
+```javascript
+mkdir( './foo', onDir );
+
+function onDir( error, path ) {
+    if ( error ) {
+        throw error;
+    } else {
+        console.log( path );
+    }
+}
+```
+
+The function accepts the same `options` and has the same defaults as [`fs.mkdir()`][node-fs].
+
+#### mkdir.sync( path\[, options] )
+
+Synchronously creates a directory and any necessary subdirectories.
+
+```javascript
+var out = mkdir.sync( './foo' );
+if ( out instanceof Error ) {
+    throw out;
+}
+console.log( out );
+```
+
+The function accepts the same `options` and has the same defaults as [`fs.mkdirSync()`][node-fs].
+
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+## Notes
+
+-   The difference between this API and [`fs.mkdirSync()`][node-fs] is that [`fs.mkdirSync()`][node-fs] will throw if an `error` is encountered (e.g., if given a non-existent `path`) and this API will return an `error`. Hence, the following anti-pattern
+
+```javascript
+var fs = require( 'fs' );
+
+var dir = './foo';
+
+// Check for existence to prevent an error being thrown...
+if ( !fs.existsSync( dir ) ) { // eslint-disable-line node/no-sync
+    fs.mkdirSync( dir ); // eslint-disable-line node/no-sync
+}
+```
+
+can be replaced by an approach which addresses existence via `error` handling.
+
+```javascript
+var mkdir = require( '@stdlib/fs/mkdir' );
+
+var dir = './foo';
+
+// Explicitly handle the error...
+var out = mkdir.sync( dir );
+if ( out instanceof Error ) {
+    // You choose what to do...
+    console.error( out.message );
+}
+```
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+<!-- run-disable -->
+
+```javascript
+var mkdir = require( '@stdlib/fs/mkdir' );
+
+var opts = {
+    'mode': parseInt( '0755', 8 ),
+    'recursive': true
+};
+
+/* Sync */
+
+var out = mkdir.sync( './foo' );
+// returns undefined
+
+console.log( out instanceof Error );
+// => false
+
+out = mkdir.sync( './bar/baz', opts );
+// returns <string> || undefined
+
+console.log( out instanceof Error );
+// => false
+
+/* Async */
+
+mkdir( './foo', onDir );
+mkdir( './bar/baz', opts, onDir );
+
+function onDir( error, path ) {
+    if ( error ) {
+        throw error;
+    }
+    console.log( path );
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+* * *
+
+<section class="cli">
+
+## CLI
+
+<section class="usage">
+
+### Usage
+
+```text
+Usage: mkdir [options] <path>
+
+Options:
+
+  -h,    --help                     Print this message.
+  -V,    --version                  Print the package version.
+         --mode mode                Directory mode. Default: 0o777.
+  -p,    --recursive                Create parent directories.
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+### Notes
+
+-   Relative file paths are resolved relative to the current working directory.
+-   Errors are written to `stderr`.
+-   File contents are written to `stdout`.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+### Examples
+
+```bash
+$ mkdir ./tmp
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.cli -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[node-fs]: https://nodejs.org/api/fs.html
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/fs/mkdir/README.md
+++ b/lib/node_modules/@stdlib/fs/mkdir/README.md
@@ -79,7 +79,7 @@ The function accepts the same `options` and has the same defaults as [`fs.mkdirS
 
 ## Notes
 
--   The difference between this API and [`fs.mkdirSync()`][node-fs] is that [`fs.mkdirSync()`][node-fs] will throw if an `error` is encountered (e.g., if given a non-existent `path`) and this API will return an `error`. Hence, the following anti-pattern
+-   The difference between this API and [`fs.mkdirSync()`][node-fs] is that [`fs.mkdirSync()`][node-fs] will throw if an `error` is encountered (e.g., if given a existent `path`) and this API will return an `error`. Hence, the following anti-pattern
 
 ```javascript
 var fs = require( 'fs' );
@@ -87,8 +87,8 @@ var fs = require( 'fs' );
 var dir = './foo';
 
 // Check for existence to prevent an error being thrown...
-if ( !fs.existsSync( dir ) ) { // eslint-disable-line node/no-sync
-    fs.mkdirSync( dir ); // eslint-disable-line node/no-sync
+if ( !fs.existsSync( dir ) ) {
+    fs.mkdirSync( dir );
 }
 ```
 

--- a/lib/node_modules/@stdlib/fs/mkdir/README.md
+++ b/lib/node_modules/@stdlib/fs/mkdir/README.md
@@ -54,6 +54,8 @@ function onDir( error, path ) {
 
 The function accepts the same `options` and has the same defaults as [`fs.mkdir()`][node-fs].
 
+The `path` presents only if the `recursive` option is `true`, which is the first directory path created.
+
 #### mkdir.sync( path\[, options] )
 
 Synchronously creates a directory and any necessary subdirectories.
@@ -67,6 +69,8 @@ console.log( out );
 ```
 
 The function accepts the same `options` and has the same defaults as [`fs.mkdirSync()`][node-fs].
+
+The function returns `undefined`, or if `recursive` option is `true`, the first directory path created.
 
 
 </section>

--- a/lib/node_modules/@stdlib/fs/mkdir/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fs/mkdir/benchmark/benchmark.js
@@ -1,0 +1,124 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var rmdirSync = require( 'fs' ).rmdirSync;  // eslint-disable-line node/no-sync
+var join = require( 'path' ).join;
+var bench = require( '@stdlib/bench' );
+var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
+var pkg = require( './../package.json' ).name;
+var mkdir = require( './../lib' );
+
+
+// VARIABLES //
+
+var DIR = join( __dirname, 'fixtures' );
+
+
+// FUNCTIONS //
+
+/**
+* Removes the directory created during a benchmark.
+*
+* @private
+* @param {string} dir - directory to remove
+*/
+function remove( dir ) {
+	var opts;
+
+	opts = {
+		'recursive': true,
+		'force': true
+	};
+	rmdirSync( dir, opts);
+}
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var opts;
+	var dir;
+	var i;
+
+	opts = {
+		'mode': parseInt( '0755', 8 ),
+		'recursive': true
+	};
+	i = 0;
+	b.tic();
+
+	return next();
+
+	function next() {
+		i += 1;
+		if ( i <= b.iterations ) {
+			dir = DIR + '/' + i.toString();
+			return mkdir(dir, opts, onDir);
+		}
+		b.toc();
+		b.pass( 'benchmark finished' );
+
+		remove( dir );
+		b.end();
+	}
+
+	function onDir( error, path ) {
+		if ( error ) {
+			b.fail( error );
+		}
+		if ( !isString( path ) && path !== void 0) {
+			b.fail( 'should be a string or undefined' );
+		}
+		next();
+	}
+});
+
+bench( pkg+':sync', function benchmark( b ) {
+	var opts;
+	var out;
+	var dir;
+	var i;
+
+	opts = {
+		'mode': parseInt( '0755', 8 ),
+		'recursive': true
+	};
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		dir = DIR + '/' + i.toString();
+		out = mkdir.sync( dir, opts );
+		if ( out instanceof Error) {
+			b.fail( out );
+		}
+		if ( !isString( out ) && out !== void 0 ) {
+			b.fail( 'should be a string or undefined' );
+		}
+		remove( dir );
+	}
+	b.toc();
+	if ( out instanceof Error) {
+		b.fail( out );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/fs/mkdir/bin/cli
+++ b/lib/node_modules/@stdlib/fs/mkdir/bin/cli
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var readFileSync = require( '@stdlib/fs/read-file' ).sync;
+var CLI = require( '@stdlib/cli/ctor' );
+var cwd = require( '@stdlib/process/cwd' );
+var mkdir = require( './../lib' );
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var flags;
+	var dpath;
+	var args;
+	var opts;
+	var cli;
+
+	// Create a command-line interface:
+	cli = new CLI({
+		'pkg': require( './../package.json' ),
+		'options': require( './../etc/cli_opts.json' ),
+		'help': readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+			'encoding': 'utf8'
+		})
+	});
+
+	// Get any provided command-line options:
+	flags = cli.flags();
+	if ( flags.help || flags.version ) {
+		return;
+	}
+
+	// Get any provided command-line arguments:
+	args = cli.args();
+
+	opts = {};
+	if ( flags.mode ) {
+		opts.mode = parseInt( flags.mode, 8 );
+	}
+	if ( flags.recursive ) {
+		opts.recursive = true;
+	}
+
+	dpath = resolve( cwd(), args[ 0 ] );
+	mkdir( dpath, opts, onDir );
+
+	/**
+	* Callback invoked upon creating a directory.
+	*
+	* @private
+	* @param {(Error|null)} error - error object
+	* @param {string|undefined} path - the first directory path created
+	* @returns {void}
+	*/
+	function onDir( error, path ) {
+		if ( error ) {
+			return cli.error( error );
+		}
+		console.log( path );  // eslint-disable-line no-console
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/fs/mkdir/docs/repl.txt
+++ b/lib/node_modules/@stdlib/fs/mkdir/docs/repl.txt
@@ -1,0 +1,61 @@
+
+{{alias}}( path[, options], clbk )
+    Asynchronously creates a directory.
+
+    Parameters
+    ----------
+    path: string
+        Directory path.
+
+    options: Object|integer (optional)
+        Options. If is an integer, the value is the directory mode.
+
+    options.mode: integer (optional)
+		Directory mode. Default: 0o777.
+
+    options.recursive: boolean (optional)
+		Boolean indicating whether to create parent directories. Default: false.
+
+    clbk: Function
+        Callback to invoke after creating a directory.
+
+    Examples
+    --------
+    > function onDir( error, path ) {
+    ...     if ( error ) {
+    ...         console.error( error.message );
+    ...     } else {
+    ...         console.log( path );
+    ...     }
+    ... };
+    > {{alias}}( './foo', onDir );
+
+
+{{alias}}.sync( path[, options] )
+    Synchronously creates a directory.
+
+    Parameters
+    ----------
+    path: string
+        Directory path.
+
+    options: Object|integer (optional)
+        Options. If is an integer, the value is the directory mode.
+
+    options.mode: integer (optional)
+        Directory mode. Default: 0o777.
+
+    options.recursive: boolean (optional)
+        Boolean indicating whether to create parent directories. Default: false.
+
+    Returns
+    -------
+    out: string|undefined
+        The first directory path created.
+
+    Examples
+    --------
+    > var out = {{alias}}.sync( './foo' );
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/fs/mkdir/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/fs/mkdir/docs/types/index.d.ts
@@ -1,0 +1,132 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Interface defining function options.
+*/
+interface Options {
+	/**
+	* Directory mode (default: 0o777).
+	*/
+	mode?: number;
+
+	/**
+	* Whether to create parent directories (default: false).
+	*/
+	recursive?: boolean;
+}
+
+/**
+* Callback invoked after creating a directory.
+*
+* @param err - error argument
+* @param path - the first directory path created (present only recursive is true)
+*/
+type Callback = ( err: Error | null, path: string | undefined ) => void;
+
+/**
+* Interface for creating a directory.
+*/
+interface Mkdir {
+	/**
+	* Asynchronously creates a directory.
+	*
+	* @param path - directory path
+	* @param options - function options
+	* @param options.mode - directory mode
+	* @param options.recursive - whether to create parent directories
+	* @param clbk - callback to invoke after creating a directory
+	* @throws must provide valid options
+	*
+	* @example
+	* mkdir( './foo/bar', { 'recursive': true }, onPath );
+	*
+	* function onDir( error, path ) {
+	*     if ( error ) {
+	*         throw error;
+	*     }
+	*     console.log( path );
+	* }
+	*/
+	( path: string, options: Options | number, clbk: Callback ): void;
+
+	/**
+	* Asynchronously creates a directory.
+	*
+	* @param path - directory path
+	* @param clbk - callback to invoke after creating a directory
+	*
+	* @example
+	* mkdir( '/baz', onPath );
+	*
+	* function onPath( error, path ) {
+	*     if ( error ) {
+	*         throw error;
+	*     }
+	*     console.log( path );
+	* }
+	*/
+	( path: string, clbk: Callback ): void;
+
+	/**
+	* Synchronously creates a directory.
+	*
+	* @param path - directory path
+	* @param options - function options
+	* @param options.mode - directory mode
+	* @param options.recursive - whether to create parent directories
+	* @throws must provide valid options
+	* @returns error object, undefined, or path (present only recursive is true)
+	*
+	* @example
+	* var out = mkdir.sync( './bar/baz', { 'recursive': true } );
+	*/
+	sync( path: string, options?: Options | number ): Error | string | undefined;
+}
+
+/**
+* Asynchronously creates a directory.
+*
+* @param path - directory path
+* @param options - function options
+* @param options.mode - directory mode
+* @param options.recursive - whether to create parent directories
+* @param clbk - callback to invoke after creating a directory
+* @throws must provide valid options
+*
+* @example
+* mkdir( './foo/bar', onDir );
+*
+* function onDir( error, path ) {
+*     if ( error ) {
+*         throw error;
+*     }
+*     console.log( path );
+* }
+*
+* @example
+* var out = mkdir.sync( './foo/bar' );
+*/
+declare var mkdir: Mkdir;
+
+
+// EXPORTS //
+
+export = mkdir;

--- a/lib/node_modules/@stdlib/fs/mkdir/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/fs/mkdir/docs/types/test.ts
@@ -1,0 +1,155 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import mkdir = require( './index' );
+
+const done = ( error: Error | null, path: string | undefined ): void => {
+	if ( error || ( path !== void 0 && typeof path !== 'string' ) ) {
+		throw error;
+	}
+};
+
+
+// TESTS //
+
+// The function does not have a return value...
+{
+	mkdir( './foo', done ); // $ExpectType void
+	mkdir( './bar', 0o755, done ); // $ExpectType void
+	mkdir( './baz', { 'mode': 0o755 }, done ); // $ExpectType void
+	mkdir( './tmp', { 'mode': 0o755, 'recursive': false }, done ); // $ExpectType void
+	mkdir( './var/tmp', { 'mode': 0o755, 'recursive': true }, done ); // $ExpectType void
+}
+
+// The compiler throws an error if the function is provided a first argument which is not a string...
+{
+	mkdir( 1, done ); // $ExpectError
+	mkdir( false, done ); // $ExpectError
+	mkdir( true, done ); // $ExpectError
+	mkdir( null, done ); // $ExpectError
+	mkdir( undefined, done ); // $ExpectError
+	mkdir( [], done ); // $ExpectError
+	mkdir( {}, done ); // $ExpectError
+	mkdir( ( x: number ): number => x, done ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a callback argument which is not a function with the expected signature...
+{
+	mkdir( './beepboop', 1 ); // $ExpectError
+	mkdir( './beepboop', false ); // $ExpectError
+	mkdir( './beepboop', true ); // $ExpectError
+	mkdir( './beepboop', null ); // $ExpectError
+	mkdir( './beepboop', undefined ); // $ExpectError
+	mkdir( './beepboop', [] ); // $ExpectError
+	mkdir( './beepboop', {} ); // $ExpectError
+	mkdir( './beepboop', ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an options argument which is not an object or number...
+{
+	mkdir( './beepboop', 'abc', done ); // $ExpectError
+	mkdir( './beepboop', true, done ); // $ExpectError
+	mkdir( './beepboop', false, done ); // $ExpectError
+	mkdir( './beepboop', null, done ); // $ExpectError
+	mkdir( './beepboop', [], done ); // $ExpectError
+	mkdir( './beepboop', ( x: number ): number => x, done ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an `mode` option which is not an number...
+{
+	mkdir( 'beepboop', { 'mode': 'abc' }, done ); // $ExpectError
+	mkdir( 'beepboop', { 'mode': true }, done ); // $ExpectError
+	mkdir( 'beepboop', { 'mode': false }, done ); // $ExpectError
+	mkdir( 'beepboop', { 'mode': null }, done ); // $ExpectError
+	mkdir( 'beepboop', { 'mode': [] }, done ); // $ExpectError
+	mkdir( 'beepboop', { 'mode': {} }, done ); // $ExpectError
+	mkdir( 'beepboop', { 'mode': ( x: number ): number => x }, done ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a `recursive` option which is not a boolean...
+{
+	mkdir( 'beepboop', { 'recursive': 123 }, done ); // $ExpectError
+	mkdir( 'beepboop', { 'recursive': 'str' }, done ); // $ExpectError
+	mkdir( 'beepboop', { 'recursive': null }, done ); // $ExpectError
+	mkdir( 'beepboop', { 'recursive': [] }, done ); // $ExpectError
+	mkdir( 'beepboop', { 'recursive': {} }, done ); // $ExpectError
+	mkdir( 'beepboop', { 'recursive': ( x: done ): number => x }, done ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	mkdir(); // $ExpectError
+	mkdir( 'C:\\foo\\bar\\baz' ); // $ExpectError
+}
+
+// The `sync` method returns an error, a string or undefined...
+{
+	mkdir.sync( './foo' ); // $ExpectType string | Error | undefined
+	mkdir.sync( './bar', 0o755, ); // $ExpectType string | Error | undefined
+	mkdir.sync( './baz', { 'mode': 0o755 }, ); // $ExpectType string | Error | undefined
+	mkdir.sync( './tmp', { 'mode': 0o755, 'recursive': false }, ); // $ExpectType string | Error | undefined
+	mkdir.sync( './var/tmp', { 'mode': 0o755, 'recursive': true } ); // $ExpectType string | Error | undefined
+}
+
+// The compiler throws an error if the `sync` method is provided a first argument which is not a string...
+{
+	mkdir.sync( 1 ); // $ExpectError
+	mkdir.sync( false ); // $ExpectError
+	mkdir.sync( true ); // $ExpectError
+	mkdir.sync( null ); // $ExpectError
+	mkdir.sync( undefined ); // $ExpectError
+	mkdir.sync( [] ); // $ExpectError
+	mkdir.sync( {} ); // $ExpectError
+	mkdir.sync( ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an options argument which is not an object or number...
+{
+	mkdir.sync( './beepboop', 'abc' ); // $ExpectError
+	mkdir.sync( './beepboop', true ); // $ExpectError
+	mkdir.sync( './beepboop', false ); // $ExpectError
+	mkdir.sync( './beepboop', null ); // $ExpectError
+	mkdir.sync( './beepboop', [] ); // $ExpectError
+	mkdir.sync( './beepboop', ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the `sync` method is provided an `mode` option which is not an number...
+{
+	mkdir.sync( 'beepboop', { 'mode': 'abc' } ); // $ExpectError
+	mkdir.sync( 'beepboop', { 'mode': true } ); // $ExpectError
+	mkdir.sync( 'beepboop', { 'mode': false } ); // $ExpectError
+	mkdir.sync( 'beepboop', { 'mode': null } ); // $ExpectError
+	mkdir.sync( 'beepboop', { 'mode': [] } ); // $ExpectError
+	mkdir.sync( 'beepboop', { 'mode': {} } ); // $ExpectError
+	mkdir.sync( 'beepboop', { 'mode': ( x: number ): number => x } ); // $ExpectError
+}
+
+// The compiler throws an error if the `sync` method is provided a `recursive` option which is not a boolean...
+{
+	mkdir.sync( 'beepboop', { 'recursive': 123 } ); // $ExpectError
+	mkdir.sync( 'beepboop', { 'recursive': 'str' } ); // $ExpectError
+	mkdir.sync( 'beepboop', { 'recursive': null } ); // $ExpectError
+	mkdir.sync( 'beepboop', { 'recursive': [] } ); // $ExpectError
+	mkdir.sync( 'beepboop', { 'recursive': {} } ); // $ExpectError
+	mkdir.sync( 'beepboop', { 'recursive': ( x: done ): number => x } ); // $ExpectError
+}
+
+// The compiler throws an error if the `sync` method is provided an unsupported number of arguments...
+{
+	mkdir.sync(); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/fs/mkdir/docs/usage.txt
+++ b/lib/node_modules/@stdlib/fs/mkdir/docs/usage.txt
@@ -1,0 +1,8 @@
+Usage: mkdir [options] <path>
+
+Options:
+
+  -h,    --help                     Print this message.
+  -V,    --version                  Print the package version.
+         --mode mode                Directory mode. Default: 0o777.
+         --recursive recursive      Create parent directories. Default: false.

--- a/lib/node_modules/@stdlib/fs/mkdir/etc/cli_opts.json
+++ b/lib/node_modules/@stdlib/fs/mkdir/etc/cli_opts.json
@@ -1,0 +1,21 @@
+{
+	"string": [
+		"mode"
+	],
+	"boolean": [
+		"help",
+		"version",
+		"recursive"
+	],
+	"alias": {
+		"help": [
+			"h"
+		],
+		"version": [
+			"V"
+		],
+		"recursive": [
+			"p"
+		]
+	}
+}

--- a/lib/node_modules/@stdlib/fs/mkdir/examples/index.js
+++ b/lib/node_modules/@stdlib/fs/mkdir/examples/index.js
@@ -20,7 +20,6 @@
 
 var join = require( 'path' ).join;
 var rmdirSync = require( 'fs' ).rmdirSync; // eslint-disable-line node/no-sync
-var mkdirSync = require( '@stdlib/fs/mkdir' ).sync;
 var mkdir = require( '@stdlib/fs/mkdir' );
 
 var dpath = join( __dirname, 'fixtures' );
@@ -29,7 +28,7 @@ var opts = {
 	'recursive': true
 };
 
-mkdirSync( dpath, opts );
+mkdir.sync( dpath, opts );
 
 function remove( path ) {
 	var opts = {

--- a/lib/node_modules/@stdlib/fs/mkdir/examples/index.js
+++ b/lib/node_modules/@stdlib/fs/mkdir/examples/index.js
@@ -1,0 +1,69 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var join = require( 'path' ).join;
+var rmdirSync = require( 'fs' ).rmdirSync; // eslint-disable-line node/no-sync
+var mkdirSync = require( '@stdlib/fs/mkdir' ).sync;
+var mkdir = require( '@stdlib/fs/mkdir' );
+
+var dpath = join( __dirname, 'fixtures' );
+var opts = {
+	'mode': parseInt( '0755', 8 ),
+	'recursive': true
+};
+
+mkdirSync( dpath, opts );
+
+function remove( path ) {
+	var opts = {
+		'recursive': true,
+		'force': true
+	};
+	rmdirSync( path, opts );
+}
+
+/* Sync */
+
+var out = mkdir.sync( join( dpath, './foo' ) );
+// returns undefined
+
+console.log( out instanceof Error );
+// => false
+
+out = mkdir.sync( join( dpath, './bar/baz' ), opts );
+// returns <string> || undefined
+
+console.log( out instanceof Error );
+// => false
+
+/* Async */
+
+mkdir( join( dpath, './baz' ), onDir );
+mkdir( join( dpath, './baz/foo/bar' ), opts, onDir );
+
+function onDir( error, path ) {
+	if ( error ) {
+		console.error( error.message );
+	} else {
+		console.log( path );
+	}
+}
+
+remove( dpath );

--- a/lib/node_modules/@stdlib/fs/mkdir/lib/async.js
+++ b/lib/node_modules/@stdlib/fs/mkdir/lib/async.js
@@ -1,0 +1,180 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var dirname = require( 'path' ).dirname;
+var resolve = require( 'path' ).resolve;
+var native = require( 'fs' ).mkdir;
+var stat = require( 'fs' ).stat;
+var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
+var isInteger = require( '@stdlib/assert/is-integer' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var isObject = require( '@stdlib/assert/is-object' );
+
+
+// MAIN //
+
+/**
+* Asynchronously creates a directory.
+*
+* @param {string} path - directory path
+* @param {Object|integer} [options] - options
+* @param {integer} [options.mode] - directory mode
+* @param {boolean} [options.recursive] - whether to create parent directories
+* @param {Function} clbk - callback to invoke after creating a directory
+* @throws {TypeError} first argument must be a string
+* @throws {TypeError} options argument must be an object, an integer
+* @throws {TypeError} callback argument must be a function
+*
+* @example
+* var opts = {
+*    'mode': parseInt( '0755', 8 ),
+*    'recursive': true
+* };
+* function onDir( error, path ) {
+*     if ( error ) {
+*		  throw error;
+*	  }
+*	  console.log( path );
+* }
+* mkdir( './foo/bar', opts, onDir );
+*/
+function mkdir( path, options, clbk ) {
+	var first;
+	var opts;
+	var par;
+
+	if ( !isString( path ) ) {
+		throw new TypeError( 'invalid argument. First argument must be a string. Value: `'+path+'`.' );
+	}
+	if ( arguments.length < 3 ) {
+		clbk = options;
+		options = {};
+	}
+	if ( !isInteger( options ) && !isObject( options ) ) {
+		throw new TypeError( 'invalid argument. Options argument must be an object or a integer. Value: `'+options+'`.' );
+	}
+	if ( isInteger( options ) ) {
+		options = {
+			'mode': options
+		};
+	}
+	if ( !isFunction( clbk ) ) {
+		throw new TypeError( 'invalid argument. Callback argument must be a function. Value: `'+clbk+'`.' );
+	}
+
+	opts = {
+		'mode': options.mode || parseInt( '0777', 8 ),
+		'recursive': options.recursive || false
+	};
+
+	if ( opts.recursive === false ) {
+		native( path, opts.mode, clbk );
+		return;
+	}
+
+	path = resolve( path );
+	par = dirname( path );
+
+	native( path, opts.mode, onDir );
+
+	/**
+	* Callback invoked upon creating a directory.
+	*
+	* @private
+	* @param {Error} [error] - error object
+	* @returns {void}
+	*/
+	function onDir( error ) {
+		if ( !error ) {
+			first = first || path;
+			clbk( null, first );
+			return;
+		}
+		if ( path === par ) {
+			if ( error.code !== 'EEXIST' && error.code !== 'EROFS' && error.code !== 'EISDIR' ) {
+				clbk( error, first );
+				return;
+			}
+			stat( par, onStat );
+			return;
+		}
+
+		if ( error.code === 'ENOENT' ) {
+			mkdir( par, opts, done );
+			return;
+		}
+
+		if ( error.code !== 'EEXIST' && error.code !== 'EROFS' ) {
+			clbk( error, first );
+			return;
+		}
+		stat( par, onStat );
+
+		/**
+		* Callback invoked upon querying a path.
+		*
+		* @private
+		* @param {(Error|null)} err - error object
+		* @param {Object} stats - path stats
+		*/
+		function onStat( err, stats ) {
+			if ( err || !stats.isDirectory() ) {
+				clbk( error, first );
+				return;
+			}
+			clbk( null, first );
+		}
+
+		/**
+		* Callback invoked after creating parent directories.
+		*
+		* @private
+		* @param {(Error|null)} err - error object
+		* @param {string|undefined} fp - the first directory path created (present only if recursive is true)
+		* @returns {void}
+		*/
+		function done( err, fp ) {
+			if ( err ) {
+				clbk( err, first );
+				return;
+			}
+			first = first || fp;
+			mkdir( path, opts, cb );
+		}
+
+		/**
+		* Callback invoked to pass the first created path after creating a directory.
+		*
+		* @private
+		* @param {(Error|null)} err - error object
+		* @returns {void}
+		*/
+		function cb( err ) {
+			clbk( err, first );
+		}
+	}
+}
+
+
+// EXPORTS //
+
+module.exports = mkdir;

--- a/lib/node_modules/@stdlib/fs/mkdir/lib/index.js
+++ b/lib/node_modules/@stdlib/fs/mkdir/lib/index.js
@@ -1,0 +1,63 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Create a directory.
+*
+* @module @stdlib/fs/mkdir
+*
+* @example
+* var mkdir = require( '@stdlib/fs/mkdir' );
+*
+* var opts = {
+*    'mode': parseInt( '755', 8 ),
+*    'recursive': true
+* };
+*
+* mkdir( './foo/bar', opts, onDir );
+*
+* function onDir( error, path ) {
+*     if ( error ) {
+*         throw error;
+*     }
+*	  console.log( path );
+* }
+*
+* @example
+* var mkdir = require( '@stdlib/fs/mkdir' );
+*
+* mkdir.sync( './foo/bar' );
+*/
+
+// MODULES //
+
+var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
+var mkdir = require( './async.js' );
+var sync = require( './sync.js' );
+
+
+// MAIN //
+
+setReadOnly( mkdir, 'sync', sync );
+
+
+// EXPORTS //
+
+module.exports = mkdir;

--- a/lib/node_modules/@stdlib/fs/mkdir/lib/sync.js
+++ b/lib/node_modules/@stdlib/fs/mkdir/lib/sync.js
@@ -1,0 +1,129 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var dirname = require( 'path' ).dirname;
+var resolve = require( 'path' ).resolve;
+var mkdir = require( 'fs' ).mkdirSync;  // eslint-disable-line node/no-sync
+var stat = require( 'fs' ).statSync;  // eslint-disable-line node/no-sync
+var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
+var isInteger = require( '@stdlib/assert/is-integer' );
+var isObject = require( '@stdlib/assert/is-object' );
+
+
+// MAIN //
+
+/**
+* Synchronously creates a directory.
+*
+* @param {string} path - directory path
+* @param {Object|integer} [options] - options
+* @param {integer} [options.mode] - directory mode
+* @param {boolean} [options.recursive] - whether to create parent directories
+* @throws {TypeError} first argument must be a string
+* @throws {TypeError} options argument must be an object, an integer, or undefined
+* @returns {(Error|string|undefined)} error or the first directory path created (only present if recursive is true)
+*
+* @example
+* var opts = {
+*    'mode': parseInt( '0755', 8 ),
+*    'recursive': true
+* };
+* var out = mkdirSync( './foo/bar', opts );
+* if ( out instanceof Error ) {
+*   throw out;
+* }
+* console.log( out );
+*/
+function mkdirSync( path, options ) {
+	var first;
+	var opts;
+	var par;
+	var out;
+
+	if ( !isString( path ) ) {
+		throw new TypeError( 'invalid argument. First argument must be a string. Value: `' + path + '`.' );
+	}
+	if ( options !== void 0 && !isInteger( options ) && !isObject( options ) ) {
+		throw new TypeError( 'invalid argument. Options argument must be an object, a integer, or undefined. Value: `' + options + '`.' );
+	}
+	if ( isInteger( options ) ) {
+		options = {
+			'mode': options
+		};
+	}
+	if ( !isObject( options ) ) {
+		options = {};
+	}
+
+	opts = {
+		'mode': options.mode || parseInt( '0777', 8 ),
+		'recursive': options.recursive || false
+	};
+
+	if ( opts.recursive === false ) {
+		try {
+			return mkdir( path, opts.mode );
+		} catch ( error ) {
+			return error;
+		}
+	}
+
+	path = resolve( path );
+	par = dirname( path );
+
+	try {
+		mkdir( path, opts.mode );
+		first = first || path;
+		return first;
+	} catch ( error ) {
+		if ( path === par ) {
+			if ( error.code !== 'EEXIST' && error.code !== 'EROFS' && error.code !== 'EISDIR' ) {
+				return error;
+			}
+			if ( !stat( path ).isDirectory() ) {
+				return error;
+			}
+		}
+
+		if ( error.code === 'ENOENT' ) {
+			out = mkdirSync( par, opts );
+			if ( out instanceof Error ) {
+				return out;
+			}
+			first = first || out;
+			mkdirSync( path, opts );
+			return first;
+		}
+
+		if ( error.code !== 'EEXIST' && error.code !== 'EROFS' ) {
+			return error;
+		}
+		if ( !stat( path ).isDirectory() ) {
+			return error;
+		}
+	}
+}
+
+
+// EXPORTS //
+
+module.exports = mkdirSync;

--- a/lib/node_modules/@stdlib/fs/mkdir/package.json
+++ b/lib/node_modules/@stdlib/fs/mkdir/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@stdlib/fs/mkdir",
+  "version": "0.0.0",
+  "description": "Create a directory and any necessary subdirectories.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "bin": {
+    "exists": "./bin/cli"
+  },
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+	"stdlib",
+	"stdfs",
+    "fs",
+    "readdir",
+    "readdirsync",
+    "path",
+    "async",
+    "sync",
+    "dir",
+    "read",
+    "open",
+    "filesystem",
+    "directory"
+  ]
+}

--- a/lib/node_modules/@stdlib/fs/mkdir/test/test.async.js
+++ b/lib/node_modules/@stdlib/fs/mkdir/test/test.async.js
@@ -1,0 +1,341 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var rmdirSync = require( 'fs' ).rmdirSync; // eslint-disable-line node/no-sync
+var statSync = require( 'fs' ).statSync; // eslint-disable-line node/no-sync
+var join = require( 'path' ).join;
+var tape = require( 'tape' );
+var IS_BROWSER = require( '@stdlib/assert/is-browser' );
+var mkdir = require( './../lib/async.js' );
+var mkdirSync = require( './../lib/sync.js' );
+
+
+// VARIABLES //
+
+// Don't run tests in the browser...for now...
+var opts = {
+	'skip': IS_BROWSER // FIXME
+};
+var dpath = join( __dirname, 'fixtures' );
+
+
+// FUNCTIONS //
+
+/**
+* Removes the directiry created during testing.
+*
+* @private
+* @param {string} dir - directory to remove
+*/
+function remove( dir ) {
+	var opts;
+
+	opts = {
+		'recursive': true,
+		'force': true
+	};
+	rmdirSync( dir, opts );
+}
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof mkdir, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function throws an error if provided a `path` argument which is not a string', opts, function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		5,
+		NaN,
+		null,
+		void 0,
+		true,
+		[],
+		{},
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws a type error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			mkdir( value, {} );
+		};
+	}
+});
+
+tape( 'the function throws an error if not provided a integer nor an object as options argurment', opts, function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		null,
+		void 0,
+		true,
+		123.456,
+		[],
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws a type error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			mkdir( './foo', value, function noop() {} );
+		};
+	}
+});
+
+tape( 'the function throws an error if not provided a callback function', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		5,
+		NaN,
+		null,
+		void 0,
+		true,
+		[],
+		{}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws a type error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			mkdir( './foo', value );
+		};
+	}
+});
+
+tape( 'the function throws an error if the third argument is not a callback function', opts, function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		5,
+		NaN,
+		null,
+		void 0,
+		true,
+		[],
+		{}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws a type error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			mkdir( './foo', {}, value );
+		};
+	}
+});
+
+tape( 'the function creates a directory without an options argument', opts, function test( t ) {
+	var dir;
+
+	dir = join( dpath, 'foo' );
+
+	mkdir( dir, onDir );
+	function onDir( error ) {
+		t.strictEqual( error, null, 'create a directory without error' );
+		t.strictEqual( statSync( dir ).isDirectory(), true, 'creates a directory' );
+		remove( dir );
+		t.end();
+	}
+});
+
+tape( 'the function creates a directory with an options argument', opts, function test( t ) {
+	var opts;
+	var dir;
+
+	opts = {
+		'mode': parseInt( '0755', 8 ),
+		'recursive': true
+	};
+	dir = join( dpath, 'foo/bar' );
+
+	mkdir( dir, opts, onDir );
+
+	function onDir( error ) {
+		t.strictEqual( error, null, 'create a directory without error' );
+		t.strictEqual( statSync( dir ).isDirectory(), true, 'creates a directory' );
+		remove( join( dpath, 'foo' ) );
+		t.end();
+	}
+});
+
+tape( 'the function creates a directory with a different options argument', opts, function test( t ) {
+	var opts;
+	var dir;
+
+	opts = {
+		'mode': parseInt( '0777', 8 ),
+		'recursive': false
+	};
+	dir = join( dpath, 'foo' );
+
+	mkdir( dir, opts, onDir );
+
+	function onDir( error ) {
+		t.strictEqual( error, null, 'create a directory without error' );
+		t.strictEqual( statSync( dir ).isDirectory(), true, 'creates a directory' );
+		remove( dir );
+		t.end();
+	}
+});
+
+tape( 'if recursive is `true`, the second argument in callback will be the first directory path created', opts, function test( t ) {
+	var opts;
+	var dir;
+
+	opts = {
+		'mode': parseInt( '0755', 8 ),
+		'recursive': true
+	};
+	dir = join( dpath, 'foo/bar' );
+
+	mkdir( dir, opts, onDir );
+
+	function onDir( error, path ) {
+		t.strictEqual( error, null, 'create a directory without error' );
+		t.strictEqual( path, join( dpath, 'foo' ), 'returns the first directory path created' );
+		t.strictEqual( statSync( dir ).isDirectory(), true, 'creates a directory' );
+		remove( join( dpath, 'foo' ) );
+		t.end();
+	}
+});
+
+tape( 'if recursive is `true`, the second argument in callback will be `undefined` if does not create any', opts, function test( t ) {
+	var opts;
+	var dir;
+
+	opts = {
+		'mode': parseInt( '0755', 8 ),
+		'recursive': true
+	};
+	dir = join( dpath, 'foo/bar' );
+
+	mkdirSync( dir, opts );
+	mkdir( dir, opts, onDir );
+
+	function onDir( error, path ) {
+		t.strictEqual( error, null, 'create a directory without error' );
+		t.strictEqual( path, void 0, 'returns undefined' );
+		t.strictEqual( statSync( dir ).isDirectory(), true, 'creates a directory' );
+		remove( join( dpath, 'foo' ) );
+		t.end();
+	}
+});
+
+tape( 'if the function attempts to create nested directories without an options argument, the first argument in callback will be an error instance (without an options argument)', opts, function test( t ) {
+	var dir;
+
+	dir = join( dpath, 'foo/bar' );
+
+	mkdir( dir, onDir );
+
+	function onDir( error ) {
+		t.strictEqual( error instanceof Error, true, 'returns an error instance' );
+		t.end();
+	}
+});
+
+tape( 'if the function attempts to create nested directories without setting recursive as `true`, the first argument in callback will be an error instance (without an options argument)', opts, function test( t ) {
+	var opts;
+	var dir;
+
+	opts = {
+		'mode': parseInt( '0755', 8 ),
+		'recursive': false
+	};
+	dir = join( dpath, 'foo/bar' );
+
+	mkdir( dir, opts, onDir );
+
+	function onDir( error ) {
+		t.strictEqual( error instanceof Error, true, 'returns an error instance' );
+		t.end();
+	}
+});
+
+tape( 'if the function attempts to create nested directories without an options argument, the first argument in callback will be an error instance (without an options argument)', opts, function test( t ) {
+	var opts;
+	var dir;
+
+	opts = {
+		'mode': parseInt( '0755', 8 ),
+		'recursive': true
+	};
+	dir = join( dpath, 'foo/bar' );
+
+	mkdirSync( dir, opts );
+
+	mkdir( dir, onDir );
+
+	function onDir( error ) {
+		t.strictEqual( error instanceof Error, true, 'returns an error instance' );
+		remove( join( dpath, 'foo' ) );
+		t.end();
+	}
+});
+
+tape( 'if the function attempts to create nested directories without setting recursive as `true`, the first argument in callback will be an error instance (without an options argument)', opts, function test( t ) {
+	var opts;
+	var dir;
+
+	opts = {
+		'mode': parseInt( '0755', 8 ),
+		'recursive': true
+	};
+	dir = join( dpath, 'foo/bar' );
+
+	mkdirSync( dir, opts );
+
+	opts.recursive = false;
+	mkdir( dir, opts, onDir );
+
+	function onDir( error ) {
+		t.strictEqual( error instanceof Error, true, 'returns an error instance' );
+		remove( join( dpath, 'foo' ) );
+		t.end();
+	}
+});

--- a/lib/node_modules/@stdlib/fs/mkdir/test/test.cli.js
+++ b/lib/node_modules/@stdlib/fs/mkdir/test/test.cli.js
@@ -1,0 +1,263 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var join = require( 'path' ).join;
+var rmdirSync = require( 'fs' ).rmdirSync; // eslint-disable-line node/no-sync
+var statSync = require( 'fs' ).statSync; // eslint-disable-line node/no-sync
+var resolve = require( 'path' ).resolve;
+var exec = require( 'child_process' ).exec;
+var tape = require( 'tape' );
+var IS_BROWSER = require( '@stdlib/assert/is-browser' );
+var IS_WINDOWS = require( '@stdlib/assert/is-windows' );
+var EXEC_PATH = require( '@stdlib/process/exec-path' );
+var readFileSync = require( '@stdlib/fs/read-file' ).sync;
+var mkdirSync = require( '@stdlib/fs/mkdir' ).sync;
+
+
+// VARIABLES //
+
+var fpath = resolve( __dirname, '..', 'bin', 'cli' );
+var dpath = resolve( __dirname, 'fixtures' );
+var opts = {
+	'skip': IS_BROWSER || IS_WINDOWS
+};
+
+
+// FIXTURES //
+
+var PKG_VERSION = require( './../package.json' ).version;
+
+
+// FUNCTIONS //
+
+/**
+* Removes the directory created during testing.
+*
+* @private
+* @param {string} dir - directory to remove
+*/
+function remove( dir ) {
+	var opts = {
+		'recursive': true,
+		'force': true
+	};
+	rmdirSync( dir, opts );
+}
+
+
+// TESTS //
+
+tape( 'command-line interface', function test( t ) {
+	t.ok( true, __filename );
+	t.end();
+});
+
+tape( 'when invoked with a `--help` flag, the command-line interface prints the help text to `stderr`', opts, function test( t ) {
+	var expected;
+	var cmd;
+
+	expected = readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+		'encoding': 'utf8'
+	});
+	cmd = [
+		EXEC_PATH,
+		fpath,
+		'--help'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), expected+'\n', 'expected value' );
+		}
+		t.end();
+	}
+});
+
+tape( 'when invoked with a `-h` flag, the command-line interface prints the help text to `stderr`', opts, function test( t ) {
+	var expected;
+	var cmd;
+
+	expected = readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+		'encoding': 'utf8'
+	});
+	cmd = [
+		EXEC_PATH,
+		fpath,
+		'-h'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), expected+'\n', 'expected value' );
+		}
+		t.end();
+	}
+});
+
+tape( 'when invoked with a `--version` flag, the command-line interface prints the version to `stderr`', opts, function test( t ) {
+	var cmd = [
+		EXEC_PATH,
+		fpath,
+		'--version'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), PKG_VERSION+'\n', 'expected value' );
+		}
+		t.end();
+	}
+});
+
+tape( 'when invoked with a `-V` flag, the command-line interface prints the version to `stderr`', opts, function test( t ) {
+	var cmd = [
+		EXEC_PATH,
+		fpath,
+		'-V'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), PKG_VERSION+'\n', 'expected value' );
+		}
+		t.end();
+	}
+});
+
+tape( 'the command-line interface creates a directory', opts, function test( t ) {
+	var opts;
+	var cmd;
+	var dir;
+
+	dir = join( dpath, 'foo' );
+	cmd = [
+		EXEC_PATH,
+		fpath,
+		dir
+	];
+	opts = {};
+
+	exec( cmd.join( ' ' ), opts, done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), 'undefined\n', 'prints return value to `stdout`' );
+			t.strictEqual( stderr.toString(), '', 'does not print to `stderr`' );
+			t.strictEqual( statSync( dir ).isDirectory(), true, 'creates a directory' );
+			remove( dir );
+		}
+		t.end();
+	}
+});
+
+tape( 'the command-line interface creates a directory and prints the first diretory path created', opts, function test( t ) {
+	var mkopts;
+	var opts;
+	var cmd;
+	var dir;
+	var out;
+
+	mkopts = {
+		'recursive': true
+	};
+	dir = join( dpath, 'foo/bar' );
+	out = mkdirSync( dir, mkopts );
+
+	if ( out instanceof Error ) {
+		t.fail( out.message );
+		t.end();
+		return;
+	}
+
+	remove( join( dpath, 'foo' ) );
+
+	cmd = [
+		EXEC_PATH,
+		fpath,
+		'-p',
+		dir
+	];
+	opts = {};
+
+	exec( cmd.join( ' ' ), opts, done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), out + '\n', 'prints the first diretory path created to `stdout`' );
+			t.strictEqual( stderr.toString(), '', 'does not print to `stderr`' );
+			remove( join( dpath, 'foo' ) );
+		}
+		t.end();
+	}
+});
+
+tape( 'if an error is encountered, the command-line interface prints an error and sets a non-zero exit code', opts, function test( t ) {
+	var opts;
+	var cmd;
+	var dir;
+
+	dir = join( dpath, 'foo/bar' );
+	cmd = [
+		EXEC_PATH,
+		fpath,
+		dir
+	];
+	opts = {};
+
+	exec( cmd.join( ' ' ), opts, done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.pass( error.message );
+			t.strictEqual( error.code, 1, 'expected exit code' );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), 'Error: beep\n', 'expected value' );
+			remove( dir );
+		}
+		t.end();
+	}
+});

--- a/lib/node_modules/@stdlib/fs/mkdir/test/test.js
+++ b/lib/node_modules/@stdlib/fs/mkdir/test/test.js
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var mkdir = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof mkdir, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the main export is a method to synchronously create a directory', function test( t ) {
+	t.strictEqual( typeof mkdir.sync, 'function', 'has method' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/fs/mkdir/test/test.sync.js
+++ b/lib/node_modules/@stdlib/fs/mkdir/test/test.sync.js
@@ -1,0 +1,266 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var rmdirSync = require( 'fs' ).rmdirSync; // eslint-disable-line node/no-sync
+var statSync = require( 'fs' ).statSync; // eslint-disable-line node/no-sync
+var join = require( 'path' ).join;
+var tape = require( 'tape' );
+var IS_BROWSER = require( '@stdlib/assert/is-browser' );
+var mkdir = require( './../lib/sync.js' );
+
+
+// VARIABLES //
+
+// Don't run tests in the browser...for now...
+var opts = {
+	'skip': IS_BROWSER // FIXME
+};
+var dpath = join( __dirname, 'fixtures' );
+
+
+// FUNCTIONS //
+
+/**
+* Removes the directory created during testing.
+*
+* @private
+* @param {string} dir - directory to remove
+*/
+function remove( dir ) {
+	var opts;
+
+	opts = {
+		'recursive': true,
+		'force': true
+	};
+	rmdirSync( dir, opts );
+}
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof mkdir, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function throws an error if provided a `path` argument which is not a string', opts, function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		5,
+		NaN,
+		null,
+		void 0,
+		true,
+		[],
+		{},
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws a type error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			mkdir( value, {} );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided the second argument which is not a integer nor an object', opts, function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		123.123,
+		true,
+		[],
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws a type error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			mkdir( './foo', value );
+		};
+	}
+});
+
+tape( 'the function creates a directory without an options argument', opts, function test( t ) {
+	var out;
+	var dir;
+
+	dir = join( dpath, 'foo' );
+	out = mkdir( dir );
+	t.strictEqual( out instanceof Error, false, 'does not return an error' );
+	t.strictEqual( statSync( dir ).isDirectory(), true, 'creates a directory' );
+	remove( dir );
+
+	t.end();
+});
+
+tape( 'the function creates a directory with an options argument', opts, function test( t ) {
+	var opts;
+	var out;
+	var dir;
+
+	opts = {
+		'mode': parseInt( '0755', 8 ),
+		'recursive': true
+	};
+	dir = join( dpath, 'foo/bar' );
+
+	out = mkdir( dir, opts );
+	t.strictEqual( out instanceof Error, false, 'does not return an error' );
+	t.strictEqual( statSync( dir ).isDirectory(), true, 'creates a directory' );
+	remove( join( dpath, 'foo' ) );
+
+	t.end();
+});
+
+tape( 'the function creates a directory with a different options argument', opts, function test( t ) {
+	var opts;
+	var out;
+	var dir;
+
+	opts = {
+		'mode': parseInt( '0777', 8 ),
+		'recursive': false
+	};
+	dir = join( dpath, 'foo' );
+
+	out = mkdir( dir, opts );
+	t.strictEqual( out instanceof Error, false, 'does not return an error' );
+	t.strictEqual( statSync( dir ).isDirectory(), true, 'creates a directory' );
+	remove( dir );
+
+	t.end();
+});
+
+tape( 'if recursive is `true`, the function returns the first directory path created', opts, function test( t ) {
+	var opts;
+	var out;
+	var dir;
+
+	opts = {
+		'mode': parseInt( '0755', 8 ),
+		'recursive': true
+	};
+	dir = join( dpath, 'foo/bar' );
+	out = mkdir( dir, opts );
+	t.strictEqual( out, join( dpath, 'foo' ), 'returns first directory path created' );
+	t.strictEqual( statSync( dir ).isDirectory(), true, 'creates a directory' );
+	remove( join( dpath, 'foo' ) );
+
+	t.end();
+});
+
+tape( 'if recursive is `true`, the function returns undefined if does not create any', opts, function test( t ) {
+	var opts;
+	var out;
+	var dir;
+
+	opts = {
+		'mode': parseInt( '0755', 8 ),
+		'recursive': true
+	};
+	dir = join( dpath, 'foo/bar' );
+
+	out = mkdir( dir, opts );
+	out = mkdir( dir, opts );
+	t.strictEqual( out, void 0, 'returns undefined if does not create any' );
+	t.strictEqual( statSync( dir ).isDirectory(), true, 'directory exists' );
+	remove( join( dpath, 'foo' ) );
+
+	t.end();
+});
+
+tape( 'if the function attempts to create nested directories without an options argument, it returns the error', opts, function test( t ) {
+	var out;
+	var dir;
+
+	dir = join( dpath, 'foo/bar' );
+
+	out = mkdir( dir );
+	t.strictEqual( out instanceof Error, true, 'returns an error' );
+	t.end();
+});
+
+tape( 'if the function attempts to create nested directories without setting recursive as `true`, it returns the error', opts, function test( t ) {
+	var opts;
+	var out;
+	var dir;
+
+	opts = {
+		'mode': parseInt( '0755', 8 ),
+		'recursive': false
+	};
+	dir = join( dpath, 'foo/bar' );
+
+	out = mkdir( dir, opts );
+	t.strictEqual( out instanceof Error, true, 'returns an error' );
+
+	t.end();
+});
+
+tape( 'if the function attempts to create an existed directory without an options argument, it returns the error (without an options argument)', opts, function test( t ) {
+	var out;
+	var dir;
+
+	dir = join( dpath, 'foo' );
+
+	mkdir( dir );
+	out = mkdir( dir );
+	t.strictEqual( out instanceof Error, true, 'returns an error' );
+	remove( dir );
+
+	t.end();
+});
+
+tape( 'if the function attempts to create an existed directory without setting recursive as `true`, it returns the error', opts, function test( t ) {
+	var opts;
+	var out;
+	var dir;
+
+	opts = {
+		'mode': parseInt( '0755', 8 ),
+		'recursive': false
+	};
+	dir = join( dpath, 'foo' );
+
+	mkdir( dir );
+	out = mkdir( dir, opts );
+	t.strictEqual( out instanceof Error, true, 'returns an error' );
+	remove( dir );
+
+	t.end();
+});


### PR DESCRIPTION
If applied, this commit will add the package `fs/mkdir`

## Description

> What is the purpose of this pull request?

This pull request adds the package `fs/mkdir` for creating a directory asynchronously and synchronously.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #2116 

## Questions

> Any questions for reviewers of this pull request?

* When the `recursive` option is set to `true`, I have to handle some potential error, and I mainly borrowed the idea from [mkdirp](https://github.com/isaacs/node-mkdirp), but I am not sure if these error codes are enough here.
* This package aligns with the `mkdir` in node, so it will return `undefined` in some cases. But I noticed some similar `stdlib` packages return `null`, so does `mkdir` also return `null` instead of `undefined`?
* When generating examples and doctest, sometimes it triggers errors, but I am not sure the reasons.


## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
