### PR TITLE
fix: resolve clashes between syntax-highlighter & auto-closer in the REPL

### DIFF
--- a/lib/node_modules/@stdlib/repl/lib/syntax_highlighter.js
+++ b/lib/node_modules/@stdlib/repl/lib/syntax_highlighter.js
@@ -79,6 +79,9 @@ function SyntaxHighlighter( repl, ostream ) {
 	// Initialize a buffer containing the current line to validate line changes:
 	this._line = '';
 
+	// Initialize a buffer to cache the highlighted line:
+	this._highlightedLine = '';
+
 	return this;
 }
 
@@ -136,24 +139,33 @@ setNonEnumerableReadOnly( SyntaxHighlighter.prototype, 'onKeypress', function on
 	var highlightedLine;
 	var tokens;
 
-	if ( !this._rli.line || this._line === this._rli.line ) {
-		debug( 'Empty line or no change detected. Skipping highlighting...' );
-		return;
-	}
-	this._line = this._rli.line;
-
-	// Tokenize:
-	debug( 'Tokenizing line: %s', this._line );
-	tokens = tokenizer( this._line, this._repl._context );
-	if ( !tokens ) {
-		debug( 'No tokens found. Skipping highlighting...' );
+	if ( !this._rli.line ) {
+		debug( 'Empty line detected. Skipping highlighting...' );
 		return;
 	}
 
-	// Highlight:
-	debug( '%d tokens found. Highlighting...', tokens.length );
-	highlightedLine = this._highlightLine( this._line, tokens );
+	// If no line change is detected, use the highlighted line from cache...
+	if ( this._line === this._rli.line ) {
+		debug( 'No line change detected. Using cache...' );
+		highlightedLine = this._highlightedLine;
+	} else {
+		// Update line buffer:
+		this._line = this._rli.line;
 
+		// Tokenize:
+		debug( 'Line change detected. Tokenizing line: %s', this._line );
+		tokens = tokenizer( this._line, this._repl._context );
+		if ( !tokens ) {
+			debug( 'No tokens found. Skipping highlighting...' );
+			return;
+		}
+		// Highlight:
+		debug( '%d tokens found. Highlighting...', tokens.length );
+		highlightedLine = this._highlightLine( this._line, tokens );
+
+		// Cache the newly highlighted line:
+		this._highlightedLine = highlightedLine;
+	}
 	// Replace:
 	debug( 'Replacing current line with the highlighted line...' );
 	readline.moveCursor( this._ostream, -1 * this._rli.cursor, 0 );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request resolves a bug where the syntax highlighter stops working after entering a closing symbol over an existing closing symbol.

**Before**:
https://github.com/stdlib-js/stdlib/assets/130062020/2694562b-4e46-47a8-a007-86d9da3236b5

**After**:
https://github.com/stdlib-js/stdlib/assets/130062020/0e57ada4-a81f-4268-a0e9-96ae6409c421

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
