### PR TITLE
fix: resolve bug with unrecognized keywords in the REPL's syntax-highlighter

### DIFF
--- a/lib/node_modules/@stdlib/repl/lib/tokenizer.js
+++ b/lib/node_modules/@stdlib/repl/lib/tokenizer.js
@@ -122,7 +122,7 @@ function tokenizer( line, context ) {
 			tokens.push( token );
 			return;
 		}
-		if ( token.type.keyword ) {
+		if ( token.type.keyword || ( token.type.label === 'name' && isUnrecognizedKeyword( token.value ) ) ) {
 			// Keywords - `function`, `import`, `var`, `const`, `let` etc.:
 			token.type = 'keyword';
 			tokens.push( token );
@@ -197,21 +197,15 @@ function tokenizer( line, context ) {
 		if ( node.start === node.end ) {
 			return true;
 		}
+		// Ignore node if it is an unrecognized `keyword`:
+		if ( isUnrecognizedKeyword( node.name ) ) {
+			return true;
+		}
 		// If node is an unrecognized `literal`, push it as a token:
 		if ( node.name === 'undefined' ) {
 			tokens.push({
 				'value': node.name,
 				'type': 'literal',
-				'start': node.start,
-				'end': node.end
-			});
-			return true;
-		}
-		// If node is an unrecognized `keyword`, push it as a token:
-		if ( isUnrecognizedKeyword( node.name ) ) {
-			tokens.push({
-				'value': node.name,
-				'type': 'keyword',
 				'start': node.start,
 				'end': node.end
 			});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request fixes a small bug with unrecognized keywords (that acorn doesn't recognize as a keyword token), ie. `let`, `async` & `await`, in the syntax highlighter.
We were checking if it's a keyword inside the `Identifier` visitor and hence it wasn't working as expected. I have moved the logic to the `onToken` callback.

@Planeshifter sorry for the oversight. This patch PR fixes it.

Example: 

`let ` : let is highlighted
`let a`: let is **not** highlighted

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
