### PR TITLE
refactor: use stdlib equivalent of `pow` in `math/base/special/roundn`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/roundn/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/roundn/manifest.json
@@ -28,7 +28,7 @@
     {
       "task": "build",
       "src": [
-        "./src/roundn.c"
+        "./src/main.c"
       ],
       "include": [
         "./include"
@@ -41,17 +41,19 @@
         "@stdlib/math/base/napi/binary",
         "@stdlib/math/base/special/abs",
         "@stdlib/math/base/special/round",
+        "@stdlib/math/base/special/pow",
         "@stdlib/constants/float64/max-safe-integer",
         "@stdlib/constants/float64/max-base10-exponent",
         "@stdlib/constants/float64/min-base10-exponent",
         "@stdlib/constants/float64/min-base10-exponent-subnormal",
-        "@stdlib/math/base/assert/is-infinite"
+        "@stdlib/math/base/assert/is-infinite",
+        "@stdlib/math/base/assert/is-nan"
       ]
     },
     {
       "task": "benchmark",
       "src": [
-        "./src/roundn.c"
+        "./src/main.c"
       ],
       "include": [
         "./include"
@@ -63,17 +65,19 @@
       "dependencies": [
         "@stdlib/math/base/special/abs",
         "@stdlib/math/base/special/round",
+        "@stdlib/math/base/special/pow",
         "@stdlib/constants/float64/max-safe-integer",
         "@stdlib/constants/float64/max-base10-exponent",
         "@stdlib/constants/float64/min-base10-exponent",
         "@stdlib/constants/float64/min-base10-exponent-subnormal",
-        "@stdlib/math/base/assert/is-infinite"
+        "@stdlib/math/base/assert/is-infinite",
+        "@stdlib/math/base/assert/is-nan"
       ]
     },
     {
       "task": "examples",
       "src": [
-        "./src/roundn.c"
+        "./src/main.c"
       ],
       "include": [
         "./include"
@@ -85,11 +89,13 @@
       "dependencies": [
         "@stdlib/math/base/special/abs",
         "@stdlib/math/base/special/round",
+        "@stdlib/math/base/special/pow",
         "@stdlib/constants/float64/max-safe-integer",
         "@stdlib/constants/float64/max-base10-exponent",
         "@stdlib/constants/float64/min-base10-exponent",
         "@stdlib/constants/float64/min-base10-exponent-subnormal",
-        "@stdlib/math/base/assert/is-infinite"
+        "@stdlib/math/base/assert/is-infinite",
+        "@stdlib/math/base/assert/is-nan"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/roundn/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/roundn/src/main.c
@@ -18,14 +18,15 @@
 
 #include "stdlib/math/base/special/roundn.h"
 #include "stdlib/math/base/assert/is_infinite.h"
+#include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/special/abs.h"
 #include "stdlib/math/base/special/round.h"
+#include "stdlib/math/base/special/pow.h"
 #include "stdlib/constants/float64/max_safe_integer.h"
 #include "stdlib/constants/float64/max_base10_exponent.h"
 #include "stdlib/constants/float64/min_base10_exponent.h"
 #include "stdlib/constants/float64/min_base10_exponent_subnormal.h"
 #include <stdint.h>
-#include <math.h>
 
 static const double MAX_INT = STDLIB_CONSTANT_FLOAT64_MAX_SAFE_INTEGER + 1.0;
 static const double HUGE_VALUE = 1.0e+308;
@@ -115,7 +116,7 @@ double stdlib_base_roundn( const double x, const int32_t n ) {
 	double s;
 	double y;
 
-	if ( isnan( x ) ){
+	if ( stdlib_base_is_nan( x ) ){
 		return 0.0 / 0.0; // NaN
 	}
 
@@ -140,14 +141,14 @@ double stdlib_base_roundn( const double x, const int32_t n ) {
 	}
 	// If we overflow, return `x`, as the number of digits to the right of the decimal is too small (i.e., `x` is too large / lacks sufficient fractional precision) for there to be any effect when rounding...
 	if ( n < STDLIB_CONSTANT_FLOAT64_MIN_BASE10_EXPONENT ){
-		s = pow( 10.0, -( n + STDLIB_CONSTANT_FLOAT64_MAX_BASE10_EXPONENT ) );  // TODO: replace use of `pow` once have stdlib equivalent
+		s = stdlib_base_pow( 10.0, -( n + STDLIB_CONSTANT_FLOAT64_MAX_BASE10_EXPONENT ) );
 		y = ( x * HUGE_VALUE ) * s; // order of operation matters!
 		if ( stdlib_base_is_infinite( y ) ){
 			return x;
 		}
 		return ( stdlib_base_round( y ) / HUGE_VALUE ) / s;
 	}
-	s = pow( 10.0, -n );  // TODO: replace use of `pow` once have stdlib equivalent
+	s = stdlib_base_pow( 10.0, -n );
 	y = x * s;
 	if ( stdlib_base_is_infinite( y ) ){
 		return x;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   completes the `TODO` to use stdlib equivalent of `pow` in [`math/base/special/roundn/src/roundn.c`](https://github.com/stdlib-js/stdlib/blob/efc3551764c30c6cae9a48058cae2868d4055190/lib/node_modules/%40stdlib/math/base/special/roundn/src/roundn.c#L143).
-   renames `roundn.c` to `main.c`.
-   uses `stdlib_base_is_nan` instead of just `isnan`.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
