### PR TITLE
feat: add boolean datatype support in `array/dtype`

### DIFF
--- a/lib/node_modules/@stdlib/array/dtype/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/dtype/docs/types/index.d.ts
@@ -88,7 +88,7 @@ declare function dtype( value: Complex64Array ): 'complex64';
 * var BooleanArray = require( '@stdlib/array/bool' );
 *
 * var dt = dtype( new BooleanArray( [ true, false, true, false ] ) );
-* // returns 'boolean'
+* // returns 'bool'
 */
 declare function dtype( value: BooleanArray ): 'bool';
 

--- a/lib/node_modules/@stdlib/array/dtype/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/dtype/docs/types/index.d.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { RealOrComplexTypedArray, Complex128Array, Complex64Array, DataType } from '@stdlib/types/array';
+import { RealOrComplexTypedArray, Complex128Array, Complex64Array, BooleanArray, DataType } from '@stdlib/types/array';
 
 /**
 * Returns the data type of an array.
@@ -77,6 +77,20 @@ declare function dtype( value: Complex128Array ): 'complex128';
 * // returns 'complex64'
 */
 declare function dtype( value: Complex64Array ): 'complex64';
+
+/**
+* Returns the data type of an array.
+*
+* @param value - input value
+* @returns data type
+*
+* @example
+* var BooleanArray = require( '@stdlib/array/bool' );
+*
+* var dt = dtype( new BooleanArray( [ true, false, true, false ] ) );
+* // returns 'boolean'
+*/
+declare function dtype( value: BooleanArray ): 'boolean';
 
 /**
 * Returns the data type of an array.

--- a/lib/node_modules/@stdlib/array/dtype/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/dtype/docs/types/index.d.ts
@@ -90,7 +90,7 @@ declare function dtype( value: Complex64Array ): 'complex64';
 * var dt = dtype( new BooleanArray( [ true, false, true, false ] ) );
 * // returns 'boolean'
 */
-declare function dtype( value: BooleanArray ): 'boolean';
+declare function dtype( value: BooleanArray ): 'bool';
 
 /**
 * Returns the data type of an array.

--- a/lib/node_modules/@stdlib/array/dtype/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/dtype/docs/types/test.ts
@@ -37,7 +37,7 @@ import dtype = require( './index' );
 	dtype( new Uint16Array( 10 ) ); // $ExpectType "uint16"
 	dtype( new Uint8Array( 10 ) ); // $ExpectType "uint8"
 	dtype( new Uint8ClampedArray( 10 ) ); // $ExpectType "uint8c"
-	dtype( new BooleanArray( 10 ) ); // $ExpectType "boolean"
+	dtype( new BooleanArray( 10 ) ); // $ExpectType "bool"
 	dtype( [] ); // $ExpectType "generic"
 }
 

--- a/lib/node_modules/@stdlib/array/dtype/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/dtype/docs/types/test.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 
 import Complex128Array = require( '@stdlib/array/complex128' );
 import Complex64Array = require( '@stdlib/array/complex64' );
+import BooleanArray = require( '@stdlib/array/bool' );
 import dtype = require( './index' );
 
 
@@ -36,6 +37,7 @@ import dtype = require( './index' );
 	dtype( new Uint16Array( 10 ) ); // $ExpectType "uint16"
 	dtype( new Uint8Array( 10 ) ); // $ExpectType "uint8"
 	dtype( new Uint8ClampedArray( 10 ) ); // $ExpectType "uint8c"
+	dtype( new BooleanArray( 10 ) ); // $ExpectType "boolean"
 	dtype( [] ); // $ExpectType "generic"
 }
 

--- a/lib/node_modules/@stdlib/array/dtype/lib/ctor2dtype.js
+++ b/lib/node_modules/@stdlib/array/dtype/lib/ctor2dtype.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,7 +33,8 @@ var ctor2dtypes = {
 	'Uint8Array': 'uint8',
 	'Uint8ClampedArray': 'uint8c',
 	'Complex64Array': 'complex64',
-	'Complex128Array': 'complex128'
+	'Complex128Array': 'complex128',
+	'BooleanArray': 'boolean'
 };
 
 

--- a/lib/node_modules/@stdlib/array/dtype/lib/ctor2dtype.js
+++ b/lib/node_modules/@stdlib/array/dtype/lib/ctor2dtype.js
@@ -34,7 +34,7 @@ var ctor2dtypes = {
 	'Uint8ClampedArray': 'uint8c',
 	'Complex64Array': 'complex64',
 	'Complex128Array': 'complex128',
-	'BooleanArray': 'boolean'
+	'BooleanArray': 'bool'
 };
 
 

--- a/lib/node_modules/@stdlib/array/dtype/lib/ctors.js
+++ b/lib/node_modules/@stdlib/array/dtype/lib/ctors.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Int8Array = require( '@stdlib/array/int8' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 
 
 // MAIN //
@@ -47,7 +48,8 @@ var CTORS = [
 	Uint8Array,
 	Uint8ClampedArray,
 	Complex64Array,
-	Complex128Array
+	Complex128Array,
+	BooleanArray
 ];
 
 

--- a/lib/node_modules/@stdlib/array/dtype/lib/dtypes.js
+++ b/lib/node_modules/@stdlib/array/dtype/lib/dtypes.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -32,7 +32,8 @@ var DTYPES = [
 	'uint8',
 	'uint8c',
 	'complex64',
-	'complex128'
+	'complex128',
+	'boolean'
 ];
 
 

--- a/lib/node_modules/@stdlib/array/dtype/lib/dtypes.js
+++ b/lib/node_modules/@stdlib/array/dtype/lib/dtypes.js
@@ -33,7 +33,7 @@ var DTYPES = [
 	'uint8c',
 	'complex64',
 	'complex128',
-	'boolean'
+	'bool'
 ];
 
 


### PR DESCRIPTION
Resolves: Subtask of #2304 

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR will add boolean datatype support in `array/dtype`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
