### PR TITLE
feat: add boolean dtype support to `array/base/cuevery`

### DIFF
--- a/lib/node_modules/@stdlib/array/base/cuevery/lib/assign.js
+++ b/lib/node_modules/@stdlib/array/base/cuevery/lib/assign.js
@@ -22,9 +22,11 @@
 
 var isComplex128Array = require( '@stdlib/array/base/assert/is-complex128array' );
 var isComplex64Array = require( '@stdlib/array/base/assert/is-complex64array' );
+var isBooleanArray = require( '@stdlib/array/base/assert/is-booleanarray' );
 var arraylike2object = require( '@stdlib/array/base/arraylike2object' );
 var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
 var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
+var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
 
 
 // FUNCTIONS //
@@ -181,6 +183,63 @@ function complex( x, y, stride, offset ) {
 	return ydata;
 }
 
+/**
+* Cumulatively tests whether every element in a provided boolean array is truthy.
+*
+* @private
+* @param {Collection} x - input array
+* @param {Object} y - output array object
+* @param {integer} stride - output array stride
+* @param {NonNegativeInteger} offset - output array offset
+* @returns {Collection} output array
+*
+* @example
+* var Uint8Array = require( '@stdlib/array/uint8' );
+* var toAccessorArray = require( '@stdlib/array/base/to-accessor-array' );
+* var arraylike2object = require( '@stdlib/array/base/arraylike2object' );
+*
+* var x = new Uint8Array( [ 1, 1, 1, 0, 1 ] );
+* var y = toAccessorArray( [ false, null, false, null, false, null, false, null, true, null ] );
+*
+* var arr = boolean( x, arraylike2object( y ), 2, 0 );
+*
+* var v = y.get( 0 );
+* // returns true
+*
+* v = y.get( 2 );
+* // returns true
+*
+* v = y.get( 4 );
+* // returns true
+*
+* v = y.get( 6 );
+* // returns false
+*
+* v = y.get( 8 );
+* // returns false
+*/
+function boolean( x, y, stride, offset ) {
+	var ydata;
+	var yset;
+	var flg;
+	var io;
+	var i;
+
+	yset = y.accessors[ 1 ];
+	ydata = y.data;
+
+	flg = true;
+	io = offset;
+	for ( i = 0; i < x.length; i++ ) {
+		if ( flg === true && !x[ i ] ) {
+			flg = false;
+		}
+		yset( ydata, io, flg );
+		io += stride;
+	}
+	return ydata;
+}
+
 
 // MAIN //
 
@@ -215,6 +274,8 @@ function assign( x, y, stride, offset ) {
 			complex( reinterpret128( x, 0 ), yo, stride, offset );
 		} else if ( isComplex64Array( x ) ) {
 			complex( reinterpret64( x, 0 ), yo, stride, offset );
+		} else if ( isBooleanArray( x ) ) {
+			boolean( reinterpretBoolean( x, 0 ), yo, stride, offset );
 		} else {
 			accessors( xo, yo, stride, offset );
 		}

--- a/lib/node_modules/@stdlib/array/base/cuevery/test/test.assign.js
+++ b/lib/node_modules/@stdlib/array/base/cuevery/test/test.assign.js
@@ -23,6 +23,7 @@
 var tape = require( 'tape' );
 var Complex128Array = require( '@stdlib/array/complex128' );
 var Complex64Array = require( '@stdlib/array/complex64' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var Float64Array = require( '@stdlib/array/float64' );
 var toAccessorArray = require( '@stdlib/array/base/to-accessor-array' );
 var cuevery = require( './../lib/assign.js' );
@@ -133,6 +134,60 @@ tape( 'the function cumulatively tests whether every element is truthy (typed)',
 	t.deepEqual( actual, expected, 'returns expected value' );
 
 	x = new Float64Array( [ 1.0 ] );
+	y = [ false, false ];
+
+	actual = cuevery( x, y, 1, 1 );
+	expected = [ false, true ];
+
+	t.strictEqual( actual, y, 'returns expected value' );
+	t.deepEqual( actual, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function cumulatively tests whether every element is truthy (boolean)', function test( t ) {
+	var expected;
+	var actual;
+	var x;
+	var y;
+
+	x = new BooleanArray( [ true, true, true, true, true ] );
+	y = [ false, true, false, true, false ];
+
+	actual = cuevery( x, y, 1, 0 );
+	expected = [ true, true, true, true, true ];
+
+	t.strictEqual( actual, y, 'returns expected value' );
+	t.deepEqual( actual, expected, 'returns expected value' );
+
+	x = new BooleanArray( [ false, false, true, false, false ] );
+	y = [ false, null, false, null, false, null, false, null, false, null ];
+
+	actual = cuevery( x, y, 2, 0 );
+	expected = [ false, null, false, null, false, null, false, null, false, null ];
+
+	t.strictEqual( actual, y, 'returns expected value' );
+	t.deepEqual( actual, expected, 'returns expected value' );
+
+	x = new BooleanArray( [ false, false, true, false, false ] );
+	y = [ false, false, false, true, true, true ];
+
+	actual = cuevery( x, y, 1, 1 );
+	expected = [ false, false, false, false, false, false ];
+
+	t.strictEqual( actual, y, 'returns expected value' );
+	t.deepEqual( actual, expected, 'returns expected value' );
+
+	x = new BooleanArray( [] );
+	y = [ false, false, false, false, false ];
+
+	actual = cuevery( x, y, 1, 0 );
+	expected = [ false, false, false, false, false ];
+
+	t.strictEqual( actual, y, 'returns expected value' );
+	t.deepEqual( actual, expected, 'returns expected value' );
+
+	x = new BooleanArray( [ true ] );
 	y = [ false, false ];
 
 	actual = cuevery( x, y, 1, 1 );

--- a/lib/node_modules/@stdlib/array/base/cuevery/test/test.main.js
+++ b/lib/node_modules/@stdlib/array/base/cuevery/test/test.main.js
@@ -23,6 +23,7 @@
 var tape = require( 'tape' );
 var Complex128Array = require( '@stdlib/array/complex128' );
 var Complex64Array = require( '@stdlib/array/complex64' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var Float64Array = require( '@stdlib/array/float64' );
 var toAccessorArray = require( '@stdlib/array/base/to-accessor-array' );
 var cuevery = require( './../lib' );
@@ -128,6 +129,39 @@ tape( 'the function cumulatively tests whether every element is truthy (complex1
 	t.deepEqual( actual, expected, 'returns expected value' );
 
 	x = new Complex128Array( [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0 ] );
+	actual = cuevery( x );
+	expected = [ true, false, false, false, false ];
+	t.deepEqual( actual, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function cumulatively tests whether every element is truthy (boolean)', function test( t ) {
+	var expected;
+	var actual;
+	var x;
+
+	x = new BooleanArray( [ false, false, true, false, false ] );
+	actual = cuevery( x );
+	expected = [ false, false, false, false, false ];
+	t.deepEqual( actual, expected, 'returns expected value' );
+
+	x = new BooleanArray( [ false, false, false, false, false ] );
+	actual = cuevery( x );
+	expected = [ false, false, false, false, false ];
+	t.deepEqual( actual, expected, 'returns expected value' );
+
+	x = new BooleanArray( [ true, true, true, true, true ] );
+	actual = cuevery( x );
+	expected = [ true, true, true, true, true ];
+	t.deepEqual( actual, expected, 'returns expected value' );
+
+	x = new BooleanArray( [ false, true, true ] );
+	actual = cuevery( x );
+	expected = [ false, false, false ];
+	t.deepEqual( actual, expected, 'returns expected value' );
+
+	x = new BooleanArray( [ true, false, true, false, false ] );
 	actual = cuevery( x );
 	expected = [ true, false, false, false, false ];
 	t.deepEqual( actual, expected, 'returns expected value' );


### PR DESCRIPTION
Resolves: Subtask of #2304 

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR will add boolean datatype support in `array/base/cuevery`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
