### PR TITLE
feat: add `constants/float32/phi`

### DIFF
--- a/lib/node_modules/@stdlib/constants/float32/phi/README.md
+++ b/lib/node_modules/@stdlib/constants/float32/phi/README.md
@@ -1,0 +1,158 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# FLOAT32_PHI
+
+> [Golden ratio][phi].
+
+<section class="intro">
+
+The [golden ratio][phi] can be defined algebraically as
+
+<!-- <equation class="equation" label="eq:golden_ratio" align="center" raw="\phi = \frac{1 + \sqrt{5}}{2}" alt="Golden ratio"> -->
+
+```math
+\phi = \frac{1 + \sqrt{5}}{2}
+```
+
+<!-- <div class="equation" align="center" data-raw-text="\phi = \frac{1 + \sqrt{5}}{2}" data-equation="eq:golden_ratio">
+    <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@5d87cc7cb2c58aeb732872f89562d2c89571cc8a/lib/node_modules/@stdlib/constants/float64/phi/docs/img/equation_golden_ratio.svg" alt="Golden ratio">
+    <br>
+</div> -->
+
+<!-- </equation> -->
+
+</section>
+
+<!-- /.intro -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var FLOAT32_PHI = require( '@stdlib/constants/float32/phi' );
+```
+
+#### FLOAT32_PHI
+
+The [golden ratio][phi-value].
+
+```javascript
+var bool = ( FLOAT32_PHI === 1.6180340051651 );
+// returns true
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- TODO: better example using Fibonacci(?) -->
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var FLOAT32_PHI = require( '@stdlib/constants/float32/phi' );
+
+console.log( FLOAT32_PHI );
+// => 1.6180340051651
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/constants/float32/phi.h"
+```
+
+#### STDLIB_CONSTANT_FLOAT32_PHI
+
+Macro for the [golden ratio][phi-value].
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[phi]: https://en.wikipedia.org/wiki/Golden_ratio
+
+[phi-value]: http://oeis.org/A001622
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/constants/float32/phi/docs/repl.txt
+++ b/lib/node_modules/@stdlib/constants/float32/phi/docs/repl.txt
@@ -1,0 +1,12 @@
+
+{{alias}}
+    Golden ratio.
+
+    Examples
+    --------
+    > {{alias}}
+    1.6180340051651
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/constants/float32/phi/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/constants/float32/phi/docs/types/index.d.ts
@@ -1,0 +1,33 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Golden ratio.
+*
+* @example
+* var val = FLOAT32_PHI;
+* // returns 1.6180340051651
+*/
+declare const FLOAT32_PHI: number;
+
+
+// EXPORTS //
+
+export = FLOAT32_PHI;

--- a/lib/node_modules/@stdlib/constants/float32/phi/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/constants/float32/phi/docs/types/test.ts
@@ -1,0 +1,28 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import FLOAT32_PHI = require( './index' );
+
+
+// TESTS //
+
+// The export is a number...
+{
+	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+	FLOAT32_PHI; // $ExpectType number
+}

--- a/lib/node_modules/@stdlib/constants/float32/phi/examples/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/phi/examples/index.js
@@ -1,0 +1,24 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var FLOAT32_PHI = require( './../lib' );
+
+console.log( FLOAT32_PHI );
+// => 1.6180340051651

--- a/lib/node_modules/@stdlib/constants/float32/phi/include/stdlib/constants/float32/phi.h
+++ b/lib/node_modules/@stdlib/constants/float32/phi/include/stdlib/constants/float32/phi.h
@@ -1,0 +1,27 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_CONSTANTS_FLOAT32_PHI_H
+#define STDLIB_CONSTANTS_FLOAT32_PHI_H
+
+/**
+* Macro for the golden ratio.
+*/
+#define STDLIB_CONSTANT_FLOAT32_PHI 1.618033988749894848f
+
+#endif // !STDLIB_CONSTANTS_FLOAT32_PHI_H

--- a/lib/node_modules/@stdlib/constants/float32/phi/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/phi/lib/index.js
@@ -1,0 +1,53 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Golden ratio.
+*
+* @module @stdlib/constants/float32/phi
+* @type {number}
+*
+* @example
+* var FLOAT32_PHI = require( '@stdlib/constants/float32/phi' );
+* // returns 1.6180340051651
+*/
+
+// MODULES //
+
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+
+
+// MAIN //
+
+/**
+* Golden ratio.
+*
+* @constant
+* @type {number}
+* @default 1.6180340051651
+* @see [OEIS]{@link http://oeis.org/A001622}
+* @see [Wikipedia]{@link https://en.wikipedia.org/wiki/Golden_ratio}
+*/
+var FLOAT32_PHI = float64ToFloat32( 1.61803398874989484820458683436563811772030917980576286213544862 ); // eslint-disable-line max-len
+
+
+// EXPORTS //
+
+module.exports = FLOAT32_PHI;

--- a/lib/node_modules/@stdlib/constants/float32/phi/manifest.json
+++ b/lib/node_modules/@stdlib/constants/float32/phi/manifest.json
@@ -1,0 +1,36 @@
+{
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": []
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float32/phi/package.json
+++ b/lib/node_modules/@stdlib/constants/float32/phi/package.json
@@ -1,0 +1,76 @@
+{
+  "name": "@stdlib/constants/float32/phi",
+  "version": "0.0.0",
+  "description": "Golden ratio.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "constant",
+    "const",
+    "mathematics",
+    "math",
+    "golden",
+    "ratio",
+    "phi",
+    "tau",
+    "golden mean",
+    "golden section",
+    "divine section",
+    "golden cut",
+    "medial section",
+    "divine proportion",
+    "golden number",
+    "number",
+    "divine",
+    "ieee754",
+    "single",
+    "floating-point",
+    "float32"
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float32/phi/test/test.js
+++ b/lib/node_modules/@stdlib/constants/float32/phi/test/test.js
@@ -1,0 +1,45 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var sqrtf = require( '@stdlib/math/base/special/sqrtf' );
+var FLOAT32_PHI = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a number', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof FLOAT32_PHI, 'number', 'main export is a number' );
+	t.end();
+});
+
+tape( 'export is a double-precision floating-point number equal to 1.6180340051651', function test( t ) {
+	t.equal( FLOAT32_PHI, float64ToFloat32( 1.618033988749895 ), 'equals 1.6180340051651' );
+	t.end();
+});
+
+tape( 'the exported value equals ( 1 + sqrtf( 5 ) ) / 2', function test( t ) {
+	t.equal( FLOAT32_PHI, float64ToFloat32( float64ToFloat32( 1.0 + sqrtf( 5.0 ) ) / 2.0 ), 'equals ( 1 + sqrtf( 5 ) ) / 2' );
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds `constants/float32/phi`, which would be the single precision variant of [`constants/float64/phi`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/constants/float64/phi).

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Float64 and Float32 values for reference:

```
In [2]: float64ToFloat32(1.618033988749895)
Out[2]: 1.6180340051651

In [3]: float64ToFloat32( 1.61803398874989484820458683436563811772030917980576286213544862 )
Out[3]: 1.6180340051651
```

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers
@Planeshifter 

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
