### PR TITLE
fix: resolve incorrect constraints for scrollable height in the REPL's pager

### DIFF
--- a/lib/node_modules/@stdlib/repl/lib/output_stream.js
+++ b/lib/node_modules/@stdlib/repl/lib/output_stream.js
@@ -271,7 +271,7 @@ setNonEnumerableReadOnly( OutputStream.prototype, '_pagerHeight', function pager
 	if ( vh < MIN_VIEWPORT_HEIGHT ) {
 		return -1;
 	}
-	return vh - RESERVED_PAGING_ROWS;
+	return vh - RESERVED_PAGING_ROWS; // FIXME: reserved paging rows being a constant assumes that the input prompt spans just 1 row. This might not be the case with multi-line inputs triggering the pager as it will result in an incomplete UI with only the last line of the multi-line input visible in the pager view.
 });
 
 /**
@@ -285,8 +285,8 @@ setNonEnumerableReadOnly( OutputStream.prototype, '_pagerHeight', function pager
 * @returns {boolean} boolean indicating whether content is "scrollable"
 */
 setNonEnumerableReadOnly( OutputStream.prototype, '_isScrollable', function isScrollable( N ) {
-	var h = this._pagerHeight();
-	return ( h > 0 && N > h );
+	var vh = this._repl.viewportHeight();
+	return ( vh >= MIN_VIEWPORT_HEIGHT && N > vh - 2 ); // 2 rows reserved for the input and the next prompt
 });
 
 /**


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-  Fixes incorrect constraints set in the `isScrollable` check that was causing paging even when the viewport could accomodate the output

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   is related to #2149

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
