### PR TITLE
feat: add boolean dtype support to `array/base/none`

### DIFF
--- a/lib/node_modules/@stdlib/array/base/none/lib/main.js
+++ b/lib/node_modules/@stdlib/array/base/none/lib/main.js
@@ -22,9 +22,11 @@
 
 var isComplex128Array = require( '@stdlib/array/base/assert/is-complex128array' );
 var isComplex64Array = require( '@stdlib/array/base/assert/is-complex64array' );
+var isBooleanArray = require( '@stdlib/assert/is-booleanarray' );
 var arraylike2object = require( '@stdlib/array/base/arraylike2object' );
 var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
 var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
+var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
 
 
 // FUNCTIONS //
@@ -129,6 +131,10 @@ function none( x ) {
 		}
 		if ( isComplex64Array( x ) ) {
 			return internal( reinterpret64( x, 0 ) );
+		}
+		// If provided a boolean array, reinterpret as a typed array and test whether all elements are false...
+		if ( isBooleanArray( x ) ) {
+			return internal( reinterpretBoolean( x, 0 ) );
 		}
 		return accessors( obj );
 	}

--- a/lib/node_modules/@stdlib/array/base/none/lib/main.js
+++ b/lib/node_modules/@stdlib/array/base/none/lib/main.js
@@ -22,7 +22,7 @@
 
 var isComplex128Array = require( '@stdlib/array/base/assert/is-complex128array' );
 var isComplex64Array = require( '@stdlib/array/base/assert/is-complex64array' );
-var isBooleanArray = require( '@stdlib/assert/is-booleanarray' );
+var isBooleanArray = require( '@stdlib/array/base/assert/is-booleanarray' );
 var arraylike2object = require( '@stdlib/array/base/arraylike2object' );
 var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
 var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );

--- a/lib/node_modules/@stdlib/array/base/none/test/test.js
+++ b/lib/node_modules/@stdlib/array/base/none/test/test.js
@@ -25,6 +25,7 @@ var AccessorArray = require( '@stdlib/array/base/accessor' );
 var Float64Array = require( '@stdlib/array/float64' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var none = require( './../lib' );
 
 
@@ -74,6 +75,17 @@ tape( 'if provided an empty collection, the function returns `true` (complex typ
 	t.end();
 });
 
+tape( 'if provided an empty collection, the function returns `true` (boolean array)', function test( t ) {
+	var out;
+	var arr;
+
+	arr = new BooleanArray( [] );
+	out = none( arr );
+
+	t.strictEqual( out, true, 'returns expected value' );
+	t.end();
+});
+
 tape( 'if provided an empty collection, the function returns `true` (accessor)', function test( t ) {
 	var out;
 	var arr;
@@ -107,7 +119,7 @@ tape( 'the function returns `true` if all elements are falsy (real typed array)'
 	t.end();
 });
 
-tape( 'the function returns `true` if all elements are falsy (real typed array)', function test( t ) {
+tape( 'the function returns `true` if all elements are falsy (complex typed array)', function test( t ) {
 	var out;
 	var arr;
 
@@ -117,6 +129,17 @@ tape( 'the function returns `true` if all elements are falsy (real typed array)'
 	t.strictEqual( out, true, 'returns expected value' );
 
 	arr = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0 ] );
+	out = none( arr );
+
+	t.strictEqual( out, true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `true` if all elements are falsy (boolean array)', function test( t ) {
+	var out;
+	var arr;
+
+	arr = new BooleanArray( [ false, false, false, false ] );
 	out = none( arr );
 
 	t.strictEqual( out, true, 'returns expected value' );
@@ -182,6 +205,17 @@ tape( 'the function returns `false` if one or more elements are truthy (complex 
 	t.strictEqual( out, false, 'returns expected value' );
 
 	arr = new Complex128Array( [ 0.0, 0.0, 0.0, 4.0 ] );
+	out = none( arr );
+
+	t.strictEqual( out, false, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `false` if one or more elements are truthy (boolean array)', function test( t ) {
+	var out;
+	var arr;
+
+	arr = new BooleanArray( [ false, true, false, false ] );
 	out = none( arr );
 
 	t.strictEqual( out, false, 'returns expected value' );


### PR DESCRIPTION
Resolves: Subtask of #2304 

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR will add boolean datatype support in `array/base/none`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
