### PR TITLE
feat: add boolean dtype support to `array/reviver`

### DIFF
--- a/lib/node_modules/@stdlib/array/reviver/lib/ctors.js
+++ b/lib/node_modules/@stdlib/array/reviver/lib/ctors.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 
 
 // MAIN //
@@ -46,7 +47,8 @@ var ctors = {
 	'Uint8Array': Uint8Array,
 	'Uint8ClampedArray': Uint8ClampedArray,
 	'Complex64Array': Complex64Array,
-	'Complex128Array': Complex128Array
+	'Complex128Array': Complex128Array,
+	'BooleanArray': BooleanArray
 };
 
 

--- a/lib/node_modules/@stdlib/array/reviver/test/test.js
+++ b/lib/node_modules/@stdlib/array/reviver/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var real = require( '@stdlib/complex/real' );
 var realf = require( '@stdlib/complex/realf' );
 var imag = require( '@stdlib/complex/imag' );
@@ -152,6 +153,23 @@ tape( 'the function will revive a JSON-serialized typed array (Float32Array)', f
 	t.strictEqual( out instanceof Float32Array, true, 'is an instance' );
 	t.strictEqual( out[ 0 ], arr[ 0 ], true, 'has expected value' );
 	t.strictEqual( out[ 1 ], arr[ 1 ], true, 'has expected value' );
+
+	t.end();
+});
+
+tape( 'the function will revive a JSON-serialized typed array (BooleanArray)', function test( t ) {
+	var json;
+	var arr;
+	var out;
+
+	arr = new BooleanArray( [ true, false ] );
+	json = JSON.stringify( toJSON( arr ) );
+
+	out = parseJSON( json, reviveTypedArray );
+
+	t.strictEqual( out instanceof BooleanArray, true, 'is an instance' );
+	t.strictEqual( out.get( 0 ), arr.get( 0 ), true, 'has expected value' );
+	t.strictEqual( out.get( 1 ), arr.get( 1 ), true, 'has expected value' );
 
 	t.end();
 });


### PR DESCRIPTION
Resolves: Subtask of #2304 

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR will add boolean datatype support in `array/reviver`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
