### PR TITLE
feat: add boolean dtype support to `strided/base/nullary`

### DIFF
--- a/lib/node_modules/@stdlib/strided/base/nullary/README.md
+++ b/lib/node_modules/@stdlib/strided/base/nullary/README.md
@@ -250,7 +250,7 @@ y[ i ] = (float)out;
 
 <!-- loops -->
 
-#### stdlib_strided_b( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_b( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -289,7 +289,7 @@ The function accepts the following arguments:
 void stdlib_strided_b( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_c( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_c( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -329,7 +329,7 @@ The function accepts the following arguments:
 void stdlib_strided_c( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_c_as_b( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_c_as_b( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -368,7 +368,7 @@ The function accepts the following arguments:
 void stdlib_strided_c_as_b( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_c_as_f( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_c_as_f( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -407,7 +407,7 @@ The function accepts the following arguments:
 void stdlib_strided_c_as_f( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_c_as_k( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_c_as_k( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -446,7 +446,7 @@ The function accepts the following arguments:
 void stdlib_strided_c_as_k( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_c_as_s( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_c_as_s( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -485,7 +485,7 @@ The function accepts the following arguments:
 void stdlib_strided_c_as_s( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_c_as_t( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_c_as_t( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -524,7 +524,7 @@ The function accepts the following arguments:
 void stdlib_strided_c_as_t( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_c_as_z( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_c_as_z( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -564,7 +564,7 @@ The function accepts the following arguments:
 void stdlib_strided_c_as_z( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_d( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_d( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -603,7 +603,7 @@ The function accepts the following arguments:
 void stdlib_strided_d( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_d_as_b( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_d_as_b( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -642,7 +642,7 @@ The function accepts the following arguments:
 void stdlib_strided_d_as_b( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_d_as_f( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_d_as_f( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -681,7 +681,7 @@ The function accepts the following arguments:
 void stdlib_strided_d_as_f( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_d_as_i( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_d_as_i( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -720,7 +720,7 @@ The function accepts the following arguments:
 void stdlib_strided_d_as_i( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_d_as_k( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_d_as_k( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -759,7 +759,7 @@ The function accepts the following arguments:
 void stdlib_strided_d_as_k( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_d_as_s( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_d_as_s( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -798,7 +798,7 @@ The function accepts the following arguments:
 void stdlib_strided_d_as_s( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_d_as_t( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_d_as_t( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -837,7 +837,7 @@ The function accepts the following arguments:
 void stdlib_strided_d_as_t( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_d_as_u( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_d_as_u( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -876,7 +876,7 @@ The function accepts the following arguments:
 void stdlib_strided_d_as_u( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_f( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_f( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -915,7 +915,7 @@ The function accepts the following arguments:
 void stdlib_strided_f( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_f_as_b( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_f_as_b( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -954,7 +954,7 @@ The function accepts the following arguments:
 void stdlib_strided_f_as_b( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_f_as_d( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_f_as_d( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -993,7 +993,7 @@ The function accepts the following arguments:
 void stdlib_strided_f_as_d( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_f_as_k( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_f_as_k( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1032,7 +1032,7 @@ The function accepts the following arguments:
 void stdlib_strided_f_as_k( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_f_as_s( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_f_as_s( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1071,7 +1071,7 @@ The function accepts the following arguments:
 void stdlib_strided_f_as_s( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_f_as_t( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_f_as_t( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1110,7 +1110,7 @@ The function accepts the following arguments:
 void stdlib_strided_f_as_t( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_i( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_i( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1149,7 +1149,7 @@ The function accepts the following arguments:
 void stdlib_strided_i( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_i_as_b( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_i_as_b( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1188,7 +1188,7 @@ The function accepts the following arguments:
 void stdlib_strided_i_as_b( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_i_as_k( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_i_as_k( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1227,7 +1227,7 @@ The function accepts the following arguments:
 void stdlib_strided_i_as_k( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_i_as_s( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_i_as_s( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1266,7 +1266,7 @@ The function accepts the following arguments:
 void stdlib_strided_i_as_s( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_i_as_t( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_i_as_t( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1305,7 +1305,7 @@ The function accepts the following arguments:
 void stdlib_strided_i_as_t( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_k( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_k( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1344,7 +1344,7 @@ The function accepts the following arguments:
 void stdlib_strided_k( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_k_as_b( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_k_as_b( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1383,7 +1383,7 @@ The function accepts the following arguments:
 void stdlib_strided_k_as_b( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_k_as_s( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_k_as_s( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1422,7 +1422,7 @@ The function accepts the following arguments:
 void stdlib_strided_k_as_s( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_s( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_s( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1461,7 +1461,7 @@ The function accepts the following arguments:
 void stdlib_strided_s( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_t( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_t( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1500,7 +1500,7 @@ The function accepts the following arguments:
 void stdlib_strided_t( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_t_as_b( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_t_as_b( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1539,7 +1539,7 @@ The function accepts the following arguments:
 void stdlib_strided_t_as_b( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_u( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_u( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1578,7 +1578,7 @@ The function accepts the following arguments:
 void stdlib_strided_u( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_u_as_b( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_u_as_b( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1617,7 +1617,7 @@ The function accepts the following arguments:
 void stdlib_strided_u_as_b( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_u_as_t( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_u_as_t( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1656,7 +1656,7 @@ The function accepts the following arguments:
 void stdlib_strided_u_as_t( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_x( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_x( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1696,7 +1696,7 @@ The function accepts the following arguments:
 void stdlib_strided_x( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_z( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_z( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1736,7 +1736,7 @@ The function accepts the following arguments:
 void stdlib_strided_z( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_z_as_b( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_z_as_b( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1775,7 +1775,7 @@ The function accepts the following arguments:
 void stdlib_strided_z_as_b( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_z_as_c( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_z_as_c( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1815,7 +1815,7 @@ The function accepts the following arguments:
 void stdlib_strided_z_as_c( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_z_as_d( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_z_as_d( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1854,7 +1854,7 @@ The function accepts the following arguments:
 void stdlib_strided_z_as_d( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_z_as_f( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_z_as_f( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1893,7 +1893,7 @@ The function accepts the following arguments:
 void stdlib_strided_z_as_f( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_z_as_i( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_z_as_i( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1932,7 +1932,7 @@ The function accepts the following arguments:
 void stdlib_strided_z_as_i( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_z_as_k( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_z_as_k( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1971,7 +1971,7 @@ The function accepts the following arguments:
 void stdlib_strided_z_as_k( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_z_as_s( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_z_as_s( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -2010,7 +2010,7 @@ The function accepts the following arguments:
 void stdlib_strided_z_as_s( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_z_as_t( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_z_as_t( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -2049,7 +2049,7 @@ The function accepts the following arguments:
 void stdlib_strided_z_as_t( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_z_as_u( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_z_as_u( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 

--- a/lib/node_modules/@stdlib/strided/base/nullary/README.md
+++ b/lib/node_modules/@stdlib/strided/base/nullary/README.md
@@ -184,6 +184,7 @@ Character codes for data types:
 
 <!-- charcodes -->
 
+-   **x**: `bool` (boolean).
 -   **z**: `complex128` (double-precision floating-point complex number).
 -   **c**: `complex64` (single-precision floating-point complex number).
 -   **f**: `float32` (single-precision floating-point number).
@@ -249,7 +250,7 @@ y[ i ] = (float)out;
 
 <!-- loops -->
 
-#### stdlib_strided_b( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_b( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -288,7 +289,7 @@ The function accepts the following arguments:
 void stdlib_strided_b( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_c( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_c( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -328,7 +329,7 @@ The function accepts the following arguments:
 void stdlib_strided_c( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_c_as_b( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_c_as_b( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -367,7 +368,7 @@ The function accepts the following arguments:
 void stdlib_strided_c_as_b( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_c_as_f( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_c_as_f( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -406,7 +407,7 @@ The function accepts the following arguments:
 void stdlib_strided_c_as_f( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_c_as_k( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_c_as_k( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -445,7 +446,7 @@ The function accepts the following arguments:
 void stdlib_strided_c_as_k( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_c_as_s( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_c_as_s( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -484,7 +485,7 @@ The function accepts the following arguments:
 void stdlib_strided_c_as_s( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_c_as_t( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_c_as_t( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -523,7 +524,7 @@ The function accepts the following arguments:
 void stdlib_strided_c_as_t( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_c_as_z( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_c_as_z( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -563,7 +564,7 @@ The function accepts the following arguments:
 void stdlib_strided_c_as_z( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_d( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_d( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -602,7 +603,7 @@ The function accepts the following arguments:
 void stdlib_strided_d( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_d_as_b( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_d_as_b( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -641,7 +642,7 @@ The function accepts the following arguments:
 void stdlib_strided_d_as_b( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_d_as_f( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_d_as_f( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -680,7 +681,7 @@ The function accepts the following arguments:
 void stdlib_strided_d_as_f( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_d_as_i( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_d_as_i( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -719,7 +720,7 @@ The function accepts the following arguments:
 void stdlib_strided_d_as_i( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_d_as_k( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_d_as_k( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -758,7 +759,7 @@ The function accepts the following arguments:
 void stdlib_strided_d_as_k( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_d_as_s( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_d_as_s( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -797,7 +798,7 @@ The function accepts the following arguments:
 void stdlib_strided_d_as_s( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_d_as_t( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_d_as_t( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -836,7 +837,7 @@ The function accepts the following arguments:
 void stdlib_strided_d_as_t( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_d_as_u( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_d_as_u( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -875,7 +876,7 @@ The function accepts the following arguments:
 void stdlib_strided_d_as_u( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_f( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_f( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -914,7 +915,7 @@ The function accepts the following arguments:
 void stdlib_strided_f( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_f_as_b( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_f_as_b( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -953,7 +954,7 @@ The function accepts the following arguments:
 void stdlib_strided_f_as_b( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_f_as_d( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_f_as_d( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -992,7 +993,7 @@ The function accepts the following arguments:
 void stdlib_strided_f_as_d( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_f_as_k( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_f_as_k( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1031,7 +1032,7 @@ The function accepts the following arguments:
 void stdlib_strided_f_as_k( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_f_as_s( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_f_as_s( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1070,7 +1071,7 @@ The function accepts the following arguments:
 void stdlib_strided_f_as_s( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_f_as_t( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_f_as_t( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1109,7 +1110,7 @@ The function accepts the following arguments:
 void stdlib_strided_f_as_t( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_i( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_i( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1148,7 +1149,7 @@ The function accepts the following arguments:
 void stdlib_strided_i( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_i_as_b( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_i_as_b( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1187,7 +1188,7 @@ The function accepts the following arguments:
 void stdlib_strided_i_as_b( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_i_as_k( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_i_as_k( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1226,7 +1227,7 @@ The function accepts the following arguments:
 void stdlib_strided_i_as_k( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_i_as_s( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_i_as_s( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1265,7 +1266,7 @@ The function accepts the following arguments:
 void stdlib_strided_i_as_s( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_i_as_t( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_i_as_t( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1304,7 +1305,7 @@ The function accepts the following arguments:
 void stdlib_strided_i_as_t( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_k( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_k( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1343,7 +1344,7 @@ The function accepts the following arguments:
 void stdlib_strided_k( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_k_as_b( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_k_as_b( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1382,7 +1383,7 @@ The function accepts the following arguments:
 void stdlib_strided_k_as_b( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_k_as_s( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_k_as_s( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1421,7 +1422,7 @@ The function accepts the following arguments:
 void stdlib_strided_k_as_s( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_s( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_s( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1460,7 +1461,7 @@ The function accepts the following arguments:
 void stdlib_strided_s( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_t( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_t( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1499,7 +1500,7 @@ The function accepts the following arguments:
 void stdlib_strided_t( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_t_as_b( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_t_as_b( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1538,7 +1539,7 @@ The function accepts the following arguments:
 void stdlib_strided_t_as_b( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_u( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_u( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1577,7 +1578,7 @@ The function accepts the following arguments:
 void stdlib_strided_u( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_u_as_b( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_u_as_b( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1616,7 +1617,7 @@ The function accepts the following arguments:
 void stdlib_strided_u_as_b( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_u_as_t( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_u_as_t( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1655,7 +1656,47 @@ The function accepts the following arguments:
 void stdlib_strided_u_as_t( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_z( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_x( \*arrays[], \*shape, \*strides, \*fcn )
+
+Applies a nullary callback and assigns results to elements in a strided output array.
+
+```c
+#include <stdbool.h>
+#include <stdint.h>
+
+// Create underlying byte arrays:
+uint8_t out[] = { 0, 0, 0 };
+
+// Define a pointer to an array containing pointers to strided arrays:
+uint8_t *arrays[] = { out };
+
+// Define the strides:
+int64_t strides[] = { 1 };
+
+// Define the number of elements over which to iterate:
+int64_t shape[] = { 3 };
+
+// Define a callback:
+static bool fcn( void ) {
+    return true;
+}
+
+// Apply the callback:
+stdlib_strided_x( arrays, shape, strides, (void *)fcn );
+```
+
+The function accepts the following arguments:
+
+-   **arrays**: `[inout] uint8_t**` array whose only element is a pointer to a strided output array.
+-   **shape**: `[in] int64_t*` array whose only element is the number of elements over which to iterate.
+-   **strides**: `[in] int64_t*` array containing strides (in bytes) for each strided array.
+-   **fcn**: `[in] void*` a `bool (*f)()` function to apply provided as a `void` pointer.
+
+```c
+void stdlib_strided_x( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
+```
+
+#### stdlib_strided_z( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1695,7 +1736,7 @@ The function accepts the following arguments:
 void stdlib_strided_z( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_z_as_b( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_z_as_b( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1734,7 +1775,7 @@ The function accepts the following arguments:
 void stdlib_strided_z_as_b( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_z_as_c( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_z_as_c( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1774,7 +1815,7 @@ The function accepts the following arguments:
 void stdlib_strided_z_as_c( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_z_as_d( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_z_as_d( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1813,7 +1854,7 @@ The function accepts the following arguments:
 void stdlib_strided_z_as_d( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_z_as_f( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_z_as_f( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1852,7 +1893,7 @@ The function accepts the following arguments:
 void stdlib_strided_z_as_f( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_z_as_i( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_z_as_i( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1891,7 +1932,7 @@ The function accepts the following arguments:
 void stdlib_strided_z_as_i( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_z_as_k( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_z_as_k( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1930,7 +1971,7 @@ The function accepts the following arguments:
 void stdlib_strided_z_as_k( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_z_as_s( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_z_as_s( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -1969,7 +2010,7 @@ The function accepts the following arguments:
 void stdlib_strided_z_as_s( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_z_as_t( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_z_as_t( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 
@@ -2008,7 +2049,7 @@ The function accepts the following arguments:
 void stdlib_strided_z_as_t( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 ```
 
-#### stdlib_strided_z_as_u( \*arrays\[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_z_as_u( \*arrays[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary.h
@@ -72,6 +72,8 @@
 #include "nullary/u_as_b.h"
 #include "nullary/u_as_t.h"
 
+#include "nullary/x.h"
+
 #include "nullary/z.h"
 #include "nullary/z_as_b.h"
 #include "nullary/z_as_c.h"

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/b.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/b.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/c_as_b.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/c_as_b.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/c_as_f.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/c_as_f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/c_as_k.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/c_as_k.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/c_as_s.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/c_as_s.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/c_as_t.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/c_as_t.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/c_as_z.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/c_as_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/d.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/d_as_b.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/d_as_b.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/d_as_f.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/d_as_f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/d_as_i.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/d_as_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/d_as_k.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/d_as_k.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/d_as_s.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/d_as_s.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/d_as_t.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/d_as_t.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/d_as_u.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/d_as_u.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/f.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/f_as_b.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/f_as_b.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/f_as_d.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/f_as_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/f_as_k.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/f_as_k.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/f_as_s.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/f_as_s.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/f_as_t.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/f_as_t.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/i.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/i_as_b.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/i_as_b.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/i_as_k.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/i_as_k.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/i_as_s.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/i_as_s.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/i_as_t.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/i_as_t.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/k.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/k.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/k_as_b.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/k_as_b.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/k_as_s.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/k_as_s.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/s.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/s.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/t.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/t.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/t_as_b.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/t_as_b.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/u.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/u.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/u_as_b.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/u_as_b.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/u_as_t.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/u_as_t.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/x.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/x.h
@@ -20,8 +20,8 @@
 * The following is auto-generated. Do not manually edit. See scripts/loops.js.
 */
 
-#ifndef STDLIB_STRIDED_BASE_NULLARY_C_H
-#define STDLIB_STRIDED_BASE_NULLARY_C_H
+#ifndef STDLIB_STRIDED_BASE_NULLARY_X_H
+#define STDLIB_STRIDED_BASE_NULLARY_X_H
 
 #include <stdint.h>
 
@@ -35,10 +35,10 @@ extern "C" {
 /**
 * Applies a nullary callback and assigns results to elements in a strided output array.
 */
-void stdlib_strided_c( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
+void stdlib_strided_x( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn );
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif // !STDLIB_STRIDED_BASE_NULLARY_C_H
+#endif // !STDLIB_STRIDED_BASE_NULLARY_X_H

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/z.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/z_as_b.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/z_as_b.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/z_as_c.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/z_as_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/z_as_d.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/z_as_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/z_as_f.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/z_as_f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/z_as_i.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/z_as_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/z_as_k.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/z_as_k.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/z_as_s.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/z_as_s.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/z_as_t.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/z_as_t.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/z_as_u.h
+++ b/lib/node_modules/@stdlib/strided/base/nullary/include/stdlib/strided/base/nullary/z_as_u.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/manifest.json
+++ b/lib/node_modules/@stdlib/strided/base/nullary/manifest.json
@@ -61,6 +61,7 @@
         "./src/u.c",
         "./src/u_as_b.c",
         "./src/u_as_t.c",
+        "./src/x.c",
         "./src/z.c",
         "./src/z_as_b.c",
         "./src/z_as_c.c",

--- a/lib/node_modules/@stdlib/strided/base/nullary/scripts/loops.js
+++ b/lib/node_modules/@stdlib/strided/base/nullary/scripts/loops.js
@@ -131,6 +131,9 @@ function callbackBody( ch1 ) {
 	if ( isComplexChar( ch1 ) ) {
 		return '// ...';
 	}
+	if ( ch1 === 'x' ) {
+		return 'return true;';
+	}
 	if ( ch1 === 'd' ) {
 		return 'return 3.0;';
 	}
@@ -383,6 +386,9 @@ function createSourceFile( signature ) {
 	if ( /z/.test( signature ) ) {
 		inc.push( '#include "stdlib/complex/float64/ctor.h"' );
 	}
+	if ( /x/.test( signature ) ) {
+		inc.push( '#include <stdbool.h>');
+	}
 	if ( inc.length ) {
 		file = replace( file, '{{INCLUDES}}', '\n'+inc.join( '\n' ) );
 	} else {
@@ -399,6 +405,9 @@ function createSourceFile( signature ) {
 	}
 	if ( /z/.test( tmp ) ) {
 		inc.push( '#include "stdlib/complex/float64/ctor.h"' );
+	}
+	if ( /x/.test( tmp ) ) {
+		inc.push( '#include <stdbool.h>');
 	}
 	if ( inc.length ) {
 		file = replace( file, '{{EXAMPLE_INCLUDES}}', '\n* '+inc.join( '\n* ' ) );
@@ -508,6 +517,9 @@ function createDoc( signature ) {
 	}
 	if ( /z/.test( tmp ) ) {
 		inc.push( '#include "stdlib/complex/float64/ctor.h"' );
+	}
+	if ( /x/.test( tmp ) ) {
+		inc.push( '#include <stdbool.h>');
 	}
 	if ( inc.length ) {
 		doc = replace( doc, '{{INCLUDES}}', '\n'+inc.join( '\n' ) );

--- a/lib/node_modules/@stdlib/strided/base/nullary/scripts/templates/docs.txt
+++ b/lib/node_modules/@stdlib/strided/base/nullary/scripts/templates/docs.txt
@@ -1,4 +1,4 @@
-#### stdlib_strided_{{SIGNATURE}}( \*arrays[], \*shape, \*strides, \*fcn )
+#### stdlib_strided_{{SIGNATURE}}( \*arrays\[], \*shape, \*strides, \*fcn )
 
 Applies a nullary callback and assigns results to elements in a strided output array.
 

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/b.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/b.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/c_as_b.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/c_as_b.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/c_as_f.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/c_as_f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/c_as_k.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/c_as_k.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/c_as_s.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/c_as_s.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/c_as_t.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/c_as_t.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/c_as_z.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/c_as_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/d.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/d_as_b.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/d_as_b.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/d_as_f.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/d_as_f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/d_as_i.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/d_as_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/d_as_k.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/d_as_k.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/d_as_s.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/d_as_s.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/d_as_t.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/d_as_t.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/d_as_u.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/d_as_u.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/f.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/f_as_b.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/f_as_b.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/f_as_d.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/f_as_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/f_as_k.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/f_as_k.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/f_as_s.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/f_as_s.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/f_as_t.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/f_as_t.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/i.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/i_as_b.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/i_as_b.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/i_as_k.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/i_as_k.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/i_as_s.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/i_as_s.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/i_as_t.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/i_as_t.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/k.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/k.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/k_as_b.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/k_as_b.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/k_as_s.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/k_as_s.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/s.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/s.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/t.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/t.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/t_as_b.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/t_as_b.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/u.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/u.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/u_as_b.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/u_as_b.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/u_as_t.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/u_as_t.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/x.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/x.c
@@ -20,9 +20,9 @@
 * The following is auto-generated. Do not manually edit. See scripts/loops.js.
 */
 
-#include "stdlib/strided/base/nullary/c.h"
+#include "stdlib/strided/base/nullary/x.h"
 #include "stdlib/strided/base/nullary/macros.h"
-#include "stdlib/complex/float32/ctor.h"
+#include <stdbool.h>
 #include <stdint.h>
 
 /**
@@ -34,32 +34,32 @@
 * @param fcn      callback
 *
 * @example
-* #include "stdlib/strided/base/nullary/c.h"
-* #include "stdlib/complex/float32/ctor.h"
+* #include "stdlib/strided/base/nullary/x.h"
+* #include <stdbool.h>
 * #include <stdint.h>
 *
 * // Create underlying byte arrays:
-* uint8_t out[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+* uint8_t out[] = { 0, 0, 0 };
 *
 * // Define a pointer to an array containing pointers to strided arrays:
 * uint8_t *arrays[] = { out };
 *
 * // Define the strides:
-* int64_t strides[] = { 8 };
+* int64_t strides[] = { 1 };
 *
 * // Define the number of elements over which to iterate:
 * int64_t shape[] = { 3 };
 *
 * // Define a callback:
-* static stdlib_complex64_t fcn( void ) {
-*     // ...
+* static bool fcn( void ) {
+*     return true;
 * }
 *
 * // Apply the callback:
-* stdlib_strided_c( arrays, shape, strides, (void *)fcn );
+* stdlib_strided_x( arrays, shape, strides, (void *)fcn );
 */
-void stdlib_strided_c( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn ) {
-	typedef stdlib_complex64_t func_type( void );
+void stdlib_strided_x( uint8_t *arrays[], const int64_t *shape, const int64_t *strides, void *fcn ) {
+	typedef bool func_type( void );
 	func_type *f = (func_type *)fcn;
-	STDLIB_STRIDED_NULLARY_LOOP_CLBK_RET_NOCAST( stdlib_complex64_t )
+	STDLIB_STRIDED_NULLARY_LOOP_CLBK( bool )
 }

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/z.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/z_as_b.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/z_as_b.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/z_as_c.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/z_as_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/z_as_d.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/z_as_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/z_as_f.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/z_as_f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/z_as_i.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/z_as_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/z_as_k.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/z_as_k.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/z_as_s.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/z_as_s.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/z_as_t.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/z_as_t.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/nullary/src/z_as_u.c
+++ b/lib/node_modules/@stdlib/strided/base/nullary/src/z_as_u.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Resolves: Subtask of #2500 

## Description

> What is the purpose of this pull request?

This pull request:

- This PR updates the `script/loops.js` which generates/updates the header, source and docs files and add support for boolean array in `strided/base/nullary`

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
