### PR TITLE
feat: add boolean dtype support to `array/convert-same`

### DIFF
--- a/lib/node_modules/@stdlib/array/convert-same/README.md
+++ b/lib/node_modules/@stdlib/array/convert-same/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2018 The Stdlib Authors.
+Copyright (c) 2024 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ limitations under the License.
 
 # convertSame
 
-> Convert an array to the same data type as a second input array.
+> Convert an array to the same [data type][@stdlib/array/dtypes] as a second input array.
 
 <!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
 
@@ -42,7 +42,7 @@ var convertSame = require( '@stdlib/array/convert-same' );
 
 #### convertSame( x, y )
 
-Converts an array to the same data type as a second input array.
+Converts an array to the same [data type][@stdlib/array/dtypes] as a second input array.
 
 ```javascript
 var Float32Array = require( '@stdlib/array/float32' );
@@ -53,21 +53,6 @@ var y = new Float32Array( 0 );
 var out = convertSame( x, y );
 // returns <Float32Array>[ 1.0, 2.0, 3.0 ]
 ```
-
-The function supports input arrays having the following data types:
-
--   `float32`: single-precision floating-point numbers.
--   `float64`: double-precision floating-point numbers.
--   `complex64`: single-precision complex floating-point numbers.
--   `complex128`: double-precision complex floating-point numbers.
--   `generic`: values of any type.
--   `int16`: signed 16-bit integers.
--   `int32`: signed 32-bit integers.
--   `int8`: signed 8-bit integers.
--   `uint16`: unsigned 16-bit integers.
--   `uint32`: unsigned 32-bit integers.
--   `uint8`: unsigned 8-bit integers.
--   `uint8c`: unsigned clamped 8-bit integers.
 
 </section>
 
@@ -146,6 +131,8 @@ for ( i = 0; i < DTYPES.length; i++ ) {
 <!-- <related-links> -->
 
 [@stdlib/array/convert]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/convert
+
+[@stdlib/array/dtypes]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/dtypes
 
 <!-- </related-links> -->
 

--- a/lib/node_modules/@stdlib/array/convert-same/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/array/convert-same/benchmark/benchmark.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var pkg = require( './../package.json' ).name;
 var convertArraySame = require( './../lib' );
 
@@ -103,6 +104,34 @@ bench( pkg+':dtype=float32', function benchmark( b ) {
 		arr.push( i );
 	}
 	v = new Float32Array( 0 );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr[ 0 ] += 1;
+		out = convertArraySame( arr, v );
+		if ( out.length !== arr.length ) {
+			b.fail( 'should have expected length' );
+		}
+	}
+	b.toc();
+	if ( !isCollection( out ) ) {
+		b.fail( 'should return an array-like object' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+':dtype=bool', function benchmark( b ) {
+	var arr;
+	var out;
+	var v;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < 10; i++ ) {
+		arr.push( i );
+	}
+	v = new BooleanArray( 0 );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/array/convert-same/benchmark/benchmark.length.js
+++ b/lib/node_modules/@stdlib/array/convert-same/benchmark/benchmark.length.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var pkg = require( './../package.json' ).name;
 var convertArraySame = require( './../lib' );
 
@@ -134,6 +135,9 @@ function main() {
 
 		f = createBenchmark( len, new Uint8ClampedArray( 0 ) );
 		bench( pkg+':len='+len+',dtype=uint8c', f );
+
+		f = createBenchmark( len, new BooleanArray( 0 ) );
+		bench( pkg+':len='+len+',dtype=bool', f );
 
 		f = createBenchmark( len, new Complex128Array( 0 ) );
 		bench( pkg+':len='+len+',dtype=complex128', f );

--- a/lib/node_modules/@stdlib/array/convert-same/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/convert-same/docs/repl.txt
@@ -2,21 +2,6 @@
 {{alias}}( x, y )
     Converts an input array to the same data type as a second input array.
 
-    The function supports input arrays having the following data types:
-
-    - float32: single-precision floating-point numbers.
-    - float64: double-precision floating-point numbers.
-    - complex64: single-precision complex floating-point numbers.
-    - complex128: double-precision complex floating-point numbers.
-    - generic: values of any type.
-    - int16: signed 16-bit integers.
-    - int32: signed 32-bit integers.
-    - int8: signed 8-bit integers.
-    - uint16: unsigned 16-bit integers.
-    - uint32: unsigned 32-bit integers.
-    - uint8: unsigned 8-bit integers.
-    - uint8c: unsigned clamped 8-bit integers.
-
     Parameters
     ----------
     x: ArrayLikeObject

--- a/lib/node_modules/@stdlib/array/convert-same/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/convert-same/docs/types/index.d.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -183,6 +183,24 @@ declare function convertSame( x: Collection, y: Uint8Array ): Uint8Array;
 * // returns <Uint8ClampedArray>[ 1, 2, 3, 4 ]
 */
 declare function convertSame( x: Collection, y: Uint8ClampedArray ): Uint8ClampedArray;
+
+/**
+* Converts an array to a `BooleanArray`.
+*
+* @param x - array to convert
+* @param y - array having the desired output data type
+* @returns output array
+*
+* @example
+* var BooleanArray = require( '@stdlib/array/bool' );
+*
+* var x = [ -1, 0, 1, 2 ];
+* var y = new BooleanArray( 0 );
+*
+* var out = convertSame( x, y );
+* // returns <BooleanArray>
+*/
+declare function convertSame( x: Collection, y: BooleanArray ): BooleanArray;
 
 /**
 * Converts an array to a `Complex128Array`.

--- a/lib/node_modules/@stdlib/array/convert-same/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/convert-same/docs/types/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { AnyArray, Collection, Complex128Array, Complex64Array } from '@stdlib/types/array';
+import { AnyArray, Collection, Complex128Array, Complex64Array, BooleanArray } from '@stdlib/types/array';
 
 /**
 * Converts an array to the same data type as a `Float64Array`.

--- a/lib/node_modules/@stdlib/array/convert-same/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/convert-same/docs/types/test.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 
 import Complex128Array = require( '@stdlib/array/complex128' );
 import Complex64Array = require( '@stdlib/array/complex64' );
+import BooleanArray = require( '@stdlib/array/bool' );
 import convertSame = require( './index' );
 
 
@@ -36,6 +37,7 @@ import convertSame = require( './index' );
 	convertSame( [ 1.0, 2.0, 3.0, 4.0 ], new Uint8ClampedArray( 0 ) ); // $ExpectType Uint8ClampedArray
 	convertSame( [ 1.0, 2.0, 3.0, 4.0 ], new Complex128Array( 0 ) ); // $ExpectType Complex128Array
 	convertSame( [ 1.0, 2.0, 3.0, 4.0 ], new Complex64Array( 0 ) ); // $ExpectType Complex64Array
+	convertSame( [ 1.0, 2.0, 3.0, 4.0 ], new BooleanArray( 0 ) ); // $ExpectType BooleanArray
 	convertSame( [ 1.0, 2.0, 3.0, 4.0 ], [] ); // $ExpectType any[]
 }
 

--- a/lib/node_modules/@stdlib/array/convert-same/test/test.js
+++ b/lib/node_modules/@stdlib/array/convert-same/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex128Array = require( '@stdlib/array/complex128' );
 var Complex64Array = require( '@stdlib/array/complex64' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var isArray = require( '@stdlib/assert/is-array' );
 var isFloat64Array = require( '@stdlib/assert/is-float64array' );
 var isFloat32Array = require( '@stdlib/assert/is-float32array' );
@@ -47,10 +48,12 @@ var isUint8Array = require( '@stdlib/assert/is-uint8array' );
 var isUint8ClampedArray = require( '@stdlib/assert/is-uint8clampedarray' );
 var isComplex64Array = require( '@stdlib/assert/is-complex64array' );
 var isComplex128Array = require( '@stdlib/assert/is-complex128array' );
+var isBooleanArray = require( '@stdlib/assert/is-booleanarray' );
 var isComplex64 = require( '@stdlib/assert/is-complex64' );
 var isComplex128 = require( '@stdlib/assert/is-complex128' );
 var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
 var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
+var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
 var real = require( '@stdlib/complex/real' );
 var imag = require( '@stdlib/complex/imag' );
 var realf = require( '@stdlib/complex/realf' );
@@ -244,6 +247,144 @@ tape( 'the function converts an array to the same data type as a second input ar
 	}
 });
 
+tape( 'the function converts an array to the same data type as a second input array (accessors => bool)', function test( t ) {
+	var expected;
+	var arr;
+	var out;
+
+	arr = {
+		'length': 3,
+		'data': [ -1, 0, 1 ],
+		'get': getter,
+		'set': setter
+	};
+	expected = new Uint8Array( [ 1, 0, 1 ] );
+	out = convertArraySame( arr, BooleanArray( 0 ) );
+
+	t.strictEqual( isBooleanArray( out ), true, 'returns expected value type' );
+	t.strictEqual( out.length, expected.length, 'returns expected length' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
+
+	t.end();
+
+	function getter( idx ) {
+		return arr.data[ idx ];
+	}
+
+	function setter( value, idx ) {
+		arr.data[ idx ] = value;
+	}
+});
+
+tape( 'the function converts an array to the same data type as a second input array (generic => bool)', function test( t ) {
+	var expected;
+	var arr;
+	var out;
+
+	arr = [ 'foo', null, [], {} ];
+	expected = new Uint8Array( [ 1, 0, 1, 1 ] );
+	out = convertArraySame( arr, BooleanArray( 0 ) );
+	t.strictEqual( isBooleanArray( out ), true, 'returns expected value type' );
+	t.strictEqual( out.length, expected.length, 'returns expected length' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function converts an array to the same data type as a second input array (real => bool)', function test( t ) {
+	var expected;
+	var arr;
+	var out;
+
+	arr = [ -1, 0, 1, 2 ];
+	expected = new Uint8Array( [ 1, 0, 1, 1 ] );
+	out = convertArraySame( arr, BooleanArray( 0 ) );
+	t.strictEqual( isBooleanArray( out ), true, 'returns expected value type' );
+	t.strictEqual( out.length, expected.length, 'returns expected length' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function converts an array to the same data type as a second input array (bool => complex)', function test( t ) {
+	var expected;
+	var arr;
+	var out;
+	var tmp;
+	var v1;
+	var v2;
+	var dt;
+	var y;
+	var i;
+	var j;
+
+	y = [
+		new Complex64Array( 0 ),
+		new Complex128Array( 0 )
+	];
+	arr = new BooleanArray( [ true, false, true, true ] );
+	expected = [
+		[ new Complex64Array( [ 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0 ] ), isComplex64Array, reinterpret64 ],
+		[ new Complex128Array( [ 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0 ] ), isComplex128Array, reinterpret128 ]
+	];
+	for ( i = 0; i < y.length; i++ ) {
+		tmp = expected[ i ];
+		dt = dtype( y[ i ] );
+		out = convertArraySame( arr, y[ i ] );
+		t.strictEqual( tmp[ 1 ]( out ), true, 'returns expected value type for ' + dt );
+		v1 = tmp[ 2 ]( out, 0 );
+		v2 = tmp[ 2 ]( tmp[ 0 ], 0 );
+		for ( j = 0; j < arr.length*2; j += 2 ) {
+			t.strictEqual( v1[ j ], v2[ j ], 'returns expected real component for element ' + (j/2) + ' for ' + dt );
+			t.strictEqual( v1[ j+1 ], v2[ j+1 ], 'returns expected imaginary component for element ' + (j/2) + ' for ' + dt );
+		}
+	}
+	t.end();
+});
+
+tape( 'the function converts an array to the same data type as a second input array (bool => real)', function test( t ) {
+	var expected;
+	var arr;
+	var out;
+	var dt;
+	var y;
+	var i;
+	var j;
+
+	y = [
+		new Float64Array( 0 ),
+		new Float32Array( 0 ),
+		new Int16Array( 0 ),
+		new Int32Array( 0 ),
+		new Int8Array( 0 ),
+		new Uint16Array( 0 ),
+		new Uint32Array( 0 ),
+		new Uint8Array( 0 ),
+		new Uint8ClampedArray( 0 )
+	];
+	arr = new BooleanArray( [ true, false, true ] );
+	expected = [
+		[ new Float64Array( [ 1.0, 0.0, 1.0 ] ), isFloat64Array ],
+		[ new Float32Array( [ 1.0, 0.0, 1.0 ] ), isFloat32Array ],
+		[ new Int16Array( [ 1, 0, 1 ] ), isInt16Array ],
+		[ new Int32Array( [ 1, 0, 1 ] ), isInt32Array ],
+		[ new Int8Array( [ 1, 0, 1 ] ), isInt8Array ],
+		[ new Uint16Array( [ 1, 0, 1 ] ), isUint16Array ],
+		[ new Uint32Array( [ 1, 0, 1 ] ), isUint32Array ],
+		[ new Uint8Array( [ 1, 0, 1 ] ), isUint8Array ],
+		[ new Uint8ClampedArray( [ 1, 0, 1 ] ), isUint8ClampedArray ]
+	];
+	for ( i = 0; i < y.length; i++ ) {
+		dt = dtype( y[ i ] );
+		out = convertArraySame( arr, y[ i ] );
+		t.strictEqual( expected[ i ][ 1 ]( out ), true, 'returns expected value type for ' + dt );
+		for ( j = 0; j < arr.length; j++ ) {
+			t.strictEqual( out[ j ], expected[ i ][ 0 ][ j ], 'returns expected element ' + j + ' for ' + dt );
+		}
+	}
+	t.end();
+});
+
 tape( 'the function converts an array to the same data type as a second input array (real => complex)', function test( t ) {
 	var expected;
 	var arr;
@@ -435,6 +576,76 @@ tape( 'the function converts an array to the same data type as a second input ar
 			t.strictEqual( out[ j ], expected[ i ][ 0 ][ j ], 'returns expected element ' + j + ' for ' + dt );
 		}
 	}
+	t.end();
+});
+
+tape( 'the function converts an arrat to the same data type as a second input array (complex64 => bool)', function test( t ) {
+	var expected;
+	var arr;
+	var out;
+
+	arr = new Complex64Array( [ -1.0, 1.0, 0.0, 0.0, 1.0, 3.0, 2.0, 4.0 ] );
+	expected = new Uint8Array( [ 1, 0, 1, 1 ] );
+
+	out = convertArraySame( arr, BooleanArray( 0 ) );
+	t.strictEqual( isBooleanArray( out ), true, 'returns expected value type' );
+	t.strictEqual( out.length, expected.length, 'returns expected length' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function converts an arrat to the same data type as a second input array (complex128 => bool)', function test( t ) {
+	var expected;
+	var arr;
+	var out;
+
+	arr = new Complex128Array( [ -1.0, 1.0, 0.0, 0.0, 1.0, 3.0, 2.0, 4.0 ] );
+	expected = new Uint8Array( [ 1, 0, 1, 1 ] );
+
+	out = convertArraySame( arr, BooleanArray( 0 ) );
+	t.strictEqual( isBooleanArray( out ), true, 'returns expected value type' );
+	t.strictEqual( out.length, expected.length, 'returns expected length' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function converts an array to the same data type as a second input array (bool => generic)', function test( t ) {
+	var expected;
+	var arr;
+	var out;
+	var v1;
+	var v2;
+	var i;
+
+	arr = new BooleanArray( [ true, false, true ] );
+	expected = [
+		arr.get( 0 ),
+		arr.get( 1 ),
+		arr.get( 2 )
+	];
+	out = convertArraySame( arr, [] );
+	t.strictEqual( isArray( out ), true, 'returns expected value type' );
+	for ( i = 0; i < arr.length; i++ ) {
+		t.strictEqual( out[ i ], expected[ i ], 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function converts an array to the same data type as a second input array (bool => bool)', function test( t ) {
+	var expected;
+	var arr;
+	var out;
+
+	arr = new BooleanArray( [ true, false, true ] );
+	expected = new Uint8Array( [ 1, 0, 1 ] );
+
+	out = convertArraySame( arr, BooleanArray( 0 ) );
+	t.strictEqual( isBooleanArray( out ), true, 'returns expected value type' );
+	t.strictEqual( out.length, expected.length, 'returns expected length' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
+
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/array/convert-same/test/test.js
+++ b/lib/node_modules/@stdlib/array/convert-same/test/test.js
@@ -721,7 +721,8 @@ tape( 'the function converts an array to the same data type as a second input ar
 		new Uint8Array( 0 ),
 		new Uint8ClampedArray( 0 ),
 		new Complex64Array( 0 ),
-		new Complex128Array( 0 )
+		new Complex128Array( 0 ),
+		new BooleanArray( 0 )
 	];
 	x = [];
 	for ( i = 0; i < 1e6; i++ ) {
@@ -739,7 +740,8 @@ tape( 'the function converts an array to the same data type as a second input ar
 		isUint8Array,
 		isUint8ClampedArray,
 		isComplex64Array,
-		isComplex128Array
+		isComplex128Array,
+		isBooleanArray
 	];
 	for ( i = 0; i < y.length; i++ ) {
 		dt = dtype( y[ i ] );

--- a/lib/node_modules/@stdlib/array/convert-same/test/test.js
+++ b/lib/node_modules/@stdlib/array/convert-same/test/test.js
@@ -259,7 +259,7 @@ tape( 'the function converts an array to the same data type as a second input ar
 		'set': setter
 	};
 	expected = new Uint8Array( [ 1, 0, 1 ] );
-	out = convertArraySame( arr, BooleanArray( 0 ) );
+	out = convertArraySame( arr, new BooleanArray( 0 ) );
 
 	t.strictEqual( isBooleanArray( out ), true, 'returns expected value type' );
 	t.strictEqual( out.length, expected.length, 'returns expected length' );
@@ -283,7 +283,7 @@ tape( 'the function converts an array to the same data type as a second input ar
 
 	arr = [ 'foo', null, [], {} ];
 	expected = new Uint8Array( [ 1, 0, 1, 1 ] );
-	out = convertArraySame( arr, BooleanArray( 0 ) );
+	out = convertArraySame( arr, new BooleanArray( 0 ) );
 	t.strictEqual( isBooleanArray( out ), true, 'returns expected value type' );
 	t.strictEqual( out.length, expected.length, 'returns expected length' );
 	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
@@ -298,7 +298,7 @@ tape( 'the function converts an array to the same data type as a second input ar
 
 	arr = [ -1, 0, 1, 2 ];
 	expected = new Uint8Array( [ 1, 0, 1, 1 ] );
-	out = convertArraySame( arr, BooleanArray( 0 ) );
+	out = convertArraySame( arr, new BooleanArray( 0 ) );
 	t.strictEqual( isBooleanArray( out ), true, 'returns expected value type' );
 	t.strictEqual( out.length, expected.length, 'returns expected length' );
 	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
@@ -579,7 +579,7 @@ tape( 'the function converts an array to the same data type as a second input ar
 	t.end();
 });
 
-tape( 'the function converts an arrat to the same data type as a second input array (complex64 => bool)', function test( t ) {
+tape( 'the function converts an array to the same data type as a second input array (complex64 => bool)', function test( t ) {
 	var expected;
 	var arr;
 	var out;
@@ -587,7 +587,7 @@ tape( 'the function converts an arrat to the same data type as a second input ar
 	arr = new Complex64Array( [ -1.0, 1.0, 0.0, 0.0, 1.0, 3.0, 2.0, 4.0 ] );
 	expected = new Uint8Array( [ 1, 0, 1, 1 ] );
 
-	out = convertArraySame( arr, BooleanArray( 0 ) );
+	out = convertArraySame( arr, new BooleanArray( 0 ) );
 	t.strictEqual( isBooleanArray( out ), true, 'returns expected value type' );
 	t.strictEqual( out.length, expected.length, 'returns expected length' );
 	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
@@ -595,7 +595,7 @@ tape( 'the function converts an arrat to the same data type as a second input ar
 	t.end();
 });
 
-tape( 'the function converts an arrat to the same data type as a second input array (complex128 => bool)', function test( t ) {
+tape( 'the function converts an array to the same data type as a second input array (complex128 => bool)', function test( t ) {
 	var expected;
 	var arr;
 	var out;
@@ -603,7 +603,7 @@ tape( 'the function converts an arrat to the same data type as a second input ar
 	arr = new Complex128Array( [ -1.0, 1.0, 0.0, 0.0, 1.0, 3.0, 2.0, 4.0 ] );
 	expected = new Uint8Array( [ 1, 0, 1, 1 ] );
 
-	out = convertArraySame( arr, BooleanArray( 0 ) );
+	out = convertArraySame( arr, new BooleanArray( 0 ) );
 	t.strictEqual( isBooleanArray( out ), true, 'returns expected value type' );
 	t.strictEqual( out.length, expected.length, 'returns expected length' );
 	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
@@ -615,8 +615,6 @@ tape( 'the function converts an array to the same data type as a second input ar
 	var expected;
 	var arr;
 	var out;
-	var v1;
-	var v2;
 	var i;
 
 	arr = new BooleanArray( [ true, false, true ] );
@@ -641,7 +639,7 @@ tape( 'the function converts an array to the same data type as a second input ar
 	arr = new BooleanArray( [ true, false, true ] );
 	expected = new Uint8Array( [ 1, 0, 1 ] );
 
-	out = convertArraySame( arr, BooleanArray( 0 ) );
+	out = convertArraySame( arr, new BooleanArray( 0 ) );
 	t.strictEqual( isBooleanArray( out ), true, 'returns expected value type' );
 	t.strictEqual( out.length, expected.length, 'returns expected length' );
 	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );


### PR DESCRIPTION
Resolves: Subtask of #2304 

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR will add boolean datatype support in `array/convert-same`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
