### PR TITLE
feat: add `includes` method to `array/bool`

### DIFF
--- a/lib/node_modules/@stdlib/array/bool/README.md
+++ b/lib/node_modules/@stdlib/array/bool/README.md
@@ -620,6 +620,28 @@ var v = arr.get( 100 );
 // returns undefined
 ```
 
+<a name="includes"></a>
+
+#### BooleanArray.prototype.includes( searchElement\[, fromIndex] )
+
+Returns a boolean indicating whether an array includes a provided value.
+
+```javascript
+var arr = new BooleanArray( 5 );
+
+arr.set( true, 0 );
+arr.set( false, 1 );
+arr.set( true, 2 );
+arr.set( true, 3 );
+arr.set( true, 4 );
+
+var bool = arr.includes( true );
+// returns true
+
+bool = arr.includes( false, 2 );
+// returns false
+```
+
 <a name="method-index-of"></a>
 
 #### BooleanArray.prototype.indexOf( searchElement\[, fromIndex] )

--- a/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.includes.js
+++ b/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.includes.js
@@ -1,0 +1,56 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var Boolean = require( '@stdlib/boolean/ctor' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var pkg = require( './../package.json' ).name;
+var BooleanArray = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg+':includes', function benchmark( b ) {
+	var bool;
+	var arr;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < 10; i++ ) {
+		arr.push( Boolean( i%2 ) );
+	}
+	arr = new BooleanArray( arr );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		bool = arr.includes( true, 0 );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.includes.length.js
+++ b/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.includes.length.js
@@ -1,0 +1,103 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var pkg = require( './../package.json' ).name;
+var BooleanArray = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var arr;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < len-1; i++ ) {
+		arr.push( false );
+	}
+	arr.push( true );
+	arr = new BooleanArray( arr );
+
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var bool;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			bool = arr.includes( true );
+			if ( typeof bool !== 'boolean' ) {
+				b.fail( 'should return a boolean' );
+			}
+		}
+		b.toc();
+		if ( !isBoolean( bool ) ) {
+			b.fail( 'should return a boolean' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':includes:len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/bool/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/bool/docs/repl.txt
@@ -257,7 +257,7 @@
     <BooleanArray>
     > var offset = arr.byteOffset
     0
-    > var buf = new {{alias:@stdlib/array/buffer}}( 240 )
+    > var buf = new {{alias:@stdlib/array/buffer}}( 240 );
     > arr = new {{alias}}( buf, 64 )
     <BooleanArray>
     > offset = arr.byteOffset
@@ -482,6 +482,34 @@
     > arr.set( true, 0 );
     > var v = arr.get( 0 )
     true
+
+
+{{alias}}.prototype.includes( searchElement[, fromIndex] )
+    Returns a boolean indicating whether an array includes a provided value.
+
+    Parameters
+    ----------
+    searchElement: boolean
+        Search element.
+
+    fromIndex: integer (optional)
+        Array index at which to start the search. If provided a negative value,
+        the method resolves the start index relative to the last array element.
+        Default: 0.
+
+    Returns
+    -------
+    bool: boolean
+        Boolean indicating whether an array includes a search element.
+
+    Examples
+    --------
+    > var arr = new {{alias}}( [ true, false, true, true, true ] )
+    <BooleanArray>
+    > var bool = arr.includes( true )
+    true
+    > bool = arr.includes( false, 3 )
+    false
 
 
 {{alias}}.prototype.indexOf( searchElement[, fromIndex] )

--- a/lib/node_modules/@stdlib/array/bool/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/bool/docs/types/index.d.ts
@@ -407,6 +407,30 @@ declare class BooleanArray implements BooleanArrayInterface {
 	get( i: number ): boolean | void;
 
 	/**
+	* Returns a boolean indicating whether an array includes a provided value.
+	*
+	* @param searchElement - element to search for
+	* @param fromIndex - starting index (inclusive)
+	* @returns boolean indicating whether an array includes a value
+	*
+	* @example
+	* var arr = new BooleanArray( 5 );
+	*
+	* arr.set( true, 0 );
+	* arr.set( false, 1 );
+	* arr.set( true, 2 );
+	* arr.set( true, 3 );
+	* arr.set( true, 4 );
+	*
+	* var bool = arr.includes( true );
+	* // returns true
+	*
+	* bool = arr.includes( false, 2 );
+	* // returns false
+	*/
+	includes( searchElement: boolean, fromIndex?: number ): boolean;
+
+	/**
 	* Returns the first index at which a given element can be found.
 	*
 	* @param searchElement - element to find

--- a/lib/node_modules/@stdlib/array/bool/lib/main.js
+++ b/lib/node_modules/@stdlib/array/bool/lib/main.js
@@ -721,6 +721,66 @@ setReadOnly( BooleanArray.prototype, 'get', function get( idx ) {
 });
 
 /**
+* Returns a boolean indicating whether an array includes a provided value.
+*
+* @name includes
+* @memberof BooleanArray.prototype
+* @type {Function}
+* @param {boolean} searchElement - search element
+* @param {integer} [fromIndex=0] - starting index (inclusive)
+* @throws {TypeError} `this` must be a boolean array
+* @throws {TypeError} first argument must be a boolean value
+* @throws {TypeError} second argument must be an integer
+* @returns {boolean} boolean indicating whether an array includes a value
+*
+* @example
+* var arr = new BooleanArray( 5 );
+*
+* arr.set( true, 0 );
+* arr.set( false, 1 );
+* arr.set( true, 2 );
+* arr.set( true, 3 );
+* arr.set( true, 4 );
+*
+* var bool = arr.includes( true );
+* // returns true
+*
+* bool = arr.includes( false, 2 );
+* // returns false
+*/
+setReadOnly( BooleanArray.prototype, 'includes', function includes( searchElement, fromIndex ) {
+	var buf;
+	var i;
+
+	if ( !isBooleanArray( this ) ) {
+		throw new TypeError( 'invalid invocation. `this` is not a boolean array.' );
+	}
+	if ( !isBoolean( searchElement ) ) {
+		throw new TypeError( format( 'invalid argument. First argument must be a boolean. Value: `%s`.', searchElement ) );
+	}
+	if ( arguments.length > 1 ) {
+		if ( !isInteger( fromIndex ) ) {
+			throw new TypeError( format( 'invalid argument. Second argument must be an integer. Value: `%s`.', fromIndex ) );
+		}
+		if ( fromIndex < 0 ) {
+			fromIndex += this._length;
+			if ( fromIndex < 0 ) {
+				fromIndex = 0;
+			}
+		}
+	} else {
+		fromIndex = 0;
+	}
+	buf = this._buffer;
+	for ( i = fromIndex; i < this._length; i++ ) {
+		if ( searchElement === Boolean( buf[ i ] ) ) {
+			return true;
+		}
+	}
+	return false;
+});
+
+/**
 * Returns the first index at which a given element can be found.
 *
 * @name indexOf

--- a/lib/node_modules/@stdlib/array/bool/test/test.includes.js
+++ b/lib/node_modules/@stdlib/array/bool/test/test.includes.js
@@ -1,0 +1,221 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var BooleanArray = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof BooleanArray, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the main export is an `includes` method', function test( t ) {
+	t.strictEqual( hasOwnProp( BooleanArray.prototype, 'includes' ), true, 'has property' );
+	t.strictEqual( isFunction( BooleanArray.prototype.includes ), true, 'has method' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a boolean array instance', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new BooleanArray( 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.includes.call( value, true );
+		};
+	}
+});
+
+tape( 'the method throws an error if provided a first argument which is not a boolean value', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new BooleanArray( 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.includes( value );
+		};
+	}
+});
+
+tape( 'the method throws an error if provided a second argument which is not an integer', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new BooleanArray( 10 );
+
+	values = [
+		'5',
+		3.14,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.includes( true, value );
+		};
+	}
+});
+
+tape( 'the method returns `false` if operating on an empty boolean array', function test( t ) {
+	var bool;
+	var arr;
+
+	arr = new BooleanArray();
+	bool = arr.includes( true );
+
+	t.strictEqual( bool, false, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method returns `false` if a boolean value is not found', function test( t ) {
+	var bool;
+	var arr;
+
+	arr = new BooleanArray( 10 );
+	bool = arr.includes( true );
+
+	t.strictEqual( bool, false, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method returns `true` if an array contains a specified boolean value', function test( t ) {
+	var bool;
+	var arr;
+
+	arr = new BooleanArray( [ true, false, false, true] );
+	bool = arr.includes( false );
+
+	t.strictEqual( bool, true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method returns `false` if provided a second argument which exceeds the input array length', function test( t ) {
+	var bool;
+	var arr;
+
+	arr = new BooleanArray( 10 );
+	bool = arr.includes( true, 20 );
+
+	t.strictEqual( bool, false, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method supports specifying a starting search index', function test( t ) {
+	var bool;
+	var arr;
+
+	arr = new BooleanArray( [ true, false, true, true, true ] );
+
+	bool = arr.includes( true, 0 );
+	t.strictEqual( bool, true, 'returns expected value' );
+
+	bool = arr.includes( false, 1 );
+	t.strictEqual( bool, true, 'returns expected value' );
+
+	bool = arr.includes( false, 3 );
+	t.strictEqual( bool, false, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method supports specifying a starting search index (negative)', function test( t ) {
+	var bool;
+	var arr;
+
+	arr = new BooleanArray( [ true, false, true, true, true ] );
+
+	bool = arr.includes( true, -5 );
+	t.strictEqual( bool, true, 'returns expected value' );
+
+	bool = arr.includes( false, -2 );
+	t.strictEqual( bool, false, 'returns expected value' );
+	t.end();
+});
+
+tape( 'when provided a starting index which resolves to an index which is less than zero, the method searches from the first array element', function test( t ) {
+	var bool;
+	var arr;
+
+	arr = new BooleanArray( [ true, false, true, true, true ] );
+
+	bool = arr.includes( true, -10 );
+	t.strictEqual( bool, true, 'returns expected value' );
+
+	bool = arr.includes( false, -10 );
+	t.strictEqual( bool, true, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
Resolves: Subtask of #2304 

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds the typed array `includes` method to prototype of `BooleanArray`

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
