### PR TITLE
feat: add boolean dtype support to `ndarray/base/buffer-ctors`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/buffer-ctors/README.md
+++ b/lib/node_modules/@stdlib/ndarray/base/buffer-ctors/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2018 The Stdlib Authors.
+Copyright (c) 2024 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ var ctor = ctors( 'float64' );
 The function returns constructors for the following data types:
 
 -   `binary`: binary.
+-   `bool`: boolean values.
 -   `complex64`: single-precision complex floating-point numbers.
 -   `complex128`: double-precision complex floating-point numbers.
 -   `float32`: single-precision floating-point numbers.

--- a/lib/node_modules/@stdlib/ndarray/base/buffer-ctors/README.md
+++ b/lib/node_modules/@stdlib/ndarray/base/buffer-ctors/README.md
@@ -42,31 +42,14 @@ var ctors = require( '@stdlib/ndarray/base/buffer-ctors' );
 
 #### ctors( dtype )
 
-Returns an ndarray data buffer constructor for a specified data type.
+Returns an ndarray data buffer constructor for a specified [data type][@stdlib/ndarray/dtypes].
 
 ```javascript
 var ctor = ctors( 'float64' );
 // returns <Function>
 ```
 
-The function returns constructors for the following data types:
-
--   `binary`: binary.
--   `bool`: boolean values.
--   `complex64`: single-precision complex floating-point numbers.
--   `complex128`: double-precision complex floating-point numbers.
--   `float32`: single-precision floating-point numbers.
--   `float64`: double-precision floating-point numbers.
--   `generic`: values of any type.
--   `int16`: signed 16-bit integers.
--   `int32`: signed 32-bit integers.
--   `int8`: signed 8-bit integers.
--   `uint16`: unsigned 16-bit integers.
--   `uint32`: unsigned 32-bit integers.
--   `uint8`: unsigned 8-bit integers.
--   `uint8c`: unsigned clamped 8-bit integers.
-
-If provided an unknown or unsupported data type, the function returns `null`.
+If provided an unknown or unsupported [data type][@stdlib/ndarray/dtypes], the function returns `null`.
 
 ```javascript
 var ctor = ctors( 'float' );
@@ -98,9 +81,9 @@ var dtypes = require( '@stdlib/ndarray/dtypes' );
 var ctors = require( '@stdlib/ndarray/base/buffer-ctors' );
 
 var DTYPES = dtypes();
+
 var ctor;
 var i;
-
 for ( i = 0; i < DTYPES.length; i++ ) {
     ctor = ctors( DTYPES[ i ] );
     console.log( ctor );
@@ -130,6 +113,8 @@ for ( i = 0; i < DTYPES.length; i++ ) {
 <!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 
 <section class="links">
+
+[@stdlib/ndarray/dtypes]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/ndarray/dtypes
 
 </section>
 

--- a/lib/node_modules/@stdlib/ndarray/base/buffer-ctors/docs/repl.txt
+++ b/lib/node_modules/@stdlib/ndarray/base/buffer-ctors/docs/repl.txt
@@ -5,6 +5,7 @@
     The function returns constructors for the following data types:
 
     - binary: binary.
+    - bool: boolean values.
     - complex64: single-precision complex floating-point numbers.
     - complex128: double-precision complex floating-point numbers.
     - float32: single-precision floating-point numbers.

--- a/lib/node_modules/@stdlib/ndarray/base/buffer-ctors/docs/repl.txt
+++ b/lib/node_modules/@stdlib/ndarray/base/buffer-ctors/docs/repl.txt
@@ -2,23 +2,6 @@
 {{alias}}( dtype )
     Returns an ndarray data buffer constructor.
 
-    The function returns constructors for the following data types:
-
-    - binary: binary.
-    - bool: boolean values.
-    - complex64: single-precision complex floating-point numbers.
-    - complex128: double-precision complex floating-point numbers.
-    - float32: single-precision floating-point numbers.
-    - float64: double-precision floating-point numbers.
-    - generic: values of any type.
-    - int16: signed 16-bit integers.
-    - int32: signed 32-bit integers.
-    - int8: signed 8-bit integers.
-    - uint16: unsigned 16-bit integers.
-    - uint32: unsigned 32-bit integers.
-    - uint8: unsigned 8-bit integers.
-    - uint8c: unsigned clamped 8-bit integers.
-
     Parameters
     ----------
     dtype: string

--- a/lib/node_modules/@stdlib/ndarray/base/buffer-ctors/examples/index.js
+++ b/lib/node_modules/@stdlib/ndarray/base/buffer-ctors/examples/index.js
@@ -22,9 +22,9 @@ var dtypes = require( '@stdlib/ndarray/dtypes' );
 var ctors = require( './../lib' );
 
 var DTYPES = dtypes();
+
 var ctor;
 var i;
-
 for ( i = 0; i < DTYPES.length; i++ ) {
 	ctor = ctors( DTYPES[ i ] );
 	console.log( ctor );

--- a/lib/node_modules/@stdlib/ndarray/base/buffer-ctors/lib/ctors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/buffer-ctors/lib/ctors.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 
 
 // MAIN //
@@ -50,7 +51,8 @@ var ctors = {
 	'uint8': Uint8Array,
 	'uint8c': Uint8ClampedArray,
 	'complex64': Complex64Array,
-	'complex128': Complex128Array
+	'complex128': Complex128Array,
+	'bool': BooleanArray
 };
 
 

--- a/lib/node_modules/@stdlib/ndarray/base/buffer-ctors/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/base/buffer-ctors/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var isFunction = require( '@stdlib/assert/is-function' );
 var ctors = require( './../lib' );
 
@@ -65,7 +66,8 @@ tape( 'the function returns ndarray data buffer constructors', function test( t 
 		'uint8',
 		'uint8c',
 		'complex64',
-		'complex128'
+		'complex128',
+		'bool'
 	];
 	expected = [
 		Buffer,
@@ -80,7 +82,8 @@ tape( 'the function returns ndarray data buffer constructors', function test( t 
 		Uint8Array,
 		Uint8ClampedArray,
 		Complex64Array,
-		Complex128Array
+		Complex128Array,
+		BooleanArray
 	];
 	for ( i = 0; i < dtypes.length; i++ ) {
 		ctor = ctors( dtypes[ i ] );


### PR DESCRIPTION
Resolves: Subtask of #2547 

## Description

> What is the purpose of this pull request?

This pull request:

- This PR will add boolean datatype support in `ndarray/base/buffer-ctors`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
