### PR TITLE
feat: add boolean dtype support to `array/base/every`

### DIFF
--- a/lib/node_modules/@stdlib/array/base/every/lib/main.js
+++ b/lib/node_modules/@stdlib/array/base/every/lib/main.js
@@ -22,7 +22,7 @@
 
 var isComplex128Array = require( '@stdlib/array/base/assert/is-complex128array' );
 var isComplex64Array = require( '@stdlib/array/base/assert/is-complex64array' );
-var isBooleanArray = require( '@stdlib/assert/is-booleanarray' );
+var isBooleanArray = require( '@stdlib/array/base/assert/is-booleanarray' );
 var arraylike2object = require( '@stdlib/array/base/arraylike2object' );
 var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
 var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );

--- a/lib/node_modules/@stdlib/array/base/every/lib/main.js
+++ b/lib/node_modules/@stdlib/array/base/every/lib/main.js
@@ -22,9 +22,11 @@
 
 var isComplex128Array = require( '@stdlib/array/base/assert/is-complex128array' );
 var isComplex64Array = require( '@stdlib/array/base/assert/is-complex64array' );
+var isBooleanArray = require( '@stdlib/assert/is-booleanarray' );
 var arraylike2object = require( '@stdlib/array/base/arraylike2object' );
 var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
 var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
+var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
 
 
 // FUNCTIONS //
@@ -164,6 +166,10 @@ function every( x ) {
 		}
 		if ( isComplex64Array( x ) ) {
 			return internalComplex( reinterpret64( x, 0 ) );
+		}
+		// If provided a boolean array, reinterpret as a typed array and test each element...
+		if ( isBooleanArray( x ) ) {
+			return internal( reinterpretBoolean( x, 0 ) );
 		}
 		return accessors( obj );
 	}

--- a/lib/node_modules/@stdlib/array/base/every/test/test.js
+++ b/lib/node_modules/@stdlib/array/base/every/test/test.js
@@ -25,6 +25,7 @@ var AccessorArray = require( '@stdlib/array/base/accessor' );
 var Float64Array = require( '@stdlib/array/float64' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var every = require( './../lib' );
 
 
@@ -74,6 +75,17 @@ tape( 'if provided an empty collection, the function returns `true` (complex typ
 	t.end();
 });
 
+tape( 'if provided an empty collection, the function returns `true` (boolean array)', function test( t ) {
+	var out;
+	var arr;
+
+	arr = new BooleanArray( [] );
+	out = every( arr );
+
+	t.strictEqual( out, true, 'returns expected value' );
+	t.end();
+});
+
 tape( 'if provided an empty collection, the function returns `true` (accessor)', function test( t ) {
 	var out;
 	var arr;
@@ -107,7 +119,7 @@ tape( 'the function returns `true` if all elements are truthy (real typed array)
 	t.end();
 });
 
-tape( 'the function returns `true` if all elements are truthy (real typed array)', function test( t ) {
+tape( 'the function returns `true` if all elements are truthy (complex typed array)', function test( t ) {
 	var out;
 	var arr;
 
@@ -117,6 +129,17 @@ tape( 'the function returns `true` if all elements are truthy (real typed array)
 	t.strictEqual( out, true, 'returns expected value' );
 
 	arr = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	out = every( arr );
+
+	t.strictEqual( out, true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `true` if all elements are truthy (boolean array)', function test( t ) {
+	var out;
+	var arr;
+
+	arr = new BooleanArray( [ true, true, true, true ] );
 	out = every( arr );
 
 	t.strictEqual( out, true, 'returns expected value' );
@@ -182,6 +205,17 @@ tape( 'the function returns `false` if one or more elements are falsy (complex t
 	t.strictEqual( out, false, 'returns expected value' );
 
 	arr = new Complex128Array( [ 0.0, 0.0, 3.0, 4.0 ] );
+	out = every( arr );
+
+	t.strictEqual( out, false, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `false` if one or more elements are falsy (boolean array)', function test( t ) {
+	var out;
+	var arr;
+
+	arr = new BooleanArray( [ true, false, false, true ] );
 	out = every( arr );
 
 	t.strictEqual( out, false, 'returns expected value' );


### PR DESCRIPTION
Resolves: Subtask of #2304 

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR will add boolean datatype support in `array/base/every`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
