### PR TITLE
feat: add boolean dtype support to `array/empty`

### DIFF
--- a/lib/node_modules/@stdlib/array/empty/README.md
+++ b/lib/node_modules/@stdlib/array/empty/README.md
@@ -49,23 +49,7 @@ var arr = empty( 2 );
 // returns <Float64Array>
 ```
 
-The function recognizes the following data types:
-
--   `float64`: double-precision floating-point numbers (IEEE 754)
--   `float32`: single-precision floating-point numbers (IEEE 754)
--   `complex128`: double-precision complex floating-point numbers
--   `complex64`: single-precision complex floating-point numbers
--   `bool`: boolean values
--   `int32`: 32-bit two's complement signed integers
--   `uint32`: 32-bit unsigned integers
--   `int16`: 16-bit two's complement signed integers
--   `uint16`: 16-bit unsigned integers
--   `int8`: 8-bit two's complement signed integers
--   `uint8`: 8-bit unsigned integers
--   `uint8c`: 8-bit unsigned integers clamped to `0-255`
--   `generic`: generic JavaScript values
-
-By default, the output array data type is `float64` (i.e., a [typed array][mdn-typed-array]). To specify an alternative data type, provide a `dtype` argument.
+By default, the output array [data type][@stdlib/array/dtypes] is `float64` (i.e., a [typed array][mdn-typed-array]). To specify an alternative [data type][@stdlib/array/dtypes], provide a `dtype` argument.
 
 ```javascript
 var arr = empty( 2, 'int32' );
@@ -149,6 +133,8 @@ for ( i = 0; i < dt.length; i++ ) {
 <section class="links">
 
 [mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
+
+[@stdlib/array/dtypes]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/dtypes
 
 <!-- <related-links> -->
 

--- a/lib/node_modules/@stdlib/array/empty/README.md
+++ b/lib/node_modules/@stdlib/array/empty/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2023 The Stdlib Authors.
+Copyright (c) 2024 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -55,6 +55,7 @@ The function recognizes the following data types:
 -   `float32`: single-precision floating-point numbers (IEEE 754)
 -   `complex128`: double-precision complex floating-point numbers
 -   `complex64`: single-precision complex floating-point numbers
+-   `bool`: boolean values
 -   `int32`: 32-bit two's complement signed integers
 -   `uint32`: 32-bit unsigned integers
 -   `int16`: 16-bit two's complement signed integers

--- a/lib/node_modules/@stdlib/array/empty/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/array/empty/benchmark/benchmark.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -71,6 +71,24 @@ bench( pkg+':dtype=float32', function benchmark( b ) {
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
 		arr = empty( 0, 'float32' );
+		if ( arr.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !isTypedArrayLike( arr ) ) {
+		b.fail( 'should return a typed array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+':dtype=bool', function benchmark( b ) {
+	var arr;
+	var i;
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = empty( 0, 'bool' );
 		if ( arr.length !== 0 ) {
 			b.fail( 'should have length 0' );
 		}

--- a/lib/node_modules/@stdlib/array/empty/benchmark/benchmark.length.bool.js
+++ b/lib/node_modules/@stdlib/array/empty/benchmark/benchmark.length.bool.js
@@ -1,0 +1,93 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isTypedArrayLike = require( '@stdlib/assert/is-typed-array-like' );
+var pkg = require( './../package.json' ).name;
+var empty = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var arr;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			arr = empty( len, 'bool' );
+			if ( arr.length !== len ) {
+				b.fail( 'unexpected length' );
+			}
+		}
+		b.toc();
+		if ( !isTypedArrayLike( arr ) ) {
+			b.fail( 'should return a typed array' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':dtype=bool,len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/empty/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/empty/docs/repl.txt
@@ -16,6 +16,7 @@
     - float32: single-precision floating-point numbers (IEEE 754)
     - complex128: double-precision complex floating-point numbers
     - complex64: single-precision complex floating-point numbers
+    - bool: boolean values
     - int32: 32-bit two's complement signed integers
     - uint32: 32-bit unsigned integers
     - int16: 16-bit two's complement signed integers

--- a/lib/node_modules/@stdlib/array/empty/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/empty/docs/repl.txt
@@ -10,24 +10,6 @@
     is *not* initialized. Memory contents are unknown and may contain
     *sensitive* data.
 
-    The function supports the following data types:
-
-    - float64: double-precision floating-point numbers (IEEE 754)
-    - float32: single-precision floating-point numbers (IEEE 754)
-    - complex128: double-precision complex floating-point numbers
-    - complex64: single-precision complex floating-point numbers
-    - bool: boolean values
-    - int32: 32-bit two's complement signed integers
-    - uint32: 32-bit unsigned integers
-    - int16: 16-bit two's complement signed integers
-    - uint16: 16-bit unsigned integers
-    - int8: 8-bit two's complement signed integers
-    - uint8: 8-bit unsigned integers
-    - uint8c: 8-bit unsigned integers clamped to 0-255
-    - generic: generic JavaScript values
-
-    The default array data type is `float64`.
-
     Parameters
     ----------
     length: integer

--- a/lib/node_modules/@stdlib/array/empty/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/empty/docs/types/index.d.ts
@@ -25,21 +25,6 @@ import { DataTypeMap } from '@stdlib/types/array';
 /**
 * Creates an uninitialized array having a specified length.
 *
-* The function recognizes the following data types:
-*
-* -   `float64`: double-precision floating-point numbers (IEEE 754)
-* -   `float32`: single-precision floating-point numbers (IEEE 754)
-* -   `complex128`: double-precision complex floating-point numbers
-* -   `complex64`: single-precision complex floating-point numbers
-* -   `int32`: 32-bit two's complement signed integers
-* -   `uint32`: 32-bit unsigned integers
-* -   `int16`: 16-bit two's complement signed integers
-* -   `uint16`: 16-bit unsigned integers
-* -   `int8`: 8-bit two's complement signed integers
-* -   `uint8`: 8-bit unsigned integers
-* -   `uint8c`: 8-bit unsigned integers clamped to `0-255`
-* -   `generic`: generic JavaScript values
-*
 * ## Notes
 *
 * -   In browser environments, the function always returns zero-filled arrays.

--- a/lib/node_modules/@stdlib/array/empty/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/empty/docs/types/test.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import empty = require( './index' );
 	empty( 10, 'float32' ); // $ExpectType Float32Array
 	empty( 10, 'complex128' ); // $ExpectType Complex128Array
 	empty( 10, 'complex64' ); // $ExpectType Complex64Array
+	empty( 10, 'bool' ); // $ExpectType BooleanArray
 	empty( 10, 'int32' ); // $ExpectType Int32Array
 	empty( 10, 'int16' ); // $ExpectType Int16Array
 	empty( 10, 'int8' ); // $ExpectType Int8Array

--- a/lib/node_modules/@stdlib/array/empty/package.json
+++ b/lib/node_modules/@stdlib/array/empty/package.json
@@ -100,6 +100,7 @@
     "short",
     "long",
     "generic",
+    "bool",
     "empty"
   ]
 }

--- a/lib/node_modules/@stdlib/array/empty/test/test.main.js
+++ b/lib/node_modules/@stdlib/array/empty/test/test.main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
 var empty = require( './../lib/main.js' );
 
@@ -164,6 +165,16 @@ tape( 'the function returns an empty array (dtype=float32)', function test( t ) 
 
 	arr = empty( 5, 'float32' );
 	t.strictEqual( instanceOf( arr, Float32Array ), true, 'returns expected value' );
+	t.strictEqual( arr.length, 5, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns an empty array (dtype=bool)', function test( t ) {
+	var arr;
+
+	arr = empty( 5, 'bool' );
+	t.strictEqual( instanceOf( arr, BooleanArray ), true, 'returns expected value' );
 	t.strictEqual( arr.length, 5, 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/array/empty/test/test.polyfill.js
+++ b/lib/node_modules/@stdlib/array/empty/test/test.polyfill.js
@@ -189,7 +189,7 @@ tape( 'the function returns a zero-filled array (dtype=bool)', function test( t 
 	var expected;
 	var arr;
 
-	expected = new Uint8Array( [ false, false, false, false ] );
+	expected = new Uint8Array( [ 0, 0, 0, 0 ] );
 
 	arr = empty( 4, 'bool' );
 	t.strictEqual( instanceOf( arr, BooleanArray ), true, 'returns expected value' );

--- a/lib/node_modules/@stdlib/array/empty/test/test.polyfill.js
+++ b/lib/node_modules/@stdlib/array/empty/test/test.polyfill.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -32,8 +32,10 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
 var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
+var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
 var empty = require( './../lib/polyfill.js' );
 
@@ -179,6 +181,20 @@ tape( 'the function returns a zero-filled array (dtype=float32)', function test(
 	t.strictEqual( instanceOf( arr, Float32Array ), true, 'returns expected value' );
 	t.strictEqual( arr.length, expected.length, 'returns expected value' );
 	t.deepEqual( arr, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a zero-filled array (dtype=bool)', function test( t ) {
+	var expected;
+	var arr;
+
+	expected = new Uint8Array( [ false, false, false, false ] );
+
+	arr = empty( 4, 'bool' );
+	t.strictEqual( instanceOf( arr, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( arr.length, expected.length, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( arr, 0 ), expected, 'returns expected value' );
 
 	t.end();
 });


### PR DESCRIPTION
Resolves: Subtask of #2304 

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR will add boolean datatype support in `array/empty`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
