### PR TITLE
feat: add `reduce` and `reduceRight` methods to `array/bool`

### DIFF
--- a/lib/node_modules/@stdlib/array/bool/README.md
+++ b/lib/node_modules/@stdlib/array/bool/README.md
@@ -779,6 +779,106 @@ var count = context.count;
 // returns 3;
 ```
 
+<a name="method-reduce"></a>
+
+#### BooleanArray.prototype.reduce( reducerFn\[, initialValue] )
+
+Applies a provided callback function to each element of the array, in order, passing in the return value from the calculation on the preceding element and returning the accumulated result upon completion.
+
+```javascript
+var Boolean = require( '@stdlib/boolean/ctor' );
+
+function reducer( acc, v ) {
+    return Boolean( acc & v );
+}
+
+var arr = new BooleanArray( 3 );
+
+arr.set( true, 0 );
+arr.set( false, 1 );
+arr.set( true, 2 );
+
+var sum = arr.reduce( reducer );
+// returns false
+```
+
+The reducer function is provided four arguments:
+
+-   **acc**: accumulated result.
+-   **value**: current array element.
+-   **index**: current array element index.
+-   **arr**: the array on which this method was called.
+
+By default, the function initializes the accumulated result to the first element in the array and passes the second array element as `value` during the first invocation of the provided callback. To begin accumulation from a different starting value and pass in the first array element as `value` during the first invocation of the provided callback, provide an `initialValue` argument.
+
+```javascript
+function reducer( acc, v ) {
+    if ( v ) {
+        return acc + 1;
+    }
+    return acc;
+}
+
+var arr = new BooleanArray( 3 );
+
+arr.set( true, 0 );
+arr.set( false, 1 );
+arr.set( true, 2 );
+
+var sum = arr.reduce( reducer );
+// returns 2
+```
+
+<a name="method-reduce-right"></a>
+
+#### Complex64Array.prototype.reduceRight( reducerFn\[, initialValue] )
+
+Applies a provided callback function to each element of the array, in reverse order, passing in the return value from the calculation on the following element and returning the accumulated result upon completion.
+
+```javascript
+var Boolean = require( '@stdlib/boolean/ctor' );
+
+function reducer( acc, v ) {
+    return Boolean( acc & v );
+}
+
+var arr = new BooleanArray( 3 );
+
+arr.set( true, 0 );
+arr.set( false, 1 );
+arr.set( true, 2 );
+
+var sum = arr.reduceRight( reducer );
+// returns false
+```
+
+The reducer function is provided four arguments:
+
+-   **acc**: accumulated result.
+-   **value**: current array element.
+-   **index**: current array element index.
+-   **arr**: the array on which this method was called.
+
+By default, the function initializes the accumulated result to the last element in the array and passes the second-last array element as `value` during the first invocation of the provided callback. To begin accumulation from a different starting value and pass in the last array element as `value` during the first invocation of the provided callback, provide an `initialValue` argument.
+
+```javascript
+function reducer( acc, v ) {
+    if ( v ) {
+        return acc + 1;
+    }
+    return acc;
+}
+
+var arr = new BooleanArray( 3 );
+
+arr.set( true, 0 );
+arr.set( false, 1 );
+arr.set( true, 2 );
+
+var sum = arr.reduceRight( reducer );
+// returns 2
+```
+
 <a name="method-reverse"></a>
 
 #### BooleanArray.prototype.reverse()

--- a/lib/node_modules/@stdlib/array/bool/README.md
+++ b/lib/node_modules/@stdlib/array/bool/README.md
@@ -786,10 +786,8 @@ var count = context.count;
 Applies a provided callback function to each element of the array, in order, passing in the return value from the calculation on the preceding element and returning the accumulated result upon completion.
 
 ```javascript
-var Boolean = require( '@stdlib/boolean/ctor' );
-
 function reducer( acc, v ) {
-    return Boolean( acc & v );
+    return ( acc && v );
 }
 
 var arr = new BooleanArray( 3 );
@@ -798,7 +796,7 @@ arr.set( true, 0 );
 arr.set( false, 1 );
 arr.set( true, 2 );
 
-var sum = arr.reduce( reducer );
+var out = arr.reduce( reducer );
 // returns false
 ```
 
@@ -825,7 +823,7 @@ arr.set( true, 0 );
 arr.set( false, 1 );
 arr.set( true, 2 );
 
-var sum = arr.reduce( reducer );
+var out = arr.reduce( reducer, 0 );
 // returns 2
 ```
 
@@ -836,10 +834,8 @@ var sum = arr.reduce( reducer );
 Applies a provided callback function to each element of the array, in reverse order, passing in the return value from the calculation on the following element and returning the accumulated result upon completion.
 
 ```javascript
-var Boolean = require( '@stdlib/boolean/ctor' );
-
 function reducer( acc, v ) {
-    return Boolean( acc & v );
+    return ( acc && v );
 }
 
 var arr = new BooleanArray( 3 );
@@ -848,7 +844,7 @@ arr.set( true, 0 );
 arr.set( false, 1 );
 arr.set( true, 2 );
 
-var sum = arr.reduceRight( reducer );
+var out = arr.reduceRight( reducer );
 // returns false
 ```
 
@@ -875,7 +871,7 @@ arr.set( true, 0 );
 arr.set( false, 1 );
 arr.set( true, 2 );
 
-var sum = arr.reduceRight( reducer );
+var out = arr.reduceRight( reducer, 0 );
 // returns 2
 ```
 

--- a/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.reduce.js
+++ b/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.reduce.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
-var Boolean = require( '@stdlib/boolean/ctor' );
+var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var pkg = require( './../package.json' ).name;
 var BooleanArray = require( './../lib' );
 
@@ -31,14 +30,18 @@ var BooleanArray = require( './../lib' );
 
 /**
 * Reducer function.
+*
 * @private
-* @param {any} acc - accumulated value
+* @param {integer} acc - accumulated value
 * @param {boolean} value - current array element
 * @param {integer} index - current array index
-* @returns {any} accumulated value
+* @returns {integer} accumulated value
 */
 function reducer( acc, value ) {
-	return Boolean( acc & value );
+	if ( value ) {
+		return acc + 1;
+	}
+	return acc;
 }
 
 
@@ -53,14 +56,14 @@ bench( pkg+':reduce', function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		out = arr.reduce( reducer );
-		if ( typeof out !== 'boolean' ) {
-			b.fail( 'should return a boolean' );
+		out = arr.reduce( reducer, 0 );
+		if ( typeof out !== 'number' ) {
+			b.fail( 'should return an integer' );
 		}
 	}
 	b.toc();
-	if ( !isBoolean( out ) ) {
-		b.fail( 'should return a boolean' );
+	if ( !isInteger( out ) ) {
+		b.fail( 'should return an integer' );
 	}
 	b.pass( 'benchmark finished' );
 	b.end();

--- a/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.reduce.js
+++ b/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.reduce.js
@@ -1,0 +1,67 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var Boolean = require( '@stdlib/boolean/ctor' );
+var pkg = require( './../package.json' ).name;
+var BooleanArray = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Reducer function.
+* @private
+* @param {any} acc - accumulated value
+* @param {boolean} value - current array element
+* @param {integer} index - current array index
+* @returns {any} accumulated value
+*/
+function reducer( acc, value ) {
+	return Boolean( acc & value );
+}
+
+
+// MAIN //
+
+bench( pkg+':reduce', function benchmark( b ) {
+	var out;
+	var arr;
+	var i;
+
+	arr = new BooleanArray( [ true, false, false, true ] );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = arr.reduce( reducer );
+		if ( typeof out !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( out ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.reduce.length.js
+++ b/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.reduce.length.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
-var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var Boolean = require( '@stdlib/boolean/ctor' );
 var pkg = require( './../package.json' ).name;
 var BooleanArray = require( './../lib' );
@@ -32,14 +32,18 @@ var BooleanArray = require( './../lib' );
 
 /**
 * Reducer function.
+*
 * @private
-* @param {any} acc - accumulated value
+* @param {integer} acc - accumulated value
 * @param {boolean} value - current array element
 * @param {integer} index - current array index
-* @returns {any} accumulated value
+* @returns {integer} accumulated value
 */
 function reducer( acc, value ) {
-	return Boolean( acc & value );
+	if ( value ) {
+		return acc + 1;
+	}
+	return acc;
 }
 
 /**
@@ -73,14 +77,14 @@ function createBenchmark( len ) {
 
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
-			out = arr.reduce( reducer );
-			if ( typeof out !== 'boolean' ) {
-				b.fail( 'should return a boolean' );
+			out = arr.reduce( reducer, 0 );
+			if ( typeof out !== 'number' ) {
+				b.fail( 'should return an integer' );
 			}
 		}
 		b.toc();
-		if ( !isBoolean( out ) ) {
-			b.fail( 'should return a boolean' );
+		if ( !isInteger( out ) ) {
+			b.fail( 'should return an integer' );
 		}
 		b.pass( 'benchmark finished' );
 		b.end();

--- a/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.reduce.length.js
+++ b/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.reduce.length.js
@@ -1,0 +1,115 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var Boolean = require( '@stdlib/boolean/ctor' );
+var pkg = require( './../package.json' ).name;
+var BooleanArray = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Reducer function.
+* @private
+* @param {any} acc - accumulated value
+* @param {boolean} value - current array element
+* @param {integer} index - current array index
+* @returns {any} accumulated value
+*/
+function reducer( acc, value ) {
+	return Boolean( acc & value );
+}
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var arr;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < len; i++ ) {
+		arr.push( Boolean( i%2 ) );
+	}
+	arr = new BooleanArray( arr );
+
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var out;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			out = arr.reduce( reducer );
+			if ( typeof out !== 'boolean' ) {
+				b.fail( 'should return a boolean' );
+			}
+		}
+		b.toc();
+		if ( !isBoolean( out ) ) {
+			b.fail( 'should return a boolean' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':reduce:len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.reduce_right.js
+++ b/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.reduce_right.js
@@ -1,0 +1,67 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var Boolean = require( '@stdlib/boolean/ctor' );
+var pkg = require( './../package.json' ).name;
+var BooleanArray = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Reducer function.
+* @private
+* @param {any} acc - accumulated value
+* @param {boolean} value - current array element
+* @param {integer} index - current array index
+* @returns {any} accumulated value
+*/
+function reducer( acc, value ) {
+	return Boolean( acc & value );
+}
+
+
+// MAIN //
+
+bench( pkg+':reduceRight', function benchmark( b ) {
+	var out;
+	var arr;
+	var i;
+
+	arr = new BooleanArray( [ true, false, false, true ] );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = arr.reduceRight( reducer );
+		if ( typeof out !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( out ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.reduce_right.js
+++ b/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.reduce_right.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
-var Boolean = require( '@stdlib/boolean/ctor' );
+var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var pkg = require( './../package.json' ).name;
 var BooleanArray = require( './../lib' );
 
@@ -31,14 +30,18 @@ var BooleanArray = require( './../lib' );
 
 /**
 * Reducer function.
+*
 * @private
-* @param {any} acc - accumulated value
+* @param {integer} acc - accumulated value
 * @param {boolean} value - current array element
 * @param {integer} index - current array index
-* @returns {any} accumulated value
+* @returns {integer} accumulated value
 */
 function reducer( acc, value ) {
-	return Boolean( acc & value );
+	if ( value ) {
+		return acc + 1;
+	}
+	return acc;
 }
 
 
@@ -53,14 +56,14 @@ bench( pkg+':reduceRight', function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		out = arr.reduceRight( reducer );
-		if ( typeof out !== 'boolean' ) {
-			b.fail( 'should return a boolean' );
+		out = arr.reduceRight( reducer, 0 );
+		if ( typeof out !== 'number' ) {
+			b.fail( 'should return an integer' );
 		}
 	}
 	b.toc();
-	if ( !isBoolean( out ) ) {
-		b.fail( 'should return a boolean' );
+	if ( !isInteger( out ) ) {
+		b.fail( 'should return an integer' );
 	}
 	b.pass( 'benchmark finished' );
 	b.end();

--- a/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.reduce_right.length.js
+++ b/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.reduce_right.length.js
@@ -1,0 +1,115 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var Boolean = require( '@stdlib/boolean/ctor' );
+var pkg = require( './../package.json' ).name;
+var BooleanArray = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Reducer function.
+* @private
+* @param {any} acc - accumulated value
+* @param {boolean} value - current array element
+* @param {integer} index - current array index
+* @returns {any} accumulated value
+*/
+function reducer( acc, value ) {
+	return Boolean( acc & value );
+}
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var arr;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < len; i++ ) {
+		arr.push( Boolean( i%2 ) );
+	}
+	arr = new BooleanArray( arr );
+
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var out;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			out = arr.reduceRight( reducer );
+			if ( typeof out !== 'boolean' ) {
+				b.fail( 'should return a boolean' );
+			}
+		}
+		b.toc();
+		if ( !isBoolean( out ) ) {
+			b.fail( 'should return a boolean' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':reduceRight:len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.reduce_right.length.js
+++ b/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.reduce_right.length.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
-var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var isInteger = require('@stdlib/assert/is-integer').isPrimitive;
 var Boolean = require( '@stdlib/boolean/ctor' );
 var pkg = require( './../package.json' ).name;
 var BooleanArray = require( './../lib' );
@@ -32,14 +32,18 @@ var BooleanArray = require( './../lib' );
 
 /**
 * Reducer function.
+*
 * @private
-* @param {any} acc - accumulated value
+* @param {integer} acc - accumulated value
 * @param {boolean} value - current array element
 * @param {integer} index - current array index
-* @returns {any} accumulated value
+* @returns {integer} accumulated value
 */
 function reducer( acc, value ) {
-	return Boolean( acc & value );
+	if ( value ) {
+		return acc + 1;
+	}
+	return acc;
 }
 
 /**
@@ -73,14 +77,14 @@ function createBenchmark( len ) {
 
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
-			out = arr.reduceRight( reducer );
-			if ( typeof out !== 'boolean' ) {
-				b.fail( 'should return a boolean' );
+			out = arr.reduceRight( reducer, 0 );
+			if ( typeof out !== 'number' ) {
+				b.fail( 'should return an integer' );
 			}
 		}
 		b.toc();
-		if ( !isBoolean( out ) ) {
-			b.fail( 'should return a boolean' );
+		if ( !isInteger( out ) ) {
+			b.fail( 'should return an integer' );
 		}
 		b.pass( 'benchmark finished' );
 		b.end();

--- a/lib/node_modules/@stdlib/array/bool/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/bool/docs/repl.txt
@@ -692,7 +692,7 @@
     > function reducer( acc, v ) { return (acc &&  v); };
     > var arr = new {{alias}}( [ true, false, true ] )
     <BooleanArray>
-    > var sum = arr.reduceRight( reducer )
+    > var out = arr.reduceRight( reducer )
     false
 
 

--- a/lib/node_modules/@stdlib/array/bool/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/bool/docs/repl.txt
@@ -612,6 +612,90 @@
     false
 
 
+{{alias}}.prototype.reduce( reducerFn[, initialValue] )
+    Applies a provided function to each element of the array, in order, passing
+    in the return value from the calculation on the preceding element and
+    returning the accumulated result upon completion.
+
+    A reducer function is provided the following arguments:
+
+    - acc: accumulated result.
+    - value: current array element.
+    - index: current array element index.
+    - arr: the array on which the method was called.
+
+    If provided an initial value, the method invokes a provided function with
+    the initial value as the first argument and the first array element as the
+    second argument.
+
+    If not provided an initial value, the method invokes a provided function
+    with the first array element as the first argument and the second array
+    element as the second argument.
+
+    Parameters
+    ----------
+    reducerFn: Function
+        Function to apply to each array element.
+
+    initialValue: any (optional)
+        Initial accumulation value.
+
+    Returns
+    -------
+    out: any
+        Accumulated result.
+
+    Examples
+    --------
+    > function reducer( acc, v ) { return (acc &&  v); };
+    > var arr = new {{alias}}( [ true, false, true ] )
+    <BooleanArray>
+    > var sum = arr.reduce( reducer )
+    false
+
+
+{{alias}}.prototype.reduceRight( reducerFn[, initialValue] )
+    Applies a provided function to each element of the array, in reverse order,
+    passing in the return value from the calculation on the preceding element
+    and returning the accumulated result upon completion.
+
+    A reducer function is provided the following arguments:
+
+    - acc: accumulated result.
+    - value: current array element.
+    - index: current array element index.
+    - arr: the array on which the method was called.
+
+    If provided an initial value, the method invokes a provided function with
+    the initial value as the first argument and the last array element as the
+    second argument.
+
+    If not provided an initial value, the method invokes a provided function
+    with the last array element as the first argument and the second-to-last
+    array element as the second argument.
+
+    Parameters
+    ----------
+    reducerFn: Function
+        Function to apply to each array element.
+
+    initialValue: any (optional)
+        Initial accumulation value.
+    
+    Returns
+    -------
+    out: any
+        Accumulated result.
+    
+    Examples
+    --------
+    > function reducer( acc, v ) { return (acc &&  v); };
+    > var arr = new {{alias}}( [ true, false, true ] )
+    <BooleanArray>
+    > var sum = arr.reduceRight( reducer )
+    false
+
+
 {{alias}}.prototype.reverse()
     Reverses the array *in-place*.
 

--- a/lib/node_modules/@stdlib/array/bool/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/bool/docs/repl.txt
@@ -647,10 +647,10 @@
 
     Examples
     --------
-    > function reducer( acc, v ) { return (acc &&  v); };
+    > function reducer( acc, v ) { return ( acc && v ); };
     > var arr = new {{alias}}( [ true, false, true ] )
     <BooleanArray>
-    > var sum = arr.reduce( reducer )
+    > var out = arr.reduce( reducer )
     false
 
 
@@ -689,7 +689,7 @@
     
     Examples
     --------
-    > function reducer( acc, v ) { return (acc &&  v); };
+    > function reducer( acc, v ) { return ( acc && v ); };
     > var arr = new {{alias}}( [ true, false, true ] )
     <BooleanArray>
     > var out = arr.reduceRight( reducer )

--- a/lib/node_modules/@stdlib/array/bool/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/bool/docs/types/index.d.ts
@@ -591,7 +591,7 @@ declare class BooleanArray implements BooleanArrayInterface {
 	* arr.set( false, 1 );
 	* arr.set( true, 2 );
 	*
-	* var sum = arr.reduce( reducer, 0 );
+	* var out = arr.reduce( reducer, 0 );
 	* // returns 2
 	*/
 	reduce<U = unknown>( reducer: Reducer<U>, initialValue?: U ): U;
@@ -617,7 +617,7 @@ declare class BooleanArray implements BooleanArrayInterface {
 	* arr.set( false, 1 );
 	* arr.set( true, 2 );
 	*
-	* var sum = arr.reduceRight( reducer, 0 );
+	* var out = arr.reduceRight( reducer, 0 );
 	* // returns 2
 	*/
 	reduceRight<U = unknown>( reducer: Reducer<U>, initialValue?: U ): U;

--- a/lib/node_modules/@stdlib/array/bool/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/bool/docs/types/index.d.ts
@@ -151,6 +151,60 @@ type TernaryMapFcn<U> = ( this: U, value: boolean, index: number, arr: BooleanAr
 type MapFcn<U> = NullaryMapFcn<U> | UnaryMapFcn<U> | BinaryMapFcn<U> | TernaryMapFcn<U>;
 
 /**
+* Reducer function invoked for each element in an array.
+*
+* @returns accumulated result
+*/
+type NullaryReducer<U> = () => U;
+
+/**
+* Reducer function invoked for each element in an array.
+*
+* @param acc - accumulated result
+* @returns accumulated result
+*/
+type UnaryReducer<U> = ( acc: U ) => U;
+
+/**
+* Reducer function invoked for each element in an array.
+*
+* @param acc - accumulated result
+* @param value - current array element
+* @returns accumulated result
+*/
+type BinaryReducer<U> = ( acc: U, value: boolean ) => U;
+
+/**
+* Reducer function invoked for each element in an array.
+*
+* @param acc - accumulated result
+* @param value - current array element
+* @param index - current array element index
+* @returns accumulated result
+*/
+type TernaryReducer<U> = ( acc: U, value: boolean, index: number ) => U;
+
+/**
+* @param acc - accumulated result
+* @param value - current array element
+* @param index - current array element index
+* @param arr - array on which the method was called
+* @returns accumulated result
+*/
+type QuaternaryReducer<U> = ( acc: U, value: boolean, index: number, arr: BooleanArray ) => U;
+
+/**
+* Reducer function invoked for each element in an array.
+*
+* @param acc - accumulated result
+* @param value - current array element
+* @param index - current array element index
+* @param arr - array on which the method was called
+* @returns accumulated result
+*/
+type Reducer<U> = NullaryReducer<U> | UnaryReducer<U> | BinaryReducer<U> | TernaryReducer<U> | QuaternaryReducer<U>;
+
+/**
 * Comparator function.
 *
 * @param a - first boolean value for comparison
@@ -515,6 +569,58 @@ declare class BooleanArray implements BooleanArrayInterface {
 	* // returns false
 	*/
 	map<U = unknown>( fcn: MapFcn<U>, thisArg?: ThisParameterType<MapFcn<U>> ): BooleanArray;
+
+	/**
+	* Applies a provided callback function to each element of the array, in order, passing in the return value from the calculation on the preceding element and returning the accumulated result upon completion.
+	*
+	* @param reducer - callback function
+	* @param initialValue - initial value
+	* @returns accumulated result
+	*
+	* @example
+	* function reducer( acc, v ) {
+	* 	  if ( v ) {
+	*	       return acc + 1;
+	*	  }
+	*     return acc;
+	* }
+	*
+	* var arr = new BooleanArray( 3 );
+	*
+	* arr.set( true, 0 );
+	* arr.set( false, 1 );
+	* arr.set( true, 2 );
+	*
+	* var sum = arr.reduce( reducer, 0 );
+	* // returns 2
+	*/
+	reduce<U = unknown>( reducer: Reducer<U>, initialValue?: U ): U;
+
+	/**
+	* Applies a provided callback function to each element of the array, in reverse order, passing in the return value from the calculation on the following element and returning the accumulated result upon completion.
+	*
+	* @param reducer - callback function
+	* @param initialValue - initial value
+	* @returns accumulated result
+	*
+	* @example
+	* function reducer( acc, v ) {
+	* 	  if ( v ) {
+	*	       return acc + 1;
+	*	  }
+	*     return acc;
+	* }
+	*
+	* var arr = new BooleanArray( 3 );
+	*
+	* arr.set( true, 0 );
+	* arr.set( false, 1 );
+	* arr.set( true, 2 );
+	*
+	* var sum = arr.reduceRight( reducer, 0 );
+	* // returns 2
+	*/
+	reduceRight<U = unknown>( reducer: Reducer<U>, initialValue?: U ): U;
 
 	/**
 	* Reverses an array in-place.

--- a/lib/node_modules/@stdlib/array/bool/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/bool/docs/types/index.d.ts
@@ -579,9 +579,9 @@ declare class BooleanArray implements BooleanArrayInterface {
 	*
 	* @example
 	* function reducer( acc, v ) {
-	* 	  if ( v ) {
-	*	       return acc + 1;
-	*	  }
+	*     if ( v ) {
+	*          return acc + 1;
+	*     }
 	*     return acc;
 	* }
 	*
@@ -605,9 +605,9 @@ declare class BooleanArray implements BooleanArrayInterface {
 	*
 	* @example
 	* function reducer( acc, v ) {
-	* 	  if ( v ) {
-	*	       return acc + 1;
-	*	  }
+	*     if ( v ) {
+	*          return acc + 1;
+	*     }
 	*     return acc;
 	* }
 	*

--- a/lib/node_modules/@stdlib/array/bool/lib/main.js
+++ b/lib/node_modules/@stdlib/array/bool/lib/main.js
@@ -979,6 +979,124 @@ setReadOnly( BooleanArray.prototype, 'map', function map( fcn, thisArg ) {
 });
 
 /**
+* Applies a provided callback function to each element of the array, in order, passing in the return value from the calculation on the preceding element and returning the accumulated result upon completion.
+*
+* @name reduce
+* @memberof BooleanArray.prototype
+* @type {Function}
+* @param {Function} reducer - callback function
+* @param {*} [initialValue] - initial value
+* @throws {TypeError} `this` must be a boolean array
+* @throws {Error} if not provided an initial value, the array must have at least one element
+* @returns {*} accumulated result
+*
+* @example
+* function reducer( acc, v ) {
+* 	  if ( v ) {
+*	       return acc + 1;
+*	  }
+*     return acc;
+* }
+*
+* var arr = new BooleanArray( 3 );
+*
+* arr.set( true, 0 );
+* arr.set( false, 1 );
+* arr.set( true, 2 );
+*
+* var sum = arr.reduce( reducer, 0 );
+* // returns 2
+*/
+setReadOnly( BooleanArray.prototype, 'reduce', function reduce( reducer, initialValue ) {
+	var buf;
+	var len;
+	var acc;
+	var i;
+
+	if ( !isBooleanArray( this ) ) {
+		throw new TypeError( 'invalid invocation. `this` is not a boolean array.' );
+	}
+	if ( !isFunction( reducer ) ) {
+		throw new TypeError( format( 'invalid argument. First argument must be a function. Value: `%s`.', reducer ) );
+	}
+	buf = this._buffer;
+	len = this._length;
+	if ( arguments.length > 1 ) {
+		acc = initialValue;
+		i = 0;
+	} else {
+		if ( len === 0 ) {
+			throw new Error( 'invalid operation. If not provided an initial value, an array must contain at least one element.' );
+		}
+		acc = Boolean( buf[ 0 ] );
+		i = 1;
+	}
+	for ( ; i < len; i++ ) {
+		acc = reducer( acc, Boolean( buf[ i ] ), i, this );
+	}
+	return acc;
+});
+
+/**
+* Applies a provided callback function to each element of the array, in reverse order, passing in the return value from the calculation on the preceding element and returning the accumulated result upon completion.
+*
+* @name reduceRight
+* @memberof BooleanArray.prototype
+* @type {Function}
+* @param {Function} reducer - callback function
+* @param {*} [initialValue] - initial value
+* @throws {TypeError} `this` must be a boolean array
+* @throws {Error} if not provided an initial value, the array must have at least one element
+* @returns {*} accumulated result
+*
+* @example
+* function reducer( acc, v ) {
+* 	  if ( v ) {
+*	       return acc + 1;
+*	  }
+*     return acc;
+* }
+*
+* var arr = new BooleanArray( 3 );
+*
+* arr.set( true, 0 );
+* arr.set( false, 1 );
+* arr.set( true, 2 );
+*
+* var sum = arr.reduceRight( reducer, 0 );
+* // returns 2
+*/
+setReadOnly( BooleanArray.prototype, 'reduceRight', function reduceRight( reducer, initialValue ) {
+	var buf;
+	var len;
+	var acc;
+	var i;
+
+	if ( !isBooleanArray( this ) ) {
+		throw new TypeError( 'invalid invocation. `this` is not a boolean array.' );
+	}
+	if ( !isFunction( reducer ) ) {
+		throw new TypeError( format( 'invalid argument. First argument must be a function. Value: `%s`.', reducer ) );
+	}
+	buf = this._buffer;
+	len = this._length;
+	if ( arguments.length > 1 ) {
+		acc = initialValue;
+		i = len - 1;
+	} else {
+		if ( len === 0 ) {
+			throw new Error( 'invalid operation. If not provided an initial value, an array must contain at least one element.' );
+		}
+		acc = Boolean( buf[ len-1 ] );
+		i = len - 2;
+	}
+	for ( ; i >= 0; i-- ) {
+		acc = reducer( acc, Boolean( buf[ i ] ), i, this );
+	}
+	return acc;
+});
+
+/**
 * Reverses an array in-place.
 *
 * @name reverse

--- a/lib/node_modules/@stdlib/array/bool/lib/main.js
+++ b/lib/node_modules/@stdlib/array/bool/lib/main.js
@@ -992,9 +992,9 @@ setReadOnly( BooleanArray.prototype, 'map', function map( fcn, thisArg ) {
 *
 * @example
 * function reducer( acc, v ) {
-* 	  if ( v ) {
-*	       return acc + 1;
-*	  }
+*     if ( v ) {
+*          return acc + 1;
+*     }
 *     return acc;
 * }
 *
@@ -1051,9 +1051,9 @@ setReadOnly( BooleanArray.prototype, 'reduce', function reduce( reducer, initial
 *
 * @example
 * function reducer( acc, v ) {
-* 	  if ( v ) {
-*	       return acc + 1;
-*	  }
+*     if ( v ) {
+*          return acc + 1;
+*     }
 *     return acc;
 * }
 *

--- a/lib/node_modules/@stdlib/array/bool/lib/main.js
+++ b/lib/node_modules/@stdlib/array/bool/lib/main.js
@@ -1004,7 +1004,7 @@ setReadOnly( BooleanArray.prototype, 'map', function map( fcn, thisArg ) {
 * arr.set( false, 1 );
 * arr.set( true, 2 );
 *
-* var sum = arr.reduce( reducer, 0 );
+* var out = arr.reduce( reducer, 0 );
 * // returns 2
 */
 setReadOnly( BooleanArray.prototype, 'reduce', function reduce( reducer, initialValue ) {
@@ -1063,7 +1063,7 @@ setReadOnly( BooleanArray.prototype, 'reduce', function reduce( reducer, initial
 * arr.set( false, 1 );
 * arr.set( true, 2 );
 *
-* var sum = arr.reduceRight( reducer, 0 );
+* var out = arr.reduceRight( reducer, 0 );
 * // returns 2
 */
 setReadOnly( BooleanArray.prototype, 'reduceRight', function reduceRight( reducer, initialValue ) {

--- a/lib/node_modules/@stdlib/array/bool/test/test.reduce.js
+++ b/lib/node_modules/@stdlib/array/bool/test/test.reduce.js
@@ -23,7 +23,6 @@
 var tape = require( 'tape' );
 var hasOwnProp = require( '@stdlib/assert/has-own-property' );
 var isFunction = require( '@stdlib/assert/is-function' );
-var Boolean = require('@stdlib/boolean/ctor');
 var BooleanArray = require( './../lib' );
 
 
@@ -41,7 +40,7 @@ tape( 'attached to the prototype of the main export is a `reduce` method', funct
 	t.end();
 });
 
-tape( 'the method throws an error if invoked with a `this` context which is not a complex number array instance', function test( t ) {
+tape( 'the method throws an error if invoked with a `this` context which is not a boolean array instance', function test( t ) {
 	var values;
 	var arr;
 	var i;
@@ -67,7 +66,7 @@ tape( 'the method throws an error if invoked with a `this` context which is not 
 
 	function badValue( value ) {
 		return function badValue() {
-			return arr.map.reduce( value, reducer );
+			return arr.reduce.call( value, reducer );
 		};
 	}
 
@@ -109,7 +108,7 @@ tape( 'the method throws an error if provided a first argument which is not a fu
 	}
 });
 
-tape( 'the method throws an error if not provided an initial value when operating on an empty complex number array', function test( t ) {
+tape( 'the method throws an error if not provided an initial value when operating on an empty boolean array', function test( t ) {
 	var arr;
 
 	arr = new BooleanArray( 0 );
@@ -150,7 +149,7 @@ tape( 'the method uses the first element of the array as the initial value when 
 		ind = index-1;
 		t.strictEqual( acc, accArray[ ind ], 'returns expected value' );
 		t.strictEqual( value, valueArray[ ind ], 'returns expected value' );
-		return Boolean( acc & value );
+		return ( acc && value );
 	}
 });
 
@@ -193,26 +192,6 @@ tape( 'the method returns the accumulated result', function test( t ) {
 	t.end();
 
 	function reducer( acc, value ) {
-		return Boolean( acc & value );
-	}
-});
-
-tape( 'the method supports returning real-valued results', function test( t ) {
-	var expected;
-	var actual;
-	var arr;
-
-	arr = new BooleanArray( [ true, false, true, true ] );
-	expected = 3;
-	actual = arr.reduce( reducer, 0 );
-
-	t.strictEqual( actual, expected, 'returns expected value' );
-	t.end();
-
-	function reducer( acc, value ) {
-		if ( value ) {
-			return acc + 1;
-		}
-		return acc;
+		return ( acc && value );
 	}
 });

--- a/lib/node_modules/@stdlib/array/bool/test/test.reduce.js
+++ b/lib/node_modules/@stdlib/array/bool/test/test.reduce.js
@@ -1,0 +1,218 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var Boolean = require('@stdlib/boolean/ctor');
+var BooleanArray = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof BooleanArray, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the main export is a `reduce` method', function test( t ) {
+	t.strictEqual( hasOwnProp( BooleanArray.prototype, 'reduce' ), true, 'has property' );
+	t.strictEqual( isFunction( BooleanArray.prototype.reduce ), true, 'has method' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a complex number array instance', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new BooleanArray( 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.map.reduce( value, reducer );
+		};
+	}
+
+	function reducer( acc, value ) {
+		if ( value ) {
+			return acc + 1;
+		}
+		return acc;
+	}
+});
+
+tape( 'the method throws an error if provided a first argument which is not a function', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new BooleanArray( 10 );
+
+	values = [
+		'5',
+		3.14,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[]
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.reduce( value );
+		};
+	}
+});
+
+tape( 'the method throws an error if not provided an initial value when operating on an empty complex number array', function test( t ) {
+	var arr;
+
+	arr = new BooleanArray( 0 );
+	t.throws( foo, Error, 'throws an error' );
+	t.end();
+
+	function foo() {
+		arr.reduce( reducer );
+	}
+
+	function reducer( acc, value ) {
+		if ( value ) {
+			return acc + 1;
+		}
+		return acc;
+	}
+});
+
+tape( 'the method uses the first element of the array as the initial value when an initial value is not provided', function test( t ) {
+	var valueArray;
+	var accArray;
+	var expected;
+	var actual;
+	var arr;
+	var ind;
+
+	arr = new BooleanArray( [ true, false, true, false ] );
+	accArray = [ true, false, false ];
+	valueArray = [ false, true, false ];
+	expected = false;
+	actual = arr.reduce( reducer );
+
+	t.strictEqual( actual, expected, 'returns expected value' );
+
+	t.end();
+
+	function reducer( acc, value, index ) {
+		ind = index-1;
+		t.strictEqual( acc, accArray[ ind ], 'returns expected value' );
+		t.strictEqual( value, valueArray[ ind ], 'returns expected value' );
+		return Boolean( acc & value );
+	}
+});
+
+tape( 'the method supports providing an initial value as the second argument', function test( t ) {
+	var valueArray;
+	var accArray;
+	var expected;
+	var actual;
+	var arr;
+
+	arr = new BooleanArray( [ true, false, false, true ] );
+	accArray = [ 0, 1, 1, 1 ];
+	valueArray = [ true, false, false, true ];
+	expected = 2;
+	actual = arr.reduce( reducer, 0 );
+
+	t.strictEqual( actual, expected, 'returns expected value' );
+	t.end();
+
+	function reducer( acc, value, index ) {
+		t.strictEqual( acc, accArray[ index ], 'returns expected value' );
+		t.strictEqual( value, valueArray[ index ], 'returns expected value' );
+		if ( value ) {
+			return acc + 1;
+		}
+		return acc;
+	}
+});
+
+tape( 'the method returns the accumulated result', function test( t ) {
+	var expected;
+	var actual;
+	var arr;
+
+	arr = new BooleanArray( [ true, false, true, true ] );
+	expected = false;
+	actual = arr.reduce( reducer );
+
+	t.strictEqual( actual, expected, 'returns expected value' );
+	t.end();
+
+	function reducer( acc, value ) {
+		return Boolean( acc & value );
+	}
+});
+
+tape( 'the method supports returning real-valued results', function test( t ) {
+	var expected;
+	var actual;
+	var arr;
+
+	arr = new BooleanArray( [ true, false, true, true ] );
+	expected = 3;
+	actual = arr.reduce( reducer, 0 );
+
+	t.strictEqual( actual, expected, 'returns expected value' );
+	t.end();
+
+	function reducer( acc, value ) {
+		if ( value ) {
+			return acc + 1;
+		}
+		return acc;
+	}
+});

--- a/lib/node_modules/@stdlib/array/bool/test/test.reduce_right.js
+++ b/lib/node_modules/@stdlib/array/bool/test/test.reduce_right.js
@@ -23,7 +23,6 @@
 var tape = require( 'tape' );
 var hasOwnProp = require( '@stdlib/assert/has-own-property' );
 var isFunction = require( '@stdlib/assert/is-function' );
-var Boolean = require( '@stdlib/boolean/ctor' );
 var BooleanArray = require( './../lib' );
 
 
@@ -41,7 +40,7 @@ tape( 'attached to the prototype of the main export is a `reduceRight` method', 
 	t.end();
 });
 
-tape( 'the method throws an error if invoked with a `this` context which is not a complex number array instance', function test( t ) {
+tape( 'the method throws an error if invoked with a `this` context which is not a boolean array instance', function test( t ) {
 	var values;
 	var arr;
 	var i;
@@ -67,7 +66,7 @@ tape( 'the method throws an error if invoked with a `this` context which is not 
 
 	function badValue( value ) {
 		return function badValue() {
-			return arr.map.reduceRight( value, reducer );
+			return arr.reduceRight.call( value, reducer );
 		};
 	}
 
@@ -109,7 +108,7 @@ tape( 'the method throws an error if provided a first argument which is not a fu
 	}
 });
 
-tape( 'the method throws an error if not provided an initial value when operating on an empty complex number array', function test( t ) {
+tape( 'the method throws an error if not provided an initial value when operating on an empty boolean array', function test( t ) {
 	var arr;
 
 	arr = new BooleanArray( 0 );
@@ -150,7 +149,7 @@ tape( 'the method uses the last element of the array as the initial value when a
 		var ind = (len-index-2);
 		t.strictEqual( acc, accArray[ ind ], 'returns expected value' );
 		t.strictEqual( value, valueArray[ ind ], 'returns expected value' );
-		return Boolean( acc & value );
+		return ( acc && value );
 	}
 });
 
@@ -196,26 +195,6 @@ tape( 'the method returns the accumulated result', function test( t ) {
 	t.end();
 
 	function reducer( acc, value ) {
-		return Boolean( acc & value );
-	}
-});
-
-tape( 'the method supports returning real-valued results', function test( t ) {
-	var expected;
-	var actual;
-	var arr;
-
-	arr = new BooleanArray( [ true, false, true, true ] );
-	expected = 3;
-	actual = arr.reduceRight( reducer, 0 );
-
-	t.strictEqual( actual, expected, 'returns expected value' );
-	t.end();
-
-	function reducer( acc, value ) {
-		if ( value ) {
-			return acc + 1;
-		}
-		return acc;
+		return ( acc && value );
 	}
 });

--- a/lib/node_modules/@stdlib/array/bool/test/test.reduce_right.js
+++ b/lib/node_modules/@stdlib/array/bool/test/test.reduce_right.js
@@ -1,0 +1,221 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var Boolean = require( '@stdlib/boolean/ctor' );
+var BooleanArray = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof BooleanArray, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the main export is a `reduceRight` method', function test( t ) {
+	t.strictEqual( hasOwnProp( BooleanArray.prototype, 'reduceRight' ), true, 'has property' );
+	t.strictEqual( isFunction( BooleanArray.prototype.reduceRight ), true, 'has method' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a complex number array instance', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new BooleanArray( 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.map.reduceRight( value, reducer );
+		};
+	}
+
+	function reducer( acc, value ) {
+		if ( value ) {
+			return acc + 1;
+		}
+		return acc;
+	}
+});
+
+tape( 'the method throws an error if provided a first argument which is not a function', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new BooleanArray( 10 );
+
+	values = [
+		'5',
+		3.14,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[]
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.reduceRight( value );
+		};
+	}
+});
+
+tape( 'the method throws an error if not provided an initial value when operating on an empty complex number array', function test( t ) {
+	var arr;
+
+	arr = new BooleanArray( 0 );
+	t.throws( foo, Error, 'throws an error' );
+	t.end();
+
+	function foo() {
+		arr.reduceRight( reducer );
+	}
+
+	function reducer( acc, value ) {
+		if ( value ) {
+			return acc + 1;
+		}
+		return acc;
+	}
+});
+
+tape( 'the method uses the last element of the array as the initial value when an initial value is not provided', function test( t ) {
+	var valueArray;
+	var accArray;
+	var expected;
+	var actual;
+	var arr;
+	var len;
+
+	arr = new BooleanArray( [ true, false, true, false ] );
+	len = arr.length;
+	accArray = [ false, false, false ];
+	valueArray = [ true, false, true ];
+	expected = false;
+	actual = arr.reduceRight( reducer );
+
+	t.strictEqual( actual, expected, 'returns expected value' );
+	t.end();
+
+	function reducer( acc, value, index ) {
+		var ind = (len-index-2);
+		t.strictEqual( acc, accArray[ ind ], 'returns expected value' );
+		t.strictEqual( value, valueArray[ ind ], 'returns expected value' );
+		return Boolean( acc & value );
+	}
+});
+
+tape( 'the method supports providing an initial value as the second argument', function test( t ) {
+	var valueArray;
+	var accArray;
+	var expected;
+	var actual;
+	var arr;
+	var len;
+
+	arr = new BooleanArray( [ true, false, false, true ] );
+	len = arr.length;
+	accArray = [ 0, 1, 1, 1 ];
+	valueArray = [ true, false, false, true ];
+	expected = 2;
+	actual = arr.reduceRight( reducer, 0 );
+
+	t.strictEqual( actual, expected, 'returns expected value' );
+	t.end();
+
+	function reducer( acc, value, index ) {
+		var ind = (len-index-1);
+		t.strictEqual( acc, accArray[ ind ], 'returns expected value' );
+		t.strictEqual( value, valueArray[ ind ], 'returns expected value' );
+		if ( value ) {
+			return acc + 1;
+		}
+		return acc;
+	}
+});
+
+tape( 'the method returns the accumulated result', function test( t ) {
+	var expected;
+	var actual;
+	var arr;
+
+	arr = new BooleanArray( [ true, false, true, true ] );
+	expected = false;
+	actual = arr.reduceRight( reducer );
+
+	t.strictEqual( actual, expected, 'returns expected value' );
+	t.end();
+
+	function reducer( acc, value ) {
+		return Boolean( acc & value );
+	}
+});
+
+tape( 'the method supports returning real-valued results', function test( t ) {
+	var expected;
+	var actual;
+	var arr;
+
+	arr = new BooleanArray( [ true, false, true, true ] );
+	expected = 3;
+	actual = arr.reduceRight( reducer, 0 );
+
+	t.strictEqual( actual, expected, 'returns expected value' );
+	t.end();
+
+	function reducer( acc, value ) {
+		if ( value ) {
+			return acc + 1;
+		}
+		return acc;
+	}
+});


### PR DESCRIPTION
Resolves: Subtask of #2304 

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds the typed array `reduce` and `reduceRight` methods to prototype of `BooleanArray`

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
