### PR TITLE
feat: add `join` and `toString` methods to `array/bool`

### DIFF
--- a/lib/node_modules/@stdlib/array/bool/README.md
+++ b/lib/node_modules/@stdlib/array/bool/README.md
@@ -680,6 +680,36 @@ var idx = arr.indexOf( false );
 // returns -1
 ```
 
+<a name="join"></a>
+
+#### BooleanArray.prototype.join( \[separator] )
+
+Returns a new string by concatenating all array elements.
+
+```javascript
+var arr = new BooleanArray( 3 );
+
+arr.set( true, 0 );
+arr.set( false, 1 );
+arr.set( true, 2 );
+
+var str = arr.join();
+// returns 'true,false,true'
+```
+
+By default, the method separates serialized array elements with a comma. To use an alternative separator, provide a `separator` string.
+
+```javascript
+var arr = new BooleanArray( 3 );
+
+arr.set( true, 0 );
+arr.set( false, 1 );
+arr.set( true, 2 );
+
+var str = arr.join( '|' );
+// returns 'true|false|true'
+```
+
 <a name="method-last-index-of"></a>
 
 #### BooleanArray.prototype.lastIndexOf( searchElement\[, fromIndex] )
@@ -829,7 +859,7 @@ var out = arr.reduce( reducer, 0 );
 
 <a name="method-reduce-right"></a>
 
-#### Complex64Array.prototype.reduceRight( reducerFn\[, initialValue] )
+#### BooleanArray.prototype.reduceRight( reducerFn\[, initialValue] )
 
 Applies a provided callback function to each element of the array, in reverse order, passing in the return value from the calculation on the following element and returning the accumulated result upon completion.
 
@@ -1289,6 +1319,23 @@ The function should return a number where:
 -   a negative value indicates that `a` should come before `b`.
 -   a positive value indicates that `a` should come after `b`.
 -   zero or `NaN` indicates that `a` and `b` are considered equal.
+
+<a name="method-to-string"></a>
+
+#### BooleanArray.prototype.toString()
+
+Serializes an array as a string.
+
+```javascript
+var arr = new BooleanArray( 3 );
+
+arr.set( true, 0 );
+arr.set( false, 1 );
+arr.set( true, 2 );
+
+var str = arr.toString();
+// returns 'true,false,true'
+```
 
 </section>
 

--- a/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.join.js
+++ b/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.join.js
@@ -1,0 +1,50 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pkg = require( './../package.json' ).name;
+var BooleanArray = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg+':join', function benchmark( b ) {
+	var out;
+	var arr;
+	var i;
+
+	arr = new BooleanArray( [ true, false, false, true ] );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = arr.join();
+		if ( typeof out !== 'string' ) {
+			b.fail( 'should return a string' );
+		}
+	}
+	b.toc();
+	if ( typeof out !== 'string' ) {
+		b.fail( 'should return a string' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.join.length.js
+++ b/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.join.length.js
@@ -1,0 +1,102 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var Boolean = require( '@stdlib/boolean/ctor' );
+var pkg = require( './../package.json' ).name;
+var BooleanArray = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var arr;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < len; i++ ) {
+		arr.push( Boolean( i%2 ) );
+	}
+	arr = new BooleanArray( arr );
+
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var out;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			out = arr.join( '/' );
+			if ( typeof out !== 'string' ) {
+				b.fail( 'should return a string' );
+			}
+		}
+		b.toc();
+		if ( typeof out !== 'string' ) {
+			b.fail( 'should return a string' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':join:len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.to_string.js
+++ b/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.to_string.js
@@ -1,0 +1,50 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pkg = require( './../package.json' ).name;
+var BooleanArray = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg+':toString', function benchmark( b ) {
+	var out;
+	var arr;
+	var i;
+
+	arr = new BooleanArray( [ true, false, false, true ] );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = arr.toString();
+		if ( typeof out !== 'string' ) {
+			b.fail( 'should return a string' );
+		}
+	}
+	b.toc();
+	if ( typeof out !== 'string' ) {
+		b.fail( 'should return a string' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.to_string.length.js
+++ b/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.to_string.length.js
@@ -1,0 +1,102 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var Boolean = require( '@stdlib/boolean/ctor' );
+var pkg = require( './../package.json' ).name;
+var BooleanArray = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var arr;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < len; i++ ) {
+		arr.push( Boolean( i%2 ) );
+	}
+	arr = new BooleanArray( arr );
+
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var out;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			out = arr.toString();
+			if ( typeof out !== 'string' ) {
+				b.fail( 'should return a string' );
+			}
+		}
+		b.toc();
+		if ( typeof out !== 'string' ) {
+			b.fail( 'should return a string' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':toString:len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/bool/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/bool/docs/repl.txt
@@ -542,6 +542,30 @@
     -1
 
 
+{{alias}}.prototype.join( [separator] )
+    Returns a new string by concatenating all array elements separated by a
+    separator string.
+
+    Parameters
+    ----------
+    separator: string (optional)
+        Separator string. Default: ','.
+
+    Returns
+    -------
+    out: string
+        Array serialized as a string.
+
+    Examples
+    --------
+    > var arr = new {{alias}}( [ true, false, true ] )
+    <BooleanArray>
+    > var str = arr.join()
+    'true,false,true'
+    > str = arr.join( '|' )
+    'true|false|true'
+
+
 {{alias}}.prototype.lastIndexOf( searchElement[, fromIndex] )
     Returns the last index at which a given element can be found.
 
@@ -941,6 +965,22 @@
     true
     > v = out.get( 2 )
     false
+
+
+{{alias}}.prototype.toString()
+    Serializes an array as a string.
+
+    Returns
+    -------
+    out: string
+        String serialization of the array.
+
+    Examples
+    --------
+    > var arr = new {{alias}}( [ true, false, true ] )
+    <BooleanArray>
+    > var str = arr.toString()
+    'true,false,true'
 
 
     See Also

--- a/lib/node_modules/@stdlib/array/bool/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/bool/docs/types/index.d.ts
@@ -512,6 +512,27 @@ declare class BooleanArray implements BooleanArrayInterface {
 	indexOf( searchElement: boolean, fromIndex?: number ): number;
 
 	/**
+	* Returns a new string by concatenating all array elements.
+	*
+	* @param separator - value separator (default: ',')
+	* @returns string
+	*
+	* @example
+	* var arr = new BooleanArray( 3 );
+	*
+	* arr.set( true, 0 );
+	* arr.set( false, 1 );
+	* arr.set( true, 2 );
+	*
+	* var str = arr.join();
+	* // returns 'true,false,true'
+	*
+	* str = arr.join( '|' );
+	* // returns 'true|false|true'
+	*/
+	join( separator?: string ): string;
+
+	/**
 	* Returns the last index at which a given element can be found.
 	*
 	* @param searchElement - element to find
@@ -904,6 +925,23 @@ declare class BooleanArray implements BooleanArrayInterface {
 	* // returns false
 	*/
 	toSorted( compareFcn: CompareFcn ): BooleanArray;
+
+	/**
+	* Serializes an array as a string.
+	*
+	* @returns string
+	*
+	* @example
+	* var arr = new BooleanArray( 3 );
+	*
+	* arr.set( true, 0 );
+	* arr.set( false, 1 );
+	* arr.set( true, 2 );
+	*
+	* var str = arr.toString();
+	* // returns 'true,false,true'
+	*/
+	toString(): string;
 }
 
 /**

--- a/lib/node_modules/@stdlib/array/bool/lib/main.js
+++ b/lib/node_modules/@stdlib/array/bool/lib/main.js
@@ -29,6 +29,7 @@ var isObject = require( '@stdlib/assert/is-object' );
 var isFunction = require( '@stdlib/assert/is-function' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
+var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
 var hasIteratorSymbolSupport = require( '@stdlib/assert/has-iterator-symbol-support' );
 var ITERATOR_SYMBOL = require( '@stdlib/symbol/iterator' );
 var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
@@ -841,6 +842,57 @@ setReadOnly( BooleanArray.prototype, 'indexOf', function indexOf( searchElement,
 		}
 	}
 	return -1;
+});
+
+/**
+* Returns a new string by concatenating all array elements.
+*
+* @name join
+* @memberof BooleanArray.prototype
+* @type {Function}
+* @param {string} [separator=','] - element separator
+* @throws {TypeError} `this` must be a boolean array
+* @throws {TypeError} first argument must be a string
+* @returns {string} string representation
+*
+* @example
+* var arr = new BooleanArray( 3 );
+*
+* arr.set( true, 0 );
+* arr.set( false, 1 );
+* arr.set( true, 2 );
+*
+* var str = arr.join();
+* // returns 'true,false,true'
+*
+* str = arr.join( '|' );
+* // returns 'true|false|true'
+*/
+setReadOnly( BooleanArray.prototype, 'join', function join( separator ) {
+	var buf;
+	var out;
+	var i;
+
+	if ( !isBooleanArray( this ) ) {
+		throw new TypeError( 'invalid invocation. `this` is not a boolean array.' );
+	}
+	if ( arguments.length > 0 ) {
+		if ( !isString( separator ) ) {
+			throw new TypeError( format( 'invalid argument. First argument must be a string. Value: `%s`.', separator ) );
+		}
+	} else {
+		separator = ',';
+	}
+	buf = this._buffer;
+	out = [];
+	for ( i = 0; i < this._length; i++ ) {
+		if ( buf[i] ) {
+			out.push( 'true' );
+		} else {
+			out.push( 'false' );
+		}
+	}
+	return out.join( separator );
 });
 
 /**
@@ -1694,6 +1746,44 @@ setReadOnly( BooleanArray.prototype, 'toSorted', function toSorted( compareFcn )
 	function compare( a, b ) {
 		return compareFcn( Boolean( a ), Boolean( b ) );
 	}
+});
+
+/**
+* Serializes an array as a string.
+*
+* @name toString
+* @memberof BooleanArray.prototype
+* @type {Function}
+* @throws {TypeError} `this` must be a boolean array
+* @returns {string} string representation
+*
+* @example
+* var arr = new BooleanArray( 3 );
+*
+* arr.set( true, 0 );
+* arr.set( false, 1 );
+* arr.set( true, 2 );
+*
+* var str = arr.toString();
+* // returns 'true,false,true'
+*/
+setReadOnly( BooleanArray.prototype, 'toString', function toString() {
+	var out;
+	var buf;
+	var i;
+	if ( !isBooleanArray( this ) ) {
+		throw new TypeError( 'invalid invocation. `this` is not a boolean array.' );
+	}
+	out = [];
+	buf = this._buffer;
+	for ( i = 0; i < this._length; i++ ) {
+		if ( buf[i] ) {
+			out.push( 'true' );
+		} else {
+			out.push( 'false' );
+		}
+	}
+	return out.join( ',' );
 });
 
 

--- a/lib/node_modules/@stdlib/array/bool/test/test.join.js
+++ b/lib/node_modules/@stdlib/array/bool/test/test.join.js
@@ -147,7 +147,7 @@ tape( 'the method returns a string representation of a boolean array with elemen
 	t.end();
 });
 
-tape( 'if method invoked without a separator argument, the method returns a string representation of a boolean array with elements separated by a comma', function test( t ) {
+tape( 'if the method is invoked without a separator argument, the method returns a string representation of a boolean array with elements separated by a comma', function test( t ) {
 	var expected;
 	var str;
 	var arr;

--- a/lib/node_modules/@stdlib/array/bool/test/test.join.js
+++ b/lib/node_modules/@stdlib/array/bool/test/test.join.js
@@ -1,0 +1,162 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var BooleanArray = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof BooleanArray, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the main export is a `join` method', function test( t ) {
+	t.strictEqual( hasOwnProp( BooleanArray.prototype, 'join' ), true, 'has property' );
+	t.strictEqual( isFunction( BooleanArray.prototype.join ), true, 'has method' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a boolean array instance', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new BooleanArray( 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.join.call( value );
+		};
+	}
+});
+
+tape( 'the method throws an error if invoked with a `separator` argument which is not a string', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new BooleanArray( 5 );
+
+	values = [
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.join( value );
+		};
+	}
+});
+
+tape( 'the method returns an empty string if invoked on an empty array', function test( t ) {
+	var str;
+	var arr;
+
+	arr = new BooleanArray();
+	str = arr.join();
+
+	t.strictEqual( str, '', 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method returns a string representation of a boolean array with elements separated by a separator', function test( t ) {
+	var expected;
+	var str;
+	var arr;
+
+	arr = new BooleanArray( [ true, false, false, true ] );
+	expected = 'true@false@false@true';
+
+	str = arr.join( '@' );
+
+	t.strictEqual( str, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method returns a string representation of a boolean array with elements separated by a separator (single element)', function test( t ) {
+	var expected;
+	var str;
+	var arr;
+
+	arr = new BooleanArray( [ true ] );
+	expected = 'true';
+
+	str = arr.join();
+
+	t.strictEqual( str, expected, 'returns expected value' );
+
+	arr = new BooleanArray( [ false ] );
+	expected = 'false';
+
+	str = arr.join( '@' );
+
+	t.strictEqual( str, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'if method invoked without a separator argument, the method returns a string representation of a boolean array with elements separated by a comma', function test( t ) {
+	var expected;
+	var str;
+	var arr;
+
+	arr = new BooleanArray( [ true, false, false, true ] );
+	expected = 'true,false,false,true';
+
+	str = arr.join();
+
+	t.strictEqual( str, expected, 'returns expected value' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/array/bool/test/test.to_string.js
+++ b/lib/node_modules/@stdlib/array/bool/test/test.to_string.js
@@ -1,0 +1,97 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var BooleanArray = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof BooleanArray, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the main export is a `toString` method', function test( t ) {
+	t.strictEqual( hasOwnProp( BooleanArray.prototype, 'toString' ), true, 'has property' );
+	t.strictEqual( isFunction( BooleanArray.prototype.toString ), true, 'has method' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a boolean array instance', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new BooleanArray( 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.toString.call( value );
+		};
+	}
+});
+
+tape( 'the method returns an empty string if invoked on an empty array', function test( t ) {
+	var str;
+	var arr;
+
+	arr = new BooleanArray();
+	str = arr.toString();
+
+	t.strictEqual( str, '', 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method returns a string representation of a boolean array', function test( t ) {
+	var expected;
+	var str;
+	var arr;
+
+	arr = new BooleanArray( [ true, false, false, true ] );
+	expected = 'true,false,false,true';
+
+	str = arr.toString();
+
+	t.strictEqual( str, expected, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
Resolves: Subtask of #2304 

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds the typed array `join` and `toString` methods to prototype of `BooleanArray`

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
