### PR TITLE
feat: add C implementation for `math/base/special/csc`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/csc/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/csc/README.md
@@ -43,7 +43,7 @@ var v = csc( 0.0 );
 // returns Infinity
 
 v = csc( 3.141592653589793/2.0 );
-// returns ~1.0
+// returns 1.0
 
 v = csc( -3.141592653589793/6.0 );
 // returns ~-2.0
@@ -81,6 +81,94 @@ for ( i = 0; i < x.length; i++ ) {
 </section>
 
 <!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/math/base/special/csc.h"
+```
+
+#### stdlib_base_csc( x )
+
+Evaluates the [cosecant][trigonometric-functions] of `x` (in radians).
+
+```c
+double out = stdlib_base_csc( 0.0 );
+// returns Infinity
+
+out = stdlib_base_cos( 3.141592653589793 / 2.0 );
+// returns 1.0
+```
+
+The function accepts the following arguments:
+
+-   **x**: `[in] double` input value.
+
+```c
+double stdlib_base_csc( const double x );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/math/base/special/csc.h"
+#include <stdio.h>
+
+int main( void ) {
+    const double x[] = { 0.523, 0.785, 1.047, 3.14 };
+
+    double y;
+    int i;
+    for ( i = 0; i < 4; i++ ) {
+        y = stdlib_base_csc( x[ i ] );
+        printf( "csc(%lf) = %lf\n", x[ i ], y );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
 
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 

--- a/lib/node_modules/@stdlib/math/base/special/csc/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/csc/benchmark/benchmark.native.js
@@ -1,0 +1,60 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var csc = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( csc instanceof Error )
+};
+
+
+// MAIN //
+
+bench( pkg+'::native', opts, function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		x = (randu() * 20.0) - 10.0;
+		y = csc( x );
+		if ( isnan( y ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnan( y ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/csc/benchmark/c/native/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/csc/benchmark/c/native/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/csc/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/csc/benchmark/c/native/benchmark.c
@@ -1,0 +1,136 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/**
+* Benchmark `csc`.
+*/
+#include "stdlib/math/base/special/csc.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "csc"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+void print_version() {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+double tic() {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1].
+*
+* @return random number
+*/
+double rand_double() {
+	int r = rand();
+	return (double)r / ( (double)RAND_MAX + 1.0 );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+double benchmark() {
+	double elapsed;
+	double x;
+	double y;
+	double t;
+	int i;
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		x = ( 20.0 * rand_double() ) - 10.0;
+		y = stdlib_base_csc( x );
+		if ( y != y ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( y != y ) {
+		printf( "should not return NaN\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::native::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/math/base/special/csc/binding.gyp
+++ b/lib/node_modules/@stdlib/math/base/special/csc/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/math/base/special/csc/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/csc/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/csc/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/csc/examples/c/example.c
@@ -1,4 +1,4 @@
-/*
+/**
 * @license Apache-2.0
 *
 * Copyright (c) 2024 The Stdlib Authors.
@@ -16,33 +16,16 @@
 * limitations under the License.
 */
 
-// TypeScript Version: 4.1
+#include "stdlib/math/base/special/csc.h"
+#include <stdio.h>
 
-/**
-* Computes the cosecant of a number.
-*
-* @param x - input value (in radians)
-* @returns cosecant
-*
-* @example
-* var v = csc( 0.0 );
-* // returns Infinity
-*
-* @example
-* var v = csc( 3.141592653589793/2.0 );
-* // returns 1.0
-*
-* @example
-* var v = csc( -3.141592653589793/6.0 );
-* // returns ~-2.0
-*
-* @example
-* var v = csc( NaN );
-* // returns NaN
-*/
-declare function csc( x: number ): number;
+int main( void ) {
+	const double x[] = { 0.523, 0.785, 1.047, 3.14 };
 
-
-// EXPORTS //
-
-export = csc;
+	double y;
+	int i;
+	for ( i = 0; i < 4; i++ ) {
+		y = stdlib_base_csc( x[ i ] );
+		printf( "csc(%lf) = %lf\n", x[ i ], y );
+	}
+}

--- a/lib/node_modules/@stdlib/math/base/special/csc/include.gypi
+++ b/lib/node_modules/@stdlib/math/base/special/csc/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/math/base/special/csc/include/stdlib/math/base/special/csc.h
+++ b/lib/node_modules/@stdlib/math/base/special/csc/include/stdlib/math/base/special/csc.h
@@ -1,4 +1,4 @@
-/*
+/**
 * @license Apache-2.0
 *
 * Copyright (c) 2024 The Stdlib Authors.
@@ -16,33 +16,26 @@
 * limitations under the License.
 */
 
-// TypeScript Version: 4.1
+/**
+* Header file containing function declarations.
+*/
+#ifndef STDLIB_MATH_BASE_SPECIAL_CSC_H
+#define STDLIB_MATH_BASE_SPECIAL_CSC_H
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
-* Computes the cosecant of a number.
-*
-* @param x - input value (in radians)
-* @returns cosecant
-*
-* @example
-* var v = csc( 0.0 );
-* // returns Infinity
-*
-* @example
-* var v = csc( 3.141592653589793/2.0 );
-* // returns 1.0
-*
-* @example
-* var v = csc( -3.141592653589793/6.0 );
-* // returns ~-2.0
-*
-* @example
-* var v = csc( NaN );
-* // returns NaN
+* Evaluates the cosecant of a number.
 */
-declare function csc( x: number ): number;
+double stdlib_base_csc( const double x );
 
+#ifdef __cplusplus
+}
+#endif
 
-// EXPORTS //
-
-export = csc;
+#endif // !STDLIB_MATH_BASE_SPECIAL_CSC_H

--- a/lib/node_modules/@stdlib/math/base/special/csc/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/csc/lib/index.js
@@ -30,7 +30,7 @@
 * // returns Infinity
 *
 * v = csc( 3.141592653589793/2.0 );
-* // returns ~1.0
+* // returns 1.0
 *
 * v = csc( -3.141592653589793/6.0 );
 * // returns ~-2.0

--- a/lib/node_modules/@stdlib/math/base/special/csc/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/csc/lib/main.js
@@ -37,7 +37,7 @@ var sin = require('@stdlib/math/base/special/sin');
 *
 * @example
 * var v = csc( 3.141592653589793/2.0 );
-* // returns ~1.0
+* // returns 1.0
 *
 * @example
 * var v = csc( -3.141592653589793/6.0 );

--- a/lib/node_modules/@stdlib/math/base/special/csc/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/csc/lib/native.js
@@ -1,4 +1,4 @@
-/*
+/**
 * @license Apache-2.0
 *
 * Copyright (c) 2024 The Stdlib Authors.
@@ -16,33 +16,47 @@
 * limitations under the License.
 */
 
-// TypeScript Version: 4.1
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
 
 /**
-* Computes the cosecant of a number.
+* Evaluates the cosecant of a number.
 *
-* @param x - input value (in radians)
-* @returns cosecant
+* @private
+* @param {number} x - input value (in radians)
+* @returns {number} cosecant
 *
 * @example
 * var v = csc( 0.0 );
 * // returns Infinity
 *
 * @example
-* var v = csc( 3.141592653589793/2.0 );
+* var v = csc( 3.141592653589793 / 2.0 );
 * // returns 1.0
 *
 * @example
-* var v = csc( -3.141592653589793/6.0 );
+* var v = csc( -3.141592653589793 / 6.0 );
 * // returns ~-2.0
+*
+* @example
+* var v = csc( 3.141592653589793 / 6.0 );
+* // returns ~2.0
 *
 * @example
 * var v = csc( NaN );
 * // returns NaN
 */
-declare function csc( x: number ): number;
+function csc( x ) {
+	return addon( x );
+}
 
 
 // EXPORTS //
 
-export = csc;
+module.exports = csc;

--- a/lib/node_modules/@stdlib/math/base/special/csc/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/csc/manifest.json
@@ -1,0 +1,72 @@
+{
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/napi/unary",
+        "@stdlib/math/base/special/sin"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/sin"
+      ]
+    },
+    {
+      "task": "examples",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/sin"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/special/csc/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/csc/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/csc/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/csc/src/addon.c
@@ -1,4 +1,4 @@
-/*
+/**
 * @license Apache-2.0
 *
 * Copyright (c) 2024 The Stdlib Authors.
@@ -16,33 +16,7 @@
 * limitations under the License.
 */
 
-// TypeScript Version: 4.1
+#include "stdlib/math/base/special/csc.h"
+#include "stdlib/math/base/napi/unary.h"
 
-/**
-* Computes the cosecant of a number.
-*
-* @param x - input value (in radians)
-* @returns cosecant
-*
-* @example
-* var v = csc( 0.0 );
-* // returns Infinity
-*
-* @example
-* var v = csc( 3.141592653589793/2.0 );
-* // returns 1.0
-*
-* @example
-* var v = csc( -3.141592653589793/6.0 );
-* // returns ~-2.0
-*
-* @example
-* var v = csc( NaN );
-* // returns NaN
-*/
-declare function csc( x: number ): number;
-
-
-// EXPORTS //
-
-export = csc;
+STDLIB_MATH_BASE_NAPI_MODULE_D_D( stdlib_base_csc )

--- a/lib/node_modules/@stdlib/math/base/special/csc/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/csc/src/main.c
@@ -1,4 +1,4 @@
-/*
+/**
 * @license Apache-2.0
 *
 * Copyright (c) 2024 The Stdlib Authors.
@@ -16,33 +16,19 @@
 * limitations under the License.
 */
 
-// TypeScript Version: 4.1
+#include "stdlib/math/base/special/csc.h"
+#include "stdlib/math/base/special/sin.h"
 
 /**
-* Computes the cosecant of a number.
+* Evaluates the cosecant of a number.
 *
-* @param x - input value (in radians)
-* @returns cosecant
-*
-* @example
-* var v = csc( 0.0 );
-* // returns Infinity
+* @param x    input value (in radians)
+* @return     cosecant
 *
 * @example
-* var v = csc( 3.141592653589793/2.0 );
+* double y = stdlib_base_cos( 3.141592653589793 / 2.0 );
 * // returns 1.0
-*
-* @example
-* var v = csc( -3.141592653589793/6.0 );
-* // returns ~-2.0
-*
-* @example
-* var v = csc( NaN );
-* // returns NaN
 */
-declare function csc( x: number ): number;
-
-
-// EXPORTS //
-
-export = csc;
+double stdlib_base_csc( const double x ) {
+	return 1.0 / stdlib_base_sin( x );
+}

--- a/lib/node_modules/@stdlib/math/base/special/csc/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/csc/test/test.native.js
@@ -1,0 +1,405 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var abs = require( '@stdlib/math/base/special/abs' );
+var PI = require( '@stdlib/constants/float64/pi' );
+var EPS = require( '@stdlib/constants/float64/eps' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var csc = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( csc instanceof Error )
+};
+
+
+// FIXTURES //
+
+var hugeNegative = require( './fixtures/julia/huge_negative.json' );
+var hugePositive = require( './fixtures/julia/huge_positive.json' );
+var veryLargeNegative = require( './fixtures/julia/very_large_negative.json' );
+var veryLargePositive = require( './fixtures/julia/very_large_positive.json' );
+var largeNegative = require( './fixtures/julia/large_negative.json' );
+var largePositive = require( './fixtures/julia/large_positive.json' );
+var mediumNegative = require( './fixtures/julia/medium_negative.json' );
+var mediumPositive = require( './fixtures/julia/medium_positive.json' );
+var smallNegative = require( './fixtures/julia/small_negative.json' );
+var smallPositive = require( './fixtures/julia/small_positive.json' );
+var smaller = require( './fixtures/julia/smaller.json' );
+var tinyNegative = require( './fixtures/julia/tiny_negative.json' );
+var tinyPositive = require( './fixtures/julia/tiny_positive.json' );
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok(true, __filename);
+	t.true(typeof csc, 'function', 'main export is a function');
+	t.end();
+});
+
+tape( 'the function computes the cosecant (huge negative values)', opts, function test( t ) {
+	var expected;
+	var delta;
+	var tol;
+	var x;
+	var y;
+	var i;
+
+	x = hugeNegative.x;
+	expected = hugeNegative.expected;
+
+	for (i = 0; i < x.length; i++) {
+		y = csc( x[ i ] );
+		if (y === expected[ i ]) {
+			t.equal(y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ]);
+		} else {
+			delta = abs(y - expected[ i ]);
+			tol = 1.4 * EPS * abs(expected[ i ]);
+			t.ok(delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.');
+		}
+	}
+	t.end();
+});
+
+tape( 'the function computes the cosecant (huge positive values)', opts, function test( t ) {
+	var expected;
+	var delta;
+	var tol;
+	var x;
+	var y;
+	var i;
+
+	x = hugePositive.x;
+	expected = hugePositive.expected;
+
+	for (i = 0; i < x.length; i++) {
+		y = csc( x[ i ] );
+		if (y === expected[ i ]) {
+			t.equal(y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ]);
+		} else {
+			delta = abs(y - expected[ i ]);
+			tol = 1.4 * EPS * abs(expected[ i ]);
+			t.ok(delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.');
+		}
+	}
+	t.end();
+});
+
+tape( 'the function computes the cosecant (very large positive values)', opts, function test( t ) {
+	var expected;
+	var delta;
+	var tol;
+	var x;
+	var y;
+	var i;
+
+	x = veryLargePositive.x;
+	expected = veryLargePositive.expected;
+
+	for (i = 0; i < x.length; i++) {
+		y = csc( x[ i ] );
+		if (y === expected[ i ]) {
+			t.equal(y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ]);
+		} else {
+			delta = abs(y - expected[ i ]);
+			tol = 1.4 * EPS * abs(expected[ i ]);
+			t.ok(delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.');
+		}
+	}
+	t.end();
+});
+
+tape( 'the function computes the cosecant (very large negative values)', opts, function test( t ) {
+	var expected;
+	var delta;
+	var tol;
+	var x;
+	var y;
+	var i;
+
+	x = veryLargeNegative.x;
+	expected = veryLargeNegative.expected;
+
+	for (i = 0; i < x.length; i++) {
+		y = csc( x[ i ] );
+		if (y === expected[ i ]) {
+			t.equal(y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ]);
+		} else {
+			delta = abs(y - expected[ i ]);
+			tol = 1.4 * EPS * abs(expected[ i ]);
+			t.ok(delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.');
+		}
+	}
+	t.end();
+});
+
+tape( 'the function computes the cosecant (large positive values)', opts, function test( t ) {
+	var expected;
+	var delta;
+	var tol;
+	var x;
+	var y;
+	var i;
+
+	x = largePositive.x;
+	expected = largePositive.expected;
+
+	for (i = 0; i < x.length; i++) {
+		y = csc( x[ i ] );
+		if (y === expected[ i ]) {
+			t.equal(y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ]);
+		} else {
+			delta = abs(y - expected[ i ]);
+			tol = 1.4 * EPS * abs(expected[ i ]);
+			t.ok(delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.');
+		}
+	}
+	t.end();
+});
+
+tape( 'the function computes the cosecant (large negative values)', opts, function test( t ) {
+	var expected;
+	var delta;
+	var tol;
+	var x;
+	var y;
+	var i;
+
+	x = largeNegative.x;
+	expected = largeNegative.expected;
+
+	for (i = 0; i < x.length; i++) {
+		y = csc( x[ i ] );
+		if (y === expected[ i ]) {
+			t.equal(y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ]);
+		} else {
+			delta = abs(y - expected[ i ]);
+			tol = 1.4 * EPS * abs(expected[ i ]);
+			t.ok(delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.');
+		}
+	}
+	t.end();
+});
+
+tape( 'the function computes the cosecant (medium positive values)', opts, function test( t ) {
+	var expected;
+	var delta;
+	var tol;
+	var x;
+	var y;
+	var i;
+
+	x = mediumPositive.x;
+	expected = mediumPositive.expected;
+
+	for (i = 0; i < x.length; i++) {
+		y = csc( x[ i ] );
+		if (y === expected[ i ]) {
+			t.equal(y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ]);
+		} else {
+			delta = abs(y - expected[ i ]);
+			tol = 1.4 * EPS * abs(expected[ i ]);
+			t.ok(delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.');
+		}
+	}
+	t.end();
+});
+
+tape( 'the function computes the cosecant (medium negative values)', opts, function test( t ) {
+	var expected;
+	var delta;
+	var tol;
+	var x;
+	var y;
+	var i;
+
+	x = mediumNegative.x;
+	expected = mediumNegative.expected;
+
+	for (i = 0; i < x.length; i++) {
+		y = csc( x[ i ] );
+		if (y === expected[ i ]) {
+			t.equal(y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ]);
+		} else {
+			delta = abs(y - expected[ i ]);
+			tol = 1.4 * EPS * abs(expected[ i ]);
+			t.ok(delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.');
+		}
+	}
+	t.end();
+});
+
+tape( 'the function computes the cosecant (small positive values)', opts, function test( t ) {
+	var expected;
+	var delta;
+	var tol;
+	var x;
+	var y;
+	var i;
+
+	x = smallPositive.x;
+	expected = smallPositive.expected;
+
+	for (i = 0; i < x.length; i++) {
+		y = csc( x[ i ] );
+		if (y === expected[ i ]) {
+			t.equal(y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ]);
+		} else {
+			delta = abs(y - expected[ i ]);
+			tol = 1.4 * EPS * abs(expected[ i ]);
+			t.ok(delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.');
+		}
+	}
+	t.end();
+});
+
+tape( 'the function computes the cosecant (small negative values)', opts, function test( t ) {
+	var expected;
+	var delta;
+	var tol;
+	var x;
+	var y;
+	var i;
+
+	x = smallNegative.x;
+	expected = smallNegative.expected;
+
+	for (i = 0; i < x.length; i++) {
+		y = csc( x[ i ] );
+		if (y === expected[ i ]) {
+			t.equal(y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ]);
+		} else {
+			delta = abs(y - expected[ i ]);
+			tol = 1.4 * EPS * abs(expected[ i ]);
+			t.ok(delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.');
+		}
+	}
+	t.end();
+});
+
+tape( 'the function computes the cosecant (smaller values)', opts, function test( t ) {
+	var expected;
+	var delta;
+	var tol;
+	var x;
+	var y;
+	var i;
+
+	x = smaller.x;
+	expected = smaller.expected;
+
+	for (i = 0; i < x.length; i++) {
+		y = csc( x[ i ] );
+		if (y === expected[ i ]) {
+			t.equal(y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ]);
+		} else {
+			delta = abs(y - expected[ i ]);
+			tol = 1.4 * EPS * abs(expected[ i ]);
+			t.ok(delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.');
+		}
+	}
+	t.end();
+});
+
+tape( 'the function computes the cosecant (tiny positive values)', opts, function test( t ) {
+	var expected;
+	var delta;
+	var tol;
+	var x;
+	var y;
+	var i;
+
+	x = tinyPositive.x;
+	expected = tinyPositive.expected;
+
+	for (i = 0; i < x.length; i++) {
+		y = csc( x[ i ] );
+		if (y === expected[ i ]) {
+			t.equal(y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ]);
+		} else {
+			delta = abs(y - expected[ i ]);
+			tol = 1.4 * EPS * abs(expected[ i ]);
+			t.ok(delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.');
+		}
+	}
+	t.end();
+});
+
+tape( 'the function computes the cosecant (tiny negative values)', opts, function test( t ) {
+	var expected;
+	var delta;
+	var tol;
+	var x;
+	var y;
+	var i;
+
+	x = tinyNegative.x;
+	expected = tinyNegative.expected;
+
+	for (i = 0; i < x.length; i++) {
+		y = csc( x[ i ] );
+		if (y === expected[ i ]) {
+			t.equal(y, expected[ i ], 'x: ' + x[ i ] + '. E: ' + expected[ i ]);
+		} else {
+			delta = abs(y - expected[ i ]);
+			tol = 1.4 * EPS * abs(expected[ i ]);
+			t.ok(delta <= tol, 'within tolerance. x: ' + x[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.');
+		}
+	}
+	t.end();
+});
+
+tape( 'if provided a multiple of `-pi`, the function does not return `~+infinity` due to floating-point rounding errors', opts, function test( t ) {
+	t.notEqual(csc(-PI), PINF, 'returns expected value');
+	t.end();
+});
+
+tape( 'if provided a multiple of `pi`, the function does not return `~-infinity`', opts, function test( t ) {
+	t.notEqual(csc(PI), NINF, 'returns expected value');
+	t.end();
+});
+
+tape( 'if provided a `NaN`, the function returns `expected value`', opts, function test( t ) {
+	var v = csc(NaN);
+	t.equal(isnan(v), true, 'returns NaN');
+	t.end();
+});
+
+tape( 'if provided `+infinity`, the function returns `expected value`', opts, function test( t ) {
+	var v = csc(PINF);
+	t.equal(isnan(v), true, 'returns NaN');
+	t.end();
+});
+
+tape( 'if provided `-infinity`, the function returns `expected value`', opts, function test( t ) {
+	var v = csc(NINF);
+	t.equal(isnan(v), true, 'returns NaN');
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds C implementation for [`math/base/special/csc`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/csc).
-   rectifies the output of an example:
```
In [2]: csc(3.141592653589793 / 2.0)
Out[2]: 1
```

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves a part of #649.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
