### PR TITLE
feat: add a function for `dii_d` in `math/base/napi/ternary`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/napi/ternary/README.md
+++ b/lib/node_modules/@stdlib/math/base/napi/ternary/README.md
@@ -182,6 +182,45 @@ The function accepts the following arguments:
 void stdlib_math_base_napi_fff_f( napi_env env, napi_callback_info info, float (*fcn)( float, float, float ) );
 ```
 
+#### stdlib_math_base_napi_dii_d( env, info, fcn )
+
+Invokes a ternary function accepting a double precision floating point number and two signed 32-bit integers and returning a double-precision floating-point number.
+
+```c
+#include <node_api.h>
+
+// ...
+
+static double add( const double x, const int32_t y, const int32_t z ) {
+    return x + y + z;
+}
+
+// ...
+
+/**
+* Receives JavaScript callback invocation data.
+*
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @return       Node-API value
+*/
+napi_value addon( napi_env env, napi_callback_info info ) {
+    return stdlib_math_base_napi_dii_d( env, info, add );
+}
+
+// ...
+```
+
+The function accepts the following arguments:
+
+-   **env**: `[in] napi_env` environment under which the function is invoked.
+-   **info**: `[in] napi_callback_info` callback data.
+-   **fcn**: `[in] double (*fcn)( double, int32_t, int32_t )` ternary function.
+
+```c
+void stdlib_math_base_napi_dii_d( napi_env env, napi_callback_info info, double (*fcn)( double, int32_t, int32_t ) );
+```
+
 #### STDLIB_MATH_BASE_NAPI_MODULE_DDD_D( fcn )
 
 Macro for registering a Node-API module exporting an interface for invoking a ternary function accepting and returning double-precision floating-point numbers.
@@ -221,6 +260,27 @@ STDLIB_MATH_BASE_NAPI_MODULE_FFF_F( addf );
 The macro expects the following arguments:
 
 -   **fcn**: `float (*fcn)( float, float, float )` ternary function.
+
+When used, this macro should be used **instead of** `NAPI_MODULE`. The macro includes `NAPI_MODULE`, thus ensuring Node-API module registration.
+
+#### STDLIB_MATH_BASE_NAPI_MODULE_DII_D( fcn )
+
+Macro for registering a Node-API module exporting an interface for invoking a ternary function accepting a double precision floating point number and two signed 32-bit integers and returning a double-precision floating-point number.
+
+```c
+static double add( const double x, const int32_t y, const int32_t z ) {
+    return x + y + z;
+}
+
+// ...
+
+// Register a Node-API module:
+STDLIB_MATH_BASE_NAPI_MODULE_DII_D( add );
+```
+
+The macro expects the following arguments:
+
+-   **fcn**: `double (*fcn)( double, int32_t, int32_t )` ternary function.
 
 When used, this macro should be used **instead of** `NAPI_MODULE`. The macro includes `NAPI_MODULE`, thus ensuring Node-API module registration.
 

--- a/lib/node_modules/@stdlib/math/base/napi/ternary/README.md
+++ b/lib/node_modules/@stdlib/math/base/napi/ternary/README.md
@@ -191,8 +191,8 @@ Invokes a ternary function accepting a double-precision floating-point number an
 
 // ...
 
-static double add( const double x, const int32_t y, const int32_t z ) {
-    return x + y + z;
+static double fcn( const double x, const int32_t y, const int32_t z ) {
+    // ...
 }
 
 // ...
@@ -205,7 +205,7 @@ static double add( const double x, const int32_t y, const int32_t z ) {
 * @return       Node-API value
 */
 napi_value addon( napi_env env, napi_callback_info info ) {
-    return stdlib_math_base_napi_dii_d( env, info, add );
+    return stdlib_math_base_napi_dii_d( env, info, fcn );
 }
 
 // ...

--- a/lib/node_modules/@stdlib/math/base/napi/ternary/README.md
+++ b/lib/node_modules/@stdlib/math/base/napi/ternary/README.md
@@ -188,6 +188,7 @@ Invokes a ternary function accepting a double-precision floating-point number an
 
 ```c
 #include <node_api.h>
+#include <stdint.h>
 
 // ...
 
@@ -268,6 +269,8 @@ When used, this macro should be used **instead of** `NAPI_MODULE`. The macro inc
 Macro for registering a Node-API module exporting an interface for invoking a ternary function accepting a double-precision floating-point number and two signed 32-bit integers and returning a double-precision floating-point number.
 
 ```c
+#include <stdint.h>
+
 static double fcn( const double x, const int32_t y, const int32_t z ) {
     // ...
 }

--- a/lib/node_modules/@stdlib/math/base/napi/ternary/README.md
+++ b/lib/node_modules/@stdlib/math/base/napi/ternary/README.md
@@ -268,14 +268,14 @@ When used, this macro should be used **instead of** `NAPI_MODULE`. The macro inc
 Macro for registering a Node-API module exporting an interface for invoking a ternary function accepting a double precision floating point number and two signed 32-bit integers and returning a double-precision floating-point number.
 
 ```c
-static double add( const double x, const int32_t y, const int32_t z ) {
-    return x + y + z;
+static double fcn( const double x, const int32_t y, const int32_t z ) {
+    // ...
 }
 
 // ...
 
 // Register a Node-API module:
-STDLIB_MATH_BASE_NAPI_MODULE_DII_D( add );
+STDLIB_MATH_BASE_NAPI_MODULE_DII_D( fcn );
 ```
 
 The macro expects the following arguments:

--- a/lib/node_modules/@stdlib/math/base/napi/ternary/README.md
+++ b/lib/node_modules/@stdlib/math/base/napi/ternary/README.md
@@ -184,7 +184,7 @@ void stdlib_math_base_napi_fff_f( napi_env env, napi_callback_info info, float (
 
 #### stdlib_math_base_napi_dii_d( env, info, fcn )
 
-Invokes a ternary function accepting a double precision floating point number and two signed 32-bit integers and returning a double-precision floating-point number.
+Invokes a ternary function accepting a double-precision floating-point number and two signed 32-bit integers and returning a double-precision floating-point number.
 
 ```c
 #include <node_api.h>

--- a/lib/node_modules/@stdlib/math/base/napi/ternary/README.md
+++ b/lib/node_modules/@stdlib/math/base/napi/ternary/README.md
@@ -265,7 +265,7 @@ When used, this macro should be used **instead of** `NAPI_MODULE`. The macro inc
 
 #### STDLIB_MATH_BASE_NAPI_MODULE_DII_D( fcn )
 
-Macro for registering a Node-API module exporting an interface for invoking a ternary function accepting a double precision floating point number and two signed 32-bit integers and returning a double-precision floating-point number.
+Macro for registering a Node-API module exporting an interface for invoking a ternary function accepting a double-precision floating-point number and two signed 32-bit integers and returning a double-precision floating-point number.
 
 ```c
 static double fcn( const double x, const int32_t y, const int32_t z ) {

--- a/lib/node_modules/@stdlib/math/base/napi/ternary/include/stdlib/math/base/napi/ternary.h
+++ b/lib/node_modules/@stdlib/math/base/napi/ternary/include/stdlib/math/base/napi/ternary.h
@@ -102,6 +102,48 @@
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_fff_f_init )
 
+/**
+* Macro for registering a Node-API module exporting an interface invoking a ternary function accepting a double precision floating point number and two signed 32-bit integers and returning a double-precision floating-point number.
+*
+* @param fcn   ternary function
+*
+* @example
+* #include <stdint.h>
+*
+* static double add( const double x, const int_32 y, const int_32 z ) {
+*     return x + y + z;
+* }
+*
+* // ...
+*
+* // Register a Node-API module:
+* STDLIB_MATH_BASE_NAPI_MODULE_DII_D( add );
+*/
+#define STDLIB_MATH_BASE_NAPI_MODULE_DII_D( fcn )                              \
+	static napi_value stdlib_math_base_napi_dii_d_wrapper(                     \
+		napi_env env,                                                          \
+		napi_callback_info info                                                \
+	) {                                                                        \
+		return stdlib_math_base_napi_dii_d( env, info, fcn );                  \
+	};                                                                         \
+	static napi_value stdlib_math_base_napi_dii_d_init(                        \
+		napi_env env,                                                          \
+		napi_value exports                                                     \
+	) {                                                                        \
+		napi_value fcn;                                                        \
+		napi_status status = napi_create_function(                             \
+			env,                                                               \
+			"exports",                                                         \
+			NAPI_AUTO_LENGTH,                                                  \
+			stdlib_math_base_napi_dii_d_wrapper,                               \
+			NULL,                                                              \
+			&fcn                                                               \
+		);                                                                     \
+		assert( status == napi_ok );                                           \
+		return fcn;                                                            \
+	};                                                                         \
+	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_dii_d_init )
+
 /*
 * If C++, prevent name mangling so that the compiler emits a ternary file having undecorated names, thus mirroring the behavior of a C compiler.
 */
@@ -118,6 +160,11 @@ napi_value stdlib_math_base_napi_ddd_d( napi_env env, napi_callback_info info, d
 * Invokes a ternary function accepting and returning single-precision floating-point numbers.
 */
 napi_value stdlib_math_base_napi_fff_f( napi_env env, napi_callback_info info, float (*fcn)( float, float, float ) );
+
+/**
+* Invokes a ternary function accepting a double precision floating point number and two signed 32-bit integers and returning a double-precision floating-point number.
+*/
+napi_value stdlib_math_base_napi_dii_d( napi_env env, napi_callback_info info, double (*fcn)( double, int32_t, int32_t ) );
 
 #ifdef __cplusplus
 }

--- a/lib/node_modules/@stdlib/math/base/napi/ternary/include/stdlib/math/base/napi/ternary.h
+++ b/lib/node_modules/@stdlib/math/base/napi/ternary/include/stdlib/math/base/napi/ternary.h
@@ -103,21 +103,21 @@
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_fff_f_init )
 
 /**
-* Macro for registering a Node-API module exporting an interface invoking a ternary function accepting a double precision floating point number and two signed 32-bit integers and returning a double-precision floating-point number.
+* Macro for registering a Node-API module exporting an interface invoking a ternary function accepting a double-precision floating-point number and two signed 32-bit integers and returning a double-precision floating-point number.
 *
 * @param fcn   ternary function
 *
 * @example
 * #include <stdint.h>
 *
-* static double add( const double x, const int_32 y, const int_32 z ) {
-*     return x + y + z;
+* static double fcn( const double x, const int_32 y, const int_32 z ) {
+*     // ...
 * }
 *
 * // ...
 *
 * // Register a Node-API module:
-* STDLIB_MATH_BASE_NAPI_MODULE_DII_D( add );
+* STDLIB_MATH_BASE_NAPI_MODULE_DII_D( fcn );
 */
 #define STDLIB_MATH_BASE_NAPI_MODULE_DII_D( fcn )                              \
 	static napi_value stdlib_math_base_napi_dii_d_wrapper(                     \
@@ -162,7 +162,7 @@ napi_value stdlib_math_base_napi_ddd_d( napi_env env, napi_callback_info info, d
 napi_value stdlib_math_base_napi_fff_f( napi_env env, napi_callback_info info, float (*fcn)( float, float, float ) );
 
 /**
-* Invokes a ternary function accepting a double precision floating point number and two signed 32-bit integers and returning a double-precision floating-point number.
+* Invokes a ternary function accepting a double-precision floating-point number and two signed 32-bit integers and returning a double-precision floating-point number.
 */
 napi_value stdlib_math_base_napi_dii_d( napi_env env, napi_callback_info info, double (*fcn)( double, int32_t, int32_t ) );
 

--- a/lib/node_modules/@stdlib/math/base/napi/ternary/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/napi/ternary/src/main.c
@@ -174,7 +174,7 @@ napi_value stdlib_math_base_napi_fff_f( napi_env env, napi_callback_info info, f
 }
 
 /**
-* Invokes a ternary function accepting a double precision floating point number and two signed 32-bit integers and returning a double-precision floating-point number.
+* Invokes a ternary function accepting a double-precision floating-point number and two signed 32-bit integers and returning a double-precision floating-point number.
 *
 * ## Notes
 *

--- a/lib/node_modules/@stdlib/math/base/napi/ternary/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/napi/ternary/src/main.c
@@ -172,3 +172,79 @@ napi_value stdlib_math_base_napi_fff_f( napi_env env, napi_callback_info info, f
 
 	return v;
 }
+
+/**
+* Invokes a ternary function accepting a double precision floating point number and two signed 32-bit integers and returning a double-precision floating-point number.
+*
+* ## Notes
+*
+* -   This function expects that the callback `info` argument provides access to the following JavaScript arguments:
+*
+*     -   `x`: input value.
+*     -   `y`: input value.
+*     -   `z`: input value.
+*
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @param fcn    ternary function
+* @return       function return value as a Node-API double-precision floating-point number
+*/
+napi_value stdlib_math_base_napi_dii_d( napi_env env, napi_callback_info info, double (*fcn)( double, int32_t, int32_t ) ) {
+	napi_status status;
+
+	size_t argc = 3;
+	napi_value argv[ 3 ];
+	status = napi_get_cb_info( env, info, &argc, argv, NULL, NULL );
+	assert( status == napi_ok );
+
+	if ( argc < 3 ) {
+		status = napi_throw_error( env, NULL, "invalid invocation. Must provide three numbers." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	napi_valuetype vtype0;
+	status = napi_typeof( env, argv[ 0 ], &vtype0 );
+	assert( status == napi_ok );
+	if ( vtype0 != napi_number ) {
+		status = napi_throw_type_error( env, NULL, "invalid argument. First argument must be a number." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	napi_valuetype vtype1;
+	status = napi_typeof( env, argv[ 1 ], &vtype1 );
+	assert( status == napi_ok );
+	if ( vtype1 != napi_number ) {
+		status = napi_throw_type_error( env, NULL, "invalid argument. Second argument must be a number." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	napi_valuetype vtype2;
+	status = napi_typeof( env, argv[ 2 ], &vtype2 );
+	assert( status == napi_ok );
+	if ( vtype2 != napi_number ) {
+		status = napi_throw_type_error( env, NULL, "invalid argument. Third argument must be a number." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	double x;
+	status = napi_get_value_double( env, argv[ 0 ], &x );
+	assert( status == napi_ok );
+
+	int32_t y;
+	status = napi_get_value_int32_t( env, argv[ 1 ], &y );
+	assert( status == napi_ok );
+
+	int32_t z;
+	status = napi_get_value_int32_t( env, argv[ 2 ], &z );
+	assert( status == napi_ok );
+
+	napi_value v;
+	status = napi_create_double( env, fcn( x, y, z ), &v );
+	assert( status == napi_ok );
+
+	return v;
+}

--- a/lib/node_modules/@stdlib/math/base/napi/ternary/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/napi/ternary/src/main.c
@@ -235,11 +235,11 @@ napi_value stdlib_math_base_napi_dii_d( napi_env env, napi_callback_info info, d
 	assert( status == napi_ok );
 
 	int32_t y;
-	status = napi_get_value_int32_t( env, argv[ 1 ], &y );
+	status = napi_get_value_int32( env, argv[ 1 ], &y );
 	assert( status == napi_ok );
 
 	int32_t z;
-	status = napi_get_value_int32_t( env, argv[ 2 ], &z );
+	status = napi_get_value_int32( env, argv[ 2 ], &z );
 	assert( status == napi_ok );
 
 	napi_value v;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds the function `napi_value stdlib_math_base_napi_dii_d( napi_env env, napi_callback_info info, double (*fcn)( double, int32_t, int32_t ) )` in [`math/base/napi/ternary`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/@stdlib/math/base/napi/ternary).
-   is a pre-requisite for #2544.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
