### PR TITLE
feat: add boolean dtype support to `array/empty-like`

### DIFF
--- a/lib/node_modules/@stdlib/array/empty-like/README.md
+++ b/lib/node_modules/@stdlib/array/empty-like/README.md
@@ -42,7 +42,7 @@ var emptyLike = require( '@stdlib/array/empty-like' );
 
 #### emptyLike( x\[, dtype] )
 
-Creates an uninitialized array having the same length and data type as a provided array `x`.
+Creates an uninitialized array having the same length and [data type][@stdlib/array/dtypes] as a provided array `x`.
 
 ```javascript
 var x = [ 1, 2, 3, 4, 5 ];
@@ -51,23 +51,7 @@ var arr = emptyLike( x );
 // returns [ 0, 0, 0, 0, 0 ];
 ```
 
-The function recognizes the following data types:
-
--   `float64`: double-precision floating-point numbers (IEEE 754)
--   `float32`: single-precision floating-point numbers (IEEE 754)
--   `complex128`: double-precision complex floating-point numbers
--   `complex64`: single-precision complex floating-point numbers
--   `bool`: boolean values
--   `int32`: 32-bit two's complement signed integers
--   `uint32`: 32-bit unsigned integers
--   `int16`: 16-bit two's complement signed integers
--   `uint16`: 16-bit unsigned integers
--   `int8`: 8-bit two's complement signed integers
--   `uint8`: 8-bit unsigned integers
--   `uint8c`: 8-bit unsigned integers clamped to `0-255`
--   `generic`: generic JavaScript values
-
-By default, the output array data type is inferred from the provided array `x`. To return an array having a different data type, provide a `dtype` argument.
+By default, the output array [data type][@stdlib/array/dtypes] is inferred from the provided array `x`. To return an array having a different [data type][@stdlib/array/dtypes], provide a `dtype` argument.
 
 ```javascript
 var x = [ 1, 1 ];
@@ -155,6 +139,8 @@ for ( i = 0; i < dt.length; i++ ) {
 <!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 
 <section class="links">
+
+[@stdlib/array/dtypes]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/dtypes
 
 <!-- <related-links> -->
 

--- a/lib/node_modules/@stdlib/array/empty-like/README.md
+++ b/lib/node_modules/@stdlib/array/empty-like/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2023 The Stdlib Authors.
+Copyright (c) 2024 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -57,6 +57,7 @@ The function recognizes the following data types:
 -   `float32`: single-precision floating-point numbers (IEEE 754)
 -   `complex128`: double-precision complex floating-point numbers
 -   `complex64`: single-precision complex floating-point numbers
+-   `bool`: boolean values
 -   `int32`: 32-bit two's complement signed integers
 -   `uint32`: 32-bit unsigned integers
 -   `int16`: 16-bit two's complement signed integers

--- a/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -80,6 +80,28 @@ bench( pkg+':dtype=float32', function benchmark( b ) {
 	var i;
 
 	x = zeros( 0, 'float32' );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = emptyLike( x );
+		if ( arr.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !isTypedArrayLike( arr ) ) {
+		b.fail( 'should return a typed array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+':dtype=bool', function benchmark( b ) {
+	var arr;
+	var x;
+	var i;
+
+	x = zeros( 0, 'bool' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.bool.js
+++ b/lib/node_modules/@stdlib/array/empty-like/benchmark/benchmark.length.bool.js
@@ -1,0 +1,95 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isTypedArrayLike = require( '@stdlib/assert/is-typed-array-like' );
+var zeros = require( '@stdlib/array/zeros' );
+var pkg = require( './../package.json' ).name;
+var emptyLike = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = zeros( len, 'bool' );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var arr;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			arr = emptyLike( x );
+			if ( arr.length !== len ) {
+				b.fail( 'unexpected length' );
+			}
+		}
+		b.toc();
+		if ( !isTypedArrayLike( arr ) ) {
+			b.fail( 'should return a typed array' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':dtype=bool,len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/empty-like/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/empty-like/docs/repl.txt
@@ -17,6 +17,7 @@
     - float32: single-precision floating-point numbers (IEEE 754)
     - complex128: double-precision complex floating-point numbers
     - complex64: single-precision complex floating-point numbers
+    - bool: boolean values
     - int32: 32-bit two's complement signed integers
     - uint32: 32-bit unsigned integers
     - int16: 16-bit two's complement signed integers

--- a/lib/node_modules/@stdlib/array/empty-like/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/empty-like/docs/repl.txt
@@ -11,22 +11,6 @@
     is *not* initialized. Memory contents are unknown and may contain
     *sensitive* data.
 
-    The function supports the following data types:
-
-    - float64: double-precision floating-point numbers (IEEE 754)
-    - float32: single-precision floating-point numbers (IEEE 754)
-    - complex128: double-precision complex floating-point numbers
-    - complex64: single-precision complex floating-point numbers
-    - bool: boolean values
-    - int32: 32-bit two's complement signed integers
-    - uint32: 32-bit unsigned integers
-    - int16: 16-bit two's complement signed integers
-    - uint16: 16-bit unsigned integers
-    - int8: 8-bit two's complement signed integers
-    - uint8: 8-bit unsigned integers
-    - uint8c: 8-bit unsigned integers clamped to 0-255
-    - generic: generic JavaScript values
-
     Parameters
     ----------
     x: TypedArray|Array

--- a/lib/node_modules/@stdlib/array/empty-like/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/empty-like/docs/types/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { AnyArray, DataTypeMap, TypedArray, ComplexTypedArray } from '@stdlib/types/array';
+import { AnyArray, DataTypeMap, TypedArray, BooleanTypedArray, ComplexTypedArray } from '@stdlib/types/array';
 
 /**
 * Creates an uninitialized array having the same length and data type as a provided input array.
@@ -64,7 +64,7 @@ declare function emptyLike( x: Array<any> ): Array<number>;
 * var arr = emptyLike( x, 'float32' );
 * // returns <Float32Array>
 */
-declare function emptyLike<T extends TypedArray | ComplexTypedArray>( x: T ): T;
+declare function emptyLike<T extends TypedArray | ComplexTypedArray | BooleanTypedArray>( x: T ): T;
 
 /**
 * Creates an uninitialized array having the same length as a provided input array.
@@ -74,21 +74,6 @@ declare function emptyLike<T extends TypedArray | ComplexTypedArray>( x: T ): T;
 * -   In browser environments, the function always returns zero-filled arrays.
 * -   If `dtype` is `'generic'`, the function always returns a zero-filled array.
 * -   In Node.js versions `>=3.0.0`, the underlying memory of returned typed arrays is **not** initialized. Memory contents are unknown and may contain **sensitive** data.
-*
-* The function recognizes the following data types:
-*
-* -   `float64`: double-precision floating-point numbers (IEEE 754)
-* -   `float32`: single-precision floating-point numbers (IEEE 754)
-* -   `complex128`: double-precision complex floating-point numbers
-* -   `complex64`: single-precision complex floating-point numbers
-* -   `int32`: 32-bit two's complement signed integers
-* -   `uint32`: 32-bit unsigned integers
-* -   `int16`: 16-bit two's complement signed integers
-* -   `uint16`: 16-bit unsigned integers
-* -   `int8`: 8-bit two's complement signed integers
-* -   `uint8`: 8-bit unsigned integers
-* -   `uint8c`: 8-bit unsigned integers clamped to `0-255`
-* -   `generic`: generic JavaScript values
 *
 * @param x - input array from which to derive the output array length
 * @param dtype - data type

--- a/lib/node_modules/@stdlib/array/empty-like/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/empty-like/docs/types/test.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ import emptyLike = require( './index' );
 	emptyLike( [ 0, 0 ], 'complex128' ); // $ExpectType Complex128Array
 	emptyLike( [ 0, 0 ], 'complex64' ); // $ExpectType Complex64Array
 	emptyLike( [ 0, 0 ], 'complex64' ); // $ExpectType Complex64Array
+	emptyLike( [ 0, 0 ], 'bool' ); // $ExpectType BooleanArray
 	emptyLike( [ 0, 0 ], 'int32' ); // $ExpectType Int32Array
 	emptyLike( [ 0, 0 ], 'int16' ); // $ExpectType Int16Array
 	emptyLike( [ 0, 0 ], 'int8' ); // $ExpectType Int8Array

--- a/lib/node_modules/@stdlib/array/empty-like/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/empty-like/docs/types/test.ts
@@ -18,6 +18,7 @@
 
 import Complex128Array = require( '@stdlib/array/complex128' );
 import Complex64Array = require( '@stdlib/array/complex64' );
+import BooleanArray = require( '@stdlib/array/bool' );
 import emptyLike = require( './index' );
 
 
@@ -39,6 +40,7 @@ import emptyLike = require( './index' );
 	emptyLike( new Uint16Array( [ 0, 0 ] ) ); // $ExpectType Uint16Array
 	emptyLike( new Uint8Array( [ 0, 0 ] ) ); // $ExpectType Uint8Array
 	emptyLike( new Uint8ClampedArray( [ 0, 0 ] ) ); // $ExpectType Uint8ClampedArray
+	emptyLike( new BooleanArray( [ 0, 0 ] ) ); // $ExpectType BooleanArray
 	emptyLike( [ 'a', 'b', 'c' ] ); // $ExpectType number[]
 
 	emptyLike( [ 0, 0 ], 'float64' ); // $ExpectType Float64Array

--- a/lib/node_modules/@stdlib/array/empty-like/package.json
+++ b/lib/node_modules/@stdlib/array/empty-like/package.json
@@ -72,6 +72,7 @@
     "uint8clampedarray",
     "complex128array",
     "complex64array",
+    "booleanarray",
     "complex128",
     "complex64",
     "complex",
@@ -98,6 +99,7 @@
     "clamped",
     "short",
     "long",
+    "bool",
     "generic",
     "empty",
     "empty-like"

--- a/lib/node_modules/@stdlib/array/empty-like/test/test.js
+++ b/lib/node_modules/@stdlib/array/empty-like/test/test.js
@@ -203,6 +203,19 @@ tape( 'the function returns an empty array (bool)', function test( t ) {
 	t.end();
 });
 
+tape( 'the function returns an empty array (dtype=bool)', function test( t ) {
+	var arr;
+	var x;
+
+	x = new Float64Array( 5 );
+
+	arr = emptyLike( x, 'bool' );
+	t.strictEqual( instanceOf( arr, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( arr.length, x.length, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function returns an empty array (complex128)', function test( t ) {
 	var arr;
 	var x;

--- a/lib/node_modules/@stdlib/array/empty-like/test/test.js
+++ b/lib/node_modules/@stdlib/array/empty-like/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
 var emptyLike = require( './../lib' );
 
@@ -184,6 +185,19 @@ tape( 'the function returns an empty array (dtype=float32)', function test( t ) 
 
 	arr = emptyLike( x, 'float32' );
 	t.strictEqual( instanceOf( arr, Float32Array ), true, 'returns expected value' );
+	t.strictEqual( arr.length, x.length, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns an empty array (bool)', function test( t ) {
+	var arr;
+	var x;
+
+	x = new BooleanArray( 2 );
+
+	arr = emptyLike( x );
+	t.strictEqual( instanceOf( arr, BooleanArray ), true, 'returns expected value' );
 	t.strictEqual( arr.length, x.length, 'returns expected value' );
 
 	t.end();


### PR DESCRIPTION
Resolves: Subtask of #2304 

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR will add boolean datatype support in `array/empty-like`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
