### PR TITLE
fix: prevent property access if properties couldn't be resolved when syntax highlighting in the REPL

### DIFF
--- a/lib/node_modules/@stdlib/repl/lib/tokenizer.js
+++ b/lib/node_modules/@stdlib/repl/lib/tokenizer.js
@@ -270,6 +270,7 @@ function tokenizer( line, context ) {
 	function resolveMemberExpression( node, compute ) {
 		var properties = linkedList();
 		var property;
+		var computed;
 		var locals;
 		var obj;
 
@@ -350,7 +351,12 @@ function tokenizer( line, context ) {
 			}
 			// Case: `foo[a.b].bar` - recursively compute the internal `MemberExpression`...
 			if ( property.value.type === 'MemberExpression' ) {
-				obj = obj[ resolveMemberExpression( property.value, true ) ];
+				computed = resolveMemberExpression( property.value, true );
+				if ( !isLiteralType( typeof computed ) ) {
+					// Couldn't compute the internal `MemberExpression` into a definite name:
+					break;
+				}
+				obj = obj[ computed ];
 				if ( !obj ) {
 					// Property not found in context:
 					break;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   prevents property access if the internal `MemberExpression` can't be resolved into a definite property name (without any script execution) when tokenizing.
- For `a[b.c]`, if `b.c` doesn't correspond to a literal value in context, (say it's a function or an object), then no point in trying to compute `a[Function]`. To actually be able to compute it, the function (`b.c`) needs to be eagerly evaluated to resolve it into a definite literal name.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
