### PR TITLE
feat: add boolean dtype support to `array/filled-by`

### DIFF
--- a/lib/node_modules/@stdlib/array/filled-by/README.md
+++ b/lib/node_modules/@stdlib/array/filled-by/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2021 The Stdlib Authors.
+Copyright (c) 2024 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -42,29 +42,14 @@ var filledarrayBy = require( '@stdlib/array/filled-by' );
 
 #### filledarrayBy( \[dtype] )
 
-Creates a filled array having a specified data type `dtype`.
+Creates a filled array having a specified [data type][@stdlib/array/dtypes] `dtype`.
 
 ```javascript
 var arr = filledarrayBy();
 // returns <Float64Array>
 ```
 
-The function recognizes the following data types:
-
--   `float64`: double-precision floating-point numbers (IEEE 754)
--   `float32`: single-precision floating-point numbers (IEEE 754)
--   `complex128`: double-precision complex floating-point numbers
--   `complex64`: single-precision complex floating-point numbers
--   `int32`: 32-bit two's complement signed integers
--   `uint32`: 32-bit unsigned integers
--   `int16`: 16-bit two's complement signed integers
--   `uint16`: 16-bit unsigned integers
--   `int8`: 8-bit two's complement signed integers
--   `uint8`: 8-bit unsigned integers
--   `uint8c`: 8-bit unsigned integers clamped to `0-255`
--   `generic`: generic JavaScript values
-
-By default, the output array data type is `float64` (i.e., a [typed array][mdn-typed-array]). To specify an alternative data type, provide a `dtype` argument.
+By default, the output array [data type][@stdlib/array/dtypes] is `float64` (i.e., a [typed array][mdn-typed-array]). To specify an alternative [data type][@stdlib/array/dtypes], provide a `dtype` argument.
 
 ```javascript
 var arr = filledarrayBy( 'int32' );
@@ -260,6 +245,8 @@ for ( i = 0; i < dt.length; i++ ) {
 [mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
 
 [mdn-arraybuffer]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer
+
+[@stdlib/array/dtypes]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/dtypes
 
 <!-- <related-links> -->
 

--- a/lib/node_modules/@stdlib/array/filled-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/array/filled-by/benchmark/benchmark.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -86,6 +86,28 @@ bench( pkg+':dtype=float32', function benchmark( b ) {
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
 		arr = filledarrayBy( 0, 'float32', clbk );
+		if ( arr.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !isTypedArrayLike( arr ) ) {
+		b.fail( 'should return a typed array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+':dtype=bool', function benchmark( b ) {
+	var clbk;
+	var arr;
+	var i;
+
+	clbk = constantFunction( true );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = filledarrayBy( 0, 'bool', clbk );
 		if ( arr.length !== 0 ) {
 			b.fail( 'should have length 0' );
 		}

--- a/lib/node_modules/@stdlib/array/filled-by/benchmark/benchmark.length.bool.js
+++ b/lib/node_modules/@stdlib/array/filled-by/benchmark/benchmark.length.bool.js
@@ -1,0 +1,97 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isTypedArrayLike = require( '@stdlib/assert/is-typed-array-like' );
+var constantFunction = require( '@stdlib/utils/constant-function' );
+var pkg = require( './../package.json' ).name;
+var filledarray = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var clbk;
+		var arr;
+		var i;
+
+		clbk = constantFunction( true );
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			arr = filledarray( len, 'bool', clbk );
+			if ( arr.length !== len ) {
+				b.fail( 'unexpected length' );
+			}
+		}
+		b.toc();
+		if ( !isTypedArrayLike( arr ) ) {
+			b.fail( 'should return a typed array' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':dtype=bool,len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/filled-by/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/filled-by/docs/repl.txt
@@ -2,23 +2,6 @@
 {{alias}}( [dtype] )
     Creates a filled array.
 
-    The function supports the following data types:
-
-    - float64: double-precision floating-point numbers (IEEE 754)
-    - float32: single-precision floating-point numbers (IEEE 754)
-    - complex128: double-precision complex floating-point numbers
-    - complex64: single-precision complex floating-point numbers
-    - int32: 32-bit two's complement signed integers
-    - uint32: 32-bit unsigned integers
-    - int16: 16-bit two's complement signed integers
-    - uint16: 16-bit unsigned integers
-    - int8: 8-bit two's complement signed integers
-    - uint8: 8-bit unsigned integers
-    - uint8c: 8-bit unsigned integers clamped to 0-255
-    - generic: generic JavaScript values
-
-    The default array data type is `float64`.
-
     Parameters
     ----------
     dtype: string (optional)

--- a/lib/node_modules/@stdlib/array/filled-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/filled-by/docs/types/index.d.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -20,13 +20,13 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { Collection, RealOrComplexTypedArray, DataType } from '@stdlib/types/array';
+import { Collection, RealOrComplexTypedArray, BooleanArray, DataType } from '@stdlib/types/array';
 import { IterableIterator } from '@stdlib/types/iter';
 
 /**
 * Array or typed array.
 */
-type ArrayOrTypedArray = Array<any> | RealOrComplexTypedArray;
+type ArrayOrTypedArray = Array<any> | RealOrComplexTypedArray | BooleanArray;
 
 /**
 * Nullary callback function.
@@ -53,21 +53,6 @@ type Callback = Nullary | Unary;
 
 /**
 * Creates a filled array according to a provided callback function and having a specified data type.
-*
-* The function recognizes the following data types:
-*
-* -   `float64`: double-precision floating-point numbers (IEEE 754)
-* -   `float32`: single-precision floating-point numbers (IEEE 754)
-* -   `complex128`: double-precision complex floating-point numbers
-* -   `complex64`: single-precision complex floating-point numbers
-* -   `int32`: 32-bit two's complement signed integers
-* -   `uint32`: 32-bit unsigned integers
-* -   `int16`: 16-bit two's complement signed integers
-* -   `uint16`: 16-bit unsigned integers
-* -   `int8`: 8-bit two's complement signed integers
-* -   `uint8`: 8-bit unsigned integers
-* -   `uint8c`: 8-bit unsigned integers clamped to `0-255`
-* -   `generic`: generic JavaScript values
 *
 * @param dtype - data type
 * @returns filled array
@@ -101,21 +86,6 @@ declare function filledarrayBy( length: number, clbk: Callback, thisArg?: any ):
 /**
 * Creates a filled array according to a provided callback function and having a specified `length`.
 *
-* The function recognizes the following data types:
-*
-* -   `float64`: double-precision floating-point numbers (IEEE 754)
-* -   `float32`: single-precision floating-point numbers (IEEE 754)
-* -   `complex128`: double-precision complex floating-point numbers
-* -   `complex64`: single-precision complex floating-point numbers
-* -   `int32`: 32-bit two's complement signed integers
-* -   `uint32`: 32-bit unsigned integers
-* -   `int16`: 16-bit two's complement signed integers
-* -   `uint16`: 16-bit unsigned integers
-* -   `int8`: 8-bit two's complement signed integers
-* -   `uint8`: 8-bit unsigned integers
-* -   `uint8c`: 8-bit unsigned integers clamped to `0-255`
-* -   `generic`: generic JavaScript values
-*
 * @param length - array length
 * @param dtype - data type
 * @param clbk - callback function
@@ -144,25 +114,10 @@ declare function filledarrayBy( length: number, dtype: DataType, clbk: Callback,
 * var arr = filledarrayBy( [ 5.0, -3.0, 2.0 ], constantFunction( 1.0 ) );
 * // returns <Float64Array>[ 1.0, 1.0, 1.0 ]
 */
-declare function filledarrayBy( array: Collection, clbk: Callback, thisArg?: any ): ArrayOrTypedArray;
+declare function filledarrayBy( array: Collection, clbk: Callback, thisArg?: any ): ArrayOrTypedArray; // eslint-disable-line @typescript-eslint/unified-signatures
 
 /**
 * Creates a filled array from another `array` according to a provided callback function.
-*
-* The function recognizes the following data types:
-*
-* -   `float64`: double-precision floating-point numbers (IEEE 754)
-* -   `float32`: single-precision floating-point numbers (IEEE 754)
-* -   `complex128`: double-precision complex floating-point numbers
-* -   `complex64`: single-precision complex floating-point numbers
-* -   `int32`: 32-bit two's complement signed integers
-* -   `uint32`: 32-bit unsigned integers
-* -   `int16`: 16-bit two's complement signed integers
-* -   `uint16`: 16-bit unsigned integers
-* -   `int8`: 8-bit two's complement signed integers
-* -   `uint8`: 8-bit unsigned integers
-* -   `uint8c`: 8-bit unsigned integers clamped to `0-255`
-* -   `generic`: generic JavaScript values
 *
 * @param array - typed array or array-like object
 * @param dtype - data type
@@ -176,7 +131,7 @@ declare function filledarrayBy( array: Collection, clbk: Callback, thisArg?: any
 * var arr = filledarrayBy( [ 5.0, -3.0, 2.0 ], 'float64', constantFunction( 1.0 ) );
 * // returns <Float64Array>[ 1.0, 1.0, 1.0 ]
 */
-declare function filledarrayBy( array: Collection, dtype: DataType, clbk: Callback, thisArg?: any ): ArrayOrTypedArray;
+declare function filledarrayBy( array: Collection, dtype: DataType, clbk: Callback, thisArg?: any ): ArrayOrTypedArray; // eslint-disable-line @typescript-eslint/unified-signatures
 
 /**
 * Creates a filled array from an iterable according to a callback function.
@@ -196,25 +151,10 @@ declare function filledarrayBy( array: Collection, dtype: DataType, clbk: Callba
 * var arr = filledarrayBy( it, constantFunction( 1.0 ) );
 * // returns <Float64Array>[ 1.0, 1.0, 1.0 ]
 */
-declare function filledarrayBy( iterable: IterableIterator, callback: Callback, thisArg?: any ): ArrayOrTypedArray;
+declare function filledarrayBy( iterable: IterableIterator, callback: Callback, thisArg?: any ): ArrayOrTypedArray; // eslint-disable-line @typescript-eslint/unified-signatures
 
 /**
 * Creates a filled array from an iterable according to a callback function.
-*
-* The function recognizes the following data types:
-*
-* -   `float64`: double-precision floating-point numbers (IEEE 754)
-* -   `float32`: single-precision floating-point numbers (IEEE 754)
-* -   `complex128`: double-precision complex floating-point numbers
-* -   `complex64`: single-precision complex floating-point numbers
-* -   `int32`: 32-bit two's complement signed integers
-* -   `uint32`: 32-bit unsigned integers
-* -   `int16`: 16-bit two's complement signed integers
-* -   `uint16`: 16-bit unsigned integers
-* -   `int8`: 8-bit two's complement signed integers
-* -   `uint8`: 8-bit unsigned integers
-* -   `uint8c`: 8-bit unsigned integers clamped to `0-255`
-* -   `generic`: generic JavaScript values
 *
 * @param iterable - iterable
 * @param dtype - data type
@@ -232,7 +172,7 @@ declare function filledarrayBy( iterable: IterableIterator, callback: Callback, 
 * var arr = filledarrayBy( it, 'float64', constantFunction( 1.0 ) );
 * // returns <Float64Array>[ 1.0, 1.0, 1.0 ]
 */
-declare function filledarrayBy( iterable: IterableIterator, dtype: DataType, callback: Callback, thisArg?: any ): ArrayOrTypedArray;
+declare function filledarrayBy( iterable: IterableIterator, dtype: DataType, callback: Callback, thisArg?: any ): ArrayOrTypedArray; // eslint-disable-line @typescript-eslint/unified-signatures
 
 /**
 * Returns a filled typed array view of an `ArrayBuffer` according to a provided callback function.
@@ -256,25 +196,11 @@ declare function filledarrayBy( iterable: IterableIterator, dtype: DataType, cal
 * var arr = filledarrayBy( buf, 8, 2, constantFunction( 1.0 ) );
 * // returns <Float64Array>[ 1.0, 1.0 ]
 */
-declare function filledarrayBy( buffer: ArrayBuffer, byteOffset: number, length: number, clbk: Callback, thisArg?: any ): RealOrComplexTypedArray;
+declare function filledarrayBy( buffer: ArrayBuffer, byteOffset: number, length: number, clbk: Callback, thisArg?: any ): RealOrComplexTypedArray | BooleanArray;
 
 /**
 * Returns a filled typed array view of an `ArrayBuffer` according to a provided callback function.
 *
-* The function recognizes the following data types:
-*
-* -   `float64`: double-precision floating-point numbers (IEEE 754)
-* -   `float32`: single-precision floating-point numbers (IEEE 754)
-* -   `complex128`: double-precision complex floating-point numbers
-* -   `complex64`: single-precision complex floating-point numbers
-* -   `int32`: 32-bit two's complement signed integers
-* -   `uint32`: 32-bit unsigned integers
-* -   `int16`: 16-bit two's complement signed integers
-* -   `uint16`: 16-bit unsigned integers
-* -   `int8`: 8-bit two's complement signed integers
-* -   `uint8`: 8-bit unsigned integers
-* -   `uint8c`: 8-bit unsigned integers clamped to `0-255`
-* -   `generic`: generic JavaScript values
 *
 * ## Notes
 *
@@ -296,7 +222,7 @@ declare function filledarrayBy( buffer: ArrayBuffer, byteOffset: number, length:
 * var arr = filledarrayBy( buf, 8, 2, 'float64', constantFunction( 1.0 ) );
 * // returns <Float64Array>[ 1.0, 1.0 ]
 */
-declare function filledarrayBy( buffer: ArrayBuffer, byteOffset: number, length: number, dtype: DataType, clbk: Callback, thisArg?: any ): RealOrComplexTypedArray;
+declare function filledarrayBy( buffer: ArrayBuffer, byteOffset: number, length: number, dtype: DataType, clbk: Callback, thisArg?: any ): RealOrComplexTypedArray | BooleanArray;
 
 /**
 * Returns a filled typed array view of an `ArrayBuffer` according to a provided callback function.
@@ -319,25 +245,10 @@ declare function filledarrayBy( buffer: ArrayBuffer, byteOffset: number, length:
 * var arr = filledarrayBy( buf, 8, constantFunction( 1.0 ) );
 * // returns <Float64Array>[ 1.0, 1.0, 1.0 ]
 */
-declare function filledarrayBy( buffer: ArrayBuffer, byteOffset: number, clbk: Callback, thisArg?: any ): RealOrComplexTypedArray;
+declare function filledarrayBy( buffer: ArrayBuffer, byteOffset: number, clbk: Callback, thisArg?: any ): RealOrComplexTypedArray | BooleanArray;
 
 /**
 * Returns a filled typed array view of an `ArrayBuffer` according to a provided callback function.
-*
-* The function recognizes the following data types:
-*
-* -   `float64`: double-precision floating-point numbers (IEEE 754)
-* -   `float32`: single-precision floating-point numbers (IEEE 754)
-* -   `complex128`: double-precision complex floating-point numbers
-* -   `complex64`: single-precision complex floating-point numbers
-* -   `int32`: 32-bit two's complement signed integers
-* -   `uint32`: 32-bit unsigned integers
-* -   `int16`: 16-bit two's complement signed integers
-* -   `uint16`: 16-bit unsigned integers
-* -   `int8`: 8-bit two's complement signed integers
-* -   `uint8`: 8-bit unsigned integers
-* -   `uint8c`: 8-bit unsigned integers clamped to `0-255`
-* -   `generic`: generic JavaScript values
 *
 * ## Notes
 *
@@ -358,7 +269,7 @@ declare function filledarrayBy( buffer: ArrayBuffer, byteOffset: number, clbk: C
 * var arr = filledarrayBy( buf, 8, 'float64', constantFunction( 1.0 ) );
 * // returns <Float64Array>[ 1.0, 1.0, 1.0 ]
 */
-declare function filledarrayBy( buffer: ArrayBuffer, byteOffset: number, dtype: DataType, clbk: Callback, thisArg?: any ): RealOrComplexTypedArray;
+declare function filledarrayBy( buffer: ArrayBuffer, byteOffset: number, dtype: DataType, clbk: Callback, thisArg?: any ): RealOrComplexTypedArray | BooleanArray; // eslint-disable-line @typescript-eslint/unified-signatures
 
 /**
 * Returns a filled typed array view of an `ArrayBuffer` according to a provided callback function.
@@ -380,25 +291,10 @@ declare function filledarrayBy( buffer: ArrayBuffer, byteOffset: number, dtype: 
 * var arr = filledarrayBy( buf, constantFunction( 1.0 ) );
 * // returns <Float64Array>[ 1.0, 1.0, 1.0, 1.0 ]
 */
-declare function filledarrayBy( buffer: ArrayBuffer, clbk: Callback, thisArg?: any ): RealOrComplexTypedArray;
+declare function filledarrayBy( buffer: ArrayBuffer, clbk: Callback, thisArg?: any ): RealOrComplexTypedArray | BooleanArray; // eslint-disable-line @typescript-eslint/unified-signatures
 
 /**
 * Returns a filled typed array view of an `ArrayBuffer` according to a provided callback function.
-*
-* The function recognizes the following data types:
-*
-* -   `float64`: double-precision floating-point numbers (IEEE 754)
-* -   `float32`: single-precision floating-point numbers (IEEE 754)
-* -   `complex128`: double-precision complex floating-point numbers
-* -   `complex64`: single-precision complex floating-point numbers
-* -   `int32`: 32-bit two's complement signed integers
-* -   `uint32`: 32-bit unsigned integers
-* -   `int16`: 16-bit two's complement signed integers
-* -   `uint16`: 16-bit unsigned integers
-* -   `int8`: 8-bit two's complement signed integers
-* -   `uint8`: 8-bit unsigned integers
-* -   `uint8c`: 8-bit unsigned integers clamped to `0-255`
-* -   `generic`: generic JavaScript values
 *
 * ## Notes
 *
@@ -418,7 +314,7 @@ declare function filledarrayBy( buffer: ArrayBuffer, clbk: Callback, thisArg?: a
 * var arr = filledarrayBy( buf, 'float64', constantFunction( 1.0 ) );
 * // returns <Float64Array>[ 1.0, 1.0, 1.0, 1.0 ]
 */
-declare function filledarrayBy( buffer: ArrayBuffer, dtype: DataType, clbk: Callback, thisArg?: any ): RealOrComplexTypedArray;
+declare function filledarrayBy( buffer: ArrayBuffer, dtype: DataType, clbk: Callback, thisArg?: any ): RealOrComplexTypedArray | BooleanArray; // eslint-disable-line @typescript-eslint/unified-signatures
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/array/filled-by/lib/main.js
+++ b/lib/node_modules/@stdlib/array/filled-by/lib/main.js
@@ -387,7 +387,7 @@ function filledarrayBy() {
 		arr = new ctor( arguments[0], arguments[1], arguments[2] ); // (ArrayBuffer, byteOffset, length)
 	}
 	if ( arr.length > 0 ) {
-		if ( isComplexDataType( dtype ) | isBooleanDataType( dtype ) ) {
+		if ( isComplexDataType( dtype ) || isBooleanDataType( dtype ) ) {
 			filledAccessors( arr, clbk, thisArg );
 		} else {
 			gfillBy( arr.length, arr, 1, callback );

--- a/lib/node_modules/@stdlib/array/filled-by/lib/main.js
+++ b/lib/node_modules/@stdlib/array/filled-by/lib/main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@
 
 var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
 var isNonNegativeInteger = require( '@stdlib/assert/is-nonnegative-integer' ).isPrimitive;
+var isComplexDataType = require( '@stdlib/array/base/assert/is-complex-floating-point-data-type' );
+var isBooleanDataType = require( '@stdlib/array/base/assert/is-boolean-data-type' );
 var isCollection = require( '@stdlib/assert/is-collection' );
 var isArrayBuffer = require( '@stdlib/assert/is-arraybuffer' );
 var isObject = require( '@stdlib/assert/is-object' );
@@ -385,7 +387,7 @@ function filledarrayBy() {
 		arr = new ctor( arguments[0], arguments[1], arguments[2] ); // (ArrayBuffer, byteOffset, length)
 	}
 	if ( arr.length > 0 ) {
-		if ( /^complex/.test( dtype ) ) {
+		if ( isComplexDataType( dtype ) | isBooleanDataType( dtype ) ) {
 			filledAccessors( arr, clbk, thisArg );
 		} else {
 			gfillBy( arr.length, arr, 1, callback );

--- a/lib/node_modules/@stdlib/array/filled-by/test/test.js
+++ b/lib/node_modules/@stdlib/array/filled-by/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2020 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -35,9 +35,11 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var ArrayBuffer = require( '@stdlib/array/buffer' );
 var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
 var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
+var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
@@ -1829,6 +1831,20 @@ tape( 'the function returns a filled array (dtype=float32)', function test( t ) 
 	t.end();
 });
 
+tape( 'the function returns a filled array (dtype=bool)', function test( t ) {
+	var expected;
+	var arr;
+
+	expected = new BooleanArray( 0 );
+	arr = filledarrayBy( 'bool' );
+
+	t.strictEqual( instanceOf( arr, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( arr.length, 0, 'returns expected value' );
+	t.deepEqual( arr, expected, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function returns a filled array (dtype=complex128)', function test( t ) {
 	var expected;
 	var arr;
@@ -2169,6 +2185,23 @@ tape( 'the function returns a filled array (dtype=float32, length)', function te
 	t.end();
 });
 
+tape( 'the function returns a filled array (dtype=bool, length)', function test( t ) {
+	var expected;
+	var clbk;
+	var arr;
+
+	expected = new Uint8Array( [ 1, 1, 1, 1, 1 ] );
+
+	clbk = constantFunction( true );
+	arr = filledarrayBy( 5, 'bool', clbk );
+
+	t.strictEqual( instanceOf( arr, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( arr.length, expected.length, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( arr, 0 ), expected, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function returns a filled array (dtype=complex128, length)', function test( t ) {
 	var expected;
 	var clbk;
@@ -2458,6 +2491,25 @@ tape( 'the function returns a filled array (dtype=float32, array)', function tes
 	t.strictEqual( instanceOf( out, Float32Array ), true, 'returns expected value' );
 	t.strictEqual( out.length, expected.length, 'returns expected value' );
 	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a filled array (dtype=bool, array)', function test( t ) {
+	var expected;
+	var clbk;
+	var arr;
+	var out;
+
+	expected = new Uint8Array( [ 0, 0, 0, 0 ] );
+
+	clbk = constantFunction( false );
+	arr = [ 1.0, 2.0, 3.0, 4.0 ];
+	out = filledarrayBy( arr, 'bool', clbk );
+
+	t.strictEqual( instanceOf( out, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( out.length, expected.length, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
 
 	t.end();
 });
@@ -2774,6 +2826,25 @@ tape( 'the function returns a filled array (dtype=float32, typed array)', functi
 	t.end();
 });
 
+tape( 'the function returns a filled array (dtype=bool, typed array)', function test( t ) {
+	var expected;
+	var clbk;
+	var arr;
+	var out;
+
+	expected = new Uint8Array( [ 1, 1, 1, 1 ] );
+
+	clbk = constantFunction( true );
+	arr = new Float64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	out = filledarrayBy( arr, 'bool', clbk );
+
+	t.strictEqual( instanceOf( out, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( out.length, expected.length, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function returns a filled array (dtype=complex128, typed array)', function test( t ) {
 	var expected;
 	var clbk;
@@ -3083,6 +3154,25 @@ tape( 'the function returns a filled typed array (dtype=float32, arraybuffer)', 
 	t.strictEqual( instanceOf( out, Float32Array ), true, 'returns expected value' );
 	t.strictEqual( out.length, expected.length, 'returns expected value' );
 	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a filled typed array (dtype=bool, arraybuffer)', function test( t ) {
+	var expected;
+	var clbk;
+	var buf;
+	var out;
+
+	expected = new Uint8Array( [ 0, 0, 0, 0 ] );
+
+	clbk = constantFunction( false );
+	buf = new ArrayBuffer( 4 );
+	out = filledarrayBy( buf, 'bool', clbk );
+
+	t.strictEqual( instanceOf( out, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( out.length, expected.length, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
 
 	t.end();
 });
@@ -3401,6 +3491,25 @@ tape( 'the function returns a filled typed array (dtype=float32, arraybuffer, by
 	t.end();
 });
 
+tape( 'the function returns a filled typed array (dtype=bool, arraybuffer, byteoffset)', function test( t ) {
+	var expected;
+	var clbk;
+	var buf;
+	var out;
+
+	expected = new Uint8Array( [ 1, 1, 1, 1 ] );
+
+	clbk = constantFunction( true );
+	buf = new ArrayBuffer( 6 );
+	out = filledarrayBy( buf, 2, 'bool', clbk );
+
+	t.strictEqual( instanceOf( out, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( out.length, expected.length, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function returns a filled typed array (dtype=complex128, arraybuffer, byteoffset)', function test( t ) {
 	var expected;
 	var clbk;
@@ -3709,6 +3818,25 @@ tape( 'the function returns a filled typed array (dtype=float32, arraybuffer, by
 	t.strictEqual( instanceOf( out, Float32Array ), true, 'returns expected value' );
 	t.strictEqual( out.length, expected.length, 'returns expected value' );
 	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a filled typed array (dtype=complex128, arraybuffer, byteoffset, length)', function test( t ) {
+	var expected;
+	var clbk;
+	var buf;
+	var out;
+
+	expected = new Uint8Array( [ 0, 0, 0, 0 ] );
+
+	clbk = constantFunction( false );
+	buf = new ArrayBuffer( 8 );
+	out = filledarrayBy( buf, 2, 4, 'bool', clbk );
+
+	t.strictEqual( instanceOf( out, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( out.length, expected.length, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
 
 	t.end();
 });
@@ -4033,6 +4161,27 @@ tape( 'the function returns a filled array (dtype=float32, iterator)', opts, fun
 	t.strictEqual( instanceOf( out, Float32Array ), true, 'returns expected value' );
 	t.strictEqual( out.length, expected.length, 'returns expected value' );
 	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a filled array (dtype=bool, iterator)', opts, function test( t ) {
+	var expected;
+	var clbk;
+	var arr;
+	var out;
+
+	expected = new Uint8Array( [ 1, 1, 1, 1 ] );
+
+	clbk = constantFunction( true );
+	arr = iterConstant( false, {
+		'iter': 4
+	});
+	out = filledarrayBy( arr, 'bool', clbk );
+
+	t.strictEqual( instanceOf( out, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( out.length, expected.length, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/array/filled-by/test/test.js
+++ b/lib/node_modules/@stdlib/array/filled-by/test/test.js
@@ -3822,7 +3822,7 @@ tape( 'the function returns a filled typed array (dtype=float32, arraybuffer, by
 	t.end();
 });
 
-tape( 'the function returns a filled typed array (dtype=complex128, arraybuffer, byteoffset, length)', function test( t ) {
+tape( 'the function returns a filled typed array (dtype=bool, arraybuffer, byteoffset, length)', function test( t ) {
 	var expected;
 	var clbk;
 	var buf;


### PR DESCRIPTION
Resolves: Subtask of #2304 

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR will add boolean datatype support in `array/filled-by`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
