### PR TITLE
feat: add C implementation for `math/base/special/beta`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/beta/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/beta/README.md
@@ -154,7 +154,7 @@ out = stdlib_base_beta( 5.0, 0.2);
 The function accepts the following arguments:
 
 -   **a**: `[in] double` input value.
--   **b**: `[in] double` power parameter.
+-   **b**: `[in] double` input value.
 
 ```c
 double stdlib_base_beta ( const double a, const double b );

--- a/lib/node_modules/@stdlib/math/base/special/beta/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/beta/README.md
@@ -113,6 +113,99 @@ for ( x = 0; x < 10; x++ ) {
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/math/base/special/beta.h"
+```
+
+#### stdlib_base_beta( a, b )
+
+Evaluates the [beta function][beta-function].
+
+```c
+double out = stdlib_base_beta( 1.0, 1,0 );
+// returns 1.0
+
+out = stdlib_base_beta( 5.0, 0.2);
+// returns ~3.382
+```
+
+The function accepts the following arguments:
+
+-   **a**: `[in] double` input value.
+-   **b**: `[in] double` power parameter.
+
+```c
+double stdlib_base_beta ( const double a, const double b );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/math/base/special/beta.h"
+#include <stdio.h>
+
+int main( void ) {
+    const double x[] = { 1.0, 3.0, 5.0, 8.0, 10.0 };
+    const double y[] = { 2.0, 4.0, 7.0, 9.0, 10.0 };
+
+    double out;
+    int i;
+    int j;
+    for ( i = 0; i < 5; i++ ) {
+        for ( j = 0; j < 5; j++ ){
+            out = stdlib_base_beta( x[ i ], y[ j ] );
+            printf ( "x: %lf, y: %lf, out: %lf\n", x[ i ], y[ j ], out );
+        }
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/math/base/special/beta/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/beta/benchmark/benchmark.native.js
@@ -1,0 +1,62 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var beta = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( beta instanceof Error )
+};
+
+
+// MAIN //
+
+bench( pkg+'::native', opts, function benchmark( b ) {
+	var x;
+	var y;
+	var z;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		x = ( randu() * 1000.0 ) - 0.0;
+		y = ( randu() * 1000.0 ) - 0.0;
+		z = beta( x, y );
+		if ( isnan( z ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnan( z ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/beta/benchmark/c/native/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/beta/benchmark/c/native/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/beta/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/beta/benchmark/c/native/benchmark.c
@@ -1,0 +1,138 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/**
+* Benchmark `beta`.
+*/
+#include "stdlib/math/base/special/beta.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "beta"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+void print_version() {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+double tic() {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1].
+*
+* @return random number
+*/
+double rand_double() {
+	int r = rand();
+	return (double)r / ( (double)RAND_MAX + 1.0 );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+double benchmark() {
+	double elapsed;
+	double x;
+	double y;
+	double r;
+	double t;
+	int i;
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		x = ( ( rand_double() * 1000.0 ) + 0.0 );
+		y = ( ( rand_double() * 1000.0 ) + 0.0 );
+		r = stdlib_base_beta( x, y );
+		if ( r != r ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( r != r ) {
+		printf( "should not return NaN\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/math/base/special/beta/binding.gyp
+++ b/lib/node_modules/@stdlib/math/base/special/beta/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/math/base/special/beta/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/beta/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/beta/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/beta/examples/c/example.c
@@ -1,0 +1,36 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+
+#include "stdlib/math/base/special/beta.h"
+#include <stdio.h>
+
+int main( void ) {
+	const double x[] = { 1.0, 3.0, 5.0, 8.0, 10.0 };
+	const double y[] = { 2.0, 4.0, 7.0, 9.0, 10.0 };
+
+	double out;
+	int i;
+	int j;
+	for ( i = 0; i < 5; i++ ) {
+		for ( j = 0; j < 5; j++ ){
+			out = stdlib_base_beta( x[ i ], y[ j ] );
+			printf ( "x: %lf, y: %lf, out: %lf\n", x[ i ], y[ j ], out );
+		}
+	}
+}

--- a/lib/node_modules/@stdlib/math/base/special/beta/include.gypi
+++ b/lib/node_modules/@stdlib/math/base/special/beta/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/math/base/special/beta/include/stdlib/math/base/special/beta.h
+++ b/lib/node_modules/@stdlib/math/base/special/beta/include/stdlib/math/base/special/beta.h
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_MATH_BASE_SPECIAL_BETA_H
+#define STDLIB_MATH_BASE_SPECIAL_BETA_H
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Evaluates the beta function.
+*/
+double stdlib_base_beta( const double a, const double b );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_MATH_BASE_SPECIAL_BETA_H

--- a/lib/node_modules/@stdlib/math/base/special/beta/lib/lanczos_sum_expg_scaled.js
+++ b/lib/node_modules/@stdlib/math/base/special/beta/lib/lanczos_sum_expg_scaled.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2022 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 // MAIN //
 
 /**
-* Evaluates a rational function, i.e., the ratio of two polynomials described by the coefficients stored in \\(P\\) and \\(Q\\).
+* Evaluates a rational function (i.e., the ratio of two polynomials described by the coefficients stored in \\(P\\) and \\(Q\\)).
 *
 * ## Notes
 *

--- a/lib/node_modules/@stdlib/math/base/special/beta/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/beta/lib/main.js
@@ -52,7 +52,7 @@ var G = 10.90051099999999983936049829935654997826;
 // MAIN //
 
 /**
-* Evaluate the beta function.
+* Evaluates the beta function.
 *
 * @param {NonNegativeNumber} a - input value
 * @param {NonNegativeNumber} b - input value

--- a/lib/node_modules/@stdlib/math/base/special/beta/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/beta/lib/main.js
@@ -18,7 +18,7 @@
 *
 * ## Notice
 *
-* The original C++ code and copyright notice are from the [Boost library]{http://www.boost.org/doc/libs/1_64_0/boost/math/special_functions/beta.hpp}. The implementation has been modified for JavaScript.
+* The original C++ code and copyright notice are from the [Boost library]{http://www.boost.org/doc/libs/1_85_0/boost/math/special_functions/beta.hpp}. The implementation has been modified for JavaScript.
 *
 * ```text
 * (C) Copyright John Maddock 2006.

--- a/lib/node_modules/@stdlib/math/base/special/beta/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/beta/lib/native.js
@@ -1,0 +1,67 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Evaluates the beta function.
+*
+* @private
+* @param {NonNegativeNumber} a - input value
+* @param {NonNegativeNumber} b - input value
+* @returns {number} evaluated beta function
+*
+* @example
+* var v = beta( 0.0, 0.5 );
+* // returns Infinity
+*
+* @example
+* var v = beta( 1.0, 1.0 );
+* // returns 1.0
+*
+* @example
+* var v = beta( -1.0, 2.0 );
+* // returns NaN
+*
+* @example
+* var v = beta( 5.0, 0.2 );
+* // returns ~3.382
+*
+* @example
+* var v = beta( 4.0, 1.0 );
+* // returns 0.25
+*
+* @example
+* var v = beta( NaN, 2.0 );
+* // returns NaN
+*/
+function beta( a, b ) {
+	return addon( a, b );
+}
+
+
+// EXPORTS //
+
+module.exports = beta;

--- a/lib/node_modules/@stdlib/math/base/special/beta/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/beta/manifest.json
@@ -1,0 +1,93 @@
+{
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/napi/binary",
+        "@stdlib/math/base/special/abs",
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/special/sqrt",
+        "@stdlib/math/base/special/log1p",
+        "@stdlib/math/base/special/exp",
+        "@stdlib/math/base/special/pow",
+        "@stdlib/constants/float64/e",
+        "@stdlib/constants/float64/eps"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+       "@stdlib/math/base/special/abs",
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/special/sqrt",
+        "@stdlib/math/base/special/log1p",
+        "@stdlib/math/base/special/exp",
+        "@stdlib/math/base/special/pow",
+        "@stdlib/constants/float64/e",
+        "@stdlib/constants/float64/eps"
+      ]
+    },
+    {
+      "task": "examples",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+       "@stdlib/math/base/special/abs",
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/special/sqrt",
+        "@stdlib/math/base/special/log1p",
+        "@stdlib/math/base/special/exp",
+        "@stdlib/math/base/special/pow",
+        "@stdlib/constants/float64/e",
+        "@stdlib/constants/float64/eps"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/special/beta/scripts/evalrational.js
+++ b/lib/node_modules/@stdlib/math/base/special/beta/scripts/evalrational.js
@@ -24,10 +24,15 @@
 // MODULES //
 
 var resolve = require( 'path' ).resolve;
+var readFileSync = require( '@stdlib/fs/read-file' ).sync;
 var writeFileSync = require( '@stdlib/fs/write-file' ).sync;
 var currentYear = require( '@stdlib/time/current-year' );
 var licenseHeader = require( '@stdlib/_tools/licenses/header' );
 var compile = require( '@stdlib/math/base/tools/evalrational-compile' );
+var compileC = require( '@stdlib/math/base/tools/evalrational-compile-c' );
+var substringBefore = require( '@stdlib/string/substring-before' );
+var substringAfter = require( '@stdlib/string/substring-after' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -68,6 +73,33 @@ var header = licenseHeader( 'Apache-2.0', 'js', {
 header += '\n/* This is a generated file. Do not edit directly. */\n';
 
 
+// FUNCTIONS //
+
+/**
+* Inserts a compiled function into file content.
+*
+* @private
+* @param {string} text - source content
+* @param {string} id - function identifier
+* @param {string} str - function string
+* @returns {string} updated content
+*/
+function insert( text, id, str ) {
+	var before;
+	var after;
+	var begin;
+	var end;
+
+	begin = '// BEGIN: '+id;
+	end = '// END: '+id;
+
+	before = substringBefore( text, begin );
+	after = substringAfter( text, end );
+
+	return format( '%s// BEGIN: %s\n\n%s\n%s%s', before, id, str, end, after );
+}
+
+
 // MAIN //
 
 /**
@@ -77,7 +109,9 @@ header += '\n/* This is a generated file. Do not edit directly. */\n';
 */
 function main() {
 	var fpath;
+	var copts;
 	var opts;
+	var file;
 	var str;
 
 	opts = {
@@ -87,6 +121,20 @@ function main() {
 	fpath = resolve( __dirname, '..', 'lib', 'lanczos_sum_expg_scaled.js' );
 	str = header + compile( P, Q );
 	writeFileSync( fpath, str, opts );
+
+	copts = {
+		'dtype': 'double',
+		'name': 'lanczos_sum_expg_scaled_pq'
+	};
+
+	fpath = resolve( __dirname, '..', 'src', 'main.c' );
+	file = readFileSync( fpath, opts );
+
+	copts.name = 'lanczos_sum_expg_scaled_pq';
+	str = compileC( P, Q, copts );
+	file = insert( file, copts.name, str );
+
+	writeFileSync( fpath, file, opts );
 }
 
 main();

--- a/lib/node_modules/@stdlib/math/base/special/beta/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/beta/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/beta/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/beta/src/addon.c
@@ -1,0 +1,23 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/beta.h"
+#include "stdlib/math/base/napi/binary.h"
+
+// cppcheck-suppress shadowFunction
+STDLIB_MATH_BASE_NAPI_MODULE_DD_D( stdlib_base_beta )

--- a/lib/node_modules/@stdlib/math/base/special/beta/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/beta/src/main.c
@@ -1,0 +1,166 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*
+* ## Notice
+*
+* The original C++ code and copyright notice are from the [Boost library]{http://www.boost.org/doc/libs/1_64_0/boost/math/special_functions/beta.hpp}. The implementation has been modified for JavaScript.
+*
+* ```text
+* (C) Copyright John Maddock 2006.
+*
+* Use, modification and distribution are subject to the
+* Boost Software License, Version 1.0. (See accompanying file
+* LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+* ```
+*/
+
+#include "stdlib/math/base/special/beta.h"
+#include "stdlib/math/base/assert/is_nan.h"
+#include "stdlib/math/base/special/sqrt.h"
+#include "stdlib/math/base/special/abs.h"
+#include "stdlib/math/base/special/log1p.h"
+#include "stdlib/math/base/special/exp.h"
+#include "stdlib/math/base/special/pow.h"
+#include "stdlib/constants/float64/e.h"
+#include "stdlib/constants/float64/eps.h"
+
+static const double G = 10.90051099999999983936049829935654997826;
+
+/* Begin auto-generated functions. The following functions are auto-generated. Do not edit directly. */
+
+// BEGIN: lanczos_sum_expg_scaled_pq
+
+/**
+* Evaluates a rational function (i.e., the ratio of two polynomials described by the coefficients stored in \\(P\\) and \\(Q\\)).
+*
+* ## Notes
+*
+* -   Coefficients should be sorted in ascending degree.
+* -   The implementation uses [Horner's rule][horners-method] for efficient computation.
+*
+* [horners-method]: https://en.wikipedia.org/wiki/Horner%27s_method
+*
+* @param x    value at which to evaluate the rational function
+* @return     evaluated rational function
+*/
+static double lanczos_sum_expg_scaled_pq( const double x ) {
+	double ax;
+	double ix;
+	double s1;
+	double s2;
+	if ( x == 0.0 ) {
+		return 1.0 / 0.0;
+	}
+	if ( x < 0.0 ) {
+		ax = -x;
+	} else {
+		ax = x;
+	}
+	if ( ax <= 1.0 ) {
+		s1 = 709811.662581658 + (x * (679979.8474157227 + (x * (293136.7857211597 + (x * (74887.54032914672 + (x * (12555.290582413863 + (x * (1443.4299244417066 + (x * (115.24194596137347 + (x * (6.309239205732627 + (x * (0.22668404630224365 + (x * (0.004826466289237662 + (x * 0.00004624429436045379)))))))))))))))))));
+		s2 = 0.0 + (x * (362880.0 + (x * (1026576.0 + (x * (1172700.0 + (x * (723680.0 + (x * (269325.0 + (x * (63273.0 + (x * (9450.0 + (x * (870.0 + (x * (45.0 + (x * 1.0)))))))))))))))))));
+	} else {
+		ix = 1.0 / x;
+		s1 = 0.00004624429436045379 + (ix * (0.004826466289237662 + (ix * (0.22668404630224365 + (ix * (6.309239205732627 + (ix * (115.24194596137347 + (ix * (1443.4299244417066 + (ix * (12555.290582413863 + (ix * (74887.54032914672 + (ix * (293136.7857211597 + (ix * (679979.8474157227 + (ix * 709811.662581658)))))))))))))))))));
+		s2 = 1.0 + (ix * (45.0 + (ix * (870.0 + (ix * (9450.0 + (ix * (63273.0 + (ix * (269325.0 + (ix * (723680.0 + (ix * (1172700.0 + (ix * (1026576.0 + (ix * (362880.0 + (ix * 0.0)))))))))))))))))));
+	}
+	return s1 / s2;
+}
+
+// END: lanczos_sum_expg_scaled_pq
+
+/* End auto-generated functions. */
+
+/**
+* Evaluates the beta function.
+*
+* @param a    input value
+* @param b    input value
+* @return     evaluated beta function
+*
+* @example
+* double v = stdlib_base_beta( 1.0, 1.0 );
+* // returns 1.0
+*/
+double stdlib_base_beta( const double a, const double b ) {
+	double ambh;
+	double agh;
+	double bgh;
+	double cgh;
+	double res;
+	double tmp;
+	double ac;
+	double bc;
+	double c;
+
+	if ( stdlib_base_is_nan( a ) || stdlib_base_is_nan( b ) ) {
+		return 0.0 / 0.0; // NaN
+	}
+	if ( a < 0.0 || b < 0.0 ) {
+		return 0.0 / 0.0; // NaN
+	}
+	if ( b == 1.0 ) {
+		return 1.0 / a;
+	}
+	if ( a == 1.0 ) {
+		return 1.0 / b;
+	}
+	c = a + b;
+	if ( c < STDLIB_CONSTANT_FLOAT64_EPS ) {
+		res = c / a;
+		res /= b;
+		return res;
+	}
+
+	// Special cases:
+	if ( c == a && b < STDLIB_CONSTANT_FLOAT64_EPS ) {
+		return 1.0 / b;
+	}
+	if ( c == b && a < STDLIB_CONSTANT_FLOAT64_EPS ) {
+		return 1.0 / a;
+	}
+	ac = a;
+	bc = b;
+	if ( ac < bc ) {
+		// Swap `a` and `b`:
+		tmp = bc;
+		bc = ac;
+		ac = tmp;
+	}
+
+	// Lanczos calculation:
+	agh = ac + G - 0.5;
+	bgh = bc + G - 0.5;
+	cgh = c + G - 0.5;
+	res = lanczos_sum_expg_scaled_pq( ac ) * ( lanczos_sum_expg_scaled_pq( bc ) / lanczos_sum_expg_scaled_pq( c ) ); // eslint-disable-line max-len
+	ambh = ac - 0.5 - bc;
+	if ( ( stdlib_base_abs( bc * ambh ) < ( cgh * 100.0 ) ) && ac > 100.0 ) {
+		// Special case where the base of the power term is close to 1; compute `(1+x)^y` instead:
+		res *= stdlib_base_exp( ambh * stdlib_base_log1p( -bc / cgh ) );
+	} else {
+		res *= stdlib_base_pow( agh / cgh, ambh );
+	}
+	if ( cgh > 1.0e10 ) {
+		// This avoids possible overflow, but appears to be marginally less accurate:
+		res *= stdlib_base_pow( ( agh / cgh ) * ( bgh / cgh ), bc );
+	} else {
+		res *= stdlib_base_pow( ( agh * bgh ) / ( cgh * cgh ), bc );
+	}
+	res *= stdlib_base_sqrt( STDLIB_CONSTANT_FLOAT64_E / bgh );
+	return res;
+}

--- a/lib/node_modules/@stdlib/math/base/special/beta/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/beta/src/main.c
@@ -18,7 +18,7 @@
 *
 * ## Notice
 *
-* The original C++ code and copyright notice are from the [Boost library]{http://www.boost.org/doc/libs/1_64_0/boost/math/special_functions/beta.hpp}. The implementation has been modified for JavaScript.
+* The original C++ code and copyright notice are from the [Boost library]{http://www.boost.org/doc/libs/1_85_0/boost/math/special_functions/beta.hpp}. The implementation has been modified for JavaScript.
 *
 * ```text
 * (C) Copyright John Maddock 2006.

--- a/lib/node_modules/@stdlib/math/base/special/beta/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/beta/test/test.native.js
@@ -1,0 +1,134 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var isInfinite = require( '@stdlib/math/base/assert/is-infinite' );
+var isnan = require( '@stdlib/assert/is-nan' );
+var abs = require( '@stdlib/math/base/special/abs' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var EPS = require( '@stdlib/constants/float64/eps' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var beta = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( beta instanceof Error )
+};
+
+
+// FIXTURES //
+
+var a1 = require( './fixtures/r/arg1.json' );
+var b1 = require( './fixtures/r/arg2.json' );
+var expected1 = require( './fixtures/r/expected.json' );
+var cpp = require( './fixtures/cpp/output.json' );
+var expected2 = cpp.expected;
+var a2 = cpp.a;
+var b2 = cpp.b;
+var i;
+var v;
+for ( i = 0; i < expected1.length; i++ ) {
+	v = expected1[ i ];
+	if ( v === 'Inf' ) {
+		expected1[ i ] = PINF;
+	}
+	else if ( v === 'NaN' ) {
+		expected1[ i ] = NaN;
+	}
+}
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.ok( typeof beta === 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `NaN` if provided a `NaN`', opts, function test( t ) {
+	var val = beta( NaN, 2.0 );
+	t.ok( isnan( val ), 'returns expected value' );
+	val = beta( 2.0, NaN );
+	t.ok( isnan( val ), 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `NaN` if provided negative values', opts, function test( t ) {
+	var val = beta( -2.0, 5.0 );
+	t.ok( isnan( val ), 'returns expected value' );
+	val = beta( 4.0, -3.0 );
+	t.ok( isnan( val ), 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns +Infinity if at least one argument is zero', opts, function test( t ) {
+	var val = beta( 0.0, 2.0 );
+	t.equal( val, PINF, 'returns +Infinity' );
+	val = beta( 1.0, 0.0 );
+	t.equal( val, PINF, 'returns +Infinity' );
+	t.end();
+});
+
+tape( 'the function evaluates the beta function (tested against R)', opts, function test( t ) {
+	var actual;
+	var y1;
+	var y2;
+	var i;
+	for ( i = 0; i < a1.length; i++ ) {
+		actual = beta( a1[ i ], b1[ i ] );
+
+		y1 = isInfinite( actual );
+		y2 = isInfinite( expected1[ i ] );
+		t.equal( y1, y2, 'returned result is ' + ( (y2) ? 'not finite' : 'finite' ) );
+
+		y1 = isnan( actual );
+		y2 = isnan( expected1[ i ] );
+		t.equal( y1, y2, 'returned result is ' + ( (y1) ? '' : 'not' ) + ' NaN' );
+		if ( !y1 ) {
+			t.ok( abs( actual - expected1[ i ] ) < 8e-15, 'returned result is within tolerance. actual: ' + actual + '; expected: ' + expected1[ i ] + '.' );
+		}
+	}
+	t.end();
+});
+
+tape( 'the function evaluates the beta function (tested against Boost)', opts, function test( t ) {
+	var delta;
+	var tol;
+	var i;
+	var y;
+
+	for ( i = 0; i < a2.length; i++ ) {
+		y = beta( a2[i], b2[i] );
+		if ( y === expected2[i] ) {
+			t.equal( y, expected2[i], 'y: '+y+'. a: '+a2[i]+'. b: '+b2[i]+', expected: '+expected2[i] );
+		} else {
+			delta = abs( y - expected2[ i ] );
+			tol = 160.0 * EPS * abs( expected2[ i ] );
+			t.ok( delta <= tol, 'within tolerance. a: '+a2[i]+'. b: '+b2[i]+'. y: '+y+'. E: '+expected2[i]+'. Δ: '+delta+'. tol: '+tol );
+		}
+	}
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds C implementation for [`math/base/special/beta`](https://github.com/stdlib-js/stdlib/tree/ecf38443532224c35d3f5c00e50a5bdc4801875e/lib/node_modules/%40stdlib/math/base/special/beta).

```c
double stdlib_base_beta( const double a, const double b );
```

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves a part of #649.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

We might not get `100%` code coverage here, due to some lines of code being impossible to reach, such as the condition `x === 0.0` in the `evalrational` function.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
