### PR TITLE
docs: use significand mask in `math/base/special/rempio2`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/rempio2/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/rempio2/manifest.json
@@ -49,7 +49,7 @@
         "@stdlib/number/float64/base/from-words",
         "@stdlib/constants/float64/high-word-abs-mask",
         "@stdlib/constants/float64/high-word-exponent-mask",
-        "@stdlib/constants/float64/high-word-sign-mask"
+        "@stdlib/constants/float64/high-word-significand-mask"
       ]
     },
     {
@@ -71,7 +71,7 @@
         "@stdlib/number/float64/base/from-words",
         "@stdlib/constants/float64/high-word-abs-mask",
         "@stdlib/constants/float64/high-word-exponent-mask",
-        "@stdlib/constants/float64/high-word-sign-mask"
+        "@stdlib/constants/float64/high-word-significand-mask"
       ]
     },
     {
@@ -93,7 +93,7 @@
         "@stdlib/number/float64/base/from-words",
         "@stdlib/constants/float64/high-word-abs-mask",
         "@stdlib/constants/float64/high-word-exponent-mask",
-        "@stdlib/constants/float64/high-word-sign-mask"
+        "@stdlib/constants/float64/high-word-significand-mask"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/rempio2/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/rempio2/src/main.c
@@ -39,7 +39,7 @@
 #include "stdlib/number/float64/base/from_words.h"
 #include "stdlib/constants/float64/high_word_abs_mask.h"
 #include "stdlib/constants/float64/high_word_exponent_mask.h"
-#include "stdlib/constants/float64/high_word_sign_mask.h"
+#include "stdlib/constants/float64/high_word_significand_mask.h"
 #include <stdint.h>
 
 static const double ZERO =  0.00000000000000000000e+00;       // 0x00000000, 0x00000000
@@ -488,7 +488,7 @@ int32_t stdlib_base_rempio2( const double x, double *rem1, double *rem2 ) {
 	// Case: |x| ~<= 5π/4
 	if ( ix <= FIVE_PIO4_HIGH_WORD ) {
 		// Case: |x| ~= π/2 or π
-		if ( ( ix & STDLIB_CONSTANT_FLOAT64_HIGH_WORD_SIGN_MASK ) == PI_HIGH_WORD_SIGNIFICAND ) {
+		if ( ( ix & STDLIB_CONSTANT_FLOAT64_HIGH_WORD_SIGNIFICAND_MASK ) == PI_HIGH_WORD_SIGNIFICAND ) {
 			// Cancellation => use medium case
 			goto medium;
 		}


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   uses `STDLIB_CONSTANT_FLOAT64_HIGH_WORD_SIGNIFICAND_MASK`, instead of `STDLIB_CONSTANT_FLOAT64_HIGH_WORD_SIGN_MASK`, as used in both the `javascript` implementation and in the `FreeBSD` reference, in [`math/base/special/rempio2`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/rempio2).
-   Reference: https://svnweb.freebsd.org/base/release/12.2.0/lib/msun/src/e_rem_pio2.c?revision=367086&view=markup#l69

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
