### PR TITLE
feat: add boolean datatype support in `array/mostly-safe-casts`

### DIFF
--- a/lib/node_modules/@stdlib/array/mostly-safe-casts/lib/data.json
+++ b/lib/node_modules/@stdlib/array/mostly-safe-casts/lib/data.json
@@ -11,6 +11,7 @@
 		"uint8c": 0,
 		"complex128": 1,
 		"complex64": 1,
+		"bool": 0,
 		"generic": 1
 	},
 	"float32": {
@@ -25,6 +26,7 @@
 		"uint8c": 0,
 		"complex128": 1,
 		"complex64": 1,
+		"bool": 0,
 		"generic": 1
 	},
 	"int32": {
@@ -39,6 +41,7 @@
 		"uint8c": 0,
 		"complex128": 1,
 		"complex64": 0,
+		"bool": 0,
 		"generic": 1
 	},
 	"int16": {
@@ -53,6 +56,7 @@
 		"uint8c": 0,
 		"complex128": 1,
 		"complex64": 1,
+		"bool": 0,
 		"generic": 1
 	},
 	"int8": {
@@ -67,6 +71,7 @@
 		"uint8c": 0,
 		"complex128": 1,
 		"complex64": 1,
+		"bool": 0,
 		"generic": 1
 	},
 	"uint32": {
@@ -81,6 +86,7 @@
 		"uint8c": 0,
 		"complex128": 1,
 		"complex64": 0,
+		"bool": 0,
 		"generic": 1
 	},
 	"uint16": {
@@ -95,6 +101,7 @@
 		"uint8c": 0,
 		"complex128": 1,
 		"complex64": 1,
+		"bool": 0,
 		"generic": 1
 	},
 	"uint8": {
@@ -109,6 +116,7 @@
 		"uint8c": 1,
 		"complex128": 1,
 		"complex64": 1,
+		"bool": 1,
 		"generic": 1
 	},
 	"uint8c": {
@@ -123,6 +131,7 @@
 		"uint8c": 1,
 		"complex128": 1,
 		"complex64": 1,
+		"bool": 1,
 		"generic": 1
 	},
 	"complex128": {
@@ -137,6 +146,7 @@
 		"uint8c": 0,
 		"complex128": 1,
 		"complex64": 1,
+		"bool": 0,
 		"generic": 1
 	},
 	"complex64": {
@@ -151,6 +161,22 @@
 		"uint8c": 0,
 		"complex128": 1,
 		"complex64": 1,
+		"bool": 0,
+		"generic": 1
+	},
+	"bool": {
+		"float64": 0,
+		"float32": 0,
+		"int32": 0,
+		"int16": 0,
+		"int8": 0,
+		"uint32": 0,
+		"uint16": 0,
+		"uint8": 0,
+		"uint8c": 0,
+		"complex128": 0,
+		"complex64": 0,
+		"bool": 1,
 		"generic": 1
 	},
 	"generic": {
@@ -165,6 +191,7 @@
 		"uint8c": 0,
 		"complex128": 0,
 		"complex64": 0,
+		"bool": 0,
 		"generic": 1
 	}
 }

--- a/lib/node_modules/@stdlib/array/mostly-safe-casts/lib/data.json
+++ b/lib/node_modules/@stdlib/array/mostly-safe-casts/lib/data.json
@@ -116,7 +116,7 @@
 		"uint8c": 1,
 		"complex128": 1,
 		"complex64": 1,
-		"bool": 1,
+		"bool": 0,
 		"generic": 1
 	},
 	"uint8c": {
@@ -131,7 +131,7 @@
 		"uint8c": 1,
 		"complex128": 1,
 		"complex64": 1,
-		"bool": 1,
+		"bool": 0,
 		"generic": 1
 	},
 	"complex128": {


### PR DESCRIPTION
Resolves: Subtask of #2304 

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR will add boolean datatype support in `array/mostly-safe-casts`.

## Related Issues

> Does this pull request have any related issues?

This pull request:
## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
