### PR TITLE
feat: add boolean dtype support to `ndarray/min-dtype`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/min-dtype/README.md
+++ b/lib/node_modules/@stdlib/ndarray/min-dtype/README.md
@@ -68,7 +68,7 @@ dt = minDataType( '3' );
 
 ## Notes
 
--   The function does **not** provide precision guarantees for non-integer-valued real numbers. In other words, the function returns the smallest possible floating-point (i.e., inexact) [data type][@stdlib/ndarray/dtypes] for storing numbers having decimals.
+-   The function does **not** provide precision guarantees for non-integer-valued numbers. In other words, the function returns the smallest possible floating-point (i.e., inexact) [data type][@stdlib/ndarray/dtypes] for storing numbers having decimals.
 
 </section>
 

--- a/lib/node_modules/@stdlib/ndarray/min-dtype/docs/repl.txt
+++ b/lib/node_modules/@stdlib/ndarray/min-dtype/docs/repl.txt
@@ -4,7 +4,7 @@
     storing a provided scalar value.
 
     The function does *not* provide precision guarantees for non-integer-valued
-    real numbers. In other words, the function returns the smallest possible
+    numbers. In other words, the function returns the smallest possible
     floating-point (i.e., inexact) data type for storing numbers having
     decimals.
 

--- a/lib/node_modules/@stdlib/ndarray/min-dtype/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/min-dtype/lib/main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
 var isInteger = require( '@stdlib/math/base/assert/is-integer' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 var isComplexLike = require( '@stdlib/assert/is-complex-like' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var FLOAT32_SMALLEST_SUBNORMAL = require( '@stdlib/constants/float32/smallest-subnormal' ); // eslint-disable-line id-length
@@ -84,6 +85,9 @@ function minFloatDataType( value ) {
 * // returns 'uint8'
 */
 function minDataType( value ) {
+	if ( isBoolean( value ) ) {
+		return 'bool';
+	}
 	if ( typeof value !== 'number' ) {
 		if ( isComplexLike( value ) ) {
 			if ( minFloatDataType( value.re ) === 'float64' || minFloatDataType( value.im ) === 'float64' ) {

--- a/lib/node_modules/@stdlib/ndarray/min-dtype/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/min-dtype/lib/main.js
@@ -20,10 +20,11 @@
 
 // MODULES //
 
+var isNumber = require( '@stdlib/assert/is-number' ).isPrimitive;
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var isInteger = require( '@stdlib/math/base/assert/is-integer' );
 var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
 var isComplexLike = require( '@stdlib/assert/is-complex-like' );
-var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var FLOAT32_SMALLEST_SUBNORMAL = require( '@stdlib/constants/float32/smallest-subnormal' ); // eslint-disable-line id-length
@@ -85,10 +86,10 @@ function minFloatDataType( value ) {
 * // returns 'uint8'
 */
 function minDataType( value ) {
-	if ( isBoolean( value ) ) {
-		return 'bool';
-	}
-	if ( typeof value !== 'number' ) {
+	if ( !isNumber( value ) ) {
+		if ( isBoolean( value ) ) {
+			return 'bool';
+		}
 		if ( isComplexLike( value ) ) {
 			if ( minFloatDataType( value.re ) === 'float64' || minFloatDataType( value.im ) === 'float64' ) {
 				return 'complex128';

--- a/lib/node_modules/@stdlib/ndarray/min-dtype/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/min-dtype/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -177,8 +177,8 @@ tape( 'the function returns the minimum ndarray data type of the closest "kind" 
 		'float32',
 		'generic',
 		'generic',
-		'generic',
-		'generic',
+		'bool',
+		'bool',
 		'generic',
 		'complex64',
 		'complex64',


### PR DESCRIPTION
Resolves: Subtask of #2547 

## Description

> What is the purpose of this pull request?

This pull request:

- This PR will add boolean datatype support in `ndarray/min-dtype`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
