### PR TITLE
refactor: use constant packages, remove stdint

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cos/include/stdlib/math/base/special/cos.h
+++ b/lib/node_modules/@stdlib/math/base/special/cos/include/stdlib/math/base/special/cos.h
@@ -22,8 +22,6 @@
 #ifndef STDLIB_MATH_BASE_SPECIAL_COS_H
 #define STDLIB_MATH_BASE_SPECIAL_COS_H
 
-#include <stdint.h>
-
 /*
 * If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
 */

--- a/lib/node_modules/@stdlib/math/base/special/cos/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/cos/lib/main.js
@@ -38,6 +38,8 @@ var getHighWord = require( '@stdlib/number/float64/base/get-high-word' );
 var kernelCos = require( '@stdlib/math/base/special/kernel-cos' );
 var kernelSin = require( '@stdlib/math/base/special/kernel-sin' );
 var rempio2 = require( '@stdlib/math/base/special/rempio2' );
+var ABS_MASK = require( '@stdlib/constants/float64/high-word-abs-mask' );
+var EXPONENT_MASK = require( '@stdlib/constants/float64/high-word-exponent-mask' );
 
 
 // VARIABLES //
@@ -45,17 +47,11 @@ var rempio2 = require( '@stdlib/math/base/special/rempio2' );
 // Scratch array for storing temporary values:
 var buffer = [ 0.0, 0.0 ]; // WARNING: not thread safe
 
-// High word absolute value mask: 0x7fffffff => 01111111111111111111111111111111
-var HIGH_WORD_ABS_MASK = 0x7fffffff|0; // asm type annotation
-
 // High word of π/4: 0x3fe921fb => 00111111111010010010000111111011
 var HIGH_WORD_PIO4 = 0x3fe921fb|0; // asm type annotation
 
 // High word of 2^-27: 0x3e400000 => 00111110010000000000000000000000
 var HIGH_WORD_TWO_NEG_27 = 0x3e400000|0; // asm type annotation
-
-// High word exponent mask: 0x7ff00000 => 01111111111100000000000000000000
-var HIGH_WORD_EXPONENT_MASK = 0x7ff00000|0; // asm type annotation
 
 
 // MAIN //
@@ -102,7 +98,7 @@ function cos( x ) {
 	var n;
 
 	ix = getHighWord( x );
-	ix &= HIGH_WORD_ABS_MASK;
+	ix &= ABS_MASK;
 
 	// Case: |x| ~< pi/4
 	if ( ix <= HIGH_WORD_PIO4 ) {
@@ -113,7 +109,7 @@ function cos( x ) {
 		return kernelCos( x, 0.0 );
 	}
 	// Case: cos(Inf or NaN) is NaN */
-	if ( ix >= HIGH_WORD_EXPONENT_MASK ) {
+	if ( ix >= EXPONENT_MASK ) {
 		return NaN;
 	}
 	// Case: Argument reduction needed...

--- a/lib/node_modules/@stdlib/math/base/special/cos/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/cos/manifest.json
@@ -38,6 +38,8 @@
       "dependencies": [
         "@stdlib/math/base/napi/unary",
         "@stdlib/number/float64/base/get-high-word",
+        "@stdlib/constants/float64/high-word-abs-mask",
+        "@stdlib/constants/float64/high-word-exponent-mask",
         "@stdlib/math/base/special/kernel-cos",
         "@stdlib/math/base/special/kernel-sin",
         "@stdlib/math/base/special/rempio2"
@@ -55,6 +57,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/number/float64/base/get-high-word",
+        "@stdlib/constants/float64/high-word-abs-mask",
+        "@stdlib/constants/float64/high-word-exponent-mask",
         "@stdlib/math/base/special/kernel-cos",
         "@stdlib/math/base/special/kernel-sin",
         "@stdlib/math/base/special/rempio2"
@@ -72,6 +76,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/number/float64/base/get-high-word",
+        "@stdlib/constants/float64/high-word-abs-mask",
+        "@stdlib/constants/float64/high-word-exponent-mask",
         "@stdlib/math/base/special/kernel-cos",
         "@stdlib/math/base/special/kernel-sin",
         "@stdlib/math/base/special/rempio2"

--- a/lib/node_modules/@stdlib/math/base/special/cos/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/cos/src/main.c
@@ -32,22 +32,18 @@
 
 #include "stdlib/math/base/special/cos.h"
 #include "stdlib/number/float64/base/get_high_word.h"
+#include "stdlib/constants/float64/high_word_abs_mask.h"
+#include "stdlib/constants/float64/high_word_exponent_mask.h"
 #include "stdlib/math/base/special/kernel_cos.h"
 #include "stdlib/math/base/special/kernel_sin.h"
 #include "stdlib/math/base/special/rempio2.h"
 #include <stdint.h>
-
-// High word absolute value mask: 0x7fffffff => 01111111111111111111111111111111
-static const int32_t HIGH_WORD_ABS_MASK = 0x7fffffff;
 
 // High word of π/4: 0x3fe921fb => 00111111111010010010000111111011
 static const int32_t HIGH_WORD_PIO4 = 0x3fe921fb;
 
 // High word of 2^-27: 0x3e400000 => 00111110010000000000000000000000
 static const int32_t HIGH_WORD_TWO_NEG_27 = 0x3e400000;
-
-// High word exponent mask: 0x7ff00000 => 01111111111100000000000000000000
-static const int32_t HIGH_WORD_EXPONENT_MASK = 0x7ff00000;
 
 /**
 * Computes the cosine of a number.
@@ -82,7 +78,7 @@ double stdlib_base_cos( const double x ) {
 
 	stdlib_base_float64_get_high_word( x, &uix );
 	ix = (int32_t)uix;
-	ix &= HIGH_WORD_ABS_MASK;
+	ix &= STDLIB_CONSTANT_FLOAT64_HIGH_WORD_ABS_MASK;
 
 	// Case: |x| ~< π/4
 	if ( ix <= HIGH_WORD_PIO4 ) {
@@ -93,7 +89,7 @@ double stdlib_base_cos( const double x ) {
 		return stdlib_base_kernel_cos( x, 0.0 );
 	}
 	// Case: cos(Inf or NaN) is NaN */
-	if ( ix >= HIGH_WORD_EXPONENT_MASK ) {
+	if ( ix >= STDLIB_CONSTANT_FLOAT64_HIGH_WORD_EXPONENT_MASK ) {
 		return 0.0 / 0.0; // NaN
 	}
 	// Case: Argument reduction needed...


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-  applies the changes suggested at #2352.
-   removes the inclusion of `stdint` in `math/base/special/cos/include/stdlib/math/base/special/cos.h`
-   uses constant packages instead of explicitly declaring them.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
