### PR TITLE
test: fix failing tests in the REPL

### DIFF
--- a/lib/node_modules/@stdlib/repl/test/integration/test.auto_page.js
+++ b/lib/node_modules/@stdlib/repl/test/integration/test.auto_page.js
@@ -58,6 +58,7 @@ function defaultSettings() {
 	return {
 		'autoDeletePairs': false,
 		'autoClosePairs': false,
+		'autoDisableBracketedPasteOnExit': false,
 		'completionPreviews': false,
 		'syntaxHighlighting': false,
 		'autoPage': true

--- a/lib/node_modules/@stdlib/repl/test/integration/test.completer_engine.js
+++ b/lib/node_modules/@stdlib/repl/test/integration/test.completer_engine.js
@@ -45,6 +45,7 @@ function defaultSettings() {
 	return {
 		'autoDeletePairs': false,
 		'autoClosePairs': false,
+		'autoDisableBracketedPasteOnExit': false,
 		'completionPreviews': false,
 		'syntaxHighlighting': false,
 		'autoPage': false

--- a/lib/node_modules/@stdlib/repl/test/integration/test.completion_previews.js
+++ b/lib/node_modules/@stdlib/repl/test/integration/test.completion_previews.js
@@ -46,7 +46,8 @@ tape( 'a REPL instance supports displaying a completion preview of user-defined 
 		'input': istream,
 		'settings': {
 			'autoPage': false,
-			'syntaxHighlighting': false
+			'syntaxHighlighting': false,
+			'autoDisableBracketedPasteOnExit': false
 		}
 	};
 	r = repl( opts, onClose );
@@ -90,7 +91,8 @@ tape( 'a REPL instance supports displaying a completion preview for common prefi
 		'input': istream,
 		'settings': {
 			'autoPage': false,
-			'syntaxHighlighting': false
+			'syntaxHighlighting': false,
+			'autoDisableBracketedPasteOnExit': false
 		}
 	};
 	r = repl( opts, onClose );
@@ -135,7 +137,8 @@ tape( 'a REPL instance supports displaying a completion preview for recognized i
 		'input': istream,
 		'settings': {
 			'autoPage': false,
-			'syntaxHighlighting': false
+			'syntaxHighlighting': false,
+			'autoDisableBracketedPasteOnExit': false
 		}
 	};
 	r = repl( opts, onClose );
@@ -179,7 +182,8 @@ tape( 'a REPL instance supports displaying a completion preview when a cursor is
 		'input': istream,
 		'settings': {
 			'autoPage': false,
-			'syntaxHighlighting': false
+			'syntaxHighlighting': false,
+			'autoDisableBracketedPasteOnExit': false
 		}
 	};
 	r = repl( opts, onClose );
@@ -232,7 +236,8 @@ tape( 'a REPL instance supports auto-completing a completion candidate by moving
 		'input': istream,
 		'settings': {
 			'autoPage': false,
-			'syntaxHighlighting': false
+			'syntaxHighlighting': false,
+			'autoDisableBracketedPasteOnExit': false
 		}
 	};
 	r = repl( opts, onClose );
@@ -284,7 +289,8 @@ tape( 'a REPL instance supports auto-completing a completion preview and executi
 		'outputPrompt': '',
 		'settings': {
 			'autoPage': false,
-			'syntaxHighlighting': false
+			'syntaxHighlighting': false,
+			'autoDisableBracketedPasteOnExit': false
 		}
 	};
 	r = repl( opts, onClose );
@@ -337,7 +343,8 @@ tape( 'a REPL instance does not display a completion preview when no completion 
 		'input': istream,
 		'settings': {
 			'autoPage': false,
-			'syntaxHighlighting': false
+			'syntaxHighlighting': false,
+			'autoDisableBracketedPasteOnExit': false
 		}
 	};
 	r = repl( opts, onClose );
@@ -395,7 +402,8 @@ tape( 'a REPL instance does not display a completion preview once a user enters 
 		'outputPrompt': '',
 		'settings': {
 			'autoPage': false,
-			'syntaxHighlighting': false
+			'syntaxHighlighting': false,
+			'autoDisableBracketedPasteOnExit': false
 		}
 	};
 	r = repl( opts, onClose );

--- a/lib/node_modules/@stdlib/repl/test/integration/test.syntax_highlighting.js
+++ b/lib/node_modules/@stdlib/repl/test/integration/test.syntax_highlighting.js
@@ -69,6 +69,7 @@ function defaultSettings() {
 	return {
 		'autoClosePairs': false,
 		'autoDeletePairs': false,
+		'autoDisableBracketedPasteOnExit': false,
 		'autoPage': false,
 		'completionPreviews': false,
 		'syntaxHighlighting': true


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   fixes [failing tests](https://github.com/stdlib-js/stdlib/actions/runs/9812437984/job/27096502723) following the PR: #2502 

The sequence to disable bracketed paste (`\x1b[?2004l`) was polluting expected test data.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   follow up to #2502

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
