### PR TITLE
feat: add boolean dtype support to `array/base/assert/has-same-values`

### DIFF
--- a/lib/node_modules/@stdlib/array/base/assert/has-same-values/lib/main.js
+++ b/lib/node_modules/@stdlib/array/base/assert/has-same-values/lib/main.js
@@ -152,7 +152,7 @@ function hasSameValues( x, y ) {
 	if ( xo.accessorProtocol || yo.accessorProtocol ) {
 		FLG = 2;
 
-		// If provided boolean arrays, reinterpret the array to avoid using accessors to access array elements...
+		// If provided boolean arrays, reinterpret the arrays to avoid using accessors to access array elements...
 		if ( isBooleanArray( x ) ) {
 			if ( isBooleanArray( y ) ) {
 				return internal( reinterpretBoolean( x, 0 ), reinterpretBoolean( y, 0 ) );

--- a/lib/node_modules/@stdlib/array/base/assert/has-same-values/lib/main.js
+++ b/lib/node_modules/@stdlib/array/base/assert/has-same-values/lib/main.js
@@ -152,7 +152,7 @@ function hasSameValues( x, y ) {
 	if ( xo.accessorProtocol || yo.accessorProtocol ) {
 		FLG = 2;
 
-		// If provided a boolean array, reinterpret as an uint8 typed array and test...
+		// If provided boolean arrays, reinterpret the array to avoid using accessors to access array elements...
 		if ( isBooleanArray( x ) ) {
 			if ( isBooleanArray( y ) ) {
 				return internal( reinterpretBoolean( x, 0 ), reinterpretBoolean( y, 0 ) );

--- a/lib/node_modules/@stdlib/array/base/assert/has-same-values/lib/main.js
+++ b/lib/node_modules/@stdlib/array/base/assert/has-same-values/lib/main.js
@@ -159,7 +159,6 @@ function hasSameValues( x, y ) {
 			}
 			return accessors( xo, yo );
 		}
-
 		// If provided a complex number array, reinterpret as a real typed array and test interleaved real and imaginary components...
 		if ( isComplex128Array( x ) ) {
 			xr = reinterpret128( x, 0 );

--- a/lib/node_modules/@stdlib/array/base/assert/has-same-values/lib/main.js
+++ b/lib/node_modules/@stdlib/array/base/assert/has-same-values/lib/main.js
@@ -22,9 +22,11 @@
 
 var isComplex128Array = require( '@stdlib/array/base/assert/is-complex128array' );
 var isComplex64Array = require( '@stdlib/array/base/assert/is-complex64array' );
+var isBooleanArray = require( '@stdlib/array/base/assert/is-booleanarray' );
 var arraylike2object = require( '@stdlib/array/base/arraylike2object' );
 var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
 var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
+var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
 var isSameValue = require( '@stdlib/assert/is-same-value' );
 
 
@@ -149,6 +151,14 @@ function hasSameValues( x, y ) {
 	yo = arraylike2object( y );
 	if ( xo.accessorProtocol || yo.accessorProtocol ) {
 		FLG = 2;
+
+		// If provided a boolean array, reinterpret as an uint8 typed array and test...
+		if ( isBooleanArray( x ) ) {
+			if ( isBooleanArray( y ) ) {
+				return internal( reinterpretBoolean( x, 0 ), reinterpretBoolean( y, 0 ) );
+			}
+			return accessors( xo, yo );
+		}
 
 		// If provided a complex number array, reinterpret as a real typed array and test interleaved real and imaginary components...
 		if ( isComplex128Array( x ) ) {

--- a/lib/node_modules/@stdlib/array/base/assert/has-same-values/test/test.js
+++ b/lib/node_modules/@stdlib/array/base/assert/has-same-values/test/test.js
@@ -25,6 +25,7 @@ var AccessorArray = require( '@stdlib/array/base/accessor' );
 var Float64Array = require( '@stdlib/array/float64' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var hasSameValues = require( './../lib' );
 
 
@@ -105,6 +106,23 @@ tape( 'if provided empty collections, the function returns `true` (mixed)', func
 
 	x = new Float64Array( [] );
 	y = [];
+	out = hasSameValues( x, y );
+	t.strictEqual( out, true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided empty collections, the function returns `true` (boolean array)', function test( t ) {
+	var out;
+	var x;
+	var y;
+
+	x = new BooleanArray( [] );
+	out = hasSameValues( x, x );
+	t.strictEqual( out, true, 'returns expected value' );
+
+	x = new BooleanArray( [] );
+	y = new BooleanArray( [] );
 	out = hasSameValues( x, y );
 	t.strictEqual( out, true, 'returns expected value' );
 
@@ -200,6 +218,23 @@ tape( 'the function returns `true` if both arrays have the same values (mixed)',
 
 	x = new Float64Array( [ 0.0, 2.0, 0.0 ] );
 	y = [ 0.0, 2.0, 0.0 ];
+	out = hasSameValues( x, y );
+	t.strictEqual( out, true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `true` if both arrays have the same values (boolean array)', function test( t ) {
+	var out;
+	var x;
+	var y;
+
+	x = new BooleanArray( [ true, false, true ] );
+	out = hasSameValues( x, x );
+	t.strictEqual( out, true, 'returns expected value' );
+
+	x = new BooleanArray( [ true, false, true ] );
+	y = new BooleanArray( [ true, false, true ] );
 	out = hasSameValues( x, y );
 	t.strictEqual( out, true, 'returns expected value' );
 
@@ -324,6 +359,19 @@ tape( 'the function returns `false` if both arrays do not have the same values (
 
 	x = new Float64Array( [ 0.0, 0.0, 1.0, 0.0 ] );
 	y = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0 ] );
+	out = hasSameValues( x, y );
+	t.strictEqual( out, false, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `false` if both arrays do not have the same values (boolean array)', function test( t ) {
+	var out;
+	var x;
+	var y;
+
+	x = new BooleanArray( [ true, false, false, true ] );
+	y = new BooleanArray( [ true, true, false, false ] );
 	out = hasSameValues( x, y );
 	t.strictEqual( out, false, 'returns expected value' );
 


### PR DESCRIPTION
Resolves: Subtask of #2304 

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR will add boolean datatype support in `array/base/assert/has-same-values`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
