### PR TITLE
test: add missing tests for `math/base/special/tand`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/tand/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/tand/test/test.js
@@ -108,3 +108,15 @@ tape( 'if provided `-infinity`, the function returns `NaN`', function test( t ) 
 	t.equal( isnan( v ), true, 'returns NaN' );
 	t.end();
 });
+
+tape( 'if provided `90.0`, the function returns `Infinity`', function test( t ) {
+	var v = tand( 90.0 );
+	t.equal( v, PINF, 'returns expected value' );
+	t.end();
+});
+
+tape( 'if provided `180.0`, the function returns `Infinity`', function test( t ) {
+	var v = tand( 180.0 );
+	t.equal( v, 0.0, 'returns expected value' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/tand/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/tand/test/test.native.js
@@ -117,3 +117,15 @@ tape( 'if provided `-infinity`, the function returns `NaN`', opts, function test
 	t.equal( isnan( v ), true, 'returns expected value' );
 	t.end();
 });
+
+tape( 'if provided `90.0`, the function returns `Infinity`', opts, function test( t ) {
+	var v = tand( 90.0 );
+	t.equal( v, PINF, 'returns expected value' );
+	t.end();
+});
+
+tape( 'if provided `180.0`, the function returns `Infinity`', opts, function test( t ) {
+	var v = tand( 180.0 );
+	t.equal( v, 0.0, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   addresses the discussion at https://github.com/stdlib-js/stdlib/commit/cb7d8790c02f7ce9df7d5c22e662d74ad9b95cd9#commitcomment-143364024
- adds missing tests for [`math/base/special/tand`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/tand). We get `100%` code coverage now.

<img width="1710" alt="Screenshot 2024-06-21 at 09 14 23" src="https://github.com/stdlib-js/stdlib/assets/67432819/d03b7da1-4ff1-4098-b435-24eff12e108b">

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
