### PR TITLE
fix: pass options when parsing to suppress warnings in the REPL

### DIFF
--- a/lib/node_modules/@stdlib/repl/lib/acorn_detect_multiline_input.js
+++ b/lib/node_modules/@stdlib/repl/lib/acorn_detect_multiline_input.js
@@ -163,7 +163,7 @@ function plugin( Parser ) {
 
 			// First try parsing as a partially wrapped expression...
 			debug( 'Attempting to parse as a wrapped expression...' );
-			if ( CustomParser.hasMultilineError( code ) ) {
+			if ( CustomParser.hasMultilineError( code, this.options ) ) {
 				return true;
 			}
 			// Now try parsing as an unwrapped expression...


### PR DESCRIPTION
Resolves #2429

## Description

> What is the purpose of this pull request?

This pull request:

-   passes options to parser in the multiline plugin

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   fixes #2429

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
