### PR TITLE
feat: add boolean dtype support to `strided/base/unary-addon-dispatch`

### DIFF
--- a/lib/node_modules/@stdlib/strided/base/unary-addon-dispatch/lib/main.js
+++ b/lib/node_modules/@stdlib/strided/base/unary-addon-dispatch/lib/main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ var isTypedArrayLike = require( '@stdlib/assert/is-typed-array-like' );
 var resolve = require( '@stdlib/strided/base/dtype-resolve-enum' );
 var reinterpretComplex64 = require( '@stdlib/strided/base/reinterpret-complex64' );
 var reinterpretComplex128 = require( '@stdlib/strided/base/reinterpret-complex128' );
+var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
 var format = require( '@stdlib/string/format' );
 
 
@@ -32,6 +33,7 @@ var format = require( '@stdlib/string/format' );
 
 var COMPLEX64 = resolve( 'complex64' );
 var COMPLEX128 = resolve( 'complex128' );
+var BOOLEAN = resolve( 'bool' );
 
 
 // MAIN //
@@ -153,6 +155,8 @@ function dispatch( addon, fallback ) {
 			viewX = reinterpretComplex64( x, 0 );
 		} else if ( dtypeX === COMPLEX128 ) {
 			viewX = reinterpretComplex128( x, 0 );
+		} else if ( dtypeX === BOOLEAN ) {
+			viewX = reinterpretBoolean( x, 0 );
 		} else {
 			viewX = x;
 		}
@@ -160,6 +164,8 @@ function dispatch( addon, fallback ) {
 			viewY = reinterpretComplex64( y, 0 );
 		} else if ( dtypeY === COMPLEX128 ) {
 			viewY = reinterpretComplex128( y, 0 );
+		} else if ( dtypeY === BOOLEAN ) {
+			viewY = reinterpretBoolean( y, 0 );
 		} else {
 			viewY = y;
 		}

--- a/lib/node_modules/@stdlib/strided/base/unary-addon-dispatch/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/strided/base/unary-addon-dispatch/lib/ndarray.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ var isNonNegativeInteger = require( '@stdlib/assert/is-nonnegative-integer' ).is
 var resolve = require( '@stdlib/strided/base/dtype-resolve-enum' );
 var reinterpretComplex64 = require( '@stdlib/strided/base/reinterpret-complex64' );
 var reinterpretComplex128 = require( '@stdlib/strided/base/reinterpret-complex128' );
+var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
 var offsetView = require( '@stdlib/strided/base/offset-view' );
 var minViewBufferIndex = require( '@stdlib/strided/base/min-view-buffer-index' );
 var format = require( '@stdlib/string/format' );
@@ -35,6 +36,7 @@ var format = require( '@stdlib/string/format' );
 
 var COMPLEX64 = resolve( 'complex64' );
 var COMPLEX128 = resolve( 'complex128' );
+var BOOLEAN = resolve( 'bool' );
 
 
 // MAIN //
@@ -172,6 +174,8 @@ function dispatch( addon, fallback ) {
 			viewX = reinterpretComplex64( x, offsetX );
 		} else if ( dtypeX === COMPLEX128 ) {
 			viewX = reinterpretComplex128( x, offsetX );
+		} else if ( dtypeX === BOOLEAN ) {
+			viewX = reinterpretBoolean( x, offsetX );
 		} else {
 			viewX = offsetView( x, offsetX );
 		}
@@ -179,6 +183,8 @@ function dispatch( addon, fallback ) {
 			viewY = reinterpretComplex64( y, offsetY );
 		} else if ( dtypeY === COMPLEX128 ) {
 			viewY = reinterpretComplex128( y, offsetY );
+		} else if ( dtypeY === BOOLEAN ) {
+			viewY = reinterpretBoolean( y, offsetY );
 		} else {
 			viewY = offsetView( y, offsetY );
 		}

--- a/lib/node_modules/@stdlib/strided/base/unary-addon-dispatch/test/test.main.js
+++ b/lib/node_modules/@stdlib/strided/base/unary-addon-dispatch/test/test.main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -25,8 +25,10 @@ var noop = require( '@stdlib/utils/noop' );
 var Float64Array = require( '@stdlib/array/float64' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var isFloat32Array = require( '@stdlib/assert/is-float32array' );
 var isFloat64Array = require( '@stdlib/assert/is-float64array' );
+var isUint8Array = require( '@stdlib/assert/is-uint8array' );
 var resolve = require( '@stdlib/strided/base/dtype-resolve-enum' );
 var dispatch = require( './../lib' );
 
@@ -121,6 +123,38 @@ tape( 'the function returns a function which dispatches to an addon function whe
 		t.strictEqual( sx, 1, 'returns expected value' );
 		t.strictEqual( dy, resolve( 'float64' ), 'returns expected value' );
 		t.strictEqual( ay, y, 'returns expected value' );
+		t.strictEqual( sy, 1, 'returns expected value' );
+	}
+
+	function fallback() {
+		t.ok( false, 'called fallback' );
+	}
+});
+
+tape( 'the function supports boolean arrays (bool)', function test( t ) {
+	var f;
+	var x;
+	var y;
+
+	f = dispatch( addon, fallback );
+
+	x = new BooleanArray( 2 );
+	y = new BooleanArray( x.length );
+
+	f( x.length, 'bool', x, 1, 'bool', y, 1 );
+
+	t.end();
+
+	function addon( N, dx, ax, sx, dy, ay, sy ) {
+		t.ok( true, 'called addon' );
+		t.strictEqual( N, x.length, 'returns expected value' );
+		t.strictEqual( dx, resolve( 'bool' ), 'returns expected value' );
+		t.strictEqual( isUint8Array( ax ), true, 'returns expected value' );
+		t.strictEqual( ax.buffer, x.buffer, 'returns expected value' );
+		t.strictEqual( sx, 1, 'returns expected value' );
+		t.strictEqual( dy, resolve( 'bool' ), 'returns expected value' );
+		t.strictEqual( isUint8Array( ay ), true, 'returns expected value' );
+		t.strictEqual( ay.buffer, y.buffer, 'returns expected value' );
 		t.strictEqual( sy, 1, 'returns expected value' );
 	}
 

--- a/lib/node_modules/@stdlib/strided/base/unary-addon-dispatch/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/strided/base/unary-addon-dispatch/test/test.ndarray.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2021 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -25,8 +25,10 @@ var noop = require( '@stdlib/utils/noop' );
 var Float64Array = require( '@stdlib/array/float64' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var isFloat32Array = require( '@stdlib/assert/is-float32array' );
 var isFloat64Array = require( '@stdlib/assert/is-float64array' );
+var isUint8Array = require( '@stdlib/assert/is-uint8array' );
 var resolve = require( '@stdlib/strided/base/dtype-resolve-enum' );
 var dispatch = require( './../lib/ndarray.js' );
 
@@ -196,6 +198,38 @@ tape( 'the function returns a function which dispatches to an addon function whe
 		t.strictEqual( sx, 1, 'returns expected value' );
 		t.strictEqual( dy, resolve( 'float64' ), 'returns expected value' );
 		t.notEqual( ay, y, 'returns expected value' );
+		t.strictEqual( ay.buffer, y.buffer, 'returns expected value' );
+		t.strictEqual( sy, 1, 'returns expected value' );
+	}
+
+	function fallback() {
+		t.ok( false, 'called fallback' );
+	}
+});
+
+tape( 'the function supports boolean arrays (bool)', function test( t ) {
+	var f;
+	var x;
+	var y;
+
+	f = dispatch( addon, fallback );
+
+	x = new BooleanArray( 2 );
+	y = new BooleanArray( x.length );
+
+	f( x.length, 'bool', x, 1, 0, 'bool', y, 1, 0 );
+
+	t.end();
+
+	function addon( N, dx, ax, sx, dy, ay, sy ) {
+		t.ok( true, 'called addon' );
+		t.strictEqual( N, x.length, 'returns expected value' );
+		t.strictEqual( dx, resolve( 'bool' ), 'returns expected value' );
+		t.strictEqual( isUint8Array( ax ), true, 'returns expected value' );
+		t.strictEqual( ax.buffer, x.buffer, 'returns expected value' );
+		t.strictEqual( sx, 1, 'returns expected value' );
+		t.strictEqual( dy, resolve( 'bool' ), 'returns expected value' );
+		t.strictEqual( isUint8Array( ay ), true, 'returns expected value' );
 		t.strictEqual( ay.buffer, y.buffer, 'returns expected value' );
 		t.strictEqual( sy, 1, 'returns expected value' );
 	}


### PR DESCRIPTION
Resolves: Subtask of #2500 

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR will add boolean datatype support in `strided/base/unary-addon-dispatch`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
