### PR TITLE
feat: add REPL text lint rule to catch semicolon omission in examples

### DIFF
--- a/lib/node_modules/@stdlib/_tools/repl-txt/rules/code-semicolons/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/repl-txt/rules/code-semicolons/lib/main.js
@@ -26,14 +26,14 @@ var endsWith = require( '@stdlib/string/ends-with' );
 // MAIN //
 
 /**
-* Rule for enforcing that semicolons are omitted if output is not suppressed.
+* Rule for enforcing that semicolons are omitted only if output is not suppressed.
 *
 * @param {Context} context - lint context
 * @returns {Object} validators
 */
 function main( context ) {
 	/**
-	* Checks examples section for whether semicolons are always omitted if output is not suppressed.
+	* Checks examples section for whether semicolons are omitted only if output is not suppressed.
 	*
 	* @private
 	* @param {Object} section - examples section
@@ -48,6 +48,9 @@ function main( context ) {
 			current = examples[ i ];
 			if ( endsWith( current.code, ';' ) && current.output ) {
 				context.report( 'Omit semicolons if output shall not be suppressed', section );
+			}
+			if ( !endsWith( current.code, ';' ) && !current.output ) {
+				context.report( 'Semicolons must not be omitted if output is suppressed', section );
 			}
 		}
 	}

--- a/lib/node_modules/@stdlib/_tools/repl-txt/rules/code-semicolons/package.json
+++ b/lib/node_modules/@stdlib/_tools/repl-txt/rules/code-semicolons/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/_tools/repl-txt/rules/code-semicolons",
   "version": "0.0.0",
-  "description": "Lint rule to enforce that semicolons are omitted if output is not suppressed.",
+  "description": "Lint rule to enforce that semicolons are omitted only if output is not suppressed.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",


### PR DESCRIPTION
Resolves #2428 

## Description

> What is the purpose of this pull request?

This pull request:

-   add REPL text lint rule to catch semicolon omission in cases where the output is suppressed

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #2428 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
