### PR TITLE
feat: add boolean dtype support in `array/next-dtype`

### DIFF
--- a/lib/node_modules/@stdlib/array/next-dtype/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/next-dtype/docs/types/index.d.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -191,6 +191,22 @@ declare function nextDataType( dtype: 'uint8c' ): 'uint16'; // eslint-disable-li
 * // returns -1
 */
 declare function nextDataType( dtype: 'generic' ): number; // eslint-disable-line @typescript-eslint/unified-signatures
+
+/**
+* Returns the next larger array data type of the same kind.
+*
+* ## Notes
+*
+* -   If a data type does not have a next larger data type or the next larger type is not supported, the function returns `-1`.
+*
+* @param dtype - array data type
+* @returns next larger data type
+*
+* @example
+* var dt = nextDataType( 'bool' );
+* // returns -1
+*/
+declare function nextDataType( dtype: 'bool' ): number; // eslint-disable-line @typescript-eslint/unified-signatures
 
 /**
 * Returns the next larger array data type of the same kind.

--- a/lib/node_modules/@stdlib/array/next-dtype/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/next-dtype/docs/types/test.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -30,6 +30,8 @@ import nextDataType = require( './index' );
 {
 	nextDataType( 'complex128' ); // $ExpectType number
 	nextDataType( 'complex64' ); // $ExpectType "complex128"
+
+	nextDataType( 'bool' ); // $ExpectType number
 
 	nextDataType( 'float64' ); // $ExpectType number
 	nextDataType( 'float32' ); // $ExpectType "float64"

--- a/lib/node_modules/@stdlib/array/next-dtype/lib/next_dtypes.json
+++ b/lib/node_modules/@stdlib/array/next-dtype/lib/next_dtypes.json
@@ -9,6 +9,7 @@
 	"uint8": "uint16",
 	"uint8c": "uint16",
 	"generic": -1,
+	"bool": -1,
   "complex64": "complex128",
   "complex128": -1
 }


### PR DESCRIPTION
Resolves: Subtask of #2304 

## Description

> What is the purpose of this pull request?

This pull request:

-  This PR will add boolean datatype support in `array/next-dtype`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
