### PR TITLE
feat: add boolean dtype support to `array/filled`

### DIFF
--- a/lib/node_modules/@stdlib/array/filled/README.md
+++ b/lib/node_modules/@stdlib/array/filled/README.md
@@ -42,30 +42,14 @@ var filledarray = require( '@stdlib/array/filled' );
 
 #### filledarray( \[dtype] )
 
-Creates a filled array having a specified data type `dtype`.
+Creates a filled array having a specified [data type][@stdlib/array/dtypes] `dtype`.
 
 ```javascript
 var arr = filledarray();
 // returns <Float64Array>
 ```
 
-The function recognizes the following data types:
-
--   `float64`: double-precision floating-point numbers (IEEE 754)
--   `float32`: single-precision floating-point numbers (IEEE 754)
--   `complex128`: double-precision complex floating-point numbers
--   `complex64`: single-precision complex floating-point numbers
--   `bool`: boolean values
--   `int32`: 32-bit two's complement signed integers
--   `uint32`: 32-bit unsigned integers
--   `int16`: 16-bit two's complement signed integers
--   `uint16`: 16-bit unsigned integers
--   `int8`: 8-bit two's complement signed integers
--   `uint8`: 8-bit unsigned integers
--   `uint8c`: 8-bit unsigned integers clamped to `0-255`
--   `generic`: generic JavaScript values
-
-By default, the output array data type is `float64` (i.e., a [typed array][mdn-typed-array]). To specify an alternative data type, provide a `dtype` argument.
+By default, the output array [data type][@stdlib/array/dtypes] is `float64` (i.e., a [typed array][mdn-typed-array]). To specify an alternative [data type][@stdlib/array/dtypes], provide a `dtype` argument.
 
 ```javascript
 var arr = filledarray( 'int32' );
@@ -235,6 +219,8 @@ for ( i = 0; i < dt.length; i++ ) {
 [mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
 
 [mdn-arraybuffer]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer
+
+[@stdlib/array/dtypes]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/dtypes
 
 <!-- <related-links> -->
 

--- a/lib/node_modules/@stdlib/array/filled/README.md
+++ b/lib/node_modules/@stdlib/array/filled/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2020 The Stdlib Authors.
+Copyright (c) 2024 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -55,6 +55,7 @@ The function recognizes the following data types:
 -   `float32`: single-precision floating-point numbers (IEEE 754)
 -   `complex128`: double-precision complex floating-point numbers
 -   `complex64`: single-precision complex floating-point numbers
+-   `bool`: boolean values
 -   `int32`: 32-bit two's complement signed integers
 -   `uint32`: 32-bit unsigned integers
 -   `int16`: 16-bit two's complement signed integers

--- a/lib/node_modules/@stdlib/array/filled/README.md
+++ b/lib/node_modules/@stdlib/array/filled/README.md
@@ -18,7 +18,7 @@ limitations under the License.
 
 -->
 
-# Filled Array
+# filledarray
 
 > Create a filled array.
 

--- a/lib/node_modules/@stdlib/array/filled/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/array/filled/benchmark/benchmark.js
@@ -85,6 +85,24 @@ bench( pkg+':dtype=float32', function benchmark( b ) {
 	b.end();
 });
 
+bench( pkg+':dtype=bool', function benchmark( b ) {
+	var arr;
+	var i;
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = filledarray( true, 0, 'bool' );
+		if ( arr.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !isTypedArrayLike( arr ) ) {
+		b.fail( 'should return a typed array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
 bench( pkg+':dtype=complex128', function benchmark( b ) {
 	var arr;
 	var v;

--- a/lib/node_modules/@stdlib/array/filled/benchmark/benchmark.length.bool.js
+++ b/lib/node_modules/@stdlib/array/filled/benchmark/benchmark.length.bool.js
@@ -1,0 +1,93 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isTypedArrayLike = require( '@stdlib/assert/is-typed-array-like' );
+var pkg = require( './../package.json' ).name;
+var filledarray = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var arr;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			arr = filledarray( true, len, 'bool' );
+			if ( arr.length !== len ) {
+				b.fail( 'unexpected length' );
+			}
+		}
+		b.toc();
+		if ( !isTypedArrayLike( arr ) ) {
+			b.fail( 'should return a typed array' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':dtype=bool,len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/filled/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/filled/docs/repl.txt
@@ -2,24 +2,6 @@
 {{alias}}( [dtype] )
     Creates a filled array.
 
-    The function supports the following data types:
-
-    - float64: double-precision floating-point numbers (IEEE 754)
-    - float32: single-precision floating-point numbers (IEEE 754)
-    - complex128: double-precision complex floating-point numbers
-    - complex64: single-precision complex floating-point numbers
-    - bool: boolean values
-    - int32: 32-bit two's complement signed integers
-    - uint32: 32-bit unsigned integers
-    - int16: 16-bit two's complement signed integers
-    - uint16: 16-bit unsigned integers
-    - int8: 8-bit two's complement signed integers
-    - uint8: 8-bit unsigned integers
-    - uint8c: 8-bit unsigned integers clamped to 0-255
-    - generic: generic JavaScript values
-
-    The default array data type is `float64`.
-
     Parameters
     ----------
     dtype: string (optional)

--- a/lib/node_modules/@stdlib/array/filled/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/filled/docs/repl.txt
@@ -8,6 +8,7 @@
     - float32: single-precision floating-point numbers (IEEE 754)
     - complex128: double-precision complex floating-point numbers
     - complex64: single-precision complex floating-point numbers
+    - bool: boolean values
     - int32: 32-bit two's complement signed integers
     - uint32: 32-bit unsigned integers
     - int16: 16-bit two's complement signed integers

--- a/lib/node_modules/@stdlib/array/filled/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/filled/docs/types/index.d.ts
@@ -28,21 +28,6 @@ import { IterableIterator } from '@stdlib/types/iter';
 /**
 * Creates a filled array.
 *
-* The function recognizes the following data types:
-*
-* -   `float64`: double-precision floating-point numbers (IEEE 754)
-* -   `float32`: single-precision floating-point numbers (IEEE 754)
-* -   `complex128`: double-precision complex floating-point numbers
-* -   `complex64`: single-precision complex floating-point numbers
-* -   `int32`: 32-bit two's complement signed integers
-* -   `uint32`: 32-bit unsigned integers
-* -   `int16`: 16-bit two's complement signed integers
-* -   `uint16`: 16-bit unsigned integers
-* -   `int8`: 8-bit two's complement signed integers
-* -   `uint8`: 8-bit unsigned integers
-* -   `uint8c`: 8-bit unsigned integers clamped to `0-255`
-* -   `generic`: generic JavaScript values
-*
 * @param dtype - data type (default: 'float64')
 * @returns filled array
 *

--- a/lib/node_modules/@stdlib/array/filled/lib/main.js
+++ b/lib/node_modules/@stdlib/array/filled/lib/main.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var isComplexDataType = require( '@stdlib/array/base/assert/is-complex-floating-point-data-type' );
+var isBooleanDataType = require( '@stdlib/array/base/assert/is-boolean-data-type' );
 var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
 var isNonNegativeInteger = require( '@stdlib/assert/is-nonnegative-integer' ).isPrimitive;
 var isCollection = require( '@stdlib/assert/is-collection' );
@@ -30,6 +31,7 @@ var isFunction = require( '@stdlib/assert/is-function' );
 var ctors = require( '@stdlib/array/ctors' );
 var gfill = require( '@stdlib/blas/ext/base/gfill' );
 var filled = require( '@stdlib/array/base/filled' );
+var reinterpretBool = require( '@stdlib/strided/base/reinterpret-boolean' );
 var hasIteratorSymbolSupport = require( '@stdlib/assert/has-iterator-symbol-support' );
 var ITERATOR_SYMBOL = require( '@stdlib/symbol/iterator' );
 var iterLength = require( '@stdlib/iter/length' );
@@ -266,10 +268,13 @@ function filledarray() {
 		arr = new ctor( arguments[1], arguments[2], arguments[3] ); // (ArrayBuffer, byteOffset, length)
 	}
 	if ( arr.length > 0 ) {
+		value = arguments[ 0 ];
 		if ( isComplexDataType( dtype ) ) {
-			filledAccessors( arr, arguments[ 0 ] );
+			filledAccessors( arr, value );
+		} else if ( isBooleanDataType( dtype ) ) {
+			gfill( arr.length, ( value ) ? 1 : 0, reinterpretBool( arr, 0 ), 1 ); // eslint-disable-line max-len
 		} else {
-			gfill( arr.length, arguments[ 0 ], arr, 1 );
+			gfill( arr.length, value, arr, 1 );
 		}
 	}
 	return arr;

--- a/lib/node_modules/@stdlib/array/filled/lib/main.js
+++ b/lib/node_modules/@stdlib/array/filled/lib/main.js
@@ -20,6 +20,7 @@
 
 // MODULES //
 
+var isComplexDataType = require( '@stdlib/array/base/assert/is-complex-floating-point-data-type' );
 var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
 var isNonNegativeInteger = require( '@stdlib/assert/is-nonnegative-integer' ).isPrimitive;
 var isCollection = require( '@stdlib/assert/is-collection' );
@@ -265,7 +266,7 @@ function filledarray() {
 		arr = new ctor( arguments[1], arguments[2], arguments[3] ); // (ArrayBuffer, byteOffset, length)
 	}
 	if ( arr.length > 0 ) {
-		if ( /^complex/.test( dtype ) ) {
+		if ( isComplexDataType( dtype ) ) {
 			filledAccessors( arr, arguments[ 0 ] );
 		} else {
 			gfill( arr.length, arguments[ 0 ], arr, 1 );

--- a/lib/node_modules/@stdlib/array/filled/test/test.js
+++ b/lib/node_modules/@stdlib/array/filled/test/test.js
@@ -2003,6 +2003,14 @@ tape( 'the function returns a filled typed array (dtype=bool, arraybuffer, byteo
 	var buf;
 	var out;
 
+	expected = new Uint8Array( [ 0, 0, 0, 0 ] );
+
+	buf = new ArrayBuffer( 8 );
+	out = filledarray( false, buf, 4, 'bool' );
+	t.strictEqual( instanceOf( out, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( out.length, expected.length, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
+
 	expected = new Uint8Array( [ 1, 1, 1, 1 ] );
 
 	buf = new ArrayBuffer( 8 );
@@ -2220,6 +2228,14 @@ tape( 'the function returns a filled typed array (dtype=bool, arraybuffer, byteo
 	var expected;
 	var buf;
 	var out;
+
+	expected = new Uint8Array( [ 0, 0, 0, 0 ] );
+
+	buf = new ArrayBuffer( 6 );
+	out = filledarray( false, buf, 1, 4, 'bool' );
+	t.strictEqual( instanceOf( out, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( out.length, expected.length, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
 
 	expected = new Uint8Array( [ 1, 1, 1, 1 ] );
 

--- a/lib/node_modules/@stdlib/array/filled/test/test.js
+++ b/lib/node_modules/@stdlib/array/filled/test/test.js
@@ -1998,7 +1998,7 @@ tape( 'the function returns a filled typed array (dtype=float32, arraybuffer, by
 	t.end();
 });
 
-tape( 'the function returns a filled typed array (dtype=complex128, arraybuffer, byteoffset)', function test( t ) {
+tape( 'the function returns a filled typed array (dtype=bool, arraybuffer, byteoffset)', function test( t ) {
 	var expected;
 	var buf;
 	var out;

--- a/lib/node_modules/@stdlib/array/filled/test/test.js
+++ b/lib/node_modules/@stdlib/array/filled/test/test.js
@@ -1777,6 +1777,14 @@ tape( 'the function returns a filled typed array (dtype=bool, arraybuffer)', fun
 	var buf;
 	var out;
 
+	expected = new Uint8Array( [ 0, 0 ] );
+
+	buf = new ArrayBuffer( 2 );
+	out = filledarray( false, buf, 'bool' );
+	t.strictEqual( instanceOf( out, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( out.length, expected.length, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
+
 	expected = new Uint8Array( [ 1, 1 ] );
 
 	buf = new ArrayBuffer( 2 );

--- a/lib/node_modules/@stdlib/array/filled/test/test.js
+++ b/lib/node_modules/@stdlib/array/filled/test/test.js
@@ -994,6 +994,20 @@ tape( 'the function returns a filled array (value=false, dtype=bool, length)', f
 	t.end();
 });
 
+tape( 'the function returns a filled array (value=true, dtype=bool, length)', function test( t ) {
+	var expected;
+	var arr;
+
+	expected = new Uint8Array( [ 1, 1, 1, 1, 1 ] );
+
+	arr = filledarray( true, 5, 'bool' );
+	t.strictEqual( instanceOf( arr, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( arr.length, expected.length, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( arr, 0 ), expected, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function returns a filled array (value=0, dtype=complex128, length)', function test( t ) {
 	var expected;
 	var arr;

--- a/lib/node_modules/@stdlib/array/filled/test/test.js
+++ b/lib/node_modules/@stdlib/array/filled/test/test.js
@@ -1321,6 +1321,14 @@ tape( 'the function returns a filled array (dtype=bool, array)', function test( 
 	t.strictEqual( out.length, expected.length, 'returns expected value' );
 	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
 
+	expected = new Uint8Array( [ 1, 1 ] );
+
+	arr = [ 2.0, 2.0 ];
+	out = filledarray( true, arr, 'bool' );
+	t.strictEqual( instanceOf( out, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( out.length, expected.length, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
+
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/array/filled/test/test.js
+++ b/lib/node_modules/@stdlib/array/filled/test/test.js
@@ -2456,7 +2456,7 @@ tape( 'the function returns a filled array (dtype=float32, iterator)', opts, fun
 	t.end();
 });
 
-tape( 'the function returns a filled array (dtype=complex128, iterator)', opts, function test( t ) {
+tape( 'the function returns a filled array (dtype=bool, iterator)', opts, function test( t ) {
 	var expected;
 	var arr;
 	var out;
@@ -2467,6 +2467,16 @@ tape( 'the function returns a filled array (dtype=complex128, iterator)', opts, 
 		'iter': 2
 	});
 	out = filledarray( false, arr, 'bool' );
+	t.strictEqual( instanceOf( out, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( out.length, expected.length, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
+
+	expected = new Uint8Array( [ 1, 1 ] );
+
+	arr = iterConstant( 0.0, {
+		'iter': 2
+	});
+	out = filledarray( true, arr, 'bool' );
 	t.strictEqual( instanceOf( out, BooleanArray ), true, 'returns expected value' );
 	t.strictEqual( out.length, expected.length, 'returns expected value' );
 	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );

--- a/lib/node_modules/@stdlib/array/filled/test/test.js
+++ b/lib/node_modules/@stdlib/array/filled/test/test.js
@@ -1545,6 +1545,14 @@ tape( 'the function returns a filled array (dtype=bool, typed array)', function 
 	var arr;
 	var out;
 
+	expected = new Uint8Array( [ 0, 0, 0, 0 ] );
+
+	arr = new Float64Array( [ 2.0, 2.0, 2.0, 2.0 ] );
+	out = filledarray( false, arr, 'bool' );
+	t.strictEqual( instanceOf( out, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( out.length, expected.length, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
+
 	expected = new Uint8Array( [ 1, 1, 1, 1 ] );
 
 	arr = new Float64Array( [ 2.0, 2.0, 2.0, 2.0 ] );

--- a/lib/node_modules/@stdlib/array/filled/test/test.js
+++ b/lib/node_modules/@stdlib/array/filled/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2020 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,9 +33,11 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var ArrayBuffer = require( '@stdlib/array/buffer' );
 var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
 var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
+var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
@@ -740,6 +742,20 @@ tape( 'the function returns a filled array (dtype=float32)', function test( t ) 
 	t.end();
 });
 
+tape( 'the function returns a filled array (dtype=bool)', function test( t ) {
+	var expected;
+	var arr;
+
+	expected = new BooleanArray( 0 );
+
+	arr = filledarray( 'bool' );
+	t.strictEqual( instanceOf( arr, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( arr.length, 0, 'returns expected value' );
+	t.deepEqual( arr, expected, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function returns a filled array (dtype=complex64)', function test( t ) {
 	var expected;
 	var arr;
@@ -960,6 +976,20 @@ tape( 'the function returns a filled array (value=0, dtype=float32, length)', fu
 	t.strictEqual( instanceOf( arr, Float32Array ), true, 'returns expected value' );
 	t.strictEqual( arr.length, expected.length, 'returns expected value' );
 	t.deepEqual( arr, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a filled array (value=false, dtype=bool, length)', function test( t ) {
+	var expected;
+	var arr;
+
+	expected = new Uint8Array( [ 0, 0, 0, 0, 0 ] );
+
+	arr = filledarray( false, 5, 'bool' );
+	t.strictEqual( instanceOf( arr, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( arr.length, expected.length, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( arr, 0 ), expected, 'returns expected value' );
 
 	t.end();
 });
@@ -1264,6 +1294,22 @@ tape( 'the function returns a filled array (dtype=float32, array)', function tes
 	t.end();
 });
 
+tape( 'the function returns a filled array (dtype=bool, array)', function test( t ) {
+	var expected;
+	var arr;
+	var out;
+
+	expected = new Uint8Array( [ 0, 0 ] );
+
+	arr = [ 2.0, 2.0 ];
+	out = filledarray( false, arr, 'bool' );
+	t.strictEqual( instanceOf( out, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( out.length, expected.length, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function returns a filled array (dtype=complex128, array)', function test( t ) {
 	var expected;
 	var arr;
@@ -1468,6 +1514,22 @@ tape( 'the function returns a filled array (dtype=float32, typed array)', functi
 	t.strictEqual( instanceOf( out, Float32Array ), true, 'returns expected value' );
 	t.strictEqual( out.length, expected.length, 'returns expected value' );
 	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a filled array (dtype=bool, typed array)', function test( t ) {
+	var expected;
+	var arr;
+	var out;
+
+	expected = new Uint8Array( [ 1, 1, 1, 1 ] );
+
+	arr = new Float64Array( [ 2.0, 2.0, 2.0, 2.0 ] );
+	out = filledarray( true, arr, 'bool' );
+	t.strictEqual( instanceOf( out, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( out.length, expected.length, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
 
 	t.end();
 });
@@ -1680,6 +1742,22 @@ tape( 'the function returns a filled typed array (dtype=float32, arraybuffer)', 
 	t.end();
 });
 
+tape( 'the function returns a filled typed array (dtype=bool, arraybuffer)', function test( t ) {
+	var expected;
+	var buf;
+	var out;
+
+	expected = new Uint8Array( [ 1, 1 ] );
+
+	buf = new ArrayBuffer( 2 );
+	out = filledarray( true, buf, 'bool' );
+	t.strictEqual( instanceOf( out, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( out.length, expected.length, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function returns a filled typed array (dtype=complex128, arraybuffer)', function test( t ) {
 	var expected;
 	var buf;
@@ -1887,6 +1965,22 @@ tape( 'the function returns a filled typed array (dtype=complex128, arraybuffer,
 	var buf;
 	var out;
 
+	expected = new Uint8Array( [ 1, 1, 1, 1 ] );
+
+	buf = new ArrayBuffer( 8 );
+	out = filledarray( true, buf, 4, 'bool' );
+	t.strictEqual( instanceOf( out, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( out.length, expected.length, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a filled typed array (dtype=complex128, arraybuffer, byteoffset)', function test( t ) {
+	var expected;
+	var buf;
+	var out;
+
 	expected = new Float64Array( [ 1.0, 1.0, 1.0, 1.0 ] );
 
 	buf = new ArrayBuffer( 64 );
@@ -2080,6 +2174,22 @@ tape( 'the function returns a filled typed array (dtype=float32, arraybuffer, by
 	t.strictEqual( instanceOf( out, Float32Array ), true, 'returns expected value' );
 	t.strictEqual( out.length, expected.length, 'returns expected value' );
 	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a filled typed array (dtype=bool, arraybuffer, byteoffset, length)', function test( t ) {
+	var expected;
+	var buf;
+	var out;
+
+	expected = new Uint8Array( [ 1, 1, 1, 1 ] );
+
+	buf = new ArrayBuffer( 6 );
+	out = filledarray( true, buf, 1, 4, 'bool' );
+	t.strictEqual( instanceOf( out, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( out.length, expected.length, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
 
 	t.end();
 });
@@ -2288,6 +2398,24 @@ tape( 'the function returns a filled array (dtype=float32, iterator)', opts, fun
 	t.strictEqual( instanceOf( out, Float32Array ), true, 'returns expected value' );
 	t.strictEqual( out.length, expected.length, 'returns expected value' );
 	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a filled array (dtype=complex128, iterator)', opts, function test( t ) {
+	var expected;
+	var arr;
+	var out;
+
+	expected = new Uint8Array( [ 0, 0 ] );
+
+	arr = iterConstant( 3.0, {
+		'iter': 2
+	});
+	out = filledarray( false, arr, 'bool' );
+	t.strictEqual( instanceOf( out, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( out.length, expected.length, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
 
 	t.end();
 });


### PR DESCRIPTION
Resolves: Subtask of #2304 

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR will add boolean datatype support in `array/filled`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
