### PR TITLE
feat: add boolean dtype support to `array/typed`

### DIFF
--- a/lib/node_modules/@stdlib/array/typed/README.md
+++ b/lib/node_modules/@stdlib/array/typed/README.md
@@ -42,7 +42,7 @@ var typedarray = require( '@stdlib/array/typed' );
 
 #### typedarray( \[dtype] )
 
-Creates a [typed array][mdn-typed-array] having a specified data type [`dtype`][@stdlib/array/typed-dtypes].
+Creates a [typed array][mdn-typed-array] having a specified [data type][@stdlib/array/typed-dtypes].
 
 ```javascript
 var arr = typedarray();

--- a/lib/node_modules/@stdlib/array/typed/README.md
+++ b/lib/node_modules/@stdlib/array/typed/README.md
@@ -42,29 +42,14 @@ var typedarray = require( '@stdlib/array/typed' );
 
 #### typedarray( \[dtype] )
 
-Creates a [typed array][mdn-typed-array] having a specified data type `dtype`.
+Creates a [typed array][mdn-typed-array] having a specified data type [`dtype`][@stdlib/array/typed-dtypes].
 
 ```javascript
 var arr = typedarray();
 // returns <Float64Array>
 ```
 
-The function recognizes the following data types:
-
--   `float64`: double-precision floating-point numbers (IEEE 754)
--   `float32`: single-precision floating-point numbers (IEEE 754)
--   `complex128`: double-precision complex floating-point numbers
--   `complex64`: single-precision complex floating-point numbers
--   `bool`: boolean values
--   `int32`: 32-bit two's complement signed integers
--   `uint32`: 32-bit unsigned integers
--   `int16`: 16-bit two's complement signed integers
--   `uint16`: 16-bit unsigned integers
--   `int8`: 8-bit two's complement signed integers
--   `uint8`: 8-bit unsigned integers
--   `uint8c`: 8-bit unsigned integers clamped to `0-255`
-
-By default, the output [typed array][mdn-typed-array] data type is `float64`. To specify an alternative data type, provide a `dtype` argument.
+By default, the output [typed array][mdn-typed-array] data type is `float64`. To specify an alternative data type, provide a [`dtype`][@stdlib/array/typed-dtypes] argument.
 
 ```javascript
 var arr = typedarray( 'int32' );
@@ -110,7 +95,7 @@ var arr2 = typedarray( [ 0.5, 0.5, 0.5 ], 'float32' );
 // returns <Float32Array>[ 0.5, 0.5, 0.5 ]
 ```
 
-If `dtype` is complex number data type and an array-like object contains interleaved real and imaginary components, the array-like object must have a length which is a multiple of two.
+If [`dtype`][@stdlib/array/typed-dtypes] is complex number data type and an array-like object contains interleaved real and imaginary components, the array-like object must have a length which is a multiple of two.
 
 #### typedarray( buffer\[, byteOffset\[, length]]\[, dtype] )
 
@@ -149,7 +134,7 @@ var arr6 = typedarray( buf, 10, 4, 'int16' );
 
 ## Notes
 
--   When providing a complex number array, if `dtype` is unspecified or the specified data type is not a complex number data type, the returned array contains interleaved real and imaginary components.
+-   When providing a complex number array, if [`dtype`][@stdlib/array/typed-dtypes] is unspecified or the specified data type is not a complex number data type, the returned array contains interleaved real and imaginary components.
 
 </section>
 
@@ -220,6 +205,8 @@ console.log( arr );
 [mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
 
 [mdn-arraybuffer]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer
+
+[@stdlib/array/typed-dtypes]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/typed-dtypes
 
 <!-- <related-links> -->
 

--- a/lib/node_modules/@stdlib/array/typed/README.md
+++ b/lib/node_modules/@stdlib/array/typed/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2018 The Stdlib Authors.
+Copyright (c) 2024 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -55,6 +55,7 @@ The function recognizes the following data types:
 -   `float32`: single-precision floating-point numbers (IEEE 754)
 -   `complex128`: double-precision complex floating-point numbers
 -   `complex64`: single-precision complex floating-point numbers
+-   `bool`: boolean values
 -   `int32`: 32-bit two's complement signed integers
 -   `uint32`: 32-bit unsigned integers
 -   `int16`: 16-bit two's complement signed integers
@@ -197,6 +198,7 @@ console.log( arr );
 
 -   <span class="package-name">[`@stdlib/array/complex128`][@stdlib/array/complex128]</span><span class="delimiter">: </span><span class="description">Complex128Array.</span>
 -   <span class="package-name">[`@stdlib/array/complex64`][@stdlib/array/complex64]</span><span class="delimiter">: </span><span class="description">Complex64Array.</span>
+-   <span class="package-name">[`@stdlib/array/bool`][@stdlib/array/bool]</span><span class="delimiter">: </span><span class="description">BooleanArray.</span>
 -   <span class="package-name">[`@stdlib/array/float64`][@stdlib/array/float64]</span><span class="delimiter">: </span><span class="description">Float64Array.</span>
 -   <span class="package-name">[`@stdlib/array/float32`][@stdlib/array/float32]</span><span class="delimiter">: </span><span class="description">Float32Array.</span>
 -   <span class="package-name">[`@stdlib/array/int32`][@stdlib/array/int32]</span><span class="delimiter">: </span><span class="description">Int32Array.</span>
@@ -224,6 +226,8 @@ console.log( arr );
 [@stdlib/array/complex128]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/complex128
 
 [@stdlib/array/complex64]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/complex64
+
+[@stdlib/array/bool]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/bool
 
 [@stdlib/array/float64]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/float64
 

--- a/lib/node_modules/@stdlib/array/typed/README.md
+++ b/lib/node_modules/@stdlib/array/typed/README.md
@@ -18,7 +18,7 @@ limitations under the License.
 
 -->
 
-# Typed Arrays
+# typedarray
 
 > Create a typed array.
 

--- a/lib/node_modules/@stdlib/array/typed/README.md
+++ b/lib/node_modules/@stdlib/array/typed/README.md
@@ -183,7 +183,6 @@ console.log( arr );
 
 -   <span class="package-name">[`@stdlib/array/complex128`][@stdlib/array/complex128]</span><span class="delimiter">: </span><span class="description">Complex128Array.</span>
 -   <span class="package-name">[`@stdlib/array/complex64`][@stdlib/array/complex64]</span><span class="delimiter">: </span><span class="description">Complex64Array.</span>
--   <span class="package-name">[`@stdlib/array/bool`][@stdlib/array/bool]</span><span class="delimiter">: </span><span class="description">BooleanArray.</span>
 -   <span class="package-name">[`@stdlib/array/float64`][@stdlib/array/float64]</span><span class="delimiter">: </span><span class="description">Float64Array.</span>
 -   <span class="package-name">[`@stdlib/array/float32`][@stdlib/array/float32]</span><span class="delimiter">: </span><span class="description">Float32Array.</span>
 -   <span class="package-name">[`@stdlib/array/int32`][@stdlib/array/int32]</span><span class="delimiter">: </span><span class="description">Int32Array.</span>
@@ -213,8 +212,6 @@ console.log( arr );
 [@stdlib/array/complex128]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/complex128
 
 [@stdlib/array/complex64]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/complex64
-
-[@stdlib/array/bool]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/bool
 
 [@stdlib/array/float64]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/float64
 

--- a/lib/node_modules/@stdlib/array/typed/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/array/typed/benchmark/benchmark.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isTypedArray = require( '@stdlib/assert/is-typed-array' );
 var isComplexTypedArray = require( '@stdlib/assert/is-complex-typed-array' );
+var isBooleanArray = require( '@stdlib/assert/is-booleanarray' );
 var pkg = require( './../package.json' ).name;
 var typedarray = require( './../lib' );
 
@@ -114,6 +115,24 @@ bench( pkg+':dtype=complex64', function benchmark( b ) {
 	b.toc();
 	if ( !isComplexTypedArray( arr ) ) {
 		b.fail( 'should return a complex typed array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+':dtype=bool', function benchmark( b ) {
+	var arr;
+	var i;
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = typedarray( 0, 'bool' );
+		if ( arr.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !isBooleanArray( arr ) ) {
+		b.fail( 'should return a boolean array' );
 	}
 	b.pass( 'benchmark finished' );
 	b.end();

--- a/lib/node_modules/@stdlib/array/typed/benchmark/benchmark.length.bool.js
+++ b/lib/node_modules/@stdlib/array/typed/benchmark/benchmark.length.bool.js
@@ -1,0 +1,93 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isBooleanArray = require( '@stdlib/assert/is-booleanarray' );
+var pkg = require( './../package.json' ).name;
+var typedarray = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var arr;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			arr = typedarray( len, 'bool' );
+			if ( arr.length !== len ) {
+				b.fail( 'unexpected length' );
+			}
+		}
+		b.toc();
+		if ( !isBooleanArray( arr ) ) {
+			b.fail( 'should return a boolean array' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':dtype=bool,len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/typed/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/typed/docs/repl.txt
@@ -8,6 +8,7 @@
     - float32: single-precision floating-point numbers (IEEE 754)
     - complex128: double-precision complex floating-point numbers
     - complex64: single-precision complex floating-point numbers
+    - bool: boolean values
     - int32: 32-bit two's complement signed integers
     - uint32: 32-bit unsigned integers
     - int16: 16-bit two's complement signed integers

--- a/lib/node_modules/@stdlib/array/typed/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/typed/docs/repl.txt
@@ -2,23 +2,6 @@
 {{alias}}( [dtype] )
     Creates a typed array.
 
-    The function supports the following data types:
-
-    - float64: double-precision floating-point numbers (IEEE 754)
-    - float32: single-precision floating-point numbers (IEEE 754)
-    - complex128: double-precision complex floating-point numbers
-    - complex64: single-precision complex floating-point numbers
-    - bool: boolean values
-    - int32: 32-bit two's complement signed integers
-    - uint32: 32-bit unsigned integers
-    - int16: 16-bit two's complement signed integers
-    - uint16: 16-bit unsigned integers
-    - int8: 8-bit two's complement signed integers
-    - uint8: 8-bit unsigned integers
-    - uint8c: 8-bit unsigned integers clamped to 0-255
-
-    The default typed array data type is `float64`.
-
     Parameters
     ----------
     dtype: string (optional)

--- a/lib/node_modules/@stdlib/array/typed/lib/main.js
+++ b/lib/node_modules/@stdlib/array/typed/lib/main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
 var ctors = require( '@stdlib/array/typed-ctors' );
 var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
 var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
+var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
 var defaults = require( '@stdlib/array/defaults' );
 var format = require( '@stdlib/string/format' );
 
@@ -33,6 +34,7 @@ var format = require( '@stdlib/string/format' );
 var DEFAULT_DTYPE = defaults.get( 'dtypes.default' );
 var Complex64Array = ctors( 'complex64' );
 var Complex128Array = ctors( 'complex128' );
+var BooleanArray = ctors( 'bool' );
 
 
 // MAIN //
@@ -147,6 +149,8 @@ function typedarray() {
 			arg = reinterpret64( arg, 0 );
 		} else if ( arg instanceof Complex128Array ) {
 			arg = reinterpret128( arg, 0 );
+		} else if ( arg instanceof BooleanArray ) {
+			arg = reinterpretBoolean( arg, 0 );
 		}
 		return new ctor( arg );
 	}

--- a/lib/node_modules/@stdlib/array/typed/test/test.js
+++ b/lib/node_modules/@stdlib/array/typed/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -32,10 +32,12 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex128Array = require( '@stdlib/array/complex128' );
 var Complex64Array = require( '@stdlib/array/complex64' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var ArrayBuffer = require( '@stdlib/array/buffer' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
 var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
 var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
+var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
 var typedarray = require( './../lib' );
 
 
@@ -320,6 +322,13 @@ tape( 'the function returns a typed array (dtype=complex64)', function test( t )
 	t.end();
 });
 
+tape( 'the function returns a typed array (dtype=bool)', function test( t ) {
+	var arr = typedarray( 'bool' );
+	t.strictEqual( instanceOf( arr, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( arr.length, 0, 'returns expected value' );
+	t.end();
+});
+
 tape( 'the function returns a typed array (dtype=int32)', function test( t ) {
 	var arr = typedarray( 'int32' );
 	t.strictEqual( instanceOf( arr, Int32Array ), true, 'returns expected value' );
@@ -400,6 +409,13 @@ tape( 'the function returns a typed array (dtype=complex128, length)', function 
 tape( 'the function returns a typed array (dtype=complex64, length)', function test( t ) {
 	var arr = typedarray( 10, 'complex64' );
 	t.strictEqual( instanceOf( arr, Complex64Array ), true, 'returns expected value' );
+	t.strictEqual( arr.length, 10, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns a typed array (dtype=bool, length)', function test( t ) {
+	var arr = typedarray( 10, 'bool' );
+	t.strictEqual( instanceOf( arr, BooleanArray ), true, 'returns expected value' );
 	t.strictEqual( arr.length, 10, 'returns expected value' );
 	t.end();
 });
@@ -516,6 +532,25 @@ tape( 'the function returns a typed array (dtype=complex64, array)', function te
 	t.strictEqual( out.length, 2, 'returns expected value' );
 
 	view = reinterpret64( out, 0 );
+	t.strictEqual( view[ 0 ], arr[ 0 ], 'returns expected value' );
+	t.strictEqual( view[ 1 ], arr[ 1 ], 'returns expected value' );
+	t.strictEqual( view[ 2 ], arr[ 2 ], 'returns expected value' );
+	t.strictEqual( view[ 3 ], arr[ 3 ], 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a typed array (dtype=bool, array)', function test( t ) {
+	var view;
+	var arr;
+	var out;
+
+	arr = [ 1, 0, 0, 1 ];
+	out = typedarray( arr, 'bool' );
+	t.strictEqual( instanceOf( out, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( out.length, 4, 'returns expected value' );
+
+	view = reinterpretBoolean( out, 0 );
 	t.strictEqual( view[ 0 ], arr[ 0 ], 'returns expected value' );
 	t.strictEqual( view[ 1 ], arr[ 1 ], 'returns expected value' );
 	t.strictEqual( view[ 2 ], arr[ 2 ], 'returns expected value' );
@@ -664,6 +699,25 @@ tape( 'the function returns a typed array (dtype=complex64, typed array)', funct
 	t.strictEqual( out.length, 2, 'returns expected value' );
 
 	view = reinterpret64( out, 0 );
+	t.strictEqual( view[ 0 ], arr[ 0 ], 'returns expected value' );
+	t.strictEqual( view[ 1 ], arr[ 1 ], 'returns expected value' );
+	t.strictEqual( view[ 2 ], arr[ 2 ], 'returns expected value' );
+	t.strictEqual( view[ 3 ], arr[ 3 ], 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a typed array (dtype=bool, typed array)', function test( t ) {
+	var view;
+	var arr;
+	var out;
+
+	arr = new Uint8Array( [ 1, 0, 1, 0 ] );
+	out = typedarray( arr, 'bool' );
+	t.strictEqual( instanceOf( out, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( out.length, 4, 'returns expected value' );
+
+	view = reinterpretBoolean( out, 0 );
 	t.strictEqual( view[ 0 ], arr[ 0 ], 'returns expected value' );
 	t.strictEqual( view[ 1 ], arr[ 1 ], 'returns expected value' );
 	t.strictEqual( view[ 2 ], arr[ 2 ], 'returns expected value' );
@@ -1043,6 +1097,23 @@ tape( 'the function returns a typed array (dtype=complex64, arraybuffer)', funct
 	t.end();
 });
 
+tape( 'the function returns a typed array (dtype=bool, arraybuffer)', function test( t ) {
+	var view;
+	var buf;
+	var out;
+
+	buf = new ArrayBuffer( 2 );
+	out = typedarray( buf, 'bool' );
+	t.strictEqual( instanceOf( out, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( out.length, 2, 'returns expected value' );
+
+	view = reinterpretBoolean( out, 0 );
+	t.strictEqual( view[ 0 ], 0, 'returns expected value' );
+	t.strictEqual( view[ 1 ], 0, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function returns a typed array (dtype=int32, arraybuffer)', function test( t ) {
 	var buf = new ArrayBuffer( 8 );
 	var out = typedarray( buf, 'int32' );
@@ -1198,6 +1269,22 @@ tape( 'the function returns a typed array (dtype=complex64, arraybuffer, byteoff
 	view = reinterpret64( out, 0 );
 	t.strictEqual( view[ 0 ], 0.0, 'returns expected value' );
 	t.strictEqual( view[ 1 ], 0.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a typed array (dtype=bool, arraybuffer, byteoffset)', function test( t ) {
+	var view;
+	var buf;
+	var out;
+
+	buf = new ArrayBuffer( 2 );
+	out = typedarray( buf, 1, 'bool' );
+	t.strictEqual( instanceOf( out, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( out.length, 1, 'returns expected value' );
+
+	view = reinterpretBoolean( out, 0 );
+	t.strictEqual( view[ 0 ], 0, 'returns expected value' );
 
 	t.end();
 });
@@ -1376,6 +1463,23 @@ tape( 'the function returns a typed array (dtype=complex64, arraybuffer, byteoff
 	t.strictEqual( view[ 1 ], 0.0, 'returns expected value' );
 	t.strictEqual( view[ 2 ], 0.0, 'returns expected value' );
 	t.strictEqual( view[ 3 ], 0.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a typed array (dtype=bool, arraybuffer, byteoffset, length)', function test( t ) {
+	var view;
+	var buf;
+	var out;
+
+	buf = new ArrayBuffer( 4 );
+	out = typedarray( buf, 1, 2, 'bool' );
+	t.strictEqual( instanceOf( out, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( out.length, 2, 'returns expected value' );
+
+	view = reinterpretBoolean( out, 0 );
+	t.strictEqual( view[ 0 ], 0, 'returns expected value' );
+	t.strictEqual( view[ 1 ], 0, 'returns expected value' );
 
 	t.end();
 });


### PR DESCRIPTION
Resolves: Subtask of #2304 

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR will add boolean datatype support in `array/typed`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
