### PR TITLE
refactor: use signed integers for `math/base/special/log2`, as per `FreeBSD`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/log2/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/log2/src/main.c
@@ -53,6 +53,7 @@ double stdlib_base_log2( const double x ) {
 	double valHi;
 	uint32_t hx;
 	uint32_t lx;
+	int32_t ihx;
 	double hfsq;
 	double hi;
 	int32_t i;
@@ -69,10 +70,11 @@ double stdlib_base_log2( const double x ) {
 	}
 	xc = x;
 	stdlib_base_float64_to_words( xc, &hx, &lx );
+	ihx = (int32_t)hx;
 	k = 0;
-	if ( hx < HIGH_MIN_NORMAL_EXP ) {
+	if ( ihx < HIGH_MIN_NORMAL_EXP ) {
 		// Case: x < 2**-1022
-		if ( ( ( hx & STDLIB_CONSTANT_FLOAT64_HIGH_WORD_ABS_MASK ) | lx ) == 0 ) {
+		if ( ( ( ihx & STDLIB_CONSTANT_FLOAT64_HIGH_WORD_ABS_MASK ) | lx ) == 0 ) {
 			return STDLIB_CONSTANT_FLOAT64_NINF;
 		}
 		k -= 54;
@@ -80,20 +82,21 @@ double stdlib_base_log2( const double x ) {
 		// Subnormal number, scale up x:
 		xc *= TWO54;
 		stdlib_base_float64_get_high_word( xc, &hx );
+		ihx = (int32_t)hx;
 	}
-	if ( hx >= HIGH_MAX_NORMAL_EXP ) {
+	if ( ihx >= HIGH_MAX_NORMAL_EXP ) {
 		return xc + xc;
 	}
 	// Case: log(1) = +0
-	if ( hx == HIGH_BIASED_EXP_0 && lx == 0 ) {
+	if ( ihx == HIGH_BIASED_EXP_0 && lx == 0 ) {
 		return 0;
 	}
-	k += ( ( hx>>20 ) - STDLIB_CONSTANT_FLOAT64_EXPONENT_BIAS );
-	hx &= STDLIB_CONSTANT_FLOAT64_HIGH_WORD_SIGNIFICAND_MASK;
-	i = ( hx+0x95f64 ) & HIGH_MIN_NORMAL_EXP;
+	k += ( ( ihx>>20 ) - STDLIB_CONSTANT_FLOAT64_EXPONENT_BIAS );
+	ihx &= STDLIB_CONSTANT_FLOAT64_HIGH_WORD_SIGNIFICAND_MASK;
+	i = ( ihx+0x95f64 ) & HIGH_MIN_NORMAL_EXP;
 
 	// Normalize x or x/2...
-	stdlib_base_float64_set_high_word( hx|( i^HIGH_BIASED_EXP_0 ), &xc );
+	stdlib_base_float64_set_high_word( (uint32_t)( ihx|( i^HIGH_BIASED_EXP_0 ) ), &xc );
 	k += (i>>20);
 	y = (double)k;
 	f = xc - 1.0;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   uses signed integers for [`math/base/special/log2`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/log2), as per its [`FreeBSD` implementation.](https://svnweb.freebsd.org/base/release/12.2.0/lib/msun/src/e_log2.c?view=markup).
-   is a result of the discussion at https://github.com/stdlib-js/stdlib/pull/2294#pullrequestreview-2092236551.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
