### PR TITLE
feat: add C implementation for `math/base/special/roundb`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/roundb/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/README.md
@@ -102,6 +102,80 @@ for ( i = 0; i < 100; i++ ) {
 
 <!-- /.examples -->
 
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/math/base/special/roundb.h"
+```
+
+#### stdlib_base_roundb( x, n, b )
+
+Rounds a `numeric` value to the nearest multiple of `b^n` on a linear scale.
+
+```c
+double out = stdlib_base_roundb( 3.141592653589793, -2, 10 );
+// returns 3.14
+```
+
+The function accepts the following arguments:
+
+-   **x**: `[in] double` input value.
+-   **n**: `[in] double` power.
+-   **b**: `[in] double` base.
+
+```c
+double stdlib_base_roundb( const double x, const double n, const double b );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/math/base/special/roundb.h"
+#include <stdio.h>
+#include <stdint.h>
+
+int main( void ) {
+    const double x[] = { -5.0, -3.89, -2.78, -1.67, -0.56, 0.56, 1.67, 2.78, 3.89, 5.0 };
+    const int32_t n[] = { -4, -3, -2, -1, 0, 1, 2, 3, 4, 5 };
+    const int32_t b[] = { 20, 19, 18, 17, 16, 15, 14, 13, 12, 11 };
+
+    double v;
+    int i;
+    for ( i = 0; i < 10; i++ ) {
+        v = stdlib_base_roundb( x[ i ], n[ i ], b[ i ] );
+        printf( "roundb(%lf, %d, %d) = %lf\n", x[ i ], n[ i ], b[ i ], v );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/math/base/special/roundb/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/README.md
@@ -124,11 +124,11 @@ double out = stdlib_base_roundb( 3.141592653589793, -2, 10 );
 The function accepts the following arguments:
 
 -   **x**: `[in] double` input value.
--   **n**: `[in] double` power.
--   **b**: `[in] double` base.
+-   **n**: `[in] int32_t` power.
+-   **b**: `[in] int32_t` base.
 
 ```c
-double stdlib_base_roundb( const double x, const double n, const double b );
+double stdlib_base_roundb( const double x, const int32_t n, const int32_t b );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/roundb/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/benchmark/benchmark.native.js
@@ -1,0 +1,60 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var roundb = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( roundb instanceof Error )
+};
+
+
+// MAIN //
+
+bench( pkg+'::native', opts, function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		x = ( randu() * 1.0e7 ) - 5.0e6;
+		y = roundb( x, 2, 20 );
+		if ( isnan( y ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnan( y ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/roundb/benchmark/c/native/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/benchmark/c/native/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/roundb/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/benchmark/c/native/benchmark.c
@@ -1,0 +1,136 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/**
+* Benchmark `roundb`.
+*/
+#include "stdlib/math/base/special/roundb.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "roundb"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+void print_version() {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+double tic() {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1].
+*
+* @return random number
+*/
+double rand_double() {
+	int r = rand();
+	return (double)r / ( (double)RAND_MAX + 1.0 );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+double benchmark() {
+	double elapsed;
+	double x;
+	double y;
+	double t;
+	int i;
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		x = ( 1.0e7 * rand_double() ) - 5.0e6;
+		y = stdlib_base_roundb( x, 2, 20 );
+		if ( y != y ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( y != y ) {
+		printf( "should not return NaN\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::native::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/math/base/special/roundb/binding.gyp
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/math/base/special/roundb/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/roundb/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/examples/c/example.c
@@ -21,14 +21,14 @@
 #include <stdint.h>
 
 int main( void ) {
-    const double x[] = { -5.0, -3.89, -2.78, -1.67, -0.56, 0.56, 1.67, 2.78, 3.89, 5.0 };
+	const double x[] = { -5.0, -3.89, -2.78, -1.67, -0.56, 0.56, 1.67, 2.78, 3.89, 5.0 };
 	const int32_t n[] = { -4, -3, -2, -1, 0, 1, 2, 3, 4, 5 };
 	const int32_t b[] = { 20, 19, 18, 17, 16, 15, 14, 13, 12, 11 };
 
-    double v;
-    int i;
-    for ( i = 0; i < 10; i++ ) {
-        v = stdlib_base_roundb( x[ i ], n[ i ], b[ i ] );
-        printf( "roundb(%lf, %d, %d) = %lf\n", x[ i ], n[ i ], b[ i ], v );
-    }
+	double v;
+	int i;
+	for ( i = 0; i < 10; i++ ) {
+		v = stdlib_base_roundb( x[ i ], n[ i ], b[ i ] );
+		printf( "roundb(%lf, %d, %d) = %lf\n", x[ i ], n[ i ], b[ i ], v );
+	}
 }

--- a/lib/node_modules/@stdlib/math/base/special/roundb/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/examples/c/example.c
@@ -1,0 +1,34 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/roundb.h"
+#include <stdio.h>
+#include <stdint.h>
+
+int main( void ) {
+    const double x[] = { -5.0, -3.89, -2.78, -1.67, -0.56, 0.56, 1.67, 2.78, 3.89, 5.0 };
+	const int32_t n[] = { -4, -3, -2, -1, 0, 1, 2, 3, 4, 5 };
+	const int32_t b[] = { 20, 19, 18, 17, 16, 15, 14, 13, 12, 11 };
+
+    double v;
+    int i;
+    for ( i = 0; i < 10; i++ ) {
+        v = stdlib_base_roundb( x[ i ], n[ i ], b[ i ] );
+        printf( "roundb(%lf, %d, %d) = %lf\n", x[ i ], n[ i ], b[ i ], v );
+    }
+}

--- a/lib/node_modules/@stdlib/math/base/special/roundb/include.gypi
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/math/base/special/roundb/include/stdlib/math/base/special/roundb.h
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/include/stdlib/math/base/special/roundb.h
@@ -19,6 +19,8 @@
 #ifndef STDLIB_MATH_BASE_SPECIAL_ROUNDB_H
 #define STDLIB_MATH_BASE_SPECIAL_ROUNDB_H
 
+#include <stdint.h>
+
 /*
 * If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
 */
@@ -29,7 +31,7 @@ extern "C" {
 /**
 * Rounds a numeric value to the nearest multiple of \\(b^n\\) on a linear scale.
 */
-double stdlib_base_roundb( const double x, const double n, const double b );
+double stdlib_base_roundb( const double x, const int32_t n, const int32_t b );
 
 #ifdef __cplusplus
 }

--- a/lib/node_modules/@stdlib/math/base/special/roundb/include/stdlib/math/base/special/roundb.h
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/include/stdlib/math/base/special/roundb.h
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_MATH_BASE_SPECIAL_ROUNDB_H
+#define STDLIB_MATH_BASE_SPECIAL_ROUNDB_H
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Rounds a numeric value to the nearest multiple of \\(b^n\\) on a linear scale.
+*/
+double stdlib_base_roundb( const double x, const double n, const double b );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_MATH_BASE_SPECIAL_ROUNDB_H

--- a/lib/node_modules/@stdlib/math/base/special/roundb/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/lib/native.js
@@ -1,0 +1,59 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Rounds a numeric value to the nearest multiple of \\(b^n\\) on a linear scale.
+*
+* @private
+* @param {number} x - input value
+* @param {integer} n - integer power
+* @param {PositiveInteger} b - base
+* @returns {number} rounded value
+*
+* @example
+* // Round a value to 2 decimal places:
+* var v = roundb( 3.141592653589793, -2, 10 );
+* // returns 3.14
+*
+* @example
+* // If n = 0 or b = 1, `roundb` behaves like `round`:
+* var v = roundb( 3.141592653589793, 0, 2 );
+* // returns 3.0
+*
+* @example
+* // Round a value to the nearest multiple of two:
+* var v = roundb( 5.0, 1, 2 );
+* // returns 6.0
+*/
+function roundb( x, n, b ) {
+	return addon( x, n, b );
+}
+
+
+// EXPORTS //
+
+module.exports = roundb;

--- a/lib/node_modules/@stdlib/math/base/special/roundb/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/manifest.json
@@ -55,7 +55,7 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-       "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/round",
         "@stdlib/math/base/special/roundn",
@@ -73,7 +73,7 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-       "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/special/round",
         "@stdlib/math/base/special/roundn",

--- a/lib/node_modules/@stdlib/math/base/special/roundb/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/manifest.json
@@ -1,0 +1,84 @@
+{
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/napi/ternary",
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/assert/is-infinite",
+        "@stdlib/math/base/special/round",
+        "@stdlib/math/base/special/roundn",
+        "@stdlib/math/base/special/pow"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+       "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/assert/is-infinite",
+        "@stdlib/math/base/special/round",
+        "@stdlib/math/base/special/roundn",
+        "@stdlib/math/base/special/pow"
+      ]
+    },
+    {
+      "task": "examples",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+       "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/assert/is-infinite",
+        "@stdlib/math/base/special/round",
+        "@stdlib/math/base/special/roundn",
+        "@stdlib/math/base/special/pow"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/special/roundb/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/roundb/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/src/addon.c
@@ -20,4 +20,4 @@
 #include "stdlib/math/base/napi/ternary.h"
 
 // cppcheck-suppress shadowFunction
-STDLIB_MATH_BASE_NAPI_MODULE_DDD_D( stdlib_base_roundb )
+STDLIB_MATH_BASE_NAPI_MODULE_DII_D( stdlib_base_roundb )

--- a/lib/node_modules/@stdlib/math/base/special/roundb/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/src/addon.c
@@ -1,0 +1,23 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/roundb.h"
+#include "stdlib/math/base/napi/ternary.h"
+
+// cppcheck-suppress shadowFunction
+STDLIB_MATH_BASE_NAPI_MODULE_DDD_D( stdlib_base_roundb )

--- a/lib/node_modules/@stdlib/math/base/special/roundb/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/src/main.c
@@ -35,7 +35,7 @@
 * double out = stdlib_base_roundb( 3.141592653589793, -2, 10 );
 * // returns 3.14
 */
-double stdlib_base_round10( const double x, const double n, const double b ) {
+double stdlib_base_roundb( const double x, const double n, const double b ) {
 	double y;
 	double s;
 

--- a/lib/node_modules/@stdlib/math/base/special/roundb/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/src/main.c
@@ -22,6 +22,7 @@
 #include "stdlib/math/base/special/round.h"
 #include "stdlib/math/base/special/roundn.h"
 #include "stdlib/math/base/special/pow.h"
+#include <stdint.h>
 
 /**
 * Rounds a numeric value to the nearest multiple of \\(b^n\\) on a linear scale.
@@ -35,11 +36,11 @@
 * double out = stdlib_base_roundb( 3.141592653589793, -2, 10 );
 * // returns 3.14
 */
-double stdlib_base_roundb( const double x, const double n, const double b ) {
+double stdlib_base_roundb( const double x, const int32_t n, const int32_t b ) {
 	double y;
 	double s;
 
-	if ( stdlib_base_is_nan( x ) || stdlib_base_is_nan( n ) || stdlib_base_is_nan( b ) || b <= 0 || stdlib_base_is_infinite( n ) || stdlib_base_is_infinite( b ) ) {
+	if ( stdlib_base_is_nan( x ) || b <= 0 ) {
 		return 0.0 / 0.0; // NaN
 	}
 	if ( stdlib_base_is_infinite( x ) || x == 0.0 ) {

--- a/lib/node_modules/@stdlib/math/base/special/roundb/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/src/main.c
@@ -1,0 +1,67 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/roundb.h"
+#include "stdlib/math/base/assert/is_nan.h"
+#include "stdlib/math/base/assert/is_infinite.h"
+#include "stdlib/math/base/special/round.h"
+#include "stdlib/math/base/special/roundn.h"
+#include "stdlib/math/base/special/pow.h"
+
+/**
+* Rounds a numeric value to the nearest multiple of \\(b^n\\) on a linear scale.
+*
+* @param x    input value
+* @param n    integer power
+* @param b    base
+* @return     rounded value
+*
+* @example
+* double out = stdlib_base_roundb( 3.141592653589793, -2, 10 );
+* // returns 3.14
+*/
+double stdlib_base_round10( const double x, const double n, const double b ) {
+	double y;
+	double s;
+
+	if ( stdlib_base_is_nan( x ) || stdlib_base_is_nan( n ) || stdlib_base_is_nan( b ) || b <= 0 || stdlib_base_is_infinite( n ) || stdlib_base_is_infinite( b ) ) {
+		return 0.0 / 0.0; // NaN
+	}
+	if ( stdlib_base_is_infinite( x ) || x == 0.0 ) {
+		return x;
+	}
+	if ( b == 10 ) {
+		return stdlib_base_roundn( x, n );
+	}
+	if ( n == 0 || b == 1 ) {
+		return stdlib_base_round( x );
+	}
+	s = stdlib_base_pow( b, -n );
+
+	// Check for overflow:
+	if ( stdlib_base_is_infinite( s ) ) {
+		return x;
+	}
+	y = stdlib_base_round( x * s ) / s;
+
+	// Check for overflow:
+	if ( stdlib_base_is_infinite( y ) ) {
+		return x;
+	}
+	return y;
+}

--- a/lib/node_modules/@stdlib/math/base/special/roundb/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/test/test.native.js
@@ -57,49 +57,6 @@ tape( 'the function returns `NaN` if provided `NaN`', opts, function test( t ) {
 
 	v = roundb( NaN, -2, 1 );
 	t.strictEqual( isnan( v ), true, 'returns expected value' );
-
-	v = roundb( 12368.0, NaN, 1 );
-	t.strictEqual( isnan( v ), true, 'returns expected value' );
-
-	v = roundb( NaN, NaN, 1 );
-	t.strictEqual( isnan( v ), true, 'returns expected value' );
-
-	v = roundb( 12368.0, NaN, 1 );
-	t.strictEqual( isnan( v ), true, 'returns expected value' );
-
-	v = roundb( 12368.0, 1, NaN );
-	t.strictEqual( isnan( v ), true, 'returns expected value' );
-
-	v = roundb( 12368.0, NaN, NaN );
-	t.strictEqual( isnan( v ), true, 'returns expected value' );
-
-	v = roundb( NaN, 1, NaN );
-	t.strictEqual( isnan( v ), true, 'returns expected value' );
-
-	t.end();
-});
-
-tape( 'the function returns `NaN` if provided `n = +-infinity`', opts, function test( t ) {
-	var v;
-
-	v = roundb( PI, PINF, 10 );
-	t.strictEqual( isnan( v ), true, 'returns expected value' );
-
-	v = roundb( PI, NINF, 10 );
-	t.strictEqual( isnan( v ), true, 'returns expected value' );
-
-	t.end();
-});
-
-tape( 'the function returns `NaN` if provided `b = +-infinity`', opts, function test( t ) {
-	var v;
-
-	v = roundb( PI, 1, PINF );
-	t.strictEqual( isnan( v ), true, 'returns expected value' );
-
-	v = roundb( PI, 1, NINF );
-	t.strictEqual( isnan( v ), true, 'returns expected value' );
-
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/math/base/special/roundb/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/test/test.native.js
@@ -1,0 +1,357 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var PI = require( '@stdlib/constants/float64/pi' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+var EPS = require( '@stdlib/constants/float64/eps' );
+var randu = require( '@stdlib/random/base/randu' );
+var round = require( '@stdlib/math/base/special/round' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var abs = require( '@stdlib/math/base/special/abs' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
+var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var roundb = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( roundb instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof roundb, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `NaN` if provided `NaN`', opts, function test( t ) {
+	var v;
+
+	v = roundb( NaN, -2, 1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	v = roundb( 12368.0, NaN, 1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	v = roundb( NaN, NaN, 1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	v = roundb( 12368.0, NaN, 1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	v = roundb( 12368.0, 1, NaN );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	v = roundb( 12368.0, NaN, NaN );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	v = roundb( NaN, 1, NaN );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `NaN` if provided `n = +-infinity`', opts, function test( t ) {
+	var v;
+
+	v = roundb( PI, PINF, 10 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	v = roundb( PI, NINF, 10 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `NaN` if provided `b = +-infinity`', opts, function test( t ) {
+	var v;
+
+	v = roundb( PI, 1, PINF );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	v = roundb( PI, 1, NINF );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `NaN` if provided `b <= 0`', opts, function test( t ) {
+	var v;
+
+	v = roundb( PI, 5, 0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	v = roundb( PI, 5, -1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `+infinity` if provided `+infinity`', opts, function test( t ) {
+	var v = roundb( PINF, 5, 10 );
+	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.end();
+});
+
+tape( 'the function returns `-infinity` if provided `-infinity`', opts, function test( t ) {
+	var v = roundb( NINF, -3, 10 );
+	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.end();
+});
+
+tape( 'the function returns `-0` if provided `-0`', opts, function test( t ) {
+	var v;
+
+	v = roundb( -0.0, 0, 10 );
+	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+
+	v = roundb( -0.0, -2, 10 );
+	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+
+	v = roundb( -0.0, 2, 10 );
+	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+
+	t.end();
+});
+
+tape( 'the function returns `+0` if provided `+0`', opts, function test( t ) {
+	var v;
+
+	v = roundb( 0.0, 0, 10 );
+	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+
+	v = roundb( +0.0, -2, 10 );
+	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+
+	v = roundb( +0.0, 2, 10 );
+	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+
+	t.end();
+});
+
+tape( 'the function supports rounding a numeric value to a desired number of decimals', opts, function test( t ) {
+	t.strictEqual( roundb( PI, -2, 10 ), 3.14, 'returns expected value' );
+	t.strictEqual( roundb( -PI, -2, 10 ), -3.14, 'returns expected value' );
+	t.strictEqual( roundb( 9.99999, -2, 10 ), 10.0, 'returns expected value' );
+	t.strictEqual( roundb( -9.99999, -2, 10 ), -10.0, 'returns expected value' );
+	t.strictEqual( roundb( 0.0, 2, 10 ), 0.0, 'returns expected value' );
+	t.strictEqual( roundb( 12368.0, -3, 10 ), 12368.0, 'returns expected value' );
+	t.strictEqual( roundb( -12368.0, -3, 10 ), -12368.0, 'returns expected value' );
+	t.end();
+});
+
+tape( 'due to floating-point rounding error, rounding a numeric value can result in unexpected behavior', opts, function test( t ) {
+	var x;
+
+	x = 0.2 + 0.1; // => 0.30000000000000004
+	t.strictEqual( roundb( x, -16, 10 ), 0.3000000000000001, 'equals 0.3000000000000001 and not 0.3' );
+
+	x = 24.616838129811768;
+	t.strictEqual( roundb( x, 2, 7 ), 48.99999999999999, 'equals 48.99999999999999 and not 49' );
+
+	t.end();
+});
+
+tape( 'the function supports rounding a numeric value to a desired number of digits', opts, function test( t ) {
+	t.strictEqual( roundb( PI, 3, 10 ), 0.0, 'returns expected value' );
+	t.strictEqual( roundb( 12368.0, 3, 10 ), 12000.0, 'returns expected value' );
+	t.strictEqual( roundb( 12368.0, 1, 10 ), 12370.0, 'returns expected value' );
+	t.strictEqual( isNegativeZero( roundb( -PI, 3, 10 ) ), true, 'returns expected value' );
+	t.strictEqual( roundb( -12368.0, 3, 10 ), -12000.0, 'returns expected value' );
+	t.strictEqual( roundb( -12368.0, 1, 10 ), -12370.0, 'returns expected value' );
+	t.end();
+});
+
+tape( 'if `x` is too large a double to have decimals and `n < 0`, the input value is returned', opts, function test( t ) {
+	var sign;
+	var exp;
+	var x;
+	var n;
+	var v;
+	var i;
+	for ( i = 0; i < 100; i++ ) {
+		sign = ( randu()<0.5 ) ? -1.0 : 1.0;
+		exp = 54 + round( randu()*254.0 );
+		x = sign * (1.0+randu()) * pow( 10.0, exp );
+		n = -( round( randu()*324.0) );
+		v = roundb( x, n, 10 );
+		t.strictEqual( x, v, ' returns input value when provided x='+x+', n='+n+'.' );
+	}
+	t.end();
+});
+
+tape( 'if `b^n` is too large, the function returns `+-0` (sign preserving)', opts, function test( t ) {
+	var sign;
+	var exp;
+	var x;
+	var n;
+	var v;
+	var i;
+	for ( i = 0; i < 100; i++ ) {
+		sign = ( randu()<0.5 ) ? -1.0 : 1.0;
+		exp = round( randu()*307.0 );
+		x = sign * (1.0+randu()) * pow( 10.0, exp );
+		n = round( randu()*100.0 ) + 309;
+		v = roundb( x, n, 10 );
+		if ( sign === -1.0 ) {
+			t.strictEqual( isNegativeZero( v ), true, ' returns -0 when provided x='+x+', n='+n+'.' );
+		} else {
+			t.strictEqual( isPositiveZero( v ), true, ' returns +0 when provided x='+x+', n='+n+'.' );
+		}
+	}
+	t.end();
+});
+
+tape( 'the function supports rounding very small numbers (including subnormals)', opts, function test( t ) {
+	var expected;
+	var delta;
+	var tol;
+	var x;
+	var n;
+	var v;
+	var i;
+
+	x = 3.1468234343023397 * pow( 10.0, -308 );
+
+	n = [];
+	for ( i = -308; i > -325; i-- ) {
+		n.push( i );
+	}
+	expected = [
+		3e-308,
+		3.1e-308,
+		3.15e-308,
+		3.147e-308,
+		3.1468e-308,
+		3.14682e-308,
+		3.146823e-308,
+		3.1468234e-308,
+		3.14682343e-308,
+		3.146823434e-308,
+		3.1468234343e-308,
+		3.14682343430e-308,
+		3.146823434302e-308,
+		3.1468234343023e-308,
+		3.14682343430234e-308,
+		3.146823434302340e-308,
+		3.1468234343023397e-308
+	];
+
+	for ( i = 0; i < n.length; i++ ) {
+		v = roundb( x, n[i], 10 );
+		if ( v === expected[i] ) {
+			t.strictEqual( v, expected[ i ], 'returns '+expected[i]+' when provided x='+x+' and n='+n[i]+'.' );
+		} else {
+			delta = abs( v - expected[i] );
+			tol = EPS * abs( expected[i] );
+			t.strictEqual( delta <= tol, true, 'x: '+x+'. n: '+n[i]+'. v: '+v+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol );
+		}
+	}
+	t.end();
+});
+
+tape( 'if the function encounters overflow, the function returns the input value', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = 3.1468234343023397;
+	v = roundb( x, -314, 10 );
+	t.strictEqual( v, x, 'returns the input value' );
+
+	x = -3.1468234343023397;
+	v = roundb( x, -314, 10 );
+	t.strictEqual( v, x, 'returns the input value' );
+
+	x = 9007199254740000;
+	v = roundb( x, -300, 10 );
+	t.strictEqual( v, x, 'returns the input value' );
+
+	x = -9007199254740000;
+	v = roundb( x, -300, 10 );
+	t.strictEqual( v, x, 'returns the input value' );
+
+	t.end();
+});
+
+tape( 'if `n = 0`, the function exhibits standard round behavior', opts, function test( t ) {
+	var x;
+	var v;
+	var i;
+
+	for ( i = 0; i < 200; i++ ) {
+		x = (randu()*1000.0) - 500.0;
+		v = roundb( x, 0, 2 );
+		t.strictEqual( v, round( x ), 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'if `b = 1`, the function exhibits standard round behavior', opts, function test( t ) {
+	var x;
+	var v;
+	var i;
+
+	for ( i = 0; i < 200; i++ ) {
+		x = (randu()*1000.0) - 500.0;
+		v = roundb( x, 100, 1 );
+		t.strictEqual( v, round( x ), 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function supports arbitrary rounding', opts, function test( t ) {
+	t.strictEqual( roundb( 5.0, 1, 2 ), 6.0, 'returns expected value' );
+	t.strictEqual( roundb( 38.5, 1, 6 ), 36.0, 'returns expected value' );
+	t.strictEqual( roundb( 0.425, -2, 2 ), 0.5, 'returns expected value' );
+	t.strictEqual( roundb( 60.0, 1, 40.0 ), 80.0, 'returns expected value' );
+	t.strictEqual( roundb( -21.54, -1, 5 ), -21.6, 'returns expected value' );
+	t.strictEqual( roundb( 35.037, -4, 2 ), 35.0625, 'returns expected value' );
+	t.end();
+});
+
+tape( 'if the function overflows, the function returns the input value', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = 12.5;
+	v = roundb( x, -308, 10 );
+	t.strictEqual( v, x, 'returns expected value' );
+
+	x = 12.5;
+	v = roundb( x, -1022, 2 );
+	t.strictEqual( v, x, 'returns expected value' );
+
+	x = 12.5;
+	v = roundb( x, -1074, 2 );
+	t.strictEqual( v, x, 'returns expected value' );
+
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds C implementation for [`math/base/special/roundb`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/@stdlib/math/base/special/roundb).

```c
double stdlib_base_roundb( const double x, const double n, const double b );
```

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves a part of #649.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
