### PR TITLE
feat: add boolean datatype support in `array/defaults`

### DIFF
--- a/lib/node_modules/@stdlib/array/defaults/README.md
+++ b/lib/node_modules/@stdlib/array/defaults/README.md
@@ -59,6 +59,7 @@ The returned object has the following properties:
     -   **floating_point**: default floating-point data type.
     -   **real_floating_point**: default real-valued floating-point data type.
     -   **complex_floating_point**: default complex-valued floating-point data type.
+    -   **boolean**: default boolean data type.
     -   **integer**: default integer data type.
     -   **signed_integer**: default signed integer data type.
     -   **unsigned_integer**: default unsigned integer data type.

--- a/lib/node_modules/@stdlib/array/defaults/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/defaults/docs/repl.txt
@@ -27,9 +27,9 @@
 
     out.dtypes.complex_floating_point: string
         Default complex-valued floating-point data type.
-    
+
     out.dtypes.boolean: string
-        default boolean data type.
+        Default boolean data type.
 
     out.dtypes.integer: string
         Default integer data type.

--- a/lib/node_modules/@stdlib/array/defaults/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/defaults/docs/repl.txt
@@ -27,6 +27,9 @@
 
     out.dtypes.complex_floating_point: string
         Default complex-valued floating-point data type.
+    
+    out.dtypes.boolean: string
+        default boolean data type.
 
     out.dtypes.integer: string
         Default integer data type.

--- a/lib/node_modules/@stdlib/array/defaults/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/defaults/docs/types/index.d.ts
@@ -53,6 +53,11 @@ interface DataTypes {
 	complex_floating_point: 'complex128';
 
 	/**
+	* Default boolean data type.
+	*/
+	boolean: 'bool';
+
+	/**
 	* Default integer data type.
 	*/
 	integer: 'int32';

--- a/lib/node_modules/@stdlib/array/defaults/lib/get.js
+++ b/lib/node_modules/@stdlib/array/defaults/lib/get.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ var HASH = {
 	'dtypes.floating_point': DEFAULTS.dtypes.floating_point,
 	'dtypes.real_floating_point': DEFAULTS.dtypes.real_floating_point,
 	'dtypes.complex_floating_point': DEFAULTS.dtypes.complex_floating_point,
+	'dtypes.boolean': DEFAULTS.dtypes.boolean,
 	'dtypes.integer': DEFAULTS.dtypes.integer,
 	'dtypes.signed_integer': DEFAULTS.dtypes.signed_integer,
 	'dtypes.unsigned_integer': DEFAULTS.dtypes.unsigned_integer

--- a/lib/node_modules/@stdlib/array/defaults/lib/main.js
+++ b/lib/node_modules/@stdlib/array/defaults/lib/main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ function defaults() {
 			'floating_point': 'float64',
 			'real_floating_point': 'float64',
 			'complex_floating_point': 'complex128',
+			'boolean': 'bool',
 			'integer': 'int32',
 			'signed_integer': 'int32',
 			'unsigned_integer': 'uint32'

--- a/lib/node_modules/@stdlib/array/defaults/test/test.get.js
+++ b/lib/node_modules/@stdlib/array/defaults/test/test.get.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ tape( 'if provided a recognized setting, the function returns a default value', 
 		'dtypes.floating_point',
 		'dtypes.real_floating_point',
 		'dtypes.complex_floating_point',
+		'dtypes.boolean',
 		'dtypes.integer',
 		'dtypes.signed_integer',
 		'dtypes.unsigned_integer'
@@ -62,6 +63,7 @@ tape( 'if provided a recognized setting, the function returns a default value', 
 		DEFAULTS.dtypes.floating_point,
 		DEFAULTS.dtypes.real_floating_point,
 		DEFAULTS.dtypes.complex_floating_point,
+		DEFAULTS.dtypes.boolean,
 		DEFAULTS.dtypes.integer,
 		DEFAULTS.dtypes.signed_integer,
 		DEFAULTS.dtypes.unsigned_integer

--- a/lib/node_modules/@stdlib/array/defaults/test/test.main.js
+++ b/lib/node_modules/@stdlib/array/defaults/test/test.main.js
@@ -57,6 +57,9 @@ tape( 'the function returns default settings', function test( t ) {
 	t.strictEqual( hasOwnProp( o.dtypes, 'complex_floating_point' ), true, 'has property' );
 	t.strictEqual( typeof o.dtypes.complex_floating_point, 'string', 'returns expected value' );
 
+	t.strictEqual( hasOwnProp( o.dtypes, 'boolean' ), true, 'has property' );
+	t.strictEqual( typeof o.dtypes.boolean, 'string', 'returns expected value' );
+
 	t.strictEqual( hasOwnProp( o.dtypes, 'integer' ), true, 'has property' );
 	t.strictEqual( typeof o.dtypes.integer, 'string', 'returns expected value' );
 


### PR DESCRIPTION
Resolves: Subtask of #2304 

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR will add boolean datatype support in `array/defaults`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
