### PR TITLE
feat: add combined styles and inbuilt syntax highlighting themes in the REPL

### DIFF
--- a/lib/node_modules/@stdlib/repl/lib/ansi_colors.js
+++ b/lib/node_modules/@stdlib/repl/lib/ansi_colors.js
@@ -48,6 +48,33 @@ var ANSI = {
 	'brightCyan': '\u001b[96m',
 	'brightWhite': '\u001b[97m',
 
+	// Background colors:
+	'bgBlack': '\u001b[40m',
+	'bgRed': '\u001b[41m',
+	'bgGreen': '\u001b[42m',
+	'bgYellow': '\u001b[43m',
+	'bgBlue': '\u001b[44m',
+	'bgMagenta': '\u001b[45m',
+	'bgCyan': '\u001b[46m',
+	'bgWhite': '\u001b[47m',
+
+	// Bright background colors:
+	'bgBrightBlack': '\u001b[100m',
+	'bgBrightRed': '\u001b[101m',
+	'bgBrightGreen': '\u001b[102m',
+	'bgBrightYellow': '\u001b[103m',
+	'bgBrightBlue': '\u001b[104m',
+	'bgBrightMagenta': '\u001b[105m',
+	'bgBrightCyan': '\u001b[106m',
+	'bgBrightWhite': '\u001b[107m',
+
+	// Styles:
+	'bold': '\u001b[1m',
+	'underline': '\u001b[4m',
+	'reversed': '\u001b[7m',
+	'italic': '\u001b[3m',
+	'strikethrough': '\u001b[9m',
+
 	// Reset colors:
 	'reset': '\u001b[0m'
 };

--- a/lib/node_modules/@stdlib/repl/lib/syntax_highlighter.js
+++ b/lib/node_modules/@stdlib/repl/lib/syntax_highlighter.js
@@ -115,28 +115,35 @@ setNonEnumerableReadOnly( SyntaxHighlighter.prototype, '_highlightLine', functio
 	var highlightedLine = '';
 	var resetCode = ANSI[ 'reset' ];
 	var colorCode;
-	var colors = this._themes[ this._theme ];
 	var offset = 0;
+	var color;
+	var theme = this._themes[ this._theme ];
 	var token;
 	var i;
+	var j;
 
 	// Sort and traverse the tokens...
 	tokens.sort( tokenComparator );
 	for ( i = 0; i < tokens.length; i++ ) {
 		token = tokens[ i ];
-		colorCode = ANSI[ colors[ token.type ] ];
-
-		// Highlight token if it's color exists in the theme...
-		if ( colorCode ) {
-			highlightedLine += line.slice( offset, token.start ); // add text before token
-			highlightedLine += colorCode; // insert colorCode
-			highlightedLine += line.slice( token.start, token.end ); // add token
-			highlightedLine += resetCode; // reset color
-			offset = token.end;
+		color = theme[ token.type ];
+		if ( !color ) {
+			continue; // no color defined for the token type
 		}
+		color = color.split( ' ' ); // allow combination of styles. eg: `bold magenta`
+		highlightedLine += line.slice( offset, token.start ); // add text before token
+		for ( j = 0; j < color.length; j++ ) {
+			// Highlight token if it's color is supported...
+			colorCode = ANSI[ color[ j ] ];
+			if ( colorCode ) {
+				highlightedLine += colorCode; // insert colorCode
+			}
+		}
+		highlightedLine += line.slice( token.start, token.end ); // add token
+		highlightedLine += resetCode; // reset color
+		offset = token.end;
 	}
 	highlightedLine += line.slice( offset ); // add remaining text
-
 	return highlightedLine;
 });
 

--- a/lib/node_modules/@stdlib/repl/lib/themes.js
+++ b/lib/node_modules/@stdlib/repl/lib/themes.js
@@ -30,20 +30,20 @@
 var THEMES = {
 	'stdlib-ansi-basic': {
 		// Keywords:
-		'control': 'magenta',
-		'keyword': 'blue',
+		'control': 'brightMagenta',
+		'keyword': 'bold brightBlue',
 		'specialIdentifier': 'cyan',
 
 		// Literals:
-		'string': 'brightYellow',
-		'number': 'brightGreen',
-		'literal': 'brightBlue',
-		'regexp': 'red',
+		'string': 'green',
+		'number': 'yellow',
+		'literal': 'italic brightCyan',
+		'regexp': 'underline brightRed',
 
 		// Identifiers:
-		'command': 'brightMagenta',
-		'function': 'yellow',
-		'object': 'brightCyan',
+		'command': 'bold magenta',
+		'function': 'bold yellow',
+		'object': 'cyan',
 		'variable': null,
 		'name': null,
 
@@ -51,6 +51,150 @@ var THEMES = {
 		'comment': 'brightBlack',
 		'punctuation': null,
 		'operator': null
+	},
+	'stdlib-ansi-dark': {
+		// Keywords:
+		'control': 'bold brightMagenta',
+		'keyword': 'green',
+		'specialIdentifier': 'cyan',
+
+		// Literals:
+		'string': 'yellow',
+		'number': 'brightBlue',
+		'literal': 'italic brightCyan',
+		'regexp': 'bold red',
+
+		// Identifiers:
+		'command': 'brightGreen',
+		'function': 'bold magenta',
+		'object': 'cyan',
+		'variable': null,
+		'name': null,
+
+		// Others:
+		'comment': 'bold brightBlack',
+		'punctuation': null,
+		'operator': null
+	},
+	'stdlib-ansi-light': {
+		// Keywords:
+		'control': 'magenta',
+		'keyword': 'blue',
+		'specialIdentifier': 'bold cyan',
+
+		// Literals:
+		'string': 'yellow',
+		'number': 'green',
+		'literal': 'italic brightBlue',
+		'regexp': 'underline red',
+
+		// Identifiers:
+		'command': 'brightMagenta',
+		'function': 'yellow',
+		'object': 'bold',
+		'variable': null,
+		'name': null,
+
+		// Others:
+		'comment': 'brightBlack',
+		'punctuation': null,
+		'operator': null
+	},
+	'stdlib-ansi-strong': {
+		// Keywords:
+		'control': 'bold magenta',
+		'keyword': 'bold blue',
+		'specialIdentifier': 'italic cyan',
+
+		// Literals:
+		'string': 'bold brightGreen',
+		'number': 'bold brightYellow',
+		'literal': 'italic brightBlue',
+		'regexp': 'underline red',
+
+		// Identifiers:
+		'command': 'underline brightBlue',
+		'function': 'bold yellow',
+		'object': 'italic cyan',
+		'variable': 'green',
+		'name': null,
+
+		// Others:
+		'comment': 'italic brightBlack',
+		'punctuation': null,
+		'operator': null
+	},
+	'minimalist': {
+		// Keywords:
+		'control': 'underline',
+		'keyword': 'bold',
+		'specialIdentifier': 'italic',
+
+		// Literals:
+		'string': 'underline',
+		'number': 'bold',
+		'literal': 'italic',
+		'regexp': 'bold underline',
+
+		// Identifiers:
+		'command': 'underline bold',
+		'function': 'italic bold',
+		'object': 'italic',
+		'variable': null,
+		'name': null,
+
+		// Others:
+		'comment': 'italic brightBlack',
+		'punctuation': null,
+		'operator': null
+	},
+	'solarized': {
+		// Keywords:
+		'control': 'green',
+		'keyword': 'bold',
+		'specialIdentifier': 'red',
+
+		// Literals:
+		'string': 'cyan',
+		'number': 'brightMagenta',
+		'literal': 'brightYellow',
+		'regexp': 'red',
+
+		// Identifiers:
+		'command': 'bold magenta',
+		'function': 'brightBlue',
+		'object': 'brightRed',
+		'variable': 'brightBlue',
+		'name': null,
+
+		// Others:
+		'comment': 'italic brightBlack',
+		'punctuation': null,
+		'operator': 'green'
+	},
+	'monokai': {
+		// Keywords:
+		'control': 'brightRed',
+		'keyword': 'italic brightCyan',
+		'specialIdentifier': 'brightMagenta',
+
+		// Literals:
+		'string': 'brightYellow',
+		'number': 'brightBlue',
+		'literal': 'brightBlue',
+		'regexp': 'underline yellow',
+
+		// Identifiers:
+		'command': 'bold brightGreen',
+		'function': 'brightGreen',
+		'object': 'italic brightMagenta',
+		'variable': null,
+		'name': null,
+
+		// Others:
+		'comment': 'brightBlack',
+		'punctuation': null,
+		'operator': 'brightRed'
 	}
 };
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds the ability to combine styles and colors. styles like `bold brightBlue`, `italic magenta` are now supported.
-   adds the following inbuilt themes: 'stdlib-ansi-basic', 'stdlib-ansi-dark', 'stdlib-ansi-light', 'stdlib-ansi-strong', 'minimalist', 'monokai', 'solarized'. 

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   is a follow up to #2291

## Questions

> Any questions for reviewers of this pull request?

One of the challenges is finding out how accessible these themes are across different terminal emulators. How these ANSI colors are rendered depends on the terminal application. In my system, all of the terminal applications render all ANSI colors according to accessibility standards. So it was difficult for me to judge which color is suitable for dark/light backgrounds. If most modern emulators do this then this might be a win for us. 

It would be great if you could try out the themes on your terminals and suggest changes that make the themes more accessible.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
