### PR TITLE
feat: add boolean dtype support to `strided/dtypes`

### DIFF
--- a/lib/node_modules/@stdlib/strided/dtypes/README.md
+++ b/lib/node_modules/@stdlib/strided/dtypes/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2020 The Stdlib Authors.
+Copyright (c) 2024 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -46,12 +46,13 @@ Returns a list of strided array data types.
 
 ```javascript
 var out = dtypes();
-// returns [ 'binary', 'complex64', 'complex128', 'float32', 'float64', 'generic', 'int16', 'int32', 'int8', 'uint16', 'uint32', 'uint8', 'uint8c' ]
+// returns [ 'binary', 'bool', 'complex64', 'complex128', 'float32', 'float64', 'generic', 'int16', 'int32', 'int8', 'uint16', 'uint32', 'uint8', 'uint8c' ]
 ```
 
 The output `array` contains the following data types:
 
 -   `binary`: binary.
+-   `bool`: boolean values.
 -   `complex64`: single-precision complex floating-point numbers.
 -   `complex128`: double-precision complex floating-point numbers.
 -   `float32`: single-precision floating-point numbers.

--- a/lib/node_modules/@stdlib/strided/dtypes/README.md
+++ b/lib/node_modules/@stdlib/strided/dtypes/README.md
@@ -49,7 +49,7 @@ var out = dtypes();
 // e.g., returns [ 'binary', 'bool', 'complex64', ... ]
 ```
 
-The output `array` contains the following data types:
+The output array contains the following data types:
 
 -   `binary`: binary.
 -   `bool`: boolean values.

--- a/lib/node_modules/@stdlib/strided/dtypes/README.md
+++ b/lib/node_modules/@stdlib/strided/dtypes/README.md
@@ -46,7 +46,7 @@ Returns a list of strided array data types.
 
 ```javascript
 var out = dtypes();
-// returns [ 'binary', 'bool', 'complex64', 'complex128', 'float32', 'float64', 'generic', 'int16', 'int32', 'int8', 'uint16', 'uint32', 'uint8', 'uint8c' ]
+// e.g., returns [ 'binary', 'bool', 'complex64', ... ]
 ```
 
 The output `array` contains the following data types:

--- a/lib/node_modules/@stdlib/strided/dtypes/README.md
+++ b/lib/node_modules/@stdlib/strided/dtypes/README.md
@@ -87,17 +87,12 @@ The output `array` contains the following data types:
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var indexOf = require( '@stdlib/utils/index-of' );
+var contains = require( '@stdlib/array/base/assert/contains' ).factory;
 var dtypes = require( '@stdlib/strided/dtypes' );
 
-var DTYPES = dtypes();
-var bool;
+var isdtype = contains( dtypes() );
 
-function isdtype( str ) {
-    return ( indexOf( DTYPES, str ) >= 0 );
-}
-
-bool = isdtype( 'float64' );
+var bool = isdtype( 'float64' );
 // returns true
 
 bool = isdtype( 'int16' );

--- a/lib/node_modules/@stdlib/strided/dtypes/docs/repl.txt
+++ b/lib/node_modules/@stdlib/strided/dtypes/docs/repl.txt
@@ -5,6 +5,7 @@
     The output array contains the following data types:
 
     - binary: binary.
+    - bool: boolean values.
     - complex64: single-precision complex floating-point numbers.
     - complex128: double-precision complex floating-point numbers.
     - float32: single-precision floating-point numbers.

--- a/lib/node_modules/@stdlib/strided/dtypes/examples/index.js
+++ b/lib/node_modules/@stdlib/strided/dtypes/examples/index.js
@@ -18,17 +18,12 @@
 
 'use strict';
 
-var indexOf = require( '@stdlib/utils/index-of' );
+var contains = require( '@stdlib/array/base/assert/contains' ).factory;
 var dtypes = require( './../lib' );
 
-var DTYPES = dtypes();
-var bool;
+var isdtype = contains( dtypes() );
 
-function isdtype( str ) {
-	return ( indexOf( DTYPES, str ) >= 0 );
-}
-
-bool = isdtype( 'float64' );
+var bool = isdtype( 'float64' );
 console.log( bool );
 // => true
 

--- a/lib/node_modules/@stdlib/strided/dtypes/lib/dtypes.json
+++ b/lib/node_modules/@stdlib/strided/dtypes/lib/dtypes.json
@@ -1,5 +1,6 @@
 [
 	"binary",
+  "bool",
   "complex64",
   "complex128",
   "float32",

--- a/lib/node_modules/@stdlib/strided/dtypes/lib/dtypes.json
+++ b/lib/node_modules/@stdlib/strided/dtypes/lib/dtypes.json
@@ -1,5 +1,5 @@
 [
-	"binary",
+  "binary",
   "bool",
   "complex64",
   "complex128",

--- a/lib/node_modules/@stdlib/strided/dtypes/test/test.js
+++ b/lib/node_modules/@stdlib/strided/dtypes/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2020 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -43,7 +43,9 @@ var DTYPES = [
 	'float64',
 
 	'complex64',
-	'complex128'
+	'complex128',
+
+	'bool'
 ];
 
 
@@ -61,6 +63,7 @@ tape( 'the function returns a list of strided array data type strings', function
 
 	expected = [
 		'binary',
+		'bool',
 		'complex64',
 		'complex128',
 		'float32',


### PR DESCRIPTION
Resolves: Subtask of #2500 

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR will add boolean datatype support in `strided/dtypes`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
