### PR TITLE
feat: add boolean dtype support to `ndarray/base/buffer-dtype`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/buffer-dtype/README.md
+++ b/lib/node_modules/@stdlib/ndarray/base/buffer-dtype/README.md
@@ -85,20 +85,17 @@ var bufferCtors = require( '@stdlib/ndarray/base/buffer-ctors' );
 var isFunction = require( '@stdlib/assert/is-function' );
 var dtype = require( '@stdlib/ndarray/base/buffer-dtype' );
 
-var DTYPES;
-var ctor;
-var buf;
-var len;
-var dt;
-var i;
-
 // Get a list of supported ndarray buffer data types:
-DTYPES = dtypes();
+var DTYPES = dtypes();
 
 // Buffer length:
-len = 10;
+var len = 10;
 
 // For each supported data type, create a buffer and confirm its data type...
+var ctor;
+var buf;
+var dt;
+var i;
 for ( i = 0; i < DTYPES.length; i++ ) {
     ctor = bufferCtors( DTYPES[ i ] );
     if ( DTYPES[ i ] === 'binary' && isFunction( ctor.alloc ) ) {

--- a/lib/node_modules/@stdlib/ndarray/base/buffer-dtype/examples/index.js
+++ b/lib/node_modules/@stdlib/ndarray/base/buffer-dtype/examples/index.js
@@ -23,20 +23,17 @@ var bufferCtors = require( '@stdlib/ndarray/base/buffer-ctors' );
 var isFunction = require( '@stdlib/assert/is-function' );
 var dtype = require( './../lib' );
 
-var DTYPES;
-var ctor;
-var buf;
-var len;
-var dt;
-var i;
-
 // Get a list of supported ndarray buffer data types:
-DTYPES = dtypes();
+var DTYPES = dtypes();
 
 // Buffer length:
-len = 10;
+var len = 10;
 
 // For each supported data type, create a buffer and confirm its data type...
+var ctor;
+var buf;
+var dt;
+var i;
 for ( i = 0; i < DTYPES.length; i++ ) {
 	ctor = bufferCtors( DTYPES[ i ] );
 	if ( DTYPES[ i ] === 'binary' && isFunction( ctor.alloc ) ) {

--- a/lib/node_modules/@stdlib/ndarray/base/buffer-dtype/lib/ctor2dtype.js
+++ b/lib/node_modules/@stdlib/ndarray/base/buffer-dtype/lib/ctor2dtype.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -35,7 +35,8 @@ var dtypes = {
 	'Uint8Array': 'uint8',
 	'Uint8ClampedArray': 'uint8c',
 	'Complex64Array': 'complex64',
-	'Complex128Array': 'complex128'
+	'Complex128Array': 'complex128',
+	'BooleanArray': 'bool'
 };
 
 

--- a/lib/node_modules/@stdlib/ndarray/base/buffer-dtype/lib/ctors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/buffer-dtype/lib/ctors.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Int8Array = require( '@stdlib/array/int8' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 
 
 // MAIN //
@@ -47,7 +48,8 @@ var CTORS = [
 	Uint8Array,
 	Uint8ClampedArray,
 	Complex64Array,
-	Complex128Array
+	Complex128Array,
+	BooleanArray
 ];
 
 

--- a/lib/node_modules/@stdlib/ndarray/base/buffer-dtype/lib/dtypes.js
+++ b/lib/node_modules/@stdlib/ndarray/base/buffer-dtype/lib/dtypes.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -32,7 +32,8 @@ var DTYPES = [
 	'uint8',
 	'uint8c',
 	'complex64',
-	'complex128'
+	'complex128',
+	'bool'
 ];
 
 


### PR DESCRIPTION
Resolves: Subtask of #2547 

## Description

> What is the purpose of this pull request?

This pull request:

- This PR will add boolean datatype support in `ndarray/base/buffer-dtype`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
