### PR TITLE
feat: add boolean dtype support in `array/to-json`

### DIFF
--- a/lib/node_modules/@stdlib/array/to-json/README.md
+++ b/lib/node_modules/@stdlib/array/to-json/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2018 The Stdlib Authors.
+Copyright (c) 2024 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -76,6 +76,7 @@ For guidance on reviving a JSON-serialized typed array, see [`reviver()`][@stdli
     -   [`Float32Array`][@stdlib/array/float32]
     -   [`Complex128Array`][@stdlib/array/complex128]
     -   [`Complex64Array`][@stdlib/array/complex64]
+    -   [`BooleanArray`][@stdlib/array/bool]
     -   [`Int32Array`][@stdlib/array/int32]
     -   [`Uint32Array`][@stdlib/array/uint32]
     -   [`Int16Array`][@stdlib/array/int16]
@@ -130,6 +131,7 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var typedarray2json = require( '@stdlib/array/to-json' );
 
 var arr = new Float64Array( [ 5.0, 3.0 ] );
@@ -165,6 +167,15 @@ json = typedarray2json( arr );
     {
         'type': 'Complex64Array',
         'data': [ 5.0, 3.0 ]
+    }
+*/
+
+arr = new BooleanArray( [ true, false ] );
+json = typedarray2json( arr );
+/* returns
+    {
+        'type': 'BooleanArray',
+        'data': [ 1, 0 ]
     }
 */
 
@@ -271,6 +282,8 @@ json = typedarray2json( arr );
 [@stdlib/array/complex128]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/complex128
 
 [@stdlib/array/complex64]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/complex64
+
+[@stdlib/array/bool]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/bool
 
 [@stdlib/array/int32]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/int32
 

--- a/lib/node_modules/@stdlib/array/to-json/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/to-json/docs/repl.txt
@@ -15,6 +15,7 @@
     - Uint8ClampedArray
     - Complex64Array
     - Complex128Array
+    - BooleanArray
 
     The returned JSON object has the following properties:
 

--- a/lib/node_modules/@stdlib/array/to-json/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/to-json/docs/types/index.d.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/array/to-json/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/to-json/docs/types/index.d.ts
@@ -25,7 +25,7 @@ import { RealOrComplexTypedArray } from '@stdlib/types/array';
 /**
 * Typed array data type.
 */
-type dtype = 'Float64Array' | 'Float32Array' | 'Int32Array' | 'Uint32Array' | 'Int16Array' | 'Uint16Array' | 'Int8Array' | 'Uint8Array' | 'Uint8ClampedArray' | 'Complex64Array' | 'Complex128Array';
+type dtype = 'Float64Array' | 'Float32Array' | 'Int32Array' | 'Uint32Array' | 'Int16Array' | 'Uint16Array' | 'Int8Array' | 'Uint8Array' | 'Uint8ClampedArray' | 'Complex64Array' | 'Complex128Array' | 'BooleanArray';
 
 /**
 * JSON representation of typed array.

--- a/lib/node_modules/@stdlib/array/to-json/examples/index.js
+++ b/lib/node_modules/@stdlib/array/to-json/examples/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var typedarray2json = require( './../lib' );
 
 var arr = new Float64Array( [ 5.0, 3.0 ] );
@@ -65,6 +66,15 @@ console.log( typedarray2json( arr ) );
 		'type': 'Complex64Array',
 		'data': [ 5.0, -3.0 ]
 	}
+*/
+
+arr = new BooleanArray( [ true, false ] );
+console.log( typedarray2json( arr ) );
+/* =>
+    {
+        'type': 'BooleanArray',
+        'data': [ 1, 0 ]
+    }
 */
 
 arr = new Int32Array( [ -5, 3 ] );

--- a/lib/node_modules/@stdlib/array/to-json/lib/ctors.js
+++ b/lib/node_modules/@stdlib/array/to-json/lib/ctors.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ var Float32Array = require( '@stdlib/array/float32' );
 var Float64Array = require( '@stdlib/array/float64' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 
 
 // MAIN //
@@ -46,7 +47,8 @@ var CTORS = [
 	[ Uint8Array, 'Uint8Array' ],
 	[ Uint8ClampedArray, 'Uint8ClampedArray' ],
 	[ Complex64Array, 'Complex64Array' ],
-	[ Complex128Array, 'Complex128Array' ]
+	[ Complex128Array, 'Complex128Array' ],
+	[ BooleanArray, 'BooleanArray' ]
 ];
 
 

--- a/lib/node_modules/@stdlib/array/to-json/lib/main.js
+++ b/lib/node_modules/@stdlib/array/to-json/lib/main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -22,8 +22,10 @@
 
 var isTypedArray = require( '@stdlib/assert/is-typed-array' );
 var isComplexTypedArray = require( '@stdlib/assert/is-complex-typed-array' );
+var isBooleanArray = require( '@stdlib/assert/is-booleanarray' );
 var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
 var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
+var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
 var format = require( '@stdlib/string/format' );
 var typeName = require( './type.js' );
 
@@ -63,6 +65,8 @@ function typedarray2json( arr ) {
 		} else { // arr.BYTES_PER_ELEMENT === 16
 			data = reinterpret128( arr, 0 );
 		}
+	} else if ( isBooleanArray( arr ) ) {
+		data = reinterpretBoolean( arr, 0 );
 	} else {
 		throw new TypeError( format( 'invalid argument. Must provide a typed array. Value: `%s`.', arr ) );
 	}

--- a/lib/node_modules/@stdlib/array/to-json/test/test.js
+++ b/lib/node_modules/@stdlib/array/to-json/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ var Float32Array = require( '@stdlib/array/float32' );
 var Float64Array = require( '@stdlib/array/float64' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var toJSON = require( './../lib' );
 
 
@@ -119,7 +120,8 @@ tape( 'the JSON object includes a typed array type', function test( t ) {
 		new Uint8Array( 1 ),
 		new Uint8ClampedArray( 1 ),
 		new Complex64Array( 1 ),
-		new Complex128Array( 1 )
+		new Complex128Array( 1 ),
+		new BooleanArray( 1 )
 	];
 
 	expected = [
@@ -133,7 +135,8 @@ tape( 'the JSON object includes a typed array type', function test( t ) {
 		'Uint8Array',
 		'Uint8ClampedArray',
 		'Complex64Array',
-		'Complex128Array'
+		'Complex128Array',
+		'BooleanArray'
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
@@ -160,7 +163,8 @@ tape( 'the JSON object includes a data property', function test( t ) {
 		new Uint8Array( [ 8.0 ] ),
 		new Uint8ClampedArray( [ 9.0 ] ),
 		new Complex64Array( [ 1.0, 2.0 ] ),
-		new Complex128Array( [ 1.0, 2.0 ] )
+		new Complex128Array( [ 1.0, 2.0 ] ),
+		new BooleanArray( [ true, false ] )
 	];
 
 	expected = [
@@ -174,7 +178,8 @@ tape( 'the JSON object includes a data property', function test( t ) {
 		[ 8.0 ],
 		[ 9.0 ],
 		[ 1.0, 2.0 ],
-		[ 1.0, 2.0 ]
+		[ 1.0, 2.0 ],
+		[ 1, 0 ]
 	];
 
 	for ( i = 0; i < values.length; i++ ) {

--- a/lib/node_modules/@stdlib/array/to-json/test/test.type.js
+++ b/lib/node_modules/@stdlib/array/to-json/test/test.type.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ var Float32Array = require( '@stdlib/array/float32' );
 var Float64Array = require( '@stdlib/array/float64' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var typeName = require( './../lib/type.js' );
 
 
@@ -60,7 +61,8 @@ tape( 'if provided a typed array, the function returns the closest typed array t
 		new Uint8Array( [ 5, 3 ] ),
 		new Uint8ClampedArray( [ 5, 3 ] ),
 		new Complex64Array( [ 5.0, 3.0 ] ),
-		new Complex128Array( [ 5.0, 3.0 ] )
+		new Complex128Array( [ 5.0, 3.0 ] ),
+		new BooleanArray( [ true, false ] )
 	];
 
 	expected = [
@@ -74,7 +76,8 @@ tape( 'if provided a typed array, the function returns the closest typed array t
 		'Uint8Array',
 		'Uint8ClampedArray',
 		'Complex64Array',
-		'Complex128Array'
+		'Complex128Array',
+		'BooleanArray'
 	];
 
 	for ( i = 0; i < values.length; i++ ) {
@@ -104,7 +107,8 @@ tape( 'if provided a typed array from a different realm, the function returns th
 		new Uint8Array( [ 5, 3 ] ),
 		new Uint8ClampedArray( [ 5, 3 ] ),
 		new Complex64Array( [ 5.0, 3.0 ] ),
-		new Complex128Array( [ 5.0, 3.0 ] )
+		new Complex128Array( [ 5.0, 3.0 ] ),
+		new BooleanArray( [ true, false ] )
 	];
 
 	expected = [
@@ -118,7 +122,8 @@ tape( 'if provided a typed array from a different realm, the function returns th
 		'Uint8Array',
 		'Uint8ClampedArray',
 		'Complex64Array',
-		'Complex128Array'
+		'Complex128Array',
+		'BooleanArray'
 	];
 
 	for ( i = 0; i < values.length; i++ ) {


### PR DESCRIPTION
Resolves: Subtask of #2304 

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR will add boolean datatype support in `array/to-json`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
