### PR TITLE
feat: add boolean dtype support to `ndarray/mostly-safe-casts`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/mostly-safe-casts/lib/data.json
+++ b/lib/node_modules/@stdlib/ndarray/mostly-safe-casts/lib/data.json
@@ -220,7 +220,7 @@
 		"complex128": 0,
 		"complex64": 0,
 		"binary": 0,
-		"generic": 0,
+		"generic": 1,
 		"bool": 1
 	}
 }

--- a/lib/node_modules/@stdlib/ndarray/mostly-safe-casts/lib/data.json
+++ b/lib/node_modules/@stdlib/ndarray/mostly-safe-casts/lib/data.json
@@ -12,7 +12,8 @@
 		"complex128": 1,
 		"complex64": 1,
 		"binary": 0,
-		"generic": 1
+		"generic": 1,
+		"bool": 0
 	},
 	"float32": {
 		"float64": 1,
@@ -27,7 +28,8 @@
 		"complex128": 1,
 		"complex64": 1,
 		"binary": 0,
-		"generic": 1
+		"generic": 1,
+		"bool": 0
 	},
 	"int32": {
 		"float64": 1,
@@ -42,7 +44,8 @@
 		"complex128": 1,
 		"complex64": 0,
 		"binary": 0,
-		"generic": 1
+		"generic": 1,
+		"bool": 0
 	},
 	"int16": {
 		"float64": 1,
@@ -57,7 +60,8 @@
 		"complex128": 1,
 		"complex64": 1,
 		"binary": 0,
-		"generic": 1
+		"generic": 1,
+		"bool": 0
 	},
 	"int8": {
 		"float64": 1,
@@ -72,7 +76,8 @@
 		"complex128": 1,
 		"complex64": 1,
 		"binary": 0,
-		"generic": 1
+		"generic": 1,
+		"bool": 0
 	},
 	"uint32": {
 		"float64": 1,
@@ -87,7 +92,8 @@
 		"complex128": 1,
 		"complex64": 0,
 		"binary": 0,
-		"generic": 1
+		"generic": 1,
+		"bool": 0
 	},
 	"uint16": {
 		"float64": 1,
@@ -102,7 +108,8 @@
 		"complex128": 1,
 		"complex64": 1,
 		"binary": 0,
-		"generic": 1
+		"generic": 1,
+		"bool": 0
 	},
 	"uint8": {
 		"float64": 1,
@@ -117,7 +124,8 @@
 		"complex128": 1,
 		"complex64": 1,
 		"binary": 0,
-		"generic": 1
+		"generic": 1,
+		"bool": 0
 	},
 	"uint8c": {
 		"float64": 1,
@@ -132,7 +140,8 @@
 		"complex128": 1,
 		"complex64": 1,
 		"binary": 0,
-		"generic": 1
+		"generic": 1,
+		"bool": 0
 	},
 	"complex128": {
 		"float64": 0,
@@ -147,7 +156,8 @@
 		"complex128": 1,
 		"complex64": 1,
 		"binary": 0,
-		"generic": 1
+		"generic": 1,
+		"bool": 0
 	},
 	"complex64": {
 		"float64": 0,
@@ -162,7 +172,8 @@
 		"complex128": 1,
 		"complex64": 1,
 		"binary": 0,
-		"generic": 1
+		"generic": 1,
+		"bool": 0
 	},
 	"generic": {
 		"float64": 0,
@@ -177,7 +188,8 @@
 		"complex128": 0,
 		"complex64": 0,
 		"binary": 0,
-		"generic": 1
+		"generic": 1,
+		"bool": 0
 	},
 	"binary": {
 		"float64": 0,
@@ -192,6 +204,23 @@
 		"complex128": 0,
 		"complex64": 0,
 		"binary": 1,
-		"generic": 0
+		"generic": 0,
+		"bool": 0
+	},
+	"bool": {
+		"float64": 0,
+		"float32": 0,
+		"int32": 0,
+		"int16": 0,
+		"int8": 0,
+		"uint32": 0,
+		"uint16": 0,
+		"uint8": 0,
+		"uint8c": 0,
+		"complex128": 0,
+		"complex64": 0,
+		"binary": 0,
+		"generic": 0,
+		"bool": 1
 	}
 }


### PR DESCRIPTION
Resolves: Subtask of #2547 

## Description

> What is the purpose of this pull request?

This pull request:

- This PR will add boolean datatype support in `ndarray/mostly-safe-casts`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
