### PR TITLE
fix: remove `SIGWINCH` listener upon closing the REPL

### DIFF
--- a/lib/node_modules/@stdlib/repl/lib/main.js
+++ b/lib/node_modules/@stdlib/repl/lib/main.js
@@ -370,6 +370,7 @@ function REPL( options ) {
 
 		debug( 'Readline interface closed.' );
 		self._istream.removeListener( 'keypress', onKeypress );
+		proc.removeListener( 'SIGWINCH', onSIGWINCH );
 
 		debug( 'Exiting REPL...' );
 		self.emit( 'exit' );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

- Removes `SIGWINCH` event listener when the REPL is closed to avoid dangling instances in [process]
- Fixes: 
![image](https://github.com/stdlib-js/stdlib/assets/130062020/d68b746b-04ea-468c-92c0-c019ffb7b3c7)

## Questions

> Any questions for reviewers of this pull request?

I am a bit confused. Should we also remove all other listeners (like 'SIGINT' events etc) in `onClose()` or are they automatically removed?

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
