### PR TITLE
docs: use descriptive variable names for `math/base/special/sin`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/sin/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/sin/lib/main.js
@@ -34,8 +34,8 @@
 
 // MODULES //
 
-var ABS_MASK = require( '@stdlib/constants/float64/high-word-abs-mask' );
-var EXPONENT_MASK = require( '@stdlib/constants/float64/high-word-exponent-mask' );
+var HIGH_WORD_ABS_MASK = require( '@stdlib/constants/float64/high-word-abs-mask' );
+var HIGH_WORD_EXPONENT_MASK = require( '@stdlib/constants/float64/high-word-exponent-mask' );
 var getHighWord = require( '@stdlib/number/float64/base/get-high-word' );
 var kernelCos = require( '@stdlib/math/base/special/kernel-cos' );
 var kernelSin = require( '@stdlib/math/base/special/kernel-sin' );
@@ -98,7 +98,7 @@ function sin( x ) {
 	var n;
 
 	ix = getHighWord( x );
-	ix &= ABS_MASK;
+	ix &= HIGH_WORD_ABS_MASK;
 
 	// Case: |x| ~< π/4
 	if ( ix <= PIO4_HIGH_WORD ) {
@@ -109,7 +109,7 @@ function sin( x ) {
 		return kernelSin( x, 0.0 );
 	}
 	// Case: x is NaN or infinity
-	if ( ix >= EXPONENT_MASK ) {
+	if ( ix >= HIGH_WORD_EXPONENT_MASK ) {
 		return NaN;
 	}
 	// Argument reduction...


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   uses descriptive variable names for [`math/base/special/sin`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/sin).
-   This is regarding our discussion at: https://github.com/stdlib-js/stdlib/pull/2368#discussion_r1639052521

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
