### PR TITLE
fix: perform float32 emulation in `blas/base/srotm`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/srotm/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/srotm/lib/ndarray.js
@@ -18,6 +18,11 @@
 
 'use strict';
 
+// MODULES //
+
+var f32 = require( '@stdlib/number/float64/base/to-float32' );
+
+
 // MAIN //
 
 /**
@@ -71,8 +76,8 @@ function srotm( N, x, strideX, offsetX, y, strideY, offsetY, param ) {
 			for ( i = 0; i < N; i++ ) {
 				w = x[ ix ];
 				z = y[ ix ];
-				x[ ix ] = ( w * sh11 ) + ( z * sh12 );
-				y[ ix ] = ( w * sh21 ) + ( z * sh22 );
+				x[ ix ] = f32( f32( w * sh11 ) + f32( z * sh12 ) );
+				y[ ix ] = f32( f32( w * sh21 ) + f32( z * sh22 ) );
 				ix += strideX;
 			}
 			return y;
@@ -83,8 +88,8 @@ function srotm( N, x, strideX, offsetX, y, strideY, offsetY, param ) {
 			for ( i = 0; i < N; i++ ) {
 				w = x[ ix ];
 				z = y[ ix ];
-				x[ ix ] = w + ( z * sh12 );
-				y[ ix ] = ( w * sh21 ) + z;
+				x[ ix ] = f32( w + f32( z * sh12 ) );
+				y[ ix ] = f32( f32( w * sh21 ) + z );
 				ix += strideX;
 			}
 			return y;
@@ -94,8 +99,8 @@ function srotm( N, x, strideX, offsetX, y, strideY, offsetY, param ) {
 		for ( i = 0; i < N; i++ ) {
 			w = x[ ix ];
 			z = y[ ix ];
-			x[ ix ] = ( w * sh11 ) + z;
-			y[ ix ] = -w + ( z * sh22 );
+			x[ ix ] = f32( f32( w * sh11 ) + z );
+			y[ ix ] = f32( -w + f32( z * sh22 ) );
 			ix += strideX;
 		}
 		return y;
@@ -108,8 +113,8 @@ function srotm( N, x, strideX, offsetX, y, strideY, offsetY, param ) {
 		for ( i = 0; i < N; i++ ) {
 			w = x[ ix ];
 			z = y[ iy ];
-			x[ ix ] = ( w * sh11 ) + ( z * sh12 );
-			y[ iy ] = ( w * sh21 ) + ( z * sh22 );
+			x[ ix ] = f32( f32( w * sh11 ) + f32( z * sh12 ) );
+			y[ iy ] = f32( f32( w * sh21 ) + f32( z * sh22 ) );
 			ix += strideX;
 			iy += strideY;
 		}
@@ -121,8 +126,8 @@ function srotm( N, x, strideX, offsetX, y, strideY, offsetY, param ) {
 		for ( i = 0; i < N; i++ ) {
 			w = x[ ix ];
 			z = y[ iy ];
-			x[ ix ] = w + ( z * sh12 );
-			y[ iy ] = ( w * sh21 ) + z;
+			x[ ix ] = f32( w + f32( z * sh12 ) );
+			y[ iy ] = f32( f32( w * sh21 ) + z );
 			ix += strideX;
 			iy += strideY;
 		}
@@ -133,8 +138,8 @@ function srotm( N, x, strideX, offsetX, y, strideY, offsetY, param ) {
 	for ( i = 0; i < N; i++ ) {
 		w = x[ ix ];
 		z = y[ iy ];
-		x[ ix ] = ( w * sh11 ) + z;
-		y[ iy ] = -w + ( z * sh22 );
+		x[ ix ] = f32( f32( w * sh11 ) + z );
+		y[ iy ] = f32( -w + f32( z * sh22 ) );
 		ix += strideX;
 		iy += strideY;
 	}

--- a/lib/node_modules/@stdlib/blas/base/srotm/lib/srotm.js
+++ b/lib/node_modules/@stdlib/blas/base/srotm/lib/srotm.js
@@ -18,6 +18,11 @@
 
 'use strict';
 
+// MODULES //
+
+var f32 = require( '@stdlib/number/float64/base/to-float32' );
+
+
 // MAIN //
 
 /**
@@ -68,8 +73,8 @@ function srotm( N, x, strideX, y, strideY, param ) {
 			for ( i = 0; i < N; i++ ) {
 				w = x[ ix ];
 				z = y[ ix ];
-				x[ ix ] = ( w * sh11 ) + ( z * sh12 );
-				y[ ix ] = ( w * sh21 ) + ( z * sh22 );
+				x[ ix ] = f32( f32( w * sh11 ) + f32( z * sh12 ) );
+				y[ ix ] = f32( f32( w * sh21 ) + f32( z * sh22 ) );
 				ix += strideX;
 			}
 			return y;
@@ -80,8 +85,8 @@ function srotm( N, x, strideX, y, strideY, param ) {
 			for ( i = 0; i < N; i++ ) {
 				w = x[ ix ];
 				z = y[ ix ];
-				x[ ix ] = w + ( z * sh12 );
-				y[ ix ] = ( w * sh21 ) + z;
+				x[ ix ] = f32( w + f32( z * sh12 ) );
+				y[ ix ] = f32( f32( w * sh21 ) + z );
 				ix += strideX;
 			}
 			return y;
@@ -91,8 +96,8 @@ function srotm( N, x, strideX, y, strideY, param ) {
 		for ( i = 0; i < N; i++ ) {
 			w = x[ ix ];
 			z = y[ ix ];
-			x[ ix ] = ( w * sh11 ) + z;
-			y[ ix ] = -w + ( z * sh22 );
+			x[ ix ] = f32( f32( w * sh11 ) + z );
+			y[ ix ] = f32( -w + f32( z * sh22 ) );
 			ix += strideX;
 		}
 		return y;
@@ -115,8 +120,8 @@ function srotm( N, x, strideX, y, strideY, param ) {
 		for ( i = 0; i < N; i++ ) {
 			w = x[ ix ];
 			z = y[ iy ];
-			x[ ix ] = ( w * sh11 ) + ( z * sh12 );
-			y[ iy ] = ( w * sh21 ) + ( z * sh22 );
+			x[ ix ] = f32( f32( w * sh11 ) + f32( z * sh12 ) );
+			y[ iy ] = f32( f32( w * sh21 ) + f32( z * sh22 ) );
 			ix += strideX;
 			iy += strideY;
 		}
@@ -128,8 +133,8 @@ function srotm( N, x, strideX, y, strideY, param ) {
 		for ( i = 0; i < N; i++ ) {
 			w = x[ ix ];
 			z = y[ iy ];
-			x[ ix ] = w + ( z * sh12 );
-			y[ iy ] = ( w * sh21 ) + z;
+			x[ ix ] = f32( w + f32( z * sh12 ) );
+			y[ iy ] = f32( f32( w * sh21 ) + z );
 			ix += strideX;
 			iy += strideY;
 		}
@@ -140,8 +145,8 @@ function srotm( N, x, strideX, y, strideY, param ) {
 	for ( i = 0; i < N; i++ ) {
 		w = x[ ix ];
 		z = y[ iy ];
-		x[ ix ] = ( w * sh11 ) + z;
-		y[ iy ] = -w + ( z * sh22 );
+		x[ ix ] = f32( f32( w * sh11 ) + z );
+		y[ iy ] = f32( -w + f32( z * sh22 ) );
 		ix += strideX;
 		iy += strideY;
 	}


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This PR proposes to perform the float 32 emulation for the implementation of  `blas/base/srotm`.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
