### PR TITLE
feat: add boolean dtype support to `array/base/count-same-value-zero`

### DIFF
--- a/lib/node_modules/@stdlib/array/base/count-same-value-zero/lib/main.js
+++ b/lib/node_modules/@stdlib/array/base/count-same-value-zero/lib/main.js
@@ -21,10 +21,13 @@
 // MODULES //
 
 var isComplexTypedArray = require( '@stdlib/array/base/assert/is-complex-typed-array' );
+var isBooleanArray = require( '@stdlib/array/base/assert/is-booleanarray' );
 var isComplexLike = require( '@stdlib/assert/is-complex-like' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var real = require( '@stdlib/complex/real' );
 var imag = require( '@stdlib/complex/imag' );
 var reinterpret = require( '@stdlib/strided/base/reinterpret-complex' );
+var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
 var isAccessorArray = require( '@stdlib/array/base/assert/is-accessor-array' );
 var resolveGetter = require( '@stdlib/array/base/resolve-getter' );
 var isSameValueZero = require( '@stdlib/assert/is-same-value-zero' );
@@ -132,6 +135,46 @@ function complex( x, value ) {
 	return n;
 }
 
+/**
+* Counts the number of elements in a boolean array that are equal to a specified value.
+*
+* @private
+* @param {Collection} x - input array
+* @param {*} value - search value
+* @returns {NonNegativeInteger} number of elements that are equal to a specified value
+*
+* @example
+* var BooleanArray = require( '@stdlib/array/bool' );
+*
+* var x = new BooleanArray( [ true, false, true, false, true ] );
+*
+* var n = boolean( x, true );
+* // returns 3
+*/
+function boolean( x, value ) {
+	var view;
+	var n;
+	var i;
+
+	if ( !isBoolean( value ) ) {
+		return 0;
+	}
+	if ( value === false ) {
+		value = 0;
+	} else {
+		value = 1;
+	}
+	view = reinterpretBoolean( x, 0 );
+
+	n = 0;
+	for ( i = 0; i < view.length; i++ ) {
+		if ( isSameValueZero( view[ i ], value ) ) {
+			n += 1;
+		}
+	}
+	return n;
+}
+
 
 // MAIN //
 
@@ -159,6 +202,9 @@ function countSameValueZero( x, value ) {
 	if ( isAccessorArray( x, value ) ) {
 		if ( isComplexTypedArray( x, value ) ) {
 			return complex( x, value );
+		}
+		if ( isBooleanArray( x, value ) ) {
+			return boolean( x, value );
 		}
 		return accessors( x, value );
 	}

--- a/lib/node_modules/@stdlib/array/base/count-same-value-zero/lib/main.js
+++ b/lib/node_modules/@stdlib/array/base/count-same-value-zero/lib/main.js
@@ -154,21 +154,18 @@ function complex( x, value ) {
 function boolean( x, value ) {
 	var view;
 	var n;
+	var v;
 	var i;
 
 	if ( !isBoolean( value ) ) {
 		return 0;
 	}
-	if ( value === false ) {
-		value = 0;
-	} else {
-		value = 1;
-	}
 	view = reinterpretBoolean( x, 0 );
 
+	v = ( value ) ? 1 : 0;
 	n = 0;
 	for ( i = 0; i < view.length; i++ ) {
-		if ( isSameValueZero( view[ i ], value ) ) {
+		if ( view[ i ] === v ) {
 			n += 1;
 		}
 	}

--- a/lib/node_modules/@stdlib/array/base/count-same-value-zero/test/test.js
+++ b/lib/node_modules/@stdlib/array/base/count-same-value-zero/test/test.js
@@ -23,6 +23,7 @@
 var tape = require( 'tape' );
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var Int32Array = require( '@stdlib/array/int32' );
 var Float32Array = require( '@stdlib/array/float32' );
 var toAccessorArray = require( '@stdlib/array/base/to-accessor-array' );
@@ -148,6 +149,19 @@ tape( 'the function considers all NaN values to be identical (real typed array)'
 	x = new Float32Array( [ NaN, 0.0, NaN, 2.0, NaN, 9.0, NaN ] );
 	expected = 4;
 	actual = countSameValueZero( x, NaN );
+
+	t.strictEqual( actual, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function counts the number of same values (boolean array)', function test( t ) {
+	var expected;
+	var actual;
+	var x;
+
+	x = new BooleanArray( [ true, false, true, false, true ] );
+	expected = 3;
+	actual = countSameValueZero( x, 2 );
 
 	t.strictEqual( actual, expected, 'returns expected value' );
 	t.end();

--- a/lib/node_modules/@stdlib/array/base/count-same-value-zero/test/test.js
+++ b/lib/node_modules/@stdlib/array/base/count-same-value-zero/test/test.js
@@ -164,6 +164,18 @@ tape( 'the function counts the number of same values (boolean array)', function 
 	actual = countSameValueZero( x, true );
 
 	t.strictEqual( actual, expected, 'returns expected value' );
+
+	x = new BooleanArray( [ true, false, true, false, true ] );
+	expected = 2;
+	actual = countSameValueZero( x, false );
+
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	x = new BooleanArray( [ true, false, true, false, true ] );
+	expected = 0;
+	actual = countSameValueZero( x, 'beep' );
+
+	t.strictEqual( actual, expected, 'returns expected value' );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/array/base/count-same-value-zero/test/test.js
+++ b/lib/node_modules/@stdlib/array/base/count-same-value-zero/test/test.js
@@ -161,7 +161,7 @@ tape( 'the function counts the number of same values (boolean array)', function 
 
 	x = new BooleanArray( [ true, false, true, false, true ] );
 	expected = 3;
-	actual = countSameValueZero( x, 2 );
+	actual = countSameValueZero( x, true );
 
 	t.strictEqual( actual, expected, 'returns expected value' );
 	t.end();


### PR DESCRIPTION
Resolves: Subtask of #2304 

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR will add boolean datatype support in `array/base/count-same-value-zero`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
