### PR TITLE
feat: add boolean dtype support to `array/typed-ctors`

### DIFF
--- a/lib/node_modules/@stdlib/array/typed-ctors/README.md
+++ b/lib/node_modules/@stdlib/array/typed-ctors/README.md
@@ -55,7 +55,7 @@ The function returns constructors for the following data types:
 -   `float64`: double-precision floating-point numbers.
 -   `complex64`: single-precision complex floating-point numbers.
 -   `complex128`: double-precision complex floating-point numbers.
--   `bool`: boolean values
+-   `bool`: boolean values.
 -   `int16`: signed 16-bit integers.
 -   `int32`: signed 32-bit integers.
 -   `int8`: signed 8-bit integers.

--- a/lib/node_modules/@stdlib/array/typed-ctors/README.md
+++ b/lib/node_modules/@stdlib/array/typed-ctors/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2018 The Stdlib Authors.
+Copyright (c) 2024 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -55,6 +55,7 @@ The function returns constructors for the following data types:
 -   `float64`: double-precision floating-point numbers.
 -   `complex64`: single-precision complex floating-point numbers.
 -   `complex128`: double-precision complex floating-point numbers.
+-   `bool`: boolean values
 -   `int16`: signed 16-bit integers.
 -   `int32`: signed 32-bit integers.
 -   `int8`: signed 8-bit integers.

--- a/lib/node_modules/@stdlib/array/typed-ctors/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/typed-ctors/docs/repl.txt
@@ -8,6 +8,7 @@
     - float64: double-precision floating-point numbers.
     - complex64: single-precision complex floating-point numbers.
     - complex128: double-precision complex floating-point numbers.
+    - bool: boolean values.
     - int16: signed 16-bit integers.
     - int32: signed 32-bit integers.
     - int8: signed 8-bit integers.

--- a/lib/node_modules/@stdlib/array/typed-ctors/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/typed-ctors/docs/types/index.d.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 
 import Complex128Array = require( '@stdlib/array/complex128' );
 import Complex64Array = require( '@stdlib/array/complex64' );
+import BooleanArray = require( '@stdlib/array/bool' );
 
 /**
 * Returns a `Float64Array` constructor.
@@ -68,6 +69,18 @@ declare function ctors( dtype: 'complex128' ): typeof Complex128Array;
 * // returns <Function>
 */
 declare function ctors( dtype: 'complex64' ): typeof Complex64Array;
+
+/**
+* Returns a `BooleanArray` constructor.
+*
+* @param dtype - data type
+* @returns constructor
+*
+* @example
+* var ctor = ctors( 'bool' );
+* // returns <Function>
+*/
+declare function ctors( dtype: 'bool' ): typeof BooleanArray;
 
 /**
 * Returns an `Int32Array` constructor.

--- a/lib/node_modules/@stdlib/array/typed-ctors/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/typed-ctors/docs/types/test.ts
@@ -27,6 +27,7 @@ import ctors = require( './index' );
 	ctors( 'float32' ); // $ExpectType Float32ArrayConstructor
 	ctors( 'complex128' ); // $ExpectType Complex128ArrayConstructor
 	ctors( 'complex64' ); // $ExpectType Complex64ArrayConstructor
+	ctors( 'bool' ); // $ExpectType BooleanArrayConstructor
 	ctors( 'int32' ); // $ExpectType Int32ArrayConstructor
 	ctors( 'int16' ); // $ExpectType Int16ArrayConstructor
 	ctors( 'int8' ); // $ExpectType Int8ArrayConstructor

--- a/lib/node_modules/@stdlib/array/typed-ctors/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/typed-ctors/docs/types/test.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/array/typed-ctors/lib/ctors.js
+++ b/lib/node_modules/@stdlib/array/typed-ctors/lib/ctors.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 
 
 // MAIN //
@@ -47,7 +48,8 @@ var ctors = {
 	'uint8': Uint8Array,
 	'uint8c': Uint8ClampedArray,
 	'complex64': Complex64Array,
-	'complex128': Complex128Array
+	'complex128': Complex128Array,
+	'bool': BooleanArray
 };
 
 

--- a/lib/node_modules/@stdlib/array/typed-ctors/test/test.js
+++ b/lib/node_modules/@stdlib/array/typed-ctors/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var isFunction = require( '@stdlib/assert/is-function' );
 var ctors = require( './../lib' );
 
@@ -62,7 +63,8 @@ tape( 'the function returns typed array constructors', function test( t ) {
 		'uint8',
 		'uint8c',
 		'complex64',
-		'complex128'
+		'complex128',
+		'bool'
 	];
 	expected = [
 		Float64Array,
@@ -75,7 +77,8 @@ tape( 'the function returns typed array constructors', function test( t ) {
 		Uint8Array,
 		Uint8ClampedArray,
 		Complex64Array,
-		Complex128Array
+		Complex128Array,
+		BooleanArray
 	];
 	for ( i = 0; i < dtypes.length; i++ ) {
 		ctor = ctors( dtypes[ i ] );


### PR DESCRIPTION
Resolves: Subtask of #2304 

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR will add boolean datatype support in `array/typed-ctors`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
