### PR TITLE
docs: use correct function name in example in `math/base/special/hacoversin`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/hacoversin/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/hacoversin/src/main.c
@@ -26,7 +26,7 @@
 * @return     half-value coversed sine
 *
 * @example
-* double y = stdlib_base_coversin( 0.0 );
+* double y = stdlib_base_hacoversin( 0.0 );
 * // returns 0.5
 */
 double stdlib_base_hacoversin( const double x ) {


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   uses the correct function name in the example for [`math/base/special/hacoversin`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/hacoversin).

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
