### PR TITLE
feat: add boolean dtype support to `array/full-like`

### DIFF
--- a/lib/node_modules/@stdlib/array/full-like/README.md
+++ b/lib/node_modules/@stdlib/array/full-like/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2022 The Stdlib Authors.
+Copyright (c) 2024 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -57,6 +57,7 @@ The function supports the following data types:
 -   `float32`: single-precision floating-point numbers (IEEE 754)
 -   `complex128`: double-precision complex floating-point numbers
 -   `complex64`: single-precision complex floating-point numbers
+-   `bool`: boolean values
 -   `int32`: 32-bit two's complement signed integers
 -   `uint32`: 32-bit unsigned integers
 -   `int16`: 16-bit two's complement signed integers

--- a/lib/node_modules/@stdlib/array/full-like/README.md
+++ b/lib/node_modules/@stdlib/array/full-like/README.md
@@ -42,7 +42,7 @@ var fullLike = require( '@stdlib/array/full-like' );
 
 #### fullLike( x, value\[, dtype] )
 
-Creates a filled array having the same length and data type as a provided array `x`.
+Creates a filled array having the same length and [data type][@stdlib/array/dtypes] as a provided array `x`.
 
 ```javascript
 var x = [ 1, 2, 3, 4, 5 ];
@@ -51,23 +51,7 @@ var arr = fullLike( x, 1 );
 // returns [ 1, 1, 1, 1, 1 ]
 ```
 
-The function supports the following data types:
-
--   `float64`: double-precision floating-point numbers (IEEE 754)
--   `float32`: single-precision floating-point numbers (IEEE 754)
--   `complex128`: double-precision complex floating-point numbers
--   `complex64`: single-precision complex floating-point numbers
--   `bool`: boolean values
--   `int32`: 32-bit two's complement signed integers
--   `uint32`: 32-bit unsigned integers
--   `int16`: 16-bit two's complement signed integers
--   `uint16`: 16-bit unsigned integers
--   `int8`: 8-bit two's complement signed integers
--   `uint8`: 8-bit unsigned integers
--   `uint8c`: 8-bit unsigned integers clamped to `0-255`
--   `generic`: generic JavaScript values
-
-By default, the output array data type is inferred from the provided array `x`. To return an array having a different data type, provide a `dtype` argument.
+By default, the output array [data type][@stdlib/array/dtypes] is inferred from the provided array `x`. To return an array having a different [data type][@stdlib/array/dtypes], provide a `dtype` argument.
 
 ```javascript
 var x = [ 1, 1 ];
@@ -86,7 +70,7 @@ var arr = fullLike( x, 1, 'int32' );
 
 ## Notes
 
--   If provided a number and the output array data type is a complex number data type, the function returns a complex number array where each element has a real component whose value equals the provided fill value and where each element has an imaginary component equal to `0`.
+-   If provided a number and the output array [data type][@stdlib/array/dtypes] is a complex number [data type][@stdlib/array/dtypes], the function returns a complex number array where each element has a real component whose value equals the provided fill value and where each element has an imaginary component equal to `0`.
 
 </section>
 
@@ -151,6 +135,8 @@ for ( i = 0; i < dt.length; i++ ) {
 <!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 
 <section class="links">
+
+[@stdlib/array/dtypes]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/dtypes
 
 <!-- <related-links> -->
 

--- a/lib/node_modules/@stdlib/array/full-like/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/array/full-like/benchmark/benchmark.js
@@ -98,6 +98,28 @@ bench( pkg+':dtype=float32', function benchmark( b ) {
 	b.end();
 });
 
+bench( pkg+':dtype=bool', function benchmark( b ) {
+	var arr;
+	var x;
+	var i;
+
+	x = zeros( 0, 'bool' );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = fullLike( x, true );
+		if ( arr.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !isTypedArrayLike( arr ) ) {
+		b.fail( 'should return a typed array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
 bench( pkg+':dtype=complex128', function benchmark( b ) {
 	var arr;
 	var z;

--- a/lib/node_modules/@stdlib/array/full-like/benchmark/benchmark.length.bool.js
+++ b/lib/node_modules/@stdlib/array/full-like/benchmark/benchmark.length.bool.js
@@ -1,0 +1,95 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isTypedArrayLike = require( '@stdlib/assert/is-typed-array-like' );
+var zeros = require( '@stdlib/array/zeros' );
+var pkg = require( './../package.json' ).name;
+var fullLike = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = zeros( len, 'bool' );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var arr;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			arr = fullLike( x, true );
+			if ( arr.length !== len ) {
+				b.fail( 'unexpected length' );
+			}
+		}
+		b.toc();
+		if ( !isTypedArrayLike( arr ) ) {
+			b.fail( 'should return a typed array' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':dtype=bool,len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/full-like/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/full-like/docs/repl.txt
@@ -3,22 +3,6 @@
     Returns a filled array having the same length and data type as a provided
     input array.
 
-    The function supports the following data types:
-
-    - float64: double-precision floating-point numbers (IEEE 754)
-    - float32: single-precision floating-point numbers (IEEE 754)
-    - complex128: double-precision complex floating-point numbers
-    - complex64: single-precision complex floating-point numbers
-    - bool: boolean values
-    - int32: 32-bit two's complement signed integers
-    - uint32: 32-bit unsigned integers
-    - int16: 16-bit two's complement signed integers
-    - uint16: 16-bit unsigned integers
-    - int8: 8-bit two's complement signed integers
-    - uint8: 8-bit unsigned integers
-    - uint8c: 8-bit unsigned integers clamped to 0-255
-    - generic: generic JavaScript values
-
     Parameters
     ----------
     x: TypedArray|Array

--- a/lib/node_modules/@stdlib/array/full-like/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/full-like/docs/repl.txt
@@ -9,6 +9,7 @@
     - float32: single-precision floating-point numbers (IEEE 754)
     - complex128: double-precision complex floating-point numbers
     - complex64: single-precision complex floating-point numbers
+    - bool: boolean values
     - int32: 32-bit two's complement signed integers
     - uint32: 32-bit unsigned integers
     - int16: 16-bit two's complement signed integers

--- a/lib/node_modules/@stdlib/array/full-like/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/full-like/docs/types/index.d.ts
@@ -281,21 +281,6 @@ declare function fullLike( x: AnyArray, value: any, dtype: 'generic' ): Array<an
 /**
 * Creates a filled array having the same length and data type as a provided input array.
 *
-* The function supports the following data types:
-*
-* -   `float64`: double-precision floating-point numbers (IEEE 754)
-* -   `float32`: single-precision floating-point numbers (IEEE 754)
-* -   `complex128`: double-precision complex floating-point numbers
-* -   `complex64`: single-precision complex floating-point numbers
-* -   `int32`: 32-bit two's complement signed integers
-* -   `uint32`: 32-bit unsigned integers
-* -   `int16`: 16-bit two's complement signed integers
-* -   `uint16`: 16-bit unsigned integers
-* -   `int8`: 8-bit two's complement signed integers
-* -   `uint8`: 8-bit unsigned integers
-* -   `uint8c`: 8-bit unsigned integers clamped to `0-255`
-* -   `generic`: generic JavaScript values
-*
 * @param x - input array from which to derive the output array length
 * @param value - fill value
 * @param dtype - data type
@@ -314,21 +299,6 @@ declare function fullLike( x: Float64Array, value: number, dtype?: DataType ): F
 
 /**
 * Creates a filled array having the same length and data type as a provided input array.
-*
-* The function supports the following data types:
-*
-* -   `float64`: double-precision floating-point numbers (IEEE 754)
-* -   `float32`: single-precision floating-point numbers (IEEE 754)
-* -   `complex128`: double-precision complex floating-point numbers
-* -   `complex64`: single-precision complex floating-point numbers
-* -   `int32`: 32-bit two's complement signed integers
-* -   `uint32`: 32-bit unsigned integers
-* -   `int16`: 16-bit two's complement signed integers
-* -   `uint16`: 16-bit unsigned integers
-* -   `int8`: 8-bit two's complement signed integers
-* -   `uint8`: 8-bit unsigned integers
-* -   `uint8c`: 8-bit unsigned integers clamped to `0-255`
-* -   `generic`: generic JavaScript values
 *
 * @param x - input array from which to derive the output array length
 * @param value - fill value
@@ -349,21 +319,6 @@ declare function fullLike( x: Float32Array, value: number, dtype?: DataType ): F
 /**
 * Creates a filled array having the same length and data type as a provided input array.
 *
-* The function supports the following data types:
-*
-* -   `float64`: double-precision floating-point numbers (IEEE 754)
-* -   `float32`: single-precision floating-point numbers (IEEE 754)
-* -   `complex128`: double-precision complex floating-point numbers
-* -   `complex64`: single-precision complex floating-point numbers
-* -   `int32`: 32-bit two's complement signed integers
-* -   `uint32`: 32-bit unsigned integers
-* -   `int16`: 16-bit two's complement signed integers
-* -   `uint16`: 16-bit unsigned integers
-* -   `int8`: 8-bit two's complement signed integers
-* -   `uint8`: 8-bit unsigned integers
-* -   `uint8c`: 8-bit unsigned integers clamped to `0-255`
-* -   `generic`: generic JavaScript values
-*
 * @param x - input array from which to derive the output array length
 * @param value - fill value
 * @param dtype - data type
@@ -382,21 +337,6 @@ declare function fullLike( x: BooleanArray, value: boolean, dtype?: DataType ): 
 
 /**
 * Creates a filled array having the same length and data type as a provided input array.
-*
-* The function supports the following data types:
-*
-* -   `float64`: double-precision floating-point numbers (IEEE 754)
-* -   `float32`: single-precision floating-point numbers (IEEE 754)
-* -   `complex128`: double-precision complex floating-point numbers
-* -   `complex64`: single-precision complex floating-point numbers
-* -   `int32`: 32-bit two's complement signed integers
-* -   `uint32`: 32-bit unsigned integers
-* -   `int16`: 16-bit two's complement signed integers
-* -   `uint16`: 16-bit unsigned integers
-* -   `int8`: 8-bit two's complement signed integers
-* -   `uint8`: 8-bit unsigned integers
-* -   `uint8c`: 8-bit unsigned integers clamped to `0-255`
-* -   `generic`: generic JavaScript values
 *
 * ## Notes
 *
@@ -421,21 +361,6 @@ declare function fullLike( x: Complex128Array, value: number | ComplexLike, dtyp
 /**
 * Creates a filled array having the same length and data type as a provided input array.
 *
-* The function supports the following data types:
-*
-* -   `float64`: double-precision floating-point numbers (IEEE 754)
-* -   `float32`: single-precision floating-point numbers (IEEE 754)
-* -   `complex128`: double-precision complex floating-point numbers
-* -   `complex64`: single-precision complex floating-point numbers
-* -   `int32`: 32-bit two's complement signed integers
-* -   `uint32`: 32-bit unsigned integers
-* -   `int16`: 16-bit two's complement signed integers
-* -   `uint16`: 16-bit unsigned integers
-* -   `int8`: 8-bit two's complement signed integers
-* -   `uint8`: 8-bit unsigned integers
-* -   `uint8c`: 8-bit unsigned integers clamped to `0-255`
-* -   `generic`: generic JavaScript values
-*
 * ## Notes
 *
 * -   If provided a number, the function returns a complex number array where each element has a real component whose value equals the provided fill value and where each element has an imaginary component equal to `0`.
@@ -459,21 +384,6 @@ declare function fullLike( x: Complex64Array, value: number | ComplexLike, dtype
 /**
 * Creates a filled array having the same length and data type as a provided input array.
 *
-* The function supports the following data types:
-*
-* -   `float64`: double-precision floating-point numbers (IEEE 754)
-* -   `float32`: single-precision floating-point numbers (IEEE 754)
-* -   `complex128`: double-precision complex floating-point numbers
-* -   `complex64`: single-precision complex floating-point numbers
-* -   `int32`: 32-bit two's complement signed integers
-* -   `uint32`: 32-bit unsigned integers
-* -   `int16`: 16-bit two's complement signed integers
-* -   `uint16`: 16-bit unsigned integers
-* -   `int8`: 8-bit two's complement signed integers
-* -   `uint8`: 8-bit unsigned integers
-* -   `uint8c`: 8-bit unsigned integers clamped to `0-255`
-* -   `generic`: generic JavaScript values
-*
 * @param x - input array from which to derive the output array length
 * @param value - fill value
 * @param dtype - data type
@@ -492,21 +402,6 @@ declare function fullLike( x: Int32Array, value: number, dtype?: DataType ): Int
 
 /**
 * Creates a filled array having the same length and data type as a provided input array.
-*
-* The function supports the following data types:
-*
-* -   `float64`: double-precision floating-point numbers (IEEE 754)
-* -   `float32`: single-precision floating-point numbers (IEEE 754)
-* -   `complex128`: double-precision complex floating-point numbers
-* -   `complex64`: single-precision complex floating-point numbers
-* -   `int32`: 32-bit two's complement signed integers
-* -   `uint32`: 32-bit unsigned integers
-* -   `int16`: 16-bit two's complement signed integers
-* -   `uint16`: 16-bit unsigned integers
-* -   `int8`: 8-bit two's complement signed integers
-* -   `uint8`: 8-bit unsigned integers
-* -   `uint8c`: 8-bit unsigned integers clamped to `0-255`
-* -   `generic`: generic JavaScript values
 *
 * @param x - input array from which to derive the output array length
 * @param value - fill value
@@ -527,21 +422,6 @@ declare function fullLike( x: Int16Array, value: number, dtype?: DataType ): Int
 /**
 * Creates a filled array having the same length and data type as a provided input array.
 *
-* The function supports the following data types:
-*
-* -   `float64`: double-precision floating-point numbers (IEEE 754)
-* -   `float32`: single-precision floating-point numbers (IEEE 754)
-* -   `complex128`: double-precision complex floating-point numbers
-* -   `complex64`: single-precision complex floating-point numbers
-* -   `int32`: 32-bit two's complement signed integers
-* -   `uint32`: 32-bit unsigned integers
-* -   `int16`: 16-bit two's complement signed integers
-* -   `uint16`: 16-bit unsigned integers
-* -   `int8`: 8-bit two's complement signed integers
-* -   `uint8`: 8-bit unsigned integers
-* -   `uint8c`: 8-bit unsigned integers clamped to `0-255`
-* -   `generic`: generic JavaScript values
-*
 * @param x - input array from which to derive the output array length
 * @param value - fill value
 * @param dtype - data type
@@ -560,21 +440,6 @@ declare function fullLike( x: Int8Array, value: number, dtype?: DataType ): Int8
 
 /**
 * Creates a filled array having the same length and data type as a provided input array.
-*
-* The function supports the following data types:
-*
-* -   `float64`: double-precision floating-point numbers (IEEE 754)
-* -   `float32`: single-precision floating-point numbers (IEEE 754)
-* -   `complex128`: double-precision complex floating-point numbers
-* -   `complex64`: single-precision complex floating-point numbers
-* -   `int32`: 32-bit two's complement signed integers
-* -   `uint32`: 32-bit unsigned integers
-* -   `int16`: 16-bit two's complement signed integers
-* -   `uint16`: 16-bit unsigned integers
-* -   `int8`: 8-bit two's complement signed integers
-* -   `uint8`: 8-bit unsigned integers
-* -   `uint8c`: 8-bit unsigned integers clamped to `0-255`
-* -   `generic`: generic JavaScript values
 *
 * @param x - input array from which to derive the output array length
 * @param value - fill value
@@ -595,21 +460,6 @@ declare function fullLike( x: Uint32Array, value: number, dtype?: DataType ): Ui
 /**
 * Creates a filled array having the same length and data type as a provided input array.
 *
-* The function supports the following data types:
-*
-* -   `float64`: double-precision floating-point numbers (IEEE 754)
-* -   `float32`: single-precision floating-point numbers (IEEE 754)
-* -   `complex128`: double-precision complex floating-point numbers
-* -   `complex64`: single-precision complex floating-point numbers
-* -   `int32`: 32-bit two's complement signed integers
-* -   `uint32`: 32-bit unsigned integers
-* -   `int16`: 16-bit two's complement signed integers
-* -   `uint16`: 16-bit unsigned integers
-* -   `int8`: 8-bit two's complement signed integers
-* -   `uint8`: 8-bit unsigned integers
-* -   `uint8c`: 8-bit unsigned integers clamped to `0-255`
-* -   `generic`: generic JavaScript values
-*
 * @param x - input array from which to derive the output array length
 * @param value - fill value
 * @param dtype - data type
@@ -628,21 +478,6 @@ declare function fullLike( x: Uint16Array, value: number, dtype?: DataType ): Ui
 
 /**
 * Creates a filled array having the same length and data type as a provided input array.
-*
-* The function supports the following data types:
-*
-* -   `float64`: double-precision floating-point numbers (IEEE 754)
-* -   `float32`: single-precision floating-point numbers (IEEE 754)
-* -   `complex128`: double-precision complex floating-point numbers
-* -   `complex64`: single-precision complex floating-point numbers
-* -   `int32`: 32-bit two's complement signed integers
-* -   `uint32`: 32-bit unsigned integers
-* -   `int16`: 16-bit two's complement signed integers
-* -   `uint16`: 16-bit unsigned integers
-* -   `int8`: 8-bit two's complement signed integers
-* -   `uint8`: 8-bit unsigned integers
-* -   `uint8c`: 8-bit unsigned integers clamped to `0-255`
-* -   `generic`: generic JavaScript values
 *
 * @param x - input array from which to derive the output array length
 * @param value - fill value
@@ -663,21 +498,6 @@ declare function fullLike( x: Uint8Array, value: number, dtype?: DataType ): Uin
 /**
 * Creates a filled array having the same length and data type as a provided input array.
 *
-* The function supports the following data types:
-*
-* -   `float64`: double-precision floating-point numbers (IEEE 754)
-* -   `float32`: single-precision floating-point numbers (IEEE 754)
-* -   `complex128`: double-precision complex floating-point numbers
-* -   `complex64`: single-precision complex floating-point numbers
-* -   `int32`: 32-bit two's complement signed integers
-* -   `uint32`: 32-bit unsigned integers
-* -   `int16`: 16-bit two's complement signed integers
-* -   `uint16`: 16-bit unsigned integers
-* -   `int8`: 8-bit two's complement signed integers
-* -   `uint8`: 8-bit unsigned integers
-* -   `uint8c`: 8-bit unsigned integers clamped to `0-255`
-* -   `generic`: generic JavaScript values
-*
 * @param x - input array from which to derive the output array length
 * @param value - fill value
 * @param dtype - data type
@@ -697,21 +517,6 @@ declare function fullLike( x: Uint8ClampedArray, value: number, dtype?: DataType
 /**
 * Creates a filled array having the same length and data type as a provided input array.
 *
-* The function supports the following data types:
-*
-* -   `float64`: double-precision floating-point numbers (IEEE 754)
-* -   `float32`: single-precision floating-point numbers (IEEE 754)
-* -   `complex128`: double-precision complex floating-point numbers
-* -   `complex64`: single-precision complex floating-point numbers
-* -   `int32`: 32-bit two's complement signed integers
-* -   `uint32`: 32-bit unsigned integers
-* -   `int16`: 16-bit two's complement signed integers
-* -   `uint16`: 16-bit unsigned integers
-* -   `int8`: 8-bit two's complement signed integers
-* -   `uint8`: 8-bit unsigned integers
-* -   `uint8c`: 8-bit unsigned integers clamped to `0-255`
-* -   `generic`: generic JavaScript values
-*
 * @param x - input array from which to derive the output array length
 * @param value - fill value
 * @param dtype - data type
@@ -730,21 +535,6 @@ declare function fullLike( x: Array<any>, value: any, dtype?: DataType ): Array<
 
 /**
 * Creates a filled array having the same length and data type as a provided input array.
-*
-* The function supports the following data types:
-*
-* -   `float64`: double-precision floating-point numbers (IEEE 754)
-* -   `float32`: single-precision floating-point numbers (IEEE 754)
-* -   `complex128`: double-precision complex floating-point numbers
-* -   `complex64`: single-precision complex floating-point numbers
-* -   `int32`: 32-bit two's complement signed integers
-* -   `uint32`: 32-bit unsigned integers
-* -   `int16`: 16-bit two's complement signed integers
-* -   `uint16`: 16-bit unsigned integers
-* -   `int8`: 8-bit two's complement signed integers
-* -   `uint8`: 8-bit unsigned integers
-* -   `uint8c`: 8-bit unsigned integers clamped to `0-255`
-* -   `generic`: generic JavaScript values
 *
 * @param x - input array from which to derive the output array length
 * @param value - fill value

--- a/lib/node_modules/@stdlib/array/full-like/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/full-like/docs/types/index.d.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2022 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { Complex128Array, Complex64Array, AnyArray, DataType } from '@stdlib/types/array';
+import { Complex128Array, Complex64Array, BooleanArray, AnyArray, DataType } from '@stdlib/types/array';
 import { ComplexLike } from '@stdlib/types/complex';
 
 /**
@@ -60,6 +60,25 @@ declare function fullLike( x: AnyArray, value: number, dtype: 'float64' ): Float
 * // returns <Float32Array>[ 1.0, 1.0 ]
 */
 declare function fullLike( x: AnyArray, value: number, dtype: 'float32' ): Float32Array;
+
+/**
+* Creates a filled array having the same length as a provided input array.
+*
+* @param x - input array from which to derive the output array length
+* @param value - fill value
+* @param dtype - data type
+* @returns filled array
+*
+* @example
+* var zeros = require( '@stdlib/array/zeros' );
+*
+* var x = zeros( 2, 'uint8' );
+* // returns <Uint8Array>[ 0, 0 ]
+*
+* var y = fullLike( x, true, 'bool' );
+* // returns <BooleanArray>[ true, true ]
+*/
+declare function fullLike( x: AnyArray, value: boolean, dtype: 'bool' ): BooleanArray;
 
 /**
 * Creates a filled array having the same length as a provided input array.
@@ -326,6 +345,40 @@ declare function fullLike( x: Float64Array, value: number, dtype?: DataType ): F
 * // returns <Float32Array>[ 1.0, 1.0 ]
 */
 declare function fullLike( x: Float32Array, value: number, dtype?: DataType ): Float32Array;
+
+/**
+* Creates a filled array having the same length and data type as a provided input array.
+*
+* The function supports the following data types:
+*
+* -   `float64`: double-precision floating-point numbers (IEEE 754)
+* -   `float32`: single-precision floating-point numbers (IEEE 754)
+* -   `complex128`: double-precision complex floating-point numbers
+* -   `complex64`: single-precision complex floating-point numbers
+* -   `int32`: 32-bit two's complement signed integers
+* -   `uint32`: 32-bit unsigned integers
+* -   `int16`: 16-bit two's complement signed integers
+* -   `uint16`: 16-bit unsigned integers
+* -   `int8`: 8-bit two's complement signed integers
+* -   `uint8`: 8-bit unsigned integers
+* -   `uint8c`: 8-bit unsigned integers clamped to `0-255`
+* -   `generic`: generic JavaScript values
+*
+* @param x - input array from which to derive the output array length
+* @param value - fill value
+* @param dtype - data type
+* @returns filled array
+*
+* @example
+* var zeros = require( '@stdlib/array/zeros' );
+*
+* var x = zeros( 2, 'bool' );
+* // returns <BooleanArray>[ false, false ]
+*
+* var y = fullLike( x, true );
+* // returns <BooleanArray>[ true, true ]
+*/
+declare function fullLike( x: BooleanArray, value: boolean, dtype?: DataType ): BooleanArray;
 
 /**
 * Creates a filled array having the same length and data type as a provided input array.

--- a/lib/node_modules/@stdlib/array/full-like/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/full-like/docs/types/test.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2022 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 * limitations under the License.
 */
 
+import BooleanArray = require( '@stdlib/array/bool' );
 import Complex128Array = require( '@stdlib/array/complex128' );
 import Complex64Array = require( '@stdlib/array/complex64' );
 import Complex128 = require( '@stdlib/complex/float64/ctor' );
@@ -34,6 +35,7 @@ import fullLike = require( './index' );
 	fullLike( new Complex128Array( [ 0, 0 ] ), new Complex128( 1.0, 1.0 ) ); // $ExpectType Complex128Array
 	fullLike( new Complex64Array( [ 0, 0 ] ), 1 ); // $ExpectType Complex64Array
 	fullLike( new Complex64Array( [ 0, 0 ] ), new Complex64( 1.0, 1.0 ) ); // $ExpectType Complex64Array
+	fullLike( new BooleanArray( [ 0, 0 ] ), true ); // $ExpectType BooleanArray
 	fullLike( new Int32Array( [ 0, 0 ] ), 1 ); // $ExpectType Int32Array
 	fullLike( new Int16Array( [ 0, 0 ] ), 1 ); // $ExpectType Int16Array
 	fullLike( new Int8Array( [ 0, 0 ] ), 1 ); // $ExpectType Int8Array
@@ -48,6 +50,7 @@ import fullLike = require( './index' );
 	fullLike( [ 0, 0 ], new Complex128( 1.0, 1.0 ), 'complex128' ); // $ExpectType Complex128Array
 	fullLike( [ 0, 0 ], 1, 'complex64' ); // $ExpectType Complex64Array
 	fullLike( [ 0, 0 ], new Complex64( 1.0, 1.0 ), 'complex64' ); // $ExpectType Complex64Array
+	fullLike( [ 0, 0 ], true, 'bool' ); // $ExpectType BooleanArray
 	fullLike( [ 0, 0 ], 1, 'int32' ); // $ExpectType Int32Array
 	fullLike( [ 0, 0 ], 1, 'int16' ); // $ExpectType Int16Array
 	fullLike( [ 0, 0 ], 1, 'int8' ); // $ExpectType Int8Array

--- a/lib/node_modules/@stdlib/array/full-like/test/test.js
+++ b/lib/node_modules/@stdlib/array/full-like/test/test.js
@@ -207,7 +207,7 @@ tape( 'the function returns a filled array (dtype=float32)', function test( t ) 
 	t.end();
 });
 
-tape( 'the function returns a filled array (dtype=bool)', function test( t ) {
+tape( 'the function returns a filled array (bool)', function test( t ) {
 	var expected;
 	var arr;
 	var x;
@@ -215,7 +215,7 @@ tape( 'the function returns a filled array (dtype=bool)', function test( t ) {
 	x = new BooleanArray( 4 );
 	expected = new Uint8Array( [ true, true, true, true ] );
 
-	arr = fullLike( x, true, 'bool' );
+	arr = fullLike( x, true );
 	t.strictEqual( instanceOf( arr, BooleanArray ), true, 'returns expected value' );
 	t.strictEqual( arr.length, expected.length, 'returns expected value' );
 	t.deepEqual( reinterpretBoolean( arr, 0 ), expected, 'returns expected value' );

--- a/lib/node_modules/@stdlib/array/full-like/test/test.js
+++ b/lib/node_modules/@stdlib/array/full-like/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2022 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -32,8 +32,10 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
 var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
+var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
@@ -201,6 +203,38 @@ tape( 'the function returns a filled array (dtype=float32)', function test( t ) 
 	t.strictEqual( instanceOf( arr, Float32Array ), true, 'returns expected value' );
 	t.strictEqual( arr.length, expected.length, 'returns expected value' );
 	t.deepEqual( arr, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a filled array (dtype=bool)', function test( t ) {
+	var expected;
+	var arr;
+	var x;
+
+	x = new BooleanArray( 4 );
+	expected = new Uint8Array( [ true, true, true, true ] );
+
+	arr = fullLike( x, true, 'bool' );
+	t.strictEqual( instanceOf( arr, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( arr.length, expected.length, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( arr, 0 ), expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a filled array (dtype=bool)', function test( t ) {
+	var expected;
+	var arr;
+	var x;
+
+	x = new Float32Array( 4 );
+	expected = new Uint8Array( [ true, true, true, true ] );
+
+	arr = fullLike( x, true, 'bool' );
+	t.strictEqual( instanceOf( arr, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( arr.length, expected.length, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( arr, 0 ), expected, 'returns expected value' );
 
 	t.end();
 });


### PR DESCRIPTION
Resolves: Subtask of #2304 

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR will add boolean datatype support in `array/full-like`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
