### PR TITLE
docs: update boost version in `math/base/special/digamma`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/digamma/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/digamma/README.md
@@ -141,15 +141,15 @@ for ( i = 0; i < 10; i++ ) {
 #include "stdlib/math/base/special/digamma.h"
 ```
 
-#### digamma( x )
+#### stdlib_base_digamma( x )
 
 Evaluates the [digamma function][digamma-function].
 
 ```c
-double out = digamma( -2.5 );
+double out = stdlib_base_digamma( -2.5 );
 // returns ~1.103
 
-out = digamma( 1.0 );
+out = stdlib_base_digamma( 1.0 );
 // returns ~-0.577
 ```
 
@@ -158,7 +158,7 @@ The function accepts the following arguments:
 -   **x**: `[in] double` input value.
 
 ```c
-double digamma( const double x );
+double stdlib_base_digamma( const double x );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/digamma/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/digamma/lib/main.js
@@ -18,7 +18,7 @@
 *
 * ## Notice
 *
-* The original C++ code and copyright notice are from the [Boost library]{@link http://www.boost.org/doc/libs/1_53_0/libs/math/doc/sf_and_dist/html/math_toolkit/special/sf_gamma/digamma.html}. The implementation follows the original but has been modified for JavaScript.
+* The original C++ code and copyright notice are from the [Boost library]{@link https://www.boost.org/doc/libs/1_85_0/boost/math/special_functions/digamma.hpp}. The implementation follows the original but has been modified for JavaScript.
 *
 * ```text
 * (C) Copyright John Maddock 2006.

--- a/lib/node_modules/@stdlib/math/base/special/digamma/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/digamma/lib/main.js
@@ -18,7 +18,7 @@
 *
 * ## Notice
 *
-* The original C++ code and copyright notice are from the [Boost library]{@link https://www.boost.org/doc/libs/1_85_0/boost/math/special_functions/digamma.hpp}. The implementation follows the original but has been modified for JavaScript.
+* The original C++ code and copyright notice are from the [Boost library]{@link http://www.boost.org/doc/libs/1_53_0/libs/math/doc/sf_and_dist/html/math_toolkit/special/sf_gamma/digamma.html}. The implementation follows the original but has been modified for JavaScript.
 *
 * ```text
 * (C) Copyright John Maddock 2006.

--- a/lib/node_modules/@stdlib/math/base/special/digamma/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/digamma/src/main.c
@@ -18,7 +18,7 @@
 *
 * ## Notice
 *
-* The original C++ code and copyright notice are from the [Boost library]{@link http://www.boost.org/doc/libs/1_53_0/libs/math/doc/sf_and_dist/html/math_toolkit/special/sf_gamma/digamma.html}. The implementation follows the original but has been modified for JavaScript.
+* The original C++ code and copyright notice are from the [Boost library]{@link https://www.boost.org/doc/libs/1_85_0/boost/math/special_functions/digamma.hpp}. The implementation follows the original but has been modified for JavaScript.
 *
 * ```text
 * (C) Copyright John Maddock 2006.

--- a/lib/node_modules/@stdlib/math/base/special/digamma/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/digamma/src/main.c
@@ -62,7 +62,9 @@ static double polyval_p( const double x ) {
 	return 0.08333333333333333 + (x * (-0.008333333333333333 + (x * (0.003968253968253968 + (x * (-0.004166666666666667 + (x * (0.007575757575757576 + (x * (-0.021092796092796094 + (x * (0.08333333333333333 + (x * -0.4432598039215686)))))))))))));
 }
 
-// END: polyval_p// BEGIN: rational_pq
+// END: polyval_p
+
+// BEGIN: rational_pq
 
 /**
 * Evaluates a rational function (i.e., the ratio of two polynomials described by the coefficients stored in \\(P\\) and \\(Q\\)).
@@ -111,7 +113,7 @@ static double rational_pq( const double x ) {
 * @param x    input value
 * @returns    function value
 */
-double asymptoticApprox( const double x ) {
+static double asymptoticApprox( const double x ) {
 	double y;
 	double z;
 	double xc;
@@ -129,7 +131,7 @@ double asymptoticApprox( const double x ) {
 * @param x    input value
 * @returns    function value
 */
-double rationalApprox( const double x ) {
+static double rationalApprox( const double x ) {
 	double g;
 	double r;
 

--- a/lib/node_modules/@stdlib/math/base/special/digamma/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/digamma/src/main.c
@@ -18,7 +18,7 @@
 *
 * ## Notice
 *
-* The original C++ code and copyright notice are from the [Boost library]{@link https://www.boost.org/doc/libs/1_85_0/boost/math/special_functions/digamma.hpp}. The implementation follows the original but has been modified for JavaScript.
+* The original C++ code and copyright notice are from the [Boost library]{@link http://www.boost.org/doc/libs/1_53_0/libs/math/doc/sf_and_dist/html/math_toolkit/special/sf_gamma/digamma.html}. The implementation follows the original but has been modified for JavaScript.
 *
 * ```text
 * (C) Copyright John Maddock 2006.


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   addresses the changes discussed in https://github.com/stdlib-js/stdlib/pull/2533.
-   updates `boost` link in `main.c` and `main.js`, in [`math/base/special/digamma`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/digamma), from [`1.53`](https://www.boost.org/doc/libs/1_53_0/boost/math/special_functions/digamma.hpp) to [`1.85`](https://www.boost.org/doc/libs/1_85_0/boost/math/special_functions/digamma.hpp). 
-   earlier we had the link to the documentation of the implementation, I have replaced it with the link to the actual implementation of the latest version.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

I checked out both the implementations, but couldn't find any change, instead of some documentation changes. The function `digamma_imp(T x, const Tag* t, const Policy& pol)` is the same in both of them.

- `1.53`: https://www.boost.org/doc/libs/1_53_0/boost/math/special_functions/digamma.hpp
- `1.85`: https://www.boost.org/doc/libs/1_85_0/boost/math/special_functions/digamma.hpp

I might be mistaken regarding this, but it would be great if you can also have a look at it once, if there are any significant changes, as `boost` implementations are quite confusing.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
