### PR TITLE
feat: add `napi/create-float`

### DIFF
--- a/lib/node_modules/@stdlib/napi/create-float/README.md
+++ b/lib/node_modules/@stdlib/napi/create-float/README.md
@@ -1,0 +1,227 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# create_float
+
+> Convert a single-precision floating-point number to a Node-API value.
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var headerDir = require( '@stdlib/napi/create-float' );
+```
+
+#### headerDir
+
+Absolute file path for the directory containing header files for C APIs.
+
+```javascript
+var dir = headerDir;
+// returns <string>
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
+<section class="examples">
+
+## Examples
+
+```javascript
+var headerDir = require( '@stdlib/napi/create-float' );
+
+console.log( headerDir );
+// => <string>
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/napi/create_float.h"
+```
+
+#### stdlib_napi_create_float( env, value, \*out )
+
+Converts a single-precision floating-point number to a Node-API value.
+
+```c
+#include "stdlib/napi/create_float.h"
+#include <node_api.h>
+
+static napi_value addon( napi_env env, napi_callback_info info ) {
+    
+    // ...
+
+    napi_value value;
+    napi_status status = stdlib_napi_create_float( env, 1.0f, &value );
+    assert( status == napi_ok );
+    if ( err != NULL ) {
+        assert( napi_throw( env, err ) == napi_ok );
+        return NULL;
+    }
+
+    // ...
+}
+```
+
+The function accepts the following arguments:
+
+-   **env**: `[in] napi_env` environment under which the function is invoked.
+-   **value**: `[in] float` single-precision floating-point number.
+-   **out**: `[out] napi_value*` destination for storing output value.
+
+```c
+napi_status stdlib_napi_create_float( const napi_env env, const float value, napi_value *out );
+```
+
+The function returns a `napi_status` status code indicating success or failure (returns `napi_ok` if success).
+
+#### STDLIB_NAPI_CREATE_FLOAT( env, expression, name )
+
+Macro for converting a single-precision floating-point number to a Node-API value.
+
+```c
+#include "stdlib/napi/create_float.h"
+#include "stdlib/napi/argv_float.h"
+#include "stdlib/napi/argv.h"
+#include <node_api.h>
+
+static float fcn( const float v ) {
+    return v;
+}
+
+// ...
+
+static napi_value addon( napi_env env, napi_callback_info info ) {
+    // Retrieve add-on callback arguments:
+    STDLIB_NAPI_ARGV( env, info, argv, argc, 1 );
+
+    // Convert the first argument to a C type:
+    STDLIB_NAPI_ARGV_FLOAT( env, value, argv, 0 );
+
+    // ...
+
+    // Convert a value having a C type to a Node-API value:
+    STDLIB_NAPI_CREATE_FLOAT( env, fcn( value ), out );
+
+    return out;
+}
+```
+
+The macro expects the following arguments:
+
+-   **env**: environment under which the callback is invoked.
+-   **expression**: expression returning a single-precision floating-point number.
+-   **name**: output variable name.
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/napi/create-float/binding.gyp
+++ b/lib/node_modules/@stdlib/napi/create-float/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/napi/create-float/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/napi/create-float/docs/types/index.d.ts
@@ -1,0 +1,33 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Absolute file path for the directory containing header files for C APIs.
+*
+* @example
+* var dir = headerDir;
+* // returns <string>
+*/
+declare const headerDir: string;
+
+
+// EXPORTS //
+
+export = headerDir;

--- a/lib/node_modules/@stdlib/napi/create-float/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/napi/create-float/docs/types/test.ts
@@ -1,0 +1,28 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import headerDir = require( './index' );
+
+
+// TESTS //
+
+// The variable is a string...
+{
+	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+	headerDir; // $ExpectType string
+}

--- a/lib/node_modules/@stdlib/napi/create-float/examples/index.js
+++ b/lib/node_modules/@stdlib/napi/create-float/examples/index.js
@@ -1,0 +1,24 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var headerDir = require( './../lib' );
+
+console.log( headerDir );
+// => <string>

--- a/lib/node_modules/@stdlib/napi/create-float/include.gypi
+++ b/lib/node_modules/@stdlib/napi/create-float/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/napi/create-float/include/stdlib/napi/create_float.h
+++ b/lib/node_modules/@stdlib/napi/create-float/include/stdlib/napi/create_float.h
@@ -1,0 +1,77 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_NAPI_CREATE_FLOAT_H
+#define STDLIB_NAPI_CREATE_FLOAT_H
+
+#include <node_api.h>
+
+/**
+* Macro for converting a single-precision floating-point number to a Node-API value.
+*
+* @param env         environment under which the function is invoked
+* @param expression  expression returning a single-precision floating-point number
+* @param name        output variable name
+*
+* @example
+# #include "stdlib/napi/create_float.h"
+* #include "stdlib/napi/argv_float.h"
+* #include "stdlib/napi/argv.h"
+* #include <node_api.h>
+*
+* static float fcn( const float v ) {
+*     return v;
+* }
+*
+* // ...
+*
+* static napi_value addon( napi_env env, napi_callback_info info ) {
+*     // Retrieve add-on callback arguments:
+*     STDLIB_NAPI_ARGV( env, info, argv, argc, 1 );
+*
+*     // Convert the first argument to a C type:
+*     STDLIB_NAPI_ARGV_FLOAT( env, value, argv, 0 );
+*
+*     // ...
+*
+*     // Convert a value having a C type to a Node-API value:
+*     STDLIB_NAPI_CREATE_FLOAT( env, fcn( value ), out );
+*     return out;
+* }
+*/
+#define STDLIB_NAPI_CREATE_FLOAT( env, expression, name )                      \
+	napi_value name;                                                           \
+	stdlib_napi_create_float( env, expression, &name );
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Converts a single-precision floating-point number to a Node-API value.
+*/
+napi_status stdlib_napi_create_float( const napi_env env, const float value, napi_value *out );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_NAPI_CREATE_FLOAT_H

--- a/lib/node_modules/@stdlib/napi/create-float/lib/browser.js
+++ b/lib/node_modules/@stdlib/napi/create-float/lib/browser.js
@@ -1,0 +1,28 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MAIN //
+
+var dir = null;
+
+
+// EXPORTS //
+
+module.exports = dir;

--- a/lib/node_modules/@stdlib/napi/create-float/lib/index.js
+++ b/lib/node_modules/@stdlib/napi/create-float/lib/index.js
@@ -1,0 +1,39 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Absolute file path for the directory containing header files for C APIs.
+*
+* @module @stdlib/napi/create-float
+*
+* @example
+* var headerDir = require( '@stdlib/napi/create-float' );
+*
+* console.log( headerDir );
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/napi/create-float/lib/main.js
+++ b/lib/node_modules/@stdlib/napi/create-float/lib/main.js
@@ -1,0 +1,33 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+
+
+// MAIN //
+
+var dir = resolve( __dirname, '..', 'include' );
+
+
+// EXPORTS //
+
+module.exports = dir;

--- a/lib/node_modules/@stdlib/napi/create-float/lib/native.js
+++ b/lib/node_modules/@stdlib/napi/create-float/lib/native.js
@@ -1,0 +1,46 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Wrapper function exposing the C API to JavaScript.
+*
+* @private
+* @param {number} v - input value
+* @returns {number} input value
+*
+* @example
+* var v = wrapper( 1 );
+* // returns 1.0
+*/
+function wrapper( v ) {
+	return addon( v );
+}
+
+
+// EXPORTS //
+
+module.exports = wrapper;

--- a/lib/node_modules/@stdlib/napi/create-float/manifest.json
+++ b/lib/node_modules/@stdlib/napi/create-float/manifest.json
@@ -1,0 +1,43 @@
+{
+	"options": {},
+	"fields": [
+		{
+			"field": "src",
+			"resolve": true,
+			"relative": true
+		},
+		{
+			"field": "include",
+			"resolve": true,
+			"relative": true
+		},
+		{
+			"field": "libraries",
+			"resolve": false,
+			"relative": false
+		},
+		{
+			"field": "libpath",
+			"resolve": true,
+			"relative": false
+		}
+	],
+	"confs": [
+		{
+			"src": [
+        "./src/main.c"
+      ],
+			"include": [
+				"./include"
+			],
+			"libraries": [],
+			"libpath": [],
+			"dependencies": [
+        "@stdlib/assert/napi/status-ok",
+        "@stdlib/napi/argv-float",
+        "@stdlib/napi/create-double",
+        "@stdlib/napi/argv"
+      ]
+		}
+	]
+}

--- a/lib/node_modules/@stdlib/napi/create-float/package.json
+++ b/lib/node_modules/@stdlib/napi/create-float/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@stdlib/napi/create-float",
+  "version": "0.0.0",
+  "description": "Convert a single-precision floating-point number to a Node-API value.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "browser": "./lib/browser.js",
+  "gypfile": true,
+  "directories": {
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "src": "./src",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "napi",
+    "native",
+    "addon",
+    "utilities",
+    "utils",
+    "macros",
+    "float",
+    "float32"
+  ],
+  "__stdlib__": {
+    "envs": {
+      "browser": false
+    }
+  }
+}

--- a/lib/node_modules/@stdlib/napi/create-float/src/Makefile
+++ b/lib/node_modules/@stdlib/napi/create-float/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/napi/create-float/src/addon.c
+++ b/lib/node_modules/@stdlib/napi/create-float/src/addon.c
@@ -1,0 +1,71 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/napi/create_float.h"
+#include "stdlib/napi/argv_float.h"
+#include "stdlib/napi/argv.h"
+#include <node_api.h>
+#include <assert.h>
+
+/**
+* Identity function.
+*
+* @private
+* @param v      input value
+* @return       input value
+*/
+static float identity( const float v ) {
+	return v;
+}
+
+/**
+* Receives JavaScript callback invocation data.
+*
+* @private
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @return       Node-API value
+*/
+static napi_value addon( napi_env env, napi_callback_info info ) {
+	STDLIB_NAPI_ARGV( env, info, argv, argc, 1 )
+	STDLIB_NAPI_ARGV_FLOAT( env, value, argv, 0 )
+	float out = identity( value );
+	if ( out == 3.14567890123 ) {
+		assert( napi_throw_error( env, NULL, "unexpected error" ) == napi_ok );
+		return NULL;
+	}
+	STDLIB_NAPI_CREATE_FLOAT( env, out, v )
+	return v;
+}
+
+/**
+* Initializes a Node-API module.
+*
+* @private
+* @param env      environment under which the function is invoked
+* @param exports  exports object
+* @return         main export
+*/
+static napi_value init( napi_env env, napi_value exports ) {
+	napi_value fcn;
+	napi_status status = napi_create_function( env, "exports", NAPI_AUTO_LENGTH, addon, NULL, &fcn );
+	assert( status == napi_ok );
+	return fcn;
+}
+
+NAPI_MODULE( NODE_GYP_MODULE_NAME, init )

--- a/lib/node_modules/@stdlib/napi/create-float/src/main.c
+++ b/lib/node_modules/@stdlib/napi/create-float/src/main.c
@@ -1,0 +1,54 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/napi/create_float.h"
+#include "stdlib/assert/napi/status_ok.h"
+#include "stdlib/napi/create_double.h"
+#include <node_api.h>
+
+/**
+* Converts a single-precision floating-point number to a Node-API value.
+*
+* @param env       environment under which the function is invoked
+* @param value     single-precision floating-point number
+* @param out       destination for storing output value
+* @return          status code indicating success or failure (returns `napi_ok` if success)
+*
+* @example
+* #include "stdlib/napi/create_float.h"
+* #include <node_api.h>
+*
+* static napi_value addon( napi_env env, napi_callback_info info ) {
+*
+*     // ...
+*
+*     napi_value value;
+*     napi_status status = stdlib_napi_create_float( env, 1.0f, &value );
+*     assert( status == napi_ok );
+*     if ( err != NULL ) {
+*         assert( napi_throw( env, err ) == napi_ok );
+*         return NULL;
+*     }
+*
+*     // ...
+* }
+*/
+napi_status stdlib_napi_create_float( const napi_env env, const float value, napi_value *out ) {
+	STDLIB_ASSERT_NAPI_STATUS_OK_RET_VALUE( env, napi_create_double( env, (double)value, out ), "", napi_ok )
+	return napi_ok;
+}

--- a/lib/node_modules/@stdlib/napi/create-float/test/test.browser.js
+++ b/lib/node_modules/@stdlib/napi/create-float/test/test.browser.js
@@ -1,0 +1,33 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var headerDir = require( './../lib/browser.js' );
+
+
+// TESTS //
+
+tape( 'main export is null', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( headerDir, null, 'main export is null' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/napi/create-float/test/test.js
+++ b/lib/node_modules/@stdlib/napi/create-float/test/test.js
@@ -1,0 +1,48 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var IS_BROWSER = require( '@stdlib/assert/is-browser' );
+var headerDir = require( './../lib' );
+
+
+// VARIABLES //
+
+var opts = {
+	'skip': IS_BROWSER
+};
+
+
+// TESTS //
+
+tape( 'main export is a string', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof headerDir, 'string', 'main export is a string' );
+	t.end();
+});
+
+tape( 'the exported value corresponds to the package directory containing header files', opts, function test( t ) {
+	var dir = resolve( __dirname, '..', 'include' );
+	t.strictEqual( headerDir, dir, 'exports expected value' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/napi/create-float/test/test.native.js
+++ b/lib/node_modules/@stdlib/napi/create-float/test/test.native.js
@@ -1,0 +1,89 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var addon = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( addon instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof addon, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function throws an error if provided argument which is not a number', opts, function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		{}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), Error, 'throws an error when provided '+values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			addon( value );
+		};
+	}
+});
+
+tape( 'the function does not throw an error if provided a number', opts, function test( t ) {
+	var values;
+	var v;
+	var i;
+
+	values = [
+		5,
+		-5,
+		NaN,
+		0
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		v = addon( values[ i ] );
+		if ( values[ i ] === values[ i ] ) {
+			t.strictEqual( v, values[ i ], 'returns expected value when provided '+values[ i ] );
+		} else {
+			t.strictEqual( v !== v, true, 'returns expected value when provided '+values[ i ] );
+		}
+	}
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This RFC proposes add C APIs for converting a single-precision floating-point C value to a JavaScript object.

This is the reverse of [`@stdlib/napi/argv-float`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/napi/argv-float).

Package: `@stdlib/napi/create-float`

## Related Issues

> Does this pull request have any related issues?

None. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

