### PR TITLE
feat: add boolean dtype support to `array/convert`

### DIFF
--- a/lib/node_modules/@stdlib/array/convert/README.md
+++ b/lib/node_modules/@stdlib/array/convert/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # convert
 
-> Convert an array to an array of a different data type.
+> Convert an array to an array of a different [data type][@stdlib/array/dtypes].
 
 <!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
 
@@ -42,29 +42,13 @@ var convert = require( '@stdlib/array/convert' );
 
 #### convert( arr, dtype )
 
-Converts an array to an array of a different data type.
+Converts an array to an array of a different [data type][@stdlib/array/dtypes].
 
 ```javascript
 var arr = [ 1.0, 2.0, 3.0 ];
 var out = convert( arr, 'float32' );
 // returns <Float32Array>[ 1.0, 2.0, 3.0 ]
 ```
-
-The function supports the following data types:
-
--   `float32`: single-precision floating-point numbers.
--   `float64`: double-precision floating-point numbers.
--   `complex64`: single-precision complex floating-point numbers.
--   `complex128`: double-precision complex floating-point numbers.
--   `bool`: boolean values
--   `generic`: values of any type.
--   `int16`: signed 16-bit integers.
--   `int32`: signed 32-bit integers.
--   `int8`: signed 8-bit integers.
--   `uint16`: unsigned 16-bit integers.
--   `uint32`: unsigned 32-bit integers.
--   `uint8`: unsigned 8-bit integers.
--   `uint8c`: unsigned clamped 8-bit integers.
 
 </section>
 
@@ -136,6 +120,8 @@ for ( i = 0; i < DTYPES.length; i++ ) {
 <!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 
 <section class="links">
+
+[@stdlib/array/dtypes]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/dtypes
 
 <!-- <related-links> -->
 

--- a/lib/node_modules/@stdlib/array/convert/README.md
+++ b/lib/node_modules/@stdlib/array/convert/README.md
@@ -56,6 +56,7 @@ The function supports the following data types:
 -   `float64`: double-precision floating-point numbers.
 -   `complex64`: single-precision complex floating-point numbers.
 -   `complex128`: double-precision complex floating-point numbers.
+-   `bool`: boolean values
 -   `generic`: values of any type.
 -   `int16`: signed 16-bit integers.
 -   `int32`: signed 32-bit integers.

--- a/lib/node_modules/@stdlib/array/convert/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/array/convert/benchmark/benchmark.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -91,6 +91,31 @@ bench( pkg+':dtype=float32', function benchmark( b ) {
 	for ( i = 0; i < b.iterations; i++ ) {
 		arr[ 0 ] += 1;
 		out = convertArray( arr, 'float32' );
+		if ( out.length !== arr.length ) {
+			b.fail( 'should have expected length' );
+		}
+	}
+	b.toc();
+	if ( !isCollection( out ) ) {
+		b.fail( 'should return an array-like object' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+':dtype=bool', function benchmark( b ) {
+	var arr;
+	var out;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < 10; i++ ) {
+		arr.push( i );
+	}
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr[ 0 ] += 1;
+		out = convertArray( arr, 'bool' );
 		if ( out.length !== arr.length ) {
 			b.fail( 'should have expected length' );
 		}

--- a/lib/node_modules/@stdlib/array/convert/benchmark/benchmark.length.js
+++ b/lib/node_modules/@stdlib/array/convert/benchmark/benchmark.length.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -102,6 +102,9 @@ function main() {
 
 		f = createBenchmark( len, 'float32' );
 		bench( pkg+':len='+len+',dtype=float32', f );
+
+		f = createBenchmark( len, 'bool' );
+		bench( pkg+':len='+len+',dtype=bool', f );
 
 		f = createBenchmark( len, 'complex128' );
 		bench( pkg+':len='+len+',dtype=complex128', f );

--- a/lib/node_modules/@stdlib/array/convert/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/convert/docs/repl.txt
@@ -2,21 +2,6 @@
 {{alias}}( arr, dtype )
     Converts an input array to an array of a different data type.
 
-    The function supports the following data types:
-
-    - float32: single-precision floating-point numbers.
-    - float64: double-precision floating-point numbers.
-    - complex64: single-precision complex floating-point numbers.
-    - complex128: double-precision complex floating-point numbers.
-    - generic: values of any type.
-    - int16: signed 16-bit integers.
-    - int32: signed 32-bit integers.
-    - int8: signed 8-bit integers.
-    - uint16: unsigned 16-bit integers.
-    - uint32: unsigned 32-bit integers.
-    - uint8: unsigned 8-bit integers.
-    - uint8c: unsigned clamped 8-bit integers.
-
     Parameters
     ----------
     arr: ArrayLikeObject

--- a/lib/node_modules/@stdlib/array/convert/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/convert/docs/types/test.ts
@@ -34,6 +34,7 @@ import convert = require( './index' );
 	convert( [ 1.0, 2.0, 3.0, 4.0 ], 'uint8c' ); // $ExpectType Uint8ClampedArray
 	convert( [ 1.0, 2.0, 3.0, 4.0 ], 'complex128' ); // $ExpectType Complex128Array
 	convert( [ 1.0, 2.0, 3.0, 4.0 ], 'complex64' ); // $ExpectType Complex64Array
+	convert( [ 1.0, 2.0, 3.0, 4.0 ], 'bool' ); // $ExpectType BooleanArray
 	convert( [ 1.0, 2.0, 3.0, 4.0 ], 'generic' ); // $ExpectType number[]
 	convert( [ 'a', 'b', 'c', 'd' ], 'generic' ); // $ExpectType string[]
 }

--- a/lib/node_modules/@stdlib/array/convert/lib/main.js
+++ b/lib/node_modules/@stdlib/array/convert/lib/main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ var getType = require( '@stdlib/array/dtype' );
 var ctors = require( '@stdlib/array/ctors' );
 var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
 var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
+var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
 var format = require( '@stdlib/string/format' );
 var gcopy = require( '@stdlib/blas/base/gcopy' );
 var copy = require( '@stdlib/array/base/copy' );
@@ -70,6 +71,25 @@ function isComplex128( dtype ) {
 	return ( dtype === 'complex128' );
 }
 
+/**
+* Tests whether a data type is a boolean data type.
+*
+* @private
+* @param {string} dtype - data type
+* @returns {boolean} boolean indicating whether a provided data type is a boolean data type
+*
+* @example
+* var bool = isBool( 'bool' );
+* // returns true
+*
+* @example
+* var bool = isBool( 'complex128' );
+* // returns false
+*/
+function isBool( dtype ) {
+	return ( dtype === 'bool' );
+}
+
 
 // MAIN //
 
@@ -96,6 +116,7 @@ function convert( x, dtype ) {
 	var out;
 	var len;
 	var t;
+	var i;
 
 	if ( !isCollection( x ) ) {
 		throw new TypeError( format( 'invalid argument. First argument must be an array-like object. Value: `%s`.', x ) );
@@ -136,8 +157,44 @@ function convert( x, dtype ) {
 			gcopy( len*2, xbuf, 1, obuf, 1 );
 			return out;
 		}
+		// Check whether the output data type is a boolean data type...
+		if ( isBool( dtype ) ) { // cmplx => bool
+			obuf = reinterpretBoolean( out, 0 );
+			for ( i = 0; i < len; i++ ) {
+				if ( xbuf[ 2*i ] || xbuf[ (2*i)+1 ] ) {
+					obuf[ i ] = 1;
+				} else {
+					obuf[ i ] = 0;
+				}
+			}
+			return out;
+		}
 		// We assume that the output data type is a real number data type, given that we're looking to convert a provided complex number array; in which case, we'll only extract the real components from the complex number input array...
 		gcopy( len, xbuf, 2, out, 1 ); // cmplx => real
+		return out;
+	}
+	// Check whether the input array is a boolean array...
+	if ( isBool( t ) ) {
+		xbuf = reinterpretBoolean( x, 0 );
+
+		// Check whether the output data type is a boolean data type...
+		if ( isBool( dtype ) ) { // bool => bool
+			obuf = reinterpretBoolean( out, 0 );
+			gcopy( len, xbuf, 1, obuf, 1 );
+			return out;
+		}
+		// Check whether the output data type is a complex number data type...
+		if ( isComplex64( dtype ) ) { // bool => cmplx
+			obuf = reinterpret64( out, 0 );
+			gcopy( len, xbuf, 1, obuf, 2 );
+			return out;
+		}
+		if ( isComplex128( dtype ) ) { // bool => cmplx
+			obuf = reinterpret128( out, 0 );
+			gcopy( len, xbuf, 1, obuf, 2 );
+			return out;
+		}
+		gcopy( len, xbuf, 1, out, 1 ); // bool => real
 		return out;
 	}
 	// Check whether we need to explicitly handle complex number output arrays...
@@ -152,7 +209,19 @@ function convert( x, dtype ) {
 		gcopy( len, x, 1, obuf, 2 ); // real => cmplx
 		return out;
 	}
-	// At this point, we're no longer handling complex number arrays, so we'll just assume that we can perform a straightforward copy...
+	// Check whether the output data type is a boolean data type...
+	if ( isBool( dtype ) ) {
+		obuf = reinterpretBoolean( out, 0 );
+		for ( i = 0; i < len; i++ ) {
+			if ( x[ i ] ) {
+				obuf[ i ] = 1;
+			} else {
+				obuf[ i ] = 0;
+			}
+		}
+		return out;
+	}
+	// At this point, we're no longer handling complex number or boolean arrays, so we'll just assume that we can perform a straightforward copy...
 	gcopy( len, x, 1, out, 1 ); // note: `gcopy` is assumed to support arrays using accessors
 	return out;
 }

--- a/lib/node_modules/@stdlib/array/convert/lib/main.js
+++ b/lib/node_modules/@stdlib/array/convert/lib/main.js
@@ -26,9 +26,10 @@ var ctors = require( '@stdlib/array/ctors' );
 var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
 var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
 var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
-var format = require( '@stdlib/string/format' );
 var gcopy = require( '@stdlib/blas/base/gcopy' );
 var copy = require( '@stdlib/array/base/copy' );
+var resolveGetter = require( '@stdlib/array/base/resolve-getter' );
+var format = require( '@stdlib/string/format' );
 
 
 // FUNCTIONS //
@@ -113,6 +114,7 @@ function convert( x, dtype ) {
 	var ctor;
 	var xbuf;
 	var obuf;
+	var get;
 	var out;
 	var len;
 	var t;
@@ -213,8 +215,9 @@ function convert( x, dtype ) {
 	// Check whether the output data type is a boolean data type...
 	if ( isBool( dtype ) ) {
 		obuf = reinterpretBoolean( out, 0 );
+		get = resolveGetter( x );
 		for ( i = 0; i < len; i++ ) {
-			if ( x[ i ] ) {
+			if ( get( x, i ) ) {
 				obuf[ i ] = 1;
 			} else {
 				obuf[ i ] = 0;

--- a/lib/node_modules/@stdlib/array/convert/lib/main.js
+++ b/lib/node_modules/@stdlib/array/convert/lib/main.js
@@ -161,7 +161,7 @@ function convert( x, dtype ) {
 		if ( isBool( dtype ) ) { // cmplx => bool
 			obuf = reinterpretBoolean( out, 0 );
 			for ( i = 0; i < len; i++ ) {
-				// A complex number is only falsy when both the real and imaginary component are zero...
+				// A complex number is only falsy when both the real and imaginary components are zero...
 				if ( xbuf[ 2*i ] || xbuf[ (2*i)+1 ] ) {
 					obuf[ i ] = 1;
 				} else {

--- a/lib/node_modules/@stdlib/array/convert/lib/main.js
+++ b/lib/node_modules/@stdlib/array/convert/lib/main.js
@@ -161,6 +161,7 @@ function convert( x, dtype ) {
 		if ( isBool( dtype ) ) { // cmplx => bool
 			obuf = reinterpretBoolean( out, 0 );
 			for ( i = 0; i < len; i++ ) {
+				// A complex number is only falsy when both the real and imaginary component are zero...
 				if ( xbuf[ 2*i ] || xbuf[ (2*i)+1 ] ) {
 					obuf[ i ] = 1;
 				} else {

--- a/lib/node_modules/@stdlib/array/convert/test/test.js
+++ b/lib/node_modules/@stdlib/array/convert/test/test.js
@@ -186,8 +186,7 @@ tape( 'the function converts an array to an array of a different data type (acce
 		'uint16',
 		'uint32',
 		'uint8',
-		'uint8c',
-		'bool'
+		'uint8c'
 	];
 	arr = {
 		'length': 3,

--- a/lib/node_modules/@stdlib/array/convert/test/test.js
+++ b/lib/node_modules/@stdlib/array/convert/test/test.js
@@ -34,6 +34,7 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex128Array = require( '@stdlib/array/complex128' );
 var Complex64Array = require( '@stdlib/array/complex64' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var isArray = require( '@stdlib/assert/is-array' );
 var isFloat64Array = require( '@stdlib/assert/is-float64array' );
 var isFloat32Array = require( '@stdlib/assert/is-float32array' );
@@ -46,10 +47,12 @@ var isUint8Array = require( '@stdlib/assert/is-uint8array' );
 var isUint8ClampedArray = require( '@stdlib/assert/is-uint8clampedarray' );
 var isComplex64Array = require( '@stdlib/assert/is-complex64array' );
 var isComplex128Array = require( '@stdlib/assert/is-complex128array' );
+var isBooleanArray = require( '@stdlib/assert/is-booleanarray' );
 var isComplex64 = require( '@stdlib/assert/is-complex64' );
 var isComplex128 = require( '@stdlib/assert/is-complex128' );
 var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
 var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
+var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
 var real = require( '@stdlib/complex/real' );
 var imag = require( '@stdlib/complex/imag' );
 var realf = require( '@stdlib/complex/realf' );
@@ -183,7 +186,8 @@ tape( 'the function converts an array to an array of a different data type (acce
 		'uint16',
 		'uint32',
 		'uint8',
-		'uint8c'
+		'uint8c',
+		'bool'
 	];
 	arr = {
 		'length': 3,
@@ -201,7 +205,8 @@ tape( 'the function converts an array to an array of a different data type (acce
 		[ new Uint16Array( [ 65535, 0, 1 ] ), isUint16Array ],
 		[ new Uint32Array( [ 4294967295, 0, 1 ] ), isUint32Array ],
 		[ new Uint8Array( [ 255, 0, 1 ] ), isUint8Array ],
-		[ new Uint8ClampedArray( [ 0, 0, 1 ] ), isUint8ClampedArray ]
+		[ new Uint8ClampedArray( [ 0, 0, 1 ] ), isUint8ClampedArray ],
+		[ new BooleanArray( [ true, false, true ] ), isBooleanArray ]
 	];
 	for ( i = 0; i < dtypes.length; i++ ) {
 		out = convertArray( arr, dtypes[ i ] );
@@ -219,6 +224,55 @@ tape( 'the function converts an array to an array of a different data type (acce
 	function setter( value, idx ) {
 		arr.data[ idx ] = value;
 	}
+});
+
+tape( 'the function converts an array to an array of a different data type (real => bool)', function test( t ) {
+	var expected;
+	var arr;
+	var out;
+
+	arr = [ -1, 0, 1, 2 ];
+	expected = new Uint8Array( [ 1, 0, 1, 1 ] );
+	out = convertArray( arr, 'bool' );
+	t.strictEqual( isBooleanArray( out ), true, 'returns expected value type' );
+	t.strictEqual( out.length, expected.length, 'returns expected length' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function converts an array to an array of a different data type (bool => complex)', function test( t ) {
+	var expected;
+	var dtypes;
+	var arr;
+	var out;
+	var tmp;
+	var v1;
+	var v2;
+	var i;
+	var j;
+
+	dtypes = [
+		'complex64',
+		'complex128'
+	];
+	arr = new BooleanArray( [ true, false, true, true ] );
+	expected = [
+		[ new Complex64Array( [ 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0 ] ), isComplex64Array, reinterpret64 ],
+		[ new Complex128Array( [ 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0 ] ), isComplex128Array, reinterpret128 ]
+	];
+	for ( i = 0; i < dtypes.length; i++ ) {
+		tmp = expected[ i ];
+		out = convertArray( arr, dtypes[ i ] );
+		t.strictEqual( tmp[ 1 ]( out ), true, 'returns expected value type for ' + dtypes[ i ] );
+		v1 = tmp[ 2 ]( out, 0 );
+		v2 = tmp[ 2 ]( tmp[ 0 ], 0 );
+		for ( j = 0; j < arr.length*2; j += 2 ) {
+			t.strictEqual( v1[ j ], v2[ j ], 'returns expected real component for element ' + (j/2) + ' for ' + dtypes[ i ] );
+			t.strictEqual( v1[ j+1 ], v2[ j+1 ], 'returns expected imaginary component for element ' + (j/2) + ' for ' + dtypes[ i ] );
+		}
+	}
+	t.end();
 });
 
 tape( 'the function converts an array to an array of a different data type (real => complex)', function test( t ) {
@@ -323,6 +377,38 @@ tape( 'the function converts an array to an array of a different data type (comp
 	t.end();
 });
 
+tape( 'the function converts an array to an array of a different data type (complex64 => bool)', function test( t ) {
+	var expected;
+	var arr;
+	var out;
+
+	arr = new Complex64Array( [ -1.0, 1.0, 0.0, 0.0, 1.0, 3.0, 2.0, 4.0 ] );
+	expected = new Uint8Array( [ 1, 0, 1, 1 ] );
+
+	out = convertArray( arr, 'bool' );
+	t.strictEqual( isBooleanArray( out ), true, 'returns expected value type' );
+	t.strictEqual( out.length, expected.length, 'returns expected length' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function converts an array to an array of a different data type (complex128 => bool)', function test( t ) {
+	var expected;
+	var arr;
+	var out;
+
+	arr = new Complex128Array( [ -1.0, 1.0, 0.0, 0.0, 1.0, 3.0, 2.0, 4.0 ] );
+	expected = new Uint8Array( [ 1, 0, 1, 1 ] );
+
+	out = convertArray( arr, 'bool' );
+	t.strictEqual( isBooleanArray( out ), true, 'returns expected value type' );
+	t.strictEqual( out.length, expected.length, 'returns expected length' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function converts an array to an array of a different data type (complex64 => real)', function test( t ) {
 	var expected;
 	var dtypes;
@@ -405,6 +491,83 @@ tape( 'the function converts an array to an array of a different data type (comp
 	t.end();
 });
 
+tape( 'the function converts an array to an array of a different data type (bool => real)', function test( t ) {
+	var expected;
+	var dtypes;
+	var arr;
+	var out;
+	var i;
+	var j;
+
+	dtypes = [
+		'float64',
+		'float32',
+		'int16',
+		'int32',
+		'int8',
+		'uint16',
+		'uint32',
+		'uint8',
+		'uint8c'
+	];
+	arr = new BooleanArray( [ true, false, true ] );
+	expected = [
+		[ new Float64Array( [ 1.0, 0.0, 1.0 ] ), isFloat64Array ],
+		[ new Float32Array( [ 1.0, 0.0, 1.0 ] ), isFloat32Array ],
+		[ new Int16Array( [ 1, 0, 1 ] ), isInt16Array ],
+		[ new Int32Array( [ 1, 0, 1 ] ), isInt32Array ],
+		[ new Int8Array( [ 1, 0, 1 ] ), isInt8Array ],
+		[ new Uint16Array( [ 1, 0, 1 ] ), isUint16Array ],
+		[ new Uint32Array( [ 1, 0, 1 ] ), isUint32Array ],
+		[ new Uint8Array( [ 1, 0, 1 ] ), isUint8Array ],
+		[ new Uint8ClampedArray( [ 1, 0, 1 ] ), isUint8ClampedArray ]
+	];
+	for ( i = 0; i < dtypes.length; i++ ) {
+		out = convertArray( arr, dtypes[ i ] );
+		t.strictEqual( expected[ i ][ 1 ]( out ), true, 'returns expected value type for ' + dtypes[ i ] );
+		for ( j = 0; j < arr.length; j++ ) {
+			t.strictEqual( out[ j ], expected[ i ][ 0 ][ j ], 'returns expected element ' + j + ' for ' + dtypes[ i ] );
+		}
+	}
+	t.end();
+});
+
+tape( 'the function converts an array to an array of a different data type (bool => generic)', function test( t ) {
+	var expected;
+	var arr;
+	var out;
+	var i;
+
+	arr = new BooleanArray( [ true, false, true, true ] );
+	expected = [
+		arr.get( 0 ),
+		arr.get( 1 ),
+		arr.get( 2 ),
+		arr.get( 3 )
+	];
+	out = convertArray( arr, 'generic' );
+	t.strictEqual( isArray( out ), true, 'returns expected value type' );
+	for ( i = 0; i < arr.length; i++ ) {
+		t.strictEqual( out[ i ], expected[ i ], 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function converts an array to an array of a different data type (bool => bool)', function test( t ) {
+	var expected;
+	var out;
+	var arr;
+
+	arr = new BooleanArray( [ true, false, true, true ] );
+	expected = new Uint8Array( [ 1, 0, 1, 1 ] );
+
+	out = convertArray( arr, 'bool' );
+	t.deepEqual( out.length, expected.length, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function converts an array to an array of a different data type (complex64 => generic)', function test( t ) {
 	var expected;
 	var arr;
@@ -478,7 +641,8 @@ tape( 'the function converts an array to an array of a different data type (larg
 		'uint8',
 		'uint8c',
 		'complex64',
-		'complex128'
+		'complex128',
+		'bool'
 	];
 	arr = [];
 	for ( i = 0; i < 1e6; i++ ) {
@@ -496,7 +660,8 @@ tape( 'the function converts an array to an array of a different data type (larg
 		isUint8Array,
 		isUint8ClampedArray,
 		isComplex64Array,
-		isComplex128Array
+		isComplex128Array,
+		isBooleanArray
 	];
 	for ( i = 0; i < dtypes.length; i++ ) {
 		out = convertArray( arr, dtypes[ i ] );

--- a/lib/node_modules/@stdlib/array/convert/test/test.js
+++ b/lib/node_modules/@stdlib/array/convert/test/test.js
@@ -205,8 +205,7 @@ tape( 'the function converts an array to an array of a different data type (acce
 		[ new Uint16Array( [ 65535, 0, 1 ] ), isUint16Array ],
 		[ new Uint32Array( [ 4294967295, 0, 1 ] ), isUint32Array ],
 		[ new Uint8Array( [ 255, 0, 1 ] ), isUint8Array ],
-		[ new Uint8ClampedArray( [ 0, 0, 1 ] ), isUint8ClampedArray ],
-		[ new BooleanArray( [ true, false, true ] ), isBooleanArray ]
+		[ new Uint8ClampedArray( [ 0, 0, 1 ] ), isUint8ClampedArray ]
 	];
 	for ( i = 0; i < dtypes.length; i++ ) {
 		out = convertArray( arr, dtypes[ i ] );
@@ -226,6 +225,21 @@ tape( 'the function converts an array to an array of a different data type (acce
 	}
 });
 
+tape( 'the function converts an array to an array of a different data type (generic => bool)', function test( t ) {
+	var expected;
+	var arr;
+	var out;
+
+	arr = [ 'foo', null, [], {} ];
+	expected = new Uint8Array( [ 1, 0, 1, 1 ] );
+	out = convertArray( arr, 'bool' );
+	t.strictEqual( isBooleanArray( out ), true, 'returns expected value type' );
+	t.strictEqual( out.length, expected.length, 'returns expected length' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function converts an array to an array of a different data type (real => bool)', function test( t ) {
 	var expected;
 	var arr;
@@ -239,6 +253,34 @@ tape( 'the function converts an array to an array of a different data type (real
 	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
 
 	t.end();
+});
+
+tape( 'the function converts an array to an array of a different data type (accessors => bool)', function test( t ) {
+	var expected;
+	var arr;
+	var out;
+
+	arr = {
+		'length': 3,
+		'data': [ -1, 0, 1 ],
+		'get': getter,
+		'set': setter
+	};
+	expected = new Uint8Array( [ 1, 0, 1 ] );
+	out = convertArray( arr, 'bool' );
+	t.strictEqual( isBooleanArray( out ), true, 'returns expected value type' );
+	t.strictEqual( out.length, expected.length, 'returns expected length' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
+
+	t.end();
+
+	function getter( idx ) {
+		return arr.data[ idx ];
+	}
+
+	function setter( value, idx ) {
+		arr.data[ idx ] = value;
+	}
 });
 
 tape( 'the function converts an array to an array of a different data type (bool => complex)', function test( t ) {


### PR DESCRIPTION
Resolves: Subtask of #2304 

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR will add boolean datatype support in `array/convert`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
