### PR TITLE
feat: add boolean dtype support to `array/from-scalar`

### DIFF
--- a/lib/node_modules/@stdlib/array/from-scalar/README.md
+++ b/lib/node_modules/@stdlib/array/from-scalar/README.md
@@ -54,6 +54,7 @@ If not provided a `dtype` argument and `value`
 -   is a `number`, the default [data type][@stdlib/array/dtypes] is the [default][@stdlib/array/defaults] real-valued floating-point data type.
 -   is a complex number object of a known data type, the data type is the same as the provided value.
 -   is a complex number object of an unknown data type, the default [data type][@stdlib/array/dtypes] is the [default][@stdlib/array/defaults] complex-valued floating-point data type.
+-   is a boolean value, the default [data type][@stdlib/array/dtypes] is the [default][@stdlib/array/defaults] boolean data type.
 -   is any other value type, the default [data type][@stdlib/array/dtypes] is `'generic'`.
 
 To explicitly specify the [data type][@stdlib/array/dtypes] of the returned array, provide a `dtype` argument.

--- a/lib/node_modules/@stdlib/array/from-scalar/README.md
+++ b/lib/node_modules/@stdlib/array/from-scalar/README.md
@@ -51,10 +51,10 @@ var x = scalar2array( 3.0 );
 
 If not provided a `dtype` argument and `value`
 
--   is a `number`, the default [data type][@stdlib/array/dtypes] is the [default][@stdlib/array/defaults] real-valued floating-point data type.
+-   is a number, the default [data type][@stdlib/array/dtypes] is the [default][@stdlib/array/defaults] real-valued floating-point data type.
+-   is a boolean, the default [data type][@stdlib/array/dtypes] is the [default][@stdlib/array/defaults] boolean data type.
 -   is a complex number object of a known data type, the data type is the same as the provided value.
 -   is a complex number object of an unknown data type, the default [data type][@stdlib/array/dtypes] is the [default][@stdlib/array/defaults] complex-valued floating-point data type.
--   is a boolean value, the default [data type][@stdlib/array/dtypes] is the [default][@stdlib/array/defaults] boolean data type.
 -   is any other value type, the default [data type][@stdlib/array/dtypes] is `'generic'`.
 
 To explicitly specify the [data type][@stdlib/array/dtypes] of the returned array, provide a `dtype` argument.

--- a/lib/node_modules/@stdlib/array/from-scalar/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/array/from-scalar/benchmark/benchmark.js
@@ -169,6 +169,32 @@ bench( pkg+'::default,complex-like', function benchmark( b ) {
 	b.end();
 });
 
+bench( pkg+':dtype=bool', function benchmark( b ) {
+	var values;
+	var v;
+	var i;
+
+	values = [
+		true,
+		false
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		v = scalar2array( values[ i%values.length ] );
+		if ( v.length !== 1 ) {
+			b.fail( 'should return a single-element array' );
+		}
+	}
+	console.log( v );
+	b.toc();
+	if ( !isCollection ) {
+		b.fail( 'should return an array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
 bench( pkg+':dtype=float64', function benchmark( b ) {
 	var values;
 	var v;

--- a/lib/node_modules/@stdlib/array/from-scalar/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/array/from-scalar/benchmark/benchmark.js
@@ -169,7 +169,7 @@ bench( pkg+'::default,complex-like', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':dtype=bool', function benchmark( b ) {
+bench( pkg+'::default,bool', function benchmark( b ) {
 	var values;
 	var v;
 	var i;
@@ -417,6 +417,31 @@ bench( pkg+':dtype=uint8c', function benchmark( b ) {
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
 		v = scalar2array( values[ i%values.length ], 'uint8c' );
+		if ( v.length !== 1 ) {
+			b.fail( 'should return a single-element array' );
+		}
+	}
+	b.toc();
+	if ( !isCollection ) {
+		b.fail( 'should return an array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+':dtype=bool', function benchmark( b ) {
+	var values;
+	var v;
+	var i;
+
+	values = [
+		true,
+		false
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		v = scalar2array( values[ i%values.length ], 'bool' );
 		if ( v.length !== 1 ) {
 			b.fail( 'should return a single-element array' );
 		}

--- a/lib/node_modules/@stdlib/array/from-scalar/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/from-scalar/docs/repl.txt
@@ -17,12 +17,11 @@
 
         - is a number, the default data type is the default real-valued
           floating-point data type.
+        - is a boolean, the default data type is the default boolean data type.
         - is a complex number object of a known complex data type, the data type
           is the same as the provided value.
         - is a complex number object of an unknown data type, the default data
           type is the default complex-valued floating-point data type.
-        - is a boolean value, the default data type is the default boolean data
-          type.
         - is any other value type, the default data type is 'generic'.
 
     Returns

--- a/lib/node_modules/@stdlib/array/from-scalar/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/from-scalar/docs/repl.txt
@@ -21,6 +21,8 @@
           is the same as the provided value.
         - is a complex number object of an unknown data type, the default data
           type is the default complex-valued floating-point data type.
+        - is a boolean value, the default data type is the default boolean data
+          type.
         - is any other value type, the default data type is 'generic'.
 
     Returns

--- a/lib/node_modules/@stdlib/array/from-scalar/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/from-scalar/docs/types/index.d.ts
@@ -278,7 +278,7 @@ declare function scalar2array( value: Complex128 | ComplexLike ): Complex128Arra
 *     -   is a number, the default data type is the default real-valued floating-point data type.
 *     -   is a complex number object of a known complex data type, the data type is the same as the provided value.
 *     -   is a complex number object of an unknown complex data type, the default data type is the default complex-valued floating-point data type.
-*     -   is a boolean value, the default data type is the boolean data type.
+*     -   is a boolean, the default data type is the boolean data type.
 *     -   is any other value type, the default data type is `'generic'`.
 *
 * @param value - scalar value

--- a/lib/node_modules/@stdlib/array/from-scalar/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/from-scalar/docs/types/index.d.ts
@@ -275,7 +275,7 @@ declare function scalar2array( value: Complex128 | ComplexLike ): Complex128Arra
 *
 * -   If a `dtype` argument is not provided and `value`
 *
-*     -   is a `number`, the default data type is the default real-valued floating-point data type.
+*     -   is a number, the default data type is the default real-valued floating-point data type.
 *     -   is a complex number object of a known complex data type, the data type is the same as the provided value.
 *     -   is a complex number object of an unknown complex data type, the default data type is the default complex-valued floating-point data type.
 *     -   is a boolean value, the default data type is the boolean data type.

--- a/lib/node_modules/@stdlib/array/from-scalar/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/from-scalar/docs/types/index.d.ts
@@ -60,7 +60,7 @@ declare function scalar2array( value: number, dtype: 'float32' ): Float32Array;
 * var x = scalar2array( true, 'bool' );
 * // returns <BooleanArray>
 */
-declare function scalar2array( value: boolean, dtype: 'bool' ): BooleanArray;
+declare function scalar2array( value: any, dtype: 'bool' ): BooleanArray;
 
 /**
 * Returns a single-element array containing a provided scalar value.
@@ -229,6 +229,19 @@ declare function scalar2array( value: number ): Float64Array;
 * @returns output array
 *
 * @example
+* var x = scalar2array( true );
+* // returns <BooleanArray>
+*/
+declare function scalar2array( value: boolean ): BooleanArray;
+
+/**
+* Returns a single-element array containing a provided scalar value.
+*
+* @param value - scalar value
+* @param dtype - output array data type
+* @returns output array
+*
+* @example
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
 *
 * var z = new Complex64( 3.0, 4.0 );
@@ -265,6 +278,7 @@ declare function scalar2array( value: Complex128 | ComplexLike ): Complex128Arra
 *     -   is a `number`, the default data type is the default real-valued floating-point data type.
 *     -   is a complex number object of a known complex data type, the data type is the same as the provided value.
 *     -   is a complex number object of an unknown complex data type, the default data type is the default complex-valued floating-point data type.
+*     -   is a boolean value, the default data type is the boolean data type.
 *     -   is any other value type, the default data type is `'generic'`.
 *
 * @param value - scalar value

--- a/lib/node_modules/@stdlib/array/from-scalar/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/from-scalar/docs/types/index.d.ts
@@ -21,7 +21,7 @@
 /// <reference types="@stdlib/types"/>
 
 import { ComplexLike, Complex64, Complex128 } from '@stdlib/types/complex';
-import { DataType, Complex128Array, Complex64Array } from '@stdlib/types/array';
+import { DataType, Complex128Array, Complex64Array, BooleanArray } from '@stdlib/types/array';
 
 /**
 * Returns a single-element array containing a provided scalar value.
@@ -48,6 +48,19 @@ declare function scalar2array( value: number, dtype: 'float64' ): Float64Array; 
 * // returns <Float32Array>[ 1.0 ]
 */
 declare function scalar2array( value: number, dtype: 'float32' ): Float32Array;
+
+/**
+* Returns a single-element array containing a provided scalar value.
+*
+* @param value - scalar value
+* @param dtype - output array data type
+* @returns output array
+*
+* @example
+* var x = scalar2array( true, 'bool' );
+* // returns <BooleanArray>
+*/
+declare function scalar2array( value: boolean, dtype: 'bool' ): BooleanArray;
 
 /**
 * Returns a single-element array containing a provided scalar value.

--- a/lib/node_modules/@stdlib/array/from-scalar/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/from-scalar/docs/types/index.d.ts
@@ -276,9 +276,9 @@ declare function scalar2array( value: Complex128 | ComplexLike ): Complex128Arra
 * -   If a `dtype` argument is not provided and `value`
 *
 *     -   is a number, the default data type is the default real-valued floating-point data type.
+*     -   is a boolean, the default data type is the default boolean data type.
 *     -   is a complex number object of a known complex data type, the data type is the same as the provided value.
 *     -   is a complex number object of an unknown complex data type, the default data type is the default complex-valued floating-point data type.
-*     -   is a boolean, the default data type is the boolean data type.
 *     -   is any other value type, the default data type is `'generic'`.
 *
 * @param value - scalar value

--- a/lib/node_modules/@stdlib/array/from-scalar/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/from-scalar/docs/types/test.ts
@@ -35,6 +35,7 @@ import array2scalar = require( './index' );
 	array2scalar( 1.0, 'float32' ); // $ExpectType Float32Array
 	array2scalar( 1.0, 'complex128' ); // $ExpectType Complex128Array
 	array2scalar( 1.0, 'complex64' ); // $ExpectType Complex64Array
+	array2scalar( true, 'bool' ); // $ExpectType BooleanArray
 	array2scalar( 1.0, 'int32' ); // $ExpectType Int32Array
 	array2scalar( 1.0, 'int16' ); // $ExpectType Int16Array
 	array2scalar( 1.0, 'int8' ); // $ExpectType Int8Array

--- a/lib/node_modules/@stdlib/array/from-scalar/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/from-scalar/docs/types/test.ts
@@ -29,6 +29,7 @@ import array2scalar = require( './index' );
 	array2scalar( new Complex128( 3.0, 4.0 ) ); // $ExpectType Complex128Array
 	array2scalar( new Complex64( 3.0, 4.0 ) ); // $ExpectType Complex64Array
 	array2scalar( { 're': 3.0, 'im': 4.0 } ); // $ExpectType Complex128Array
+	array2scalar( true ); // $ExpectType BooleanArray
 	array2scalar( null ); // $ExpectType null[]
 
 	array2scalar( 1.0, 'float64' ); // $ExpectType Float64Array

--- a/lib/node_modules/@stdlib/array/from-scalar/lib/main.js
+++ b/lib/node_modules/@stdlib/array/from-scalar/lib/main.js
@@ -49,6 +49,7 @@ var DEFAULT_CMPLX = defaults.get( 'dtypes.complex_floating_point' );
 *     -   is a `number`, the default data type is the default real-valued floating-point data type.
 *     -   is a complex number object of a known complex data type, the data type is the same as the provided value.
 *     -   is a complex number object of an unknown complex data type, the default data type is the default complex-valued floating-point data type.
+*     -   is a boolean value, the default data type is the boolean data type.
 *     -   is any other value type, the default data type is `'generic'`.
 *
 * @param {*} value - scalar value
@@ -75,13 +76,13 @@ function scalar2array( value ) {
 	if ( arguments.length < 2 ) {
 		if ( flg ) {
 			dt = DEFAULT_REAL;
+		} else if ( isBoolean( value ) ) {
+			dt = 'bool';
 		} else if ( isComplexLike( value ) ) {
 			dt = dtype( value );
 			if ( dt === null ) {
 				dt = DEFAULT_CMPLX;
 			}
-		} else if ( isBoolean( value ) ) {
-			dt = 'bool';
 		} else {
 			dt = 'generic';
 		}

--- a/lib/node_modules/@stdlib/array/from-scalar/lib/main.js
+++ b/lib/node_modules/@stdlib/array/from-scalar/lib/main.js
@@ -22,6 +22,7 @@
 
 var isNumber = require( '@stdlib/assert/is-number' ).isPrimitive;
 var isComplexLike = require( '@stdlib/assert/is-complex-like' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var isAccessorArray = require( '@stdlib/array/base/assert/is-accessor-array' );
 var accessorSetter = require( '@stdlib/array/base/accessor-setter' );
 var setter = require( '@stdlib/array/base/setter' );
@@ -79,6 +80,8 @@ function scalar2array( value ) {
 			if ( dt === null ) {
 				dt = DEFAULT_CMPLX;
 			}
+		} else if ( isBoolean( value ) ) {
+			dt = 'bool';
 		} else {
 			dt = 'generic';
 		}

--- a/lib/node_modules/@stdlib/array/from-scalar/lib/main.js
+++ b/lib/node_modules/@stdlib/array/from-scalar/lib/main.js
@@ -20,6 +20,7 @@
 
 // MODULES //
 
+var isComplexDataType = require( '@stdlib/array/base/assert/is-complex-floating-point-data-type' );
 var isNumber = require( '@stdlib/assert/is-number' ).isPrimitive;
 var isComplexLike = require( '@stdlib/assert/is-complex-like' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
@@ -35,6 +36,7 @@ var defaults = require( '@stdlib/array/defaults' );
 
 var DEFAULT_REAL = defaults.get( 'dtypes.real_floating_point' );
 var DEFAULT_CMPLX = defaults.get( 'dtypes.complex_floating_point' );
+var DEFAULT_BOOL = defaults.get( 'dtypes.boolean' );
 
 
 // MAIN //
@@ -46,10 +48,10 @@ var DEFAULT_CMPLX = defaults.get( 'dtypes.complex_floating_point' );
 *
 * -   If a `dtype` option is not provided and `value`
 *
-*     -   is a `number`, the default data type is the default real-valued floating-point data type.
+*     -   is a number, the default data type is the default real-valued floating-point data type.
+*     -   is a boolean, the default data type is the default boolean data type.
 *     -   is a complex number object of a known complex data type, the data type is the same as the provided value.
 *     -   is a complex number object of an unknown complex data type, the default data type is the default complex-valued floating-point data type.
-*     -   is a boolean value, the default data type is the boolean data type.
 *     -   is any other value type, the default data type is `'generic'`.
 *
 * @param {*} value - scalar value
@@ -77,7 +79,7 @@ function scalar2array( value ) {
 		if ( flg ) {
 			dt = DEFAULT_REAL;
 		} else if ( isBoolean( value ) ) {
-			dt = 'bool';
+			dt = DEFAULT_BOOL;
 		} else if ( isComplexLike( value ) ) {
 			dt = dtype( value );
 			if ( dt === null ) {
@@ -90,7 +92,7 @@ function scalar2array( value ) {
 		dt = arguments[ 1 ];
 	}
 	out = zeros( 1, dt ); // delegate dtype validation to `zeros`
-	if ( /^complex/.test( dt ) && flg ) {
+	if ( flg && isComplexDataType( dt ) ) {
 		v = [ value, 0.0 ]; // note: we're assuming that the ComplexXXArray setter accepts an array of interleaved real and imaginary components
 	} else {
 		v = value;

--- a/lib/node_modules/@stdlib/array/from-scalar/test/test.js
+++ b/lib/node_modules/@stdlib/array/from-scalar/test/test.js
@@ -193,6 +193,11 @@ tape( 'the function returns a single element containing a provided scalar value 
 	expected = new BooleanArray( [ false ] );
 
 	t.strictEqual( isSameBooleanArray( actual, expected ), true, 'returns expected value' );
+
+	actual = array2scalar( true, 'bool' );
+	expected = new BooleanArray( [ true ] );
+
+	t.strictEqual( isSameBooleanArray( actual, expected ), true, 'returns expected value' );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/array/from-scalar/test/test.js
+++ b/lib/node_modules/@stdlib/array/from-scalar/test/test.js
@@ -25,9 +25,11 @@ var Complex128 = require( '@stdlib/complex/float64/ctor' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var Complex128Array = require( '@stdlib/array/complex128' );
 var Complex64Array = require( '@stdlib/array/complex64' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var Float64Array = require( '@stdlib/array/float64' );
 var Float32Array = require( '@stdlib/array/float32' );
 var Int32Array = require( '@stdlib/array/int32' );
+var isSameBooleanArray = require( '@stdlib/assert/is-same-booleanarray' );
 var isSameComplex128Array = require( '@stdlib/assert/is-same-complex128array' );
 var isSameComplex64Array = require( '@stdlib/assert/is-same-complex64array' );
 var isSameFloat64Array = require( '@stdlib/assert/is-same-float64array' );
@@ -75,6 +77,17 @@ tape( 'the function returns a single element containing a provided scalar value 
 	expected = new Float64Array( [ 3.0 ] );
 
 	t.strictEqual( isSameFloat64Array( actual, expected ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns a single element containing a provided scalar value (default, bool)', function test( t ) {
+	var expected;
+	var actual;
+
+	actual = array2scalar( true );
+	expected = new BooleanArray( [ true ] );
+
+	t.strictEqual( isSameBooleanArray( actual, expected ), true, 'returns expected value' );
 	t.end();
 });
 
@@ -169,6 +182,17 @@ tape( 'the function returns a single element containing a provided scalar value 
 	expected = [ 3.0 ];
 
 	t.strictEqual( isSameArray( actual, expected ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns a single element containing a provided scalar value (dtype=bool)', function test( t ) {
+	var expected;
+	var actual;
+
+	actual = array2scalar( false, 'bool' );
+	expected = new BooleanArray( [ false ] );
+
+	t.strictEqual( isSameBooleanArray( actual, expected ), true, 'returns expected value' );
 	t.end();
 });
 


### PR DESCRIPTION
Resolves: Subtask of #2304 

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR will add boolean datatype support in `array/from-scalar`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
