### PR TITLE
feat: add boolean dtype support to `ndarray/empty*` and `ndarray/base/empty*` packages

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/empty-like/README.md
+++ b/lib/node_modules/@stdlib/ndarray/base/empty-like/README.md
@@ -85,7 +85,7 @@ var sh = y.shape;
 
 ```javascript
 var dtypes = require( '@stdlib/ndarray/dtypes' );
-var zeros = require( '@stdlib/ndarray/base/zeros' );
+var empty = require( '@stdlib/ndarray/base/empty' );
 var emptyLike = require( '@stdlib/ndarray/base/empty-like' );
 
 // Get a list of data types:
@@ -96,7 +96,7 @@ var x;
 var y;
 var i;
 for ( i = 0; i < dt.length; i++ ) {
-    x = zeros( dt[ i ], [ 2, 2 ], 'row-major' );
+    x = empty( dt[ i ], [ 2, 2 ], 'row-major' );
     y = emptyLike( x );
     console.log( y.data );
 }

--- a/lib/node_modules/@stdlib/ndarray/base/empty-like/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/ndarray/base/empty-like/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
 var zeros = require( '@stdlib/ndarray/base/zeros' );
+var empty = require( '@stdlib/ndarray/base/empty' );
 var pkg = require( './../package.json' ).name;
 var emptyLike = require( './../lib' );
 
@@ -255,6 +256,28 @@ bench( pkg+'::base:dtype=uint8c', function benchmark( b ) {
 	var i;
 
 	x = zeros( 'uint8c', [ 0 ], 'row-major' );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		y = emptyLike( x );
+		if ( y.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !isndarrayLike( y ) ) {
+		b.fail( 'should return an ndarray' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::base:dtype=bool', function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	x = empty( 'bool', [ 0 ], 'row-major' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/ndarray/base/empty-like/benchmark/benchmark.size.bool.js
+++ b/lib/node_modules/@stdlib/ndarray/base/empty-like/benchmark/benchmark.size.bool.js
@@ -1,0 +1,95 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
+var empty = require( '@stdlib/ndarray/base/empty' );
+var pkg = require( './../package.json' ).name;
+var emptyLike = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = empty( 'bool', [ len ], 'row-major' );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var arr;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			arr = emptyLike( x );
+			if ( arr.length !== len ) {
+				b.fail( 'unexpected length' );
+			}
+		}
+		b.toc();
+		if ( !isndarrayLike( arr ) ) {
+			b.fail( 'should return an ndarray' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+'::base:dtype=bool,size='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/ndarray/base/empty-like/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/empty-like/docs/types/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { ndarray, typedndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, complex128ndarray, complex64ndarray, DataType } from '@stdlib/types/ndarray';
+import { typedndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, boolndarray, complex128ndarray, complex64ndarray } from '@stdlib/types/ndarray';
 
 /**
 * Creates an uninitialized array having the same shape and data type as a provided input ndarray.
@@ -348,6 +348,35 @@ declare function emptyLike( x: uint8cndarray ): uint8cndarray;
 * @returns output array
 *
 * @example
+* var empty = require( '@stdlib/ndarray/base/empty' );
+*
+* var x = empty( 'bool', [ 2, 2 ], 'row-major' );
+* // returns <ndarray>
+*
+* var sh = x.shape;
+* // returns [ 2, 2 ]
+*
+* var dt = x.dtype;
+* // returns 'bool'
+*
+* var y = emptyLike( x );
+* // returns <ndarray>
+*
+* sh = y.shape;
+* // returns [ 2, 2 ]
+*
+* dt = y.dtype;
+* // returns 'bool'
+*/
+declare function emptyLike( x: boolndarray ): boolndarray;
+
+/**
+* Creates an uninitialized array having the same shape and data type as a provided input ndarray.
+*
+* @param x - input array
+* @returns output array
+*
+* @example
 * var zeros = require( '@stdlib/ndarray/base/zeros' );
 *
 * var x = zeros( 'generic', [ 2, 2 ], 'row-major' );
@@ -368,7 +397,7 @@ declare function emptyLike( x: uint8cndarray ): uint8cndarray;
 * dt = y.dtype;
 * // returns 'generic'
 */
-declare function emptyLike( x: ndarray ): typedndarray<number>;
+declare function emptyLike<T = unknown>( x: typedndarray<T> ): typedndarray<T>;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/ndarray/base/empty-like/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/empty-like/docs/types/test.ts
@@ -17,6 +17,7 @@
 */
 
 import zeros = require( '@stdlib/ndarray/base/zeros' );
+import empty = require( '@stdlib/ndarray/base/empty' );
 import emptyLike = require( './index' );
 
 
@@ -38,6 +39,7 @@ import emptyLike = require( './index' );
 	emptyLike( zeros( 'uint16', sh, ord ) ); // $ExpectType uint16ndarray
 	emptyLike( zeros( 'uint8', sh, ord ) ); // $ExpectType uint8ndarray
 	emptyLike( zeros( 'uint8c', sh, ord ) ); // $ExpectType uint8cndarray
+	emptyLike( empty( 'bool', sh, ord ) ); // $ExpectType boolndarray
 	emptyLike( zeros( 'generic', sh, ord ) ); // $ExpectType typedndarray<number>
 }
 

--- a/lib/node_modules/@stdlib/ndarray/base/empty-like/examples/index.js
+++ b/lib/node_modules/@stdlib/ndarray/base/empty-like/examples/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 var dtypes = require( '@stdlib/ndarray/dtypes' );
-var zeros = require( '@stdlib/ndarray/base/zeros' );
+var empty = require( '@stdlib/ndarray/base/empty' );
 var emptyLike = require( './../lib' );
 
 // Get a list of data types:
@@ -30,7 +30,7 @@ var x;
 var y;
 var i;
 for ( i = 0; i < dt.length; i++ ) {
-	x = zeros( dt[ i ], [ 2, 2 ], 'row-major' );
+	x = empty( dt[ i ], [ 2, 2 ], 'row-major' );
 	y = emptyLike( x );
 	console.log( y.data );
 }

--- a/lib/node_modules/@stdlib/ndarray/base/empty-like/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/base/empty-like/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var Buffer = require( '@stdlib/buffer/ctor' );
 var allocUnsafe = require( '@stdlib/buffer/alloc-unsafe' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
@@ -513,6 +514,42 @@ tape( 'the function returns an uninitialized array (dtype=complex64, non-base)',
 	t.strictEqual( arr.dtype, 'complex64', 'returns expected value' );
 	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
 	t.strictEqual( instanceOf( arr.data, Complex64Array ), true, 'returns expected value' );
+	t.strictEqual( arr.order, 'column-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns an uninitialized array (dtype=bool, base)', function test( t ) {
+	var arr;
+	var x;
+
+	x = zeros( 'bool', [ 2, 2 ], 'row-major' );
+	arr = emptyLike( x );
+
+	t.strictEqual( instanceOf( arr, base ), true, 'returns expected value' );
+	t.strictEqual( arr.dtype, 'bool', 'returns expected value' );
+	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( arr.data, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( arr.order, 'row-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns an uninitialized array (dtype=bool, non-base)', function test( t ) {
+	var arr;
+	var x;
+
+	x = array( new BooleanArray( 4 ), {
+		'shape': [ 2, 2 ],
+		'dtype': 'bool',
+		'order': 'column-major'
+	});
+	arr = emptyLike( x );
+
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( arr.dtype, 'bool', 'returns expected value' );
+	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( arr.data, BooleanArray ), true, 'returns expected value' );
 	t.strictEqual( arr.order, 'column-major', 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/ndarray/base/empty-like/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/base/empty-like/test/test.js
@@ -40,6 +40,7 @@ var base = require( '@stdlib/ndarray/base/ctor' );
 var ndarray = require( '@stdlib/ndarray/ctor' );
 var array = require( '@stdlib/ndarray/array' );
 var zeros = require( '@stdlib/ndarray/base/zeros' );
+var empty = require( '@stdlib/ndarray/base/empty' );
 var emptyLike = require( './../lib' );
 
 
@@ -523,7 +524,7 @@ tape( 'the function returns an uninitialized array (dtype=bool, base)', function
 	var arr;
 	var x;
 
-	x = zeros( 'bool', [ 2, 2 ], 'row-major' );
+	x = empty( 'bool', [ 2, 2 ], 'row-major' );
 	arr = emptyLike( x );
 
 	t.strictEqual( instanceOf( arr, base ), true, 'returns expected value' );

--- a/lib/node_modules/@stdlib/ndarray/base/empty/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/ndarray/base/empty/benchmark/benchmark.js
@@ -226,6 +226,24 @@ bench( pkg+':dtype=uint8c', function benchmark( b ) {
 	b.end();
 });
 
+bench( pkg+':dtype=bool', function benchmark( b ) {
+	var arr;
+	var i;
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = empty( 'bool', [ 0 ], 'row-major' );
+		if ( arr.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !isndarrayLike( arr ) ) {
+		b.fail( 'should return an ndarray' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
 bench( pkg+':dtype=generic', function benchmark( b ) {
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/ndarray/base/empty/benchmark/benchmark.size.bool.js
+++ b/lib/node_modules/@stdlib/ndarray/base/empty/benchmark/benchmark.size.bool.js
@@ -1,0 +1,93 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
+var pkg = require( './../package.json' ).name;
+var empty = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var arr;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			arr = empty( 'bool', [ len ], 'row-major' );
+			if ( arr.length !== len ) {
+				b.fail( 'unexpected length' );
+			}
+		}
+		b.toc();
+		if ( !isndarrayLike( arr ) ) {
+			b.fail( 'should return an ndarray' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':dtype=bool,size='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/ndarray/base/empty/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/empty/docs/types/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { Shape, Order, typedndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, complex128ndarray, complex64ndarray, DataType } from '@stdlib/types/ndarray';
+import { Shape, Order, typedndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, boolndarray, complex128ndarray, complex64ndarray, DataType } from '@stdlib/types/ndarray';
 
 /**
 * Creates an uninitialized array having a specified shape and data type.
@@ -243,6 +243,26 @@ declare function empty( dtype: 'uint8', shape: Shape, order: Order ): uint8ndarr
 declare function empty( dtype: 'uint8c', shape: Shape, order: Order ): uint8cndarray;
 
 /**
+* Creates an uninitialized array having a specified shape and data type.
+*
+* @param dtype - underlying data type
+* @param shape - array shape
+* @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
+* @returns output array
+*
+* @example
+* var arr = empty( 'bool', [ 2, 2 ], 'row-major' );
+* // returns <ndarray>
+*
+* var sh = arr.shape;
+* // returns [ 2, 2 ]
+*
+* var dt = arr.dtype;
+* // returns 'bool'
+*/
+declare function empty( dtype: 'bool', shape: Shape, order: Order ): boolndarray;
+
+/**
 * Creates a zero-filled array having a specified shape and data type.
 *
 * @param dtype - underlying data type
@@ -280,7 +300,7 @@ declare function empty( dtype: 'generic', shape: Shape, order: Order ): typednda
 * var dt = arr.dtype;
 * // returns 'float32'
 */
-declare function empty( dtype: DataType, shape: Shape, order: Order ): typedndarray<number>;
+declare function empty<T = unknown>( dtype: DataType, shape: Shape, order: Order ): typedndarray<T>;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/ndarray/base/empty/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/empty/docs/types/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { Shape, Order, typedndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, boolndarray, complex128ndarray, complex64ndarray, DataType } from '@stdlib/types/ndarray';
+import { Shape, Order, typedndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, boolndarray, complex128ndarray, complex64ndarray, genericndarray, DataType } from '@stdlib/types/ndarray';
 
 /**
 * Creates an uninitialized array having a specified shape and data type.
@@ -280,7 +280,7 @@ declare function empty( dtype: 'bool', shape: Shape, order: Order ): boolndarray
 * var dt = arr.dtype;
 * // returns 'generic'
 */
-declare function empty( dtype: 'generic', shape: Shape, order: Order ): typedndarray<number>;
+declare function empty( dtype: 'generic', shape: Shape, order: Order ): genericndarray<number>;
 
 /**
 * Creates an uninitialized array having a specified shape and data type.

--- a/lib/node_modules/@stdlib/ndarray/base/empty/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/empty/docs/types/test.ts
@@ -35,7 +35,7 @@ import empty = require( './index' );
 	empty( 'uint8', [ 2, 2 ], 'row-major' ); // $ExpectType uint8ndarray
 	empty( 'uint8c', [ 2, 2 ], 'row-major' ); // $ExpectType uint8cndarray
 	empty( 'bool', [ 2, 2 ], 'row-major' ); // $ExpectType boolndarray
-	empty( 'generic', [ 2, 2 ], 'row-major' ); // $ExpectType typedndarray<number>
+	empty( 'generic', [ 2, 2 ], 'row-major' ); // $ExpectType genericndarray<number>
 
 	empty( 'float64', [ 2, 2 ], 'column-major' ); // $ExpectType float64ndarray
 	empty( 'float32', [ 2, 2 ], 'column-major' ); // $ExpectType float32ndarray
@@ -49,7 +49,7 @@ import empty = require( './index' );
 	empty( 'uint8', [ 2, 2 ], 'column-major' ); // $ExpectType uint8ndarray
 	empty( 'uint8c', [ 2, 2 ], 'column-major' ); // $ExpectType uint8cndarray
 	empty( 'bool', [ 2, 2 ], 'column-major' ); // $ExpectType boolndarray
-	empty( 'generic', [ 2, 2 ], 'column-major' ); // $ExpectType typedndarray<number>
+	empty( 'generic', [ 2, 2 ], 'column-major' ); // $ExpectType genericndarray<number>
 }
 
 // The compiler throws an error if the function is provided a first argument which is an unrecognized/unsupported data type...

--- a/lib/node_modules/@stdlib/ndarray/base/empty/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/empty/docs/types/test.ts
@@ -34,6 +34,7 @@ import empty = require( './index' );
 	empty( 'uint16', [ 2, 2 ], 'row-major' ); // $ExpectType uint16ndarray
 	empty( 'uint8', [ 2, 2 ], 'row-major' ); // $ExpectType uint8ndarray
 	empty( 'uint8c', [ 2, 2 ], 'row-major' ); // $ExpectType uint8cndarray
+	empty( 'bool', [ 2, 2 ], 'row-major' ); // $ExpectType boolndarray
 	empty( 'generic', [ 2, 2 ], 'row-major' ); // $ExpectType typedndarray<number>
 
 	empty( 'float64', [ 2, 2 ], 'column-major' ); // $ExpectType float64ndarray
@@ -47,6 +48,7 @@ import empty = require( './index' );
 	empty( 'uint16', [ 2, 2 ], 'column-major' ); // $ExpectType uint16ndarray
 	empty( 'uint8', [ 2, 2 ], 'column-major' ); // $ExpectType uint8ndarray
 	empty( 'uint8c', [ 2, 2 ], 'column-major' ); // $ExpectType uint8cndarray
+	empty( 'bool', [ 2, 2 ], 'column-major' ); // $ExpectType boolndarray
 	empty( 'generic', [ 2, 2 ], 'column-major' ); // $ExpectType typedndarray<number>
 }
 

--- a/lib/node_modules/@stdlib/ndarray/base/empty/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/base/empty/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var Buffer = require( '@stdlib/buffer/ctor' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
 var ndarray = require( '@stdlib/ndarray/base/ctor' );
@@ -388,6 +389,32 @@ tape( 'the function returns an uninitialized array (dtype=complex64, order=colum
 	t.strictEqual( arr.dtype, 'complex64', 'returns expected value' );
 	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
 	t.strictEqual( instanceOf( arr.data, Complex64Array ), true, 'returns expected value' );
+	t.strictEqual( arr.order, 'column-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns an uninitialized array (dtype=bool, order=row-major)', function test( t ) {
+	var arr;
+
+	arr = empty( 'bool', [ 2, 2 ], 'row-major' );
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( arr.dtype, 'bool', 'returns expected value' );
+	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( arr.data, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( arr.order, 'row-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns an uninitialized array (dtype=bool, order=column-major)', function test( t ) {
+	var arr;
+
+	arr = empty( 'bool', [ 2, 2 ], 'column-major' );
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( arr.dtype, 'bool', 'returns expected value' );
+	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( arr.data, BooleanArray ), true, 'returns expected value' );
 	t.strictEqual( arr.order, 'column-major', 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/ndarray/base/zeros-like/README.md
+++ b/lib/node_modules/@stdlib/ndarray/base/zeros-like/README.md
@@ -87,7 +87,7 @@ var zeros = require( '@stdlib/ndarray/base/zeros' );
 var zerosLike = require( '@stdlib/ndarray/base/zeros-like' );
 
 // Get a list of data types:
-var dt = dtypes();
+var dt = dtypes( 'numeric' );
 
 // Generate zero-filled arrays...
 var x;

--- a/lib/node_modules/@stdlib/ndarray/base/zeros-like/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/zeros-like/docs/types/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { ndarray, typedndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, complex128ndarray, complex64ndarray, DataType } from '@stdlib/types/ndarray';
+import { typedndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, genericndarray, complex128ndarray, complex64ndarray } from '@stdlib/types/ndarray';
 
 /**
 * Creates a zero-filled array having the same shape and data type as a provided input ndarray.
@@ -368,7 +368,7 @@ declare function zerosLike( x: uint8cndarray ): uint8cndarray;
 * dt = y.dtype;
 * // returns 'generic'
 */
-declare function zerosLike( x: ndarray ): typedndarray<number>;
+declare function zerosLike( x: typedndarray<number> | genericndarray<any> ): typedndarray<number>;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/ndarray/base/zeros-like/examples/index.js
+++ b/lib/node_modules/@stdlib/ndarray/base/zeros-like/examples/index.js
@@ -23,7 +23,7 @@ var zeros = require( '@stdlib/ndarray/base/zeros' );
 var zerosLike = require( './../lib' );
 
 // Get a list of data types:
-var dt = dtypes();
+var dt = dtypes( 'numeric' );
 
 // Generate zero-filled arrays...
 var x;

--- a/lib/node_modules/@stdlib/ndarray/base/zeros-like/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/base/zeros-like/test/test.js
@@ -32,10 +32,8 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
-var BooleanArray = require( '@stdlib/array/bool' );
 var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
 var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
-var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
 var base = require( '@stdlib/ndarray/base/ctor' );
 var ndarray = require( '@stdlib/ndarray/ctor' );
@@ -567,50 +565,6 @@ tape( 'the function returns a zero-filled array (dtype=complex64, non-base)', fu
 	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
 	t.strictEqual( instanceOf( arr.data, Complex64Array ), true, 'returns expected value' );
 	t.deepEqual( reinterpret64( arr.data, 0 ), expected, 'returns expected value' );
-	t.strictEqual( arr.order, 'column-major', 'returns expected value' );
-
-	t.end();
-});
-
-tape( 'the function returns a zero-filled array (dtype=bool, base)', function test( t ) {
-	var expected;
-	var arr;
-	var x;
-
-	expected = new Uint8Array( [ 0, 0, 0, 0 ] );
-
-	x = zeros( 'bool', [ 2, 2 ], 'row-major' );
-	arr = zerosLike( x );
-
-	t.strictEqual( instanceOf( arr, base ), true, 'returns expected value' );
-	t.strictEqual( arr.dtype, 'bool', 'returns expected value' );
-	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
-	t.strictEqual( instanceOf( arr.data, BooleanArray ), true, 'returns expected value' );
-	t.deepEqual( reinterpretBoolean( arr.data, 0 ), expected, 'returns expected value' );
-	t.strictEqual( arr.order, 'row-major', 'returns expected value' );
-
-	t.end();
-});
-
-tape( 'the function returns a zero-filled array (dtype=bool, non-base)', function test( t ) {
-	var expected;
-	var arr;
-	var x;
-
-	expected = new Uint8Array( [ 0, 0, 0, 0 ] );
-
-	x = array( new BooleanArray( 4 ), {
-		'shape': [ 2, 2 ],
-		'dtype': 'bool',
-		'order': 'column-major'
-	});
-	arr = zerosLike( x );
-
-	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
-	t.strictEqual( arr.dtype, 'bool', 'returns expected value' );
-	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
-	t.strictEqual( instanceOf( arr.data, BooleanArray ), true, 'returns expected value' );
-	t.deepEqual( reinterpretBoolean( arr.data, 0 ), expected, 'returns expected value' );
 	t.strictEqual( arr.order, 'column-major', 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/ndarray/base/zeros-like/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/base/zeros-like/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2022 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -32,8 +32,10 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
 var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
+var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
 var base = require( '@stdlib/ndarray/base/ctor' );
 var ndarray = require( '@stdlib/ndarray/ctor' );
@@ -565,6 +567,50 @@ tape( 'the function returns a zero-filled array (dtype=complex64, non-base)', fu
 	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
 	t.strictEqual( instanceOf( arr.data, Complex64Array ), true, 'returns expected value' );
 	t.deepEqual( reinterpret64( arr.data, 0 ), expected, 'returns expected value' );
+	t.strictEqual( arr.order, 'column-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a zero-filled array (dtype=bool, base)', function test( t ) {
+	var expected;
+	var arr;
+	var x;
+
+	expected = new Uint8Array( [ 0, 0, 0, 0 ] );
+
+	x = zeros( 'bool', [ 2, 2 ], 'row-major' );
+	arr = zerosLike( x );
+
+	t.strictEqual( instanceOf( arr, base ), true, 'returns expected value' );
+	t.strictEqual( arr.dtype, 'bool', 'returns expected value' );
+	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( arr.data, BooleanArray ), true, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( arr.data, 0 ), expected, 'returns expected value' );
+	t.strictEqual( arr.order, 'row-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a zero-filled array (dtype=bool, non-base)', function test( t ) {
+	var expected;
+	var arr;
+	var x;
+
+	expected = new Uint8Array( [ 0, 0, 0, 0 ] );
+
+	x = array( new BooleanArray( 4 ), {
+		'shape': [ 2, 2 ],
+		'dtype': 'bool',
+		'order': 'column-major'
+	});
+	arr = zerosLike( x );
+
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( arr.dtype, 'bool', 'returns expected value' );
+	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( arr.data, BooleanArray ), true, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( arr.data, 0 ), expected, 'returns expected value' );
 	t.strictEqual( arr.order, 'column-major', 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/ndarray/base/zeros/README.md
+++ b/lib/node_modules/@stdlib/ndarray/base/zeros/README.md
@@ -42,7 +42,7 @@ var zeros = require( '@stdlib/ndarray/base/zeros' );
 
 #### zeros( dtype, shape, order )
 
-Creates a zero-filled [ndarray][@stdlib/ndarray/base/ctor] having a specified shape and [data type][@stdlib/ndarray/dtypes].
+Creates a zero-filled [ndarray][@stdlib/ndarray/base/ctor] having a specified shape and numeric [data type][@stdlib/ndarray/dtypes].
 
 ```javascript
 var arr = zeros( 'float64', [ 2, 2 ], 'row-major' );
@@ -57,7 +57,7 @@ var dt = arr.dtype;
 
 The function accepts the following arguments:
 
--   **dtype**: underlying [data type][@stdlib/ndarray/dtypes].
+-   **dtype**: underlying [data type][@stdlib/ndarray/dtypes]. Must be a numeric [data type][@stdlib/ndarray/dtypes]. 
 -   **shape**: array shape.
 -   **order**: specifies whether an [ndarray][@stdlib/ndarray/base/ctor] is `'row-major'` (C-style) or `'column-major'` (Fortran-style).
 
@@ -86,7 +86,7 @@ var dtypes = require( '@stdlib/ndarray/dtypes' );
 var zeros = require( '@stdlib/ndarray/base/zeros' );
 
 // Get a list of data types:
-var dt = dtypes();
+var dt = dtypes( 'numeric' );
 
 // Generate zero-filled arrays...
 var arr;

--- a/lib/node_modules/@stdlib/ndarray/base/zeros/README.md
+++ b/lib/node_modules/@stdlib/ndarray/base/zeros/README.md
@@ -57,7 +57,7 @@ var dt = arr.dtype;
 
 The function accepts the following arguments:
 
--   **dtype**: underlying [data type][@stdlib/ndarray/dtypes]. Must be a numeric [data type][@stdlib/ndarray/dtypes]. 
+-   **dtype**: underlying [data type][@stdlib/ndarray/dtypes]. Must be a numeric [data type][@stdlib/ndarray/dtypes] or "generic". 
 -   **shape**: array shape.
 -   **order**: specifies whether an [ndarray][@stdlib/ndarray/base/ctor] is `'row-major'` (C-style) or `'column-major'` (Fortran-style).
 

--- a/lib/node_modules/@stdlib/ndarray/base/zeros/docs/repl.txt
+++ b/lib/node_modules/@stdlib/ndarray/base/zeros/docs/repl.txt
@@ -5,7 +5,7 @@
     Parameters
     ----------
     dtype: string
-        Underlying data type.
+        Underlying data type. Must be a numeric data type.
 
     shape: ArrayLikeObject<integer>
         Array shape.

--- a/lib/node_modules/@stdlib/ndarray/base/zeros/docs/repl.txt
+++ b/lib/node_modules/@stdlib/ndarray/base/zeros/docs/repl.txt
@@ -5,7 +5,7 @@
     Parameters
     ----------
     dtype: string
-        Underlying data type. Must be a numeric data type.
+        Underlying data type. Must be a numeric data type or "generic".
 
     shape: ArrayLikeObject<integer>
         Array shape.

--- a/lib/node_modules/@stdlib/ndarray/base/zeros/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/zeros/docs/types/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { Shape, Order, typedndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, complex128ndarray, complex64ndarray, NumericDataType } from '@stdlib/types/ndarray';
+import { Shape, Order, typedndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, genericndarray, complex128ndarray, complex64ndarray, NumericDataType } from '@stdlib/types/ndarray';
 
 /**
 * Creates a zero-filled array having a specified shape and data type.
@@ -260,7 +260,27 @@ declare function zeros( dtype: 'uint8c', shape: Shape, order: Order ): uint8cnda
 * var dt = arr.dtype;
 * // returns 'generic'
 */
-declare function zeros( dtype: 'generic' | NumericDataType, shape: Shape, order: Order ): typedndarray<number>;
+declare function zeros( dtype: 'generic', shape: Shape, order: Order ): genericndarray<number>;
+
+/**
+* Creates a zero-filled array having a specified shape and data type.
+*
+* @param dtype - underlying data type
+* @param shape - array shape
+* @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
+* @returns zero-filled array
+*
+* @example
+* var arr = zeros( 'generic', [ 2, 2 ], 'row-major' );
+* // returns <ndarray>
+*
+* var sh = arr.shape;
+* // returns [ 2, 2 ]
+*
+* var dt = arr.dtype;
+* // returns 'generic'
+*/
+declare function zeros( dtype: NumericDataType, shape: Shape, order: Order ): typedndarray<number>;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/ndarray/base/zeros/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/zeros/docs/types/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { Shape, Order, typedndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, genericndarray, complex128ndarray, complex64ndarray, NumericDataType } from '@stdlib/types/ndarray';
+import { Shape, Order, typedndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, genericndarray, complex128ndarray, complex64ndarray, NumericAndGenericDataType } from '@stdlib/types/ndarray';
 
 /**
 * Creates a zero-filled array having a specified shape and data type.
@@ -280,7 +280,7 @@ declare function zeros( dtype: 'generic', shape: Shape, order: Order ): genericn
 * var dt = arr.dtype;
 * // returns 'float64'
 */
-declare function zeros( dtype: NumericDataType, shape: Shape, order: Order ): typedndarray<number>;
+declare function zeros( dtype: NumericAndGenericDataType, shape: Shape, order: Order ): typedndarray<number>;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/ndarray/base/zeros/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/zeros/docs/types/index.d.ts
@@ -271,14 +271,14 @@ declare function zeros( dtype: 'generic', shape: Shape, order: Order ): genericn
 * @returns zero-filled array
 *
 * @example
-* var arr = zeros( 'generic', [ 2, 2 ], 'row-major' );
+* var arr = zeros( 'float64', [ 2, 2 ], 'row-major' );
 * // returns <ndarray>
 *
 * var sh = arr.shape;
 * // returns [ 2, 2 ]
 *
 * var dt = arr.dtype;
-* // returns 'generic'
+* // returns 'float64'
 */
 declare function zeros( dtype: NumericDataType, shape: Shape, order: Order ): typedndarray<number>;
 

--- a/lib/node_modules/@stdlib/ndarray/base/zeros/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/zeros/docs/types/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { Shape, Order, typedndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, complex128ndarray, complex64ndarray, DataType } from '@stdlib/types/ndarray';
+import { Shape, Order, typedndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, complex128ndarray, complex64ndarray, NumericDataType } from '@stdlib/types/ndarray';
 
 /**
 * Creates a zero-filled array having a specified shape and data type.
@@ -260,27 +260,7 @@ declare function zeros( dtype: 'uint8c', shape: Shape, order: Order ): uint8cnda
 * var dt = arr.dtype;
 * // returns 'generic'
 */
-declare function zeros( dtype: 'generic', shape: Shape, order: Order ): typedndarray<number>;
-
-/**
-* Creates a zero-filled array having a specified shape and data type.
-*
-* @param dtype - underlying data type
-* @param shape - array shape
-* @param order - specifies whether an array is row-major (C-style) or column-major (Fortran-style)
-* @returns zero-filled array
-*
-* @example
-* var arr = zeros( 'float32', [ 2, 2 ], 'row-major' );
-* // returns <ndarray>
-*
-* var sh = arr.shape;
-* // returns [ 2, 2 ]
-*
-* var dt = arr.dtype;
-* // returns 'float32'
-*/
-declare function zeros( dtype: DataType, shape: Shape, order: Order ): typedndarray<number>;
+declare function zeros( dtype: 'generic' | NumericDataType, shape: Shape, order: Order ): typedndarray<number>;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/ndarray/base/zeros/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/base/zeros/docs/types/test.ts
@@ -34,7 +34,7 @@ import zeros = require( './index' );
 	zeros( 'uint16', [ 2, 2 ], 'row-major' ); // $ExpectType uint16ndarray
 	zeros( 'uint8', [ 2, 2 ], 'row-major' ); // $ExpectType uint8ndarray
 	zeros( 'uint8c', [ 2, 2 ], 'row-major' ); // $ExpectType uint8cndarray
-	zeros( 'generic', [ 2, 2 ], 'row-major' ); // $ExpectType typedndarray<number>
+	zeros( 'generic', [ 2, 2 ], 'row-major' ); // $ExpectType genericndarray<number>
 
 	zeros( 'float64', [ 2, 2 ], 'column-major' ); // $ExpectType float64ndarray
 	zeros( 'float32', [ 2, 2 ], 'column-major' ); // $ExpectType float32ndarray
@@ -47,7 +47,7 @@ import zeros = require( './index' );
 	zeros( 'uint16', [ 2, 2 ], 'column-major' ); // $ExpectType uint16ndarray
 	zeros( 'uint8', [ 2, 2 ], 'column-major' ); // $ExpectType uint8ndarray
 	zeros( 'uint8c', [ 2, 2 ], 'column-major' ); // $ExpectType uint8cndarray
-	zeros( 'generic', [ 2, 2 ], 'column-major' ); // $ExpectType typedndarray<number>
+	zeros( 'generic', [ 2, 2 ], 'column-major' ); // $ExpectType genericndarray<number>
 }
 
 // The compiler throws an error if the function is provided a first argument which is an unrecognized/unsupported data type...

--- a/lib/node_modules/@stdlib/ndarray/base/zeros/examples/index.js
+++ b/lib/node_modules/@stdlib/ndarray/base/zeros/examples/index.js
@@ -22,7 +22,7 @@ var dtypes = require( '@stdlib/ndarray/dtypes' );
 var zeros = require( './../lib' );
 
 // Get a list of data types:
-var dt = dtypes();
+var dt = dtypes( 'numeric' );
 
 // Generate zero-filled arrays...
 var arr;

--- a/lib/node_modules/@stdlib/ndarray/base/zeros/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/base/zeros/lib/main.js
@@ -33,7 +33,7 @@ var numel = require( '@stdlib/ndarray/base/numel' );
 /**
 * Creates a zero-filled ndarray having a specified shape and data type.
 *
-* @param {string} dtype - data type
+* @param {string} dtype - numeric data type
 * @param {NonNegativeIntegerArray} shape - array shape
 * @param {string} order - array order
 * @throws {TypeError} first argument must be a recognized data type

--- a/lib/node_modules/@stdlib/ndarray/base/zeros/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/base/zeros/test/test.js
@@ -32,10 +32,8 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
-var BooleanArray = require( '@stdlib/array/bool' );
 var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
 var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
-var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
 var ndarray = require( '@stdlib/ndarray/base/ctor' );
 var zeros = require( './../lib' );
@@ -453,40 +451,6 @@ tape( 'the function returns a zero-filled array (dtype=complex64, order=column-m
 	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
 	t.strictEqual( instanceOf( arr.data, Complex64Array ), true, 'returns expected value' );
 	t.deepEqual( reinterpret64( arr.data, 0 ), expected, 'returns expected value' );
-	t.strictEqual( arr.order, 'column-major', 'returns expected value' );
-
-	t.end();
-});
-
-tape( 'the function returns a zero-filled array (dtype=bool, order=row-major)', function test( t ) {
-	var expected;
-	var arr;
-
-	expected = new Uint8Array( [ 0, 0, 0, 0 ] );
-
-	arr = zeros( 'bool', [ 2, 2 ], 'row-major' );
-	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
-	t.strictEqual( arr.dtype, 'bool', 'returns expected value' );
-	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
-	t.strictEqual( instanceOf( arr.data, BooleanArray ), true, 'returns expected value' );
-	t.deepEqual( reinterpretBoolean( arr.data, 0 ), expected, 'returns expected value' );
-	t.strictEqual( arr.order, 'row-major', 'returns expected value' );
-
-	t.end();
-});
-
-tape( 'the function returns a zero-filled array (dtype=bool, order=column-major)', function test( t ) {
-	var expected;
-	var arr;
-
-	expected = new Float64Array( [ 0, 0, 0, 0 ] );
-
-	arr = zeros( 'bool', [ 2, 2 ], 'column-major' );
-	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
-	t.strictEqual( arr.dtype, 'bool', 'returns expected value' );
-	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
-	t.strictEqual( instanceOf( arr.data, BooleanArray ), true, 'returns expected value' );
-	t.deepEqual( reinterpretBoolean( arr.data, 0 ), expected, 'returns expected value' );
 	t.strictEqual( arr.order, 'column-major', 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/ndarray/base/zeros/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/base/zeros/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2022 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -32,8 +32,10 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
 var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
+var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
 var ndarray = require( '@stdlib/ndarray/base/ctor' );
 var zeros = require( './../lib' );
@@ -451,6 +453,40 @@ tape( 'the function returns a zero-filled array (dtype=complex64, order=column-m
 	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
 	t.strictEqual( instanceOf( arr.data, Complex64Array ), true, 'returns expected value' );
 	t.deepEqual( reinterpret64( arr.data, 0 ), expected, 'returns expected value' );
+	t.strictEqual( arr.order, 'column-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a zero-filled array (dtype=bool, order=row-major)', function test( t ) {
+	var expected;
+	var arr;
+
+	expected = new Uint8Array( [ 0, 0, 0, 0 ] );
+
+	arr = zeros( 'bool', [ 2, 2 ], 'row-major' );
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( arr.dtype, 'bool', 'returns expected value' );
+	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( arr.data, BooleanArray ), true, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( arr.data, 0 ), expected, 'returns expected value' );
+	t.strictEqual( arr.order, 'row-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a zero-filled array (dtype=bool, order=column-major)', function test( t ) {
+	var expected;
+	var arr;
+
+	expected = new Float64Array( [ 0, 0, 0, 0 ] );
+
+	arr = zeros( 'bool', [ 2, 2 ], 'column-major' );
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( arr.dtype, 'bool', 'returns expected value' );
+	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( arr.data, BooleanArray ), true, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( arr.data, 0 ), expected, 'returns expected value' );
 	t.strictEqual( arr.order, 'column-major', 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/ndarray/empty-like/README.md
+++ b/lib/node_modules/@stdlib/ndarray/empty-like/README.md
@@ -118,7 +118,7 @@ dt = y.dtype;
 
 ```javascript
 var dtypes = require( '@stdlib/ndarray/dtypes' );
-var zeros = require( '@stdlib/ndarray/zeros' );
+var empty = require( '@stdlib/ndarray/empty' );
 var emptyLike = require( '@stdlib/ndarray/empty-like' );
 
 // Get a list of data types:
@@ -129,7 +129,7 @@ var x;
 var y;
 var i;
 for ( i = 0; i < dt.length; i++ ) {
-    x = zeros( [ 2, 2 ], {
+    x = empty( [ 2, 2 ], {
         'dtype': dt[ i ]
     });
     y = emptyLike( x );

--- a/lib/node_modules/@stdlib/ndarray/empty-like/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/ndarray/empty-like/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
 var zeros = require( '@stdlib/ndarray/base/zeros' );
+var empty = require( '@stdlib/ndarray/base/empty' );
 var pkg = require( './../package.json' ).name;
 var emptyLike = require( './../lib' );
 
@@ -255,6 +256,28 @@ bench( pkg+':dtype=uint8c', function benchmark( b ) {
 	var i;
 
 	x = zeros( 'uint8c', [ 0 ], 'row-major' );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		y = emptyLike( x );
+		if ( y.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !isndarrayLike( y ) ) {
+		b.fail( 'should return an ndarray' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+':dtype=bool', function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	x = empty( 'bool', [ 0 ], 'row-major' );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/ndarray/empty-like/benchmark/benchmark.size.bool.js
+++ b/lib/node_modules/@stdlib/ndarray/empty-like/benchmark/benchmark.size.bool.js
@@ -1,0 +1,95 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
+var empty = require( '@stdlib/ndarray/base/empty' );
+var pkg = require( './../package.json' ).name;
+var emptyLike = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = empty( 'bool', [ len ], 'row-major' );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var arr;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			arr = emptyLike( x );
+			if ( arr.length !== len ) {
+				b.fail( 'unexpected length' );
+			}
+		}
+		b.toc();
+		if ( !isndarrayLike( arr ) ) {
+			b.fail( 'should return an ndarray' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':dtype=bool,size='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/ndarray/empty-like/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/empty-like/docs/types/index.d.ts
@@ -22,7 +22,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { Shape, Order, ndarray, typedndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, complex128ndarray, complex64ndarray, DataType, Mode } from '@stdlib/types/ndarray';
+import { Shape, Order, ndarray, typedndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, boolndarray, genericndarray, complex128ndarray, complex64ndarray, DataType, Mode } from '@stdlib/types/ndarray';
 
 /**
 * Interface describing function options.
@@ -209,6 +209,34 @@ interface Uint8COptions extends Options {
 	* -   This option overrides the input array's inferred data type.
 	*/
 	dtype: 'uint8c';
+}
+
+/**
+* Interface describing function options.
+*/
+interface BoolOptions extends Options {
+	/**
+	* Underlying data type.
+	*
+	* ## Notes
+	*
+	* -   This option overrides the input array's inferred data type.
+	*/
+	dtype: 'bool';
+}
+
+/**
+* Interface describing function options.
+*/
+interface GenericOptions extends Options {
+	/**
+	* Underlying data type.
+	*
+	* ## Notes
+	*
+	* -   This option overrides the input array's inferred data type.
+	*/
+	dtype: 'generic';
 }
 
 /**
@@ -620,6 +648,78 @@ declare function emptyLike( x: uint8ndarray, options?: Options ): uint8ndarray;
 * // returns 'uint8c'
 */
 declare function emptyLike( x: uint8cndarray, options?: Options ): uint8cndarray;
+
+/**
+* Creates an uninitialized array having the same shape and data type as a provided input ndarray.
+*
+* @param x - input array
+* @param options - options
+* @param options.order - specifies whether the output array is 'row-major' (C-style) or 'column-major' (Fortran-style)
+* @param options.shape - output array shape
+* @param options.mode - specifies how to handle a linear index which exceeds array dimensions
+* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @returns output array
+*
+* @example
+* var empty = require( '@stdlib/ndarray/empty' );
+*
+* var x = empty( [ 2, 2 ], {
+*     'dtype': 'bool'
+* });
+* // returns <ndarray>
+*
+* var sh = x.shape;
+* // returns [ 2, 2 ]
+*
+* var dt = x.dtype;
+* // returns 'bool'
+*
+* var y = emptyLike( x );
+* // returns <ndarray>
+*
+* sh = y.shape;
+* // returns [ 2, 2 ]
+*
+* dt = y.dtype;
+* // returns 'bool'
+*/
+declare function emptyLike( x: boolndarray, options?: Options ): boolndarray;
+
+/**
+* Creates an uninitialized array having the same shape and data type as a provided input ndarray.
+*
+* @param x - input array
+* @param options - options
+* @param options.order - specifies whether the output array is 'row-major' (C-style) or 'column-major' (Fortran-style)
+* @param options.shape - output array shape
+* @param options.mode - specifies how to handle a linear index which exceeds array dimensions
+* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @returns output array
+*
+* @example
+* var empty = require( '@stdlib/ndarray/empty' );
+*
+* var x = empty( [ 2, 2 ], {
+*     'dtype': 'generic'
+* });
+* // returns <ndarray>
+*
+* var sh = x.shape;
+* // returns [ 2, 2 ]
+*
+* var dt = x.dtype;
+* // returns 'generic'
+*
+* var y = emptyLike( x );
+* // returns <ndarray>
+*
+* sh = y.shape;
+* // returns [ 2, 2 ]
+*
+* dt = y.dtype;
+* // returns 'generic'
+*/
+declare function emptyLike( x: genericndarray<any>, options?: Options ): genericndarray<number>;
 
 /**
 * Creates an uninitialized double-precision floating-point array having the same shape as a provided input ndarray.
@@ -1049,6 +1149,84 @@ declare function emptyLike( x: ndarray, options: Uint8Options ): uint8ndarray;
 * // returns 'uint8c'
 */
 declare function emptyLike( x: ndarray, options: Uint8COptions ): uint8cndarray;
+
+/**
+* Creates an uninitialized boolean array having the same shape as a provided input ndarray.
+*
+* @param x - input array
+* @param options - options
+* @param options.dtype - output array data type
+* @param options.order - specifies whether the output array is 'row-major' (C-style) or 'column-major' (Fortran-style)
+* @param options.shape - output array shape
+* @param options.mode - specifies how to handle a linear index which exceeds array dimensions
+* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @returns output array
+*
+* @example
+* var zeros = require( '@stdlib/ndarray/zeros' );
+*
+* var x = zeros( [ 2, 2 ], {
+*     'dtype': 'float64'
+* });
+* // returns <ndarray>
+*
+* var sh = x.shape;
+* // returns [ 2, 2 ]
+*
+* var dt = x.dtype;
+* // returns 'float64'
+*
+* var y = emptyLike( x, {
+*     'dtype': 'bool'
+* });
+* // returns <ndarray>
+*
+* sh = y.shape;
+* // returns [ 2, 2 ]
+*
+* dt = y.dtype;
+* // returns 'bool'
+*/
+declare function emptyLike( x: ndarray, options: BoolOptions ): boolndarray;
+
+/**
+* Creates an uninitialized generic array having the same shape as a provided input ndarray.
+*
+* @param x - input array
+* @param options - options
+* @param options.dtype - output array data type
+* @param options.order - specifies whether the output array is 'row-major' (C-style) or 'column-major' (Fortran-style)
+* @param options.shape - output array shape
+* @param options.mode - specifies how to handle a linear index which exceeds array dimensions
+* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @returns output array
+*
+* @example
+* var zeros = require( '@stdlib/ndarray/zeros' );
+*
+* var x = zeros( [ 2, 2 ], {
+*     'dtype': 'float64'
+* });
+* // returns <ndarray>
+*
+* var sh = x.shape;
+* // returns [ 2, 2 ]
+*
+* var dt = x.dtype;
+* // returns 'float64'
+*
+* var y = emptyLike( x, {
+*     'dtype': 'generic'
+* });
+* // returns <ndarray>
+*
+* sh = y.shape;
+* // returns [ 2, 2 ]
+*
+* dt = y.dtype;
+* // returns 'generic'
+*/
+declare function emptyLike( x: ndarray, options: GenericOptions ): genericndarray<number>;
 
 /**
 * Creates an uninitialized array having the same shape and data type as a provided input ndarray.

--- a/lib/node_modules/@stdlib/ndarray/empty-like/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/empty-like/docs/types/test.ts
@@ -17,6 +17,7 @@
 */
 
 import zeros = require( '@stdlib/ndarray/base/zeros' );
+import empty = require( '@stdlib/ndarray/base/empty' );
 import emptyLike = require( './index' );
 
 
@@ -38,7 +39,8 @@ import emptyLike = require( './index' );
 	emptyLike( zeros( 'uint16', sh, ord ) ); // $ExpectType uint16ndarray
 	emptyLike( zeros( 'uint8', sh, ord ) ); // $ExpectType uint8ndarray
 	emptyLike( zeros( 'uint8c', sh, ord ) ); // $ExpectType uint8cndarray
-	emptyLike( zeros( 'generic', sh, ord ) ); // $ExpectType typedndarray<number>
+	emptyLike( empty( 'bool', sh, ord ) ); // $ExpectType boolndarray
+	emptyLike( zeros( 'generic', sh, ord ) ); // $ExpectType genericndarray<number>
 
 
 	emptyLike( zeros( 'float64', sh, ord ), {} ); // $ExpectType float64ndarray
@@ -52,7 +54,8 @@ import emptyLike = require( './index' );
 	emptyLike( zeros( 'uint16', sh, ord ), {} ); // $ExpectType uint16ndarray
 	emptyLike( zeros( 'uint8', sh, ord ), {} ); // $ExpectType uint8ndarray
 	emptyLike( zeros( 'uint8c', sh, ord ), {} ); // $ExpectType uint8cndarray
-	emptyLike( zeros( 'generic', sh, ord ), {} ); // $ExpectType typedndarray<number>
+	emptyLike( empty( 'bool', sh, ord ), {} ); // $ExpectType boolndarray
+	emptyLike( zeros( 'generic', sh, ord ), {} ); // $ExpectType genericndarray<number>
 
 
 	emptyLike( zeros( 'float64', sh, ord ), { 'shape': [ 2, 2, 2 ] } ); // $ExpectType float64ndarray
@@ -66,7 +69,8 @@ import emptyLike = require( './index' );
 	emptyLike( zeros( 'uint16', sh, ord ), { 'shape': [ 2, 2, 2 ] } ); // $ExpectType uint16ndarray
 	emptyLike( zeros( 'uint8', sh, ord ), { 'shape': [ 2, 2, 2 ] } ); // $ExpectType uint8ndarray
 	emptyLike( zeros( 'uint8c', sh, ord ), { 'shape': [ 2, 2, 2 ] } ); // $ExpectType uint8cndarray
-	emptyLike( zeros( 'generic', sh, ord ), { 'shape': [ 2, 2, 2 ] } ); // $ExpectType typedndarray<number>
+	emptyLike( empty( 'bool', sh, ord ), { 'shape': [ 2, 2, 2 ] } ); // $ExpectType boolndarray
+	emptyLike( zeros( 'generic', sh, ord ), { 'shape': [ 2, 2, 2 ] } ); // $ExpectType genericndarray<number>
 
 
 	emptyLike( zeros( 'float64', sh, ord ), { 'order': 'column-major' } ); // $ExpectType float64ndarray
@@ -80,7 +84,8 @@ import emptyLike = require( './index' );
 	emptyLike( zeros( 'uint16', sh, ord ), { 'order': 'column-major' } ); // $ExpectType uint16ndarray
 	emptyLike( zeros( 'uint8', sh, ord ), { 'order': 'column-major' } ); // $ExpectType uint8ndarray
 	emptyLike( zeros( 'uint8c', sh, ord ), { 'order': 'column-major' } ); // $ExpectType uint8cndarray
-	emptyLike( zeros( 'generic', sh, ord ), { 'order': 'column-major' } ); // $ExpectType typedndarray<number>
+	emptyLike( empty( 'bool', sh, ord ), { 'order': 'column-major' } ); // $ExpectType boolndarray
+	emptyLike( zeros( 'generic', sh, ord ), { 'order': 'column-major' } ); // $ExpectType genericndarray<number>
 
 
 	emptyLike( zeros( 'generic', sh, ord ), { 'dtype': 'float64' } ); // $ExpectType float64ndarray
@@ -94,7 +99,8 @@ import emptyLike = require( './index' );
 	emptyLike( zeros( 'generic', sh, ord ), { 'dtype': 'uint16' } ); // $ExpectType uint16ndarray
 	emptyLike( zeros( 'generic', sh, ord ), { 'dtype': 'uint8' } ); // $ExpectType uint8ndarray
 	emptyLike( zeros( 'generic', sh, ord ), { 'dtype': 'uint8c' } ); // $ExpectType uint8cndarray
-	emptyLike( zeros( 'generic', sh, ord ), { 'dtype': 'generic' } ); // $ExpectType typedndarray<number>
+	emptyLike( zeros( 'generic', sh, ord ), { 'dtype': 'bool' } ); // $ExpectType boolndarray
+	emptyLike( zeros( 'generic', sh, ord ), { 'dtype': 'generic' } ); // $ExpectType genericndarray<number>
 }
 
 // The compiler throws an error if the function is provided a first argument is not an ndarray which has a recognized/supported data type...

--- a/lib/node_modules/@stdlib/ndarray/empty-like/examples/index.js
+++ b/lib/node_modules/@stdlib/ndarray/empty-like/examples/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 var dtypes = require( '@stdlib/ndarray/dtypes' );
-var zeros = require( '@stdlib/ndarray/zeros' );
+var empty = require( '@stdlib/ndarray/empty' );
 var emptyLike = require( './../lib' );
 
 // Get a list of data types:
@@ -30,7 +30,7 @@ var x;
 var y;
 var i;
 for ( i = 0; i < dt.length; i++ ) {
-	x = zeros( [ 2, 2 ], {
+	x = empty( [ 2, 2 ], {
 		'dtype': dt[ i ]
 	});
 	y = emptyLike( x );

--- a/lib/node_modules/@stdlib/ndarray/empty-like/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/empty-like/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var Buffer = require( '@stdlib/buffer/ctor' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
 var ndarray = require( '@stdlib/ndarray/ctor' );
@@ -734,6 +735,42 @@ tape( 'the function returns an uninitialized array (dtype=complex64, options)', 
 	t.strictEqual( arr.dtype, 'complex64', 'returns expected value' );
 	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
 	t.strictEqual( instanceOf( arr.data, Complex64Array ), true, 'returns expected value' );
+	t.strictEqual( arr.order, 'column-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns an uninitialized array (dtype=bool, inferred)', function test( t ) {
+	var arr;
+	var x;
+
+	x = zeros( 'bool', [ 2, 2 ], 'row-major' );
+	arr = emptyLike( x );
+
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( arr.dtype, 'bool', 'returns expected value' );
+	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( arr.data, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( arr.order, 'row-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns an uninitialized array (dtype=bool, options)', function test( t ) {
+	var arr;
+	var x;
+
+	x = zeros( 'generic', [ 4 ], 'row-major' );
+	arr = emptyLike( x, {
+		'shape': [ 2, 2 ],
+		'dtype': 'bool',
+		'order': 'column-major'
+	});
+
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( arr.dtype, 'bool', 'returns expected value' );
+	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( arr.data, BooleanArray ), true, 'returns expected value' );
 	t.strictEqual( arr.order, 'column-major', 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/ndarray/empty-like/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/empty-like/test/test.js
@@ -37,6 +37,7 @@ var Buffer = require( '@stdlib/buffer/ctor' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
 var ndarray = require( '@stdlib/ndarray/ctor' );
 var zeros = require( '@stdlib/ndarray/base/zeros' );
+var empty = require( '@stdlib/ndarray/base/empty' );
 var emptyLike = require( './../lib' );
 
 
@@ -744,7 +745,7 @@ tape( 'the function returns an uninitialized array (dtype=bool, inferred)', func
 	var arr;
 	var x;
 
-	x = zeros( 'bool', [ 2, 2 ], 'row-major' );
+	x = empty( 'bool', [ 2, 2 ], 'row-major' );
 	arr = emptyLike( x );
 
 	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
@@ -760,7 +761,7 @@ tape( 'the function returns an uninitialized array (dtype=bool, options)', funct
 	var arr;
 	var x;
 
-	x = zeros( 'generic', [ 4 ], 'row-major' );
+	x = empty( 'generic', [ 4 ], 'row-major' );
 	arr = emptyLike( x, {
 		'shape': [ 2, 2 ],
 		'dtype': 'bool',

--- a/lib/node_modules/@stdlib/ndarray/empty/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/ndarray/empty/benchmark/benchmark.js
@@ -266,6 +266,26 @@ bench( pkg+':dtype=uint8c', function benchmark( b ) {
 	b.end();
 });
 
+bench( pkg+':dtype=bool', function benchmark( b ) {
+	var arr;
+	var i;
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = empty( [ 0 ], {
+			'dtype': 'bool'
+		});
+		if ( arr.length !== 0 ) {
+			b.fail( 'should have length 0' );
+		}
+	}
+	b.toc();
+	if ( !isndarrayLike( arr ) ) {
+		b.fail( 'should return an ndarray' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
 bench( pkg+':dtype=generic', function benchmark( b ) {
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/ndarray/empty/benchmark/benchmark.size.bool.js
+++ b/lib/node_modules/@stdlib/ndarray/empty/benchmark/benchmark.size.bool.js
@@ -1,0 +1,98 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isndarrayLike = require( '@stdlib/assert/is-ndarray-like' );
+var pkg = require( './../package.json' ).name;
+var empty = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var opts;
+		var arr;
+		var i;
+
+		opts = {
+			'dtype': 'bool'
+		};
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			arr = empty( [ len ], opts );
+			if ( arr.length !== len ) {
+				b.fail( 'unexpected length' );
+			}
+		}
+		b.toc();
+		if ( !isndarrayLike( arr ) ) {
+			b.fail( 'should return an ndarray' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':dtype=bool,size='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/ndarray/empty/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/empty/docs/types/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { Shape, Order, typedndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, complex128ndarray, complex64ndarray, DataType, Mode } from '@stdlib/types/ndarray';
+import { Shape, Order, typedndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, boolndarray, complex128ndarray, complex64ndarray, genericndarray, DataType, Mode } from '@stdlib/types/ndarray';
 
 /**
 * Interface describing function options.
@@ -198,6 +198,34 @@ interface Uint8COptions extends Options {
 	* -   This option overrides the input array's inferred data type.
 	*/
 	dtype: 'uint8c';
+}
+
+/**
+* Interface describing function options.
+*/
+interface BoolOptions extends Options {
+	/**
+	* Underlying data type.
+	*
+	* ## Notes
+	*
+	* -   This option overrides the input array's inferred data type.
+	*/
+	dtype: 'bool';
+}
+
+/**
+* Interface describing function options.
+*/
+interface GenericOptions extends Options {
+	/**
+	* Underlying data type.
+	*
+	* ## Notes
+	*
+	* -   This option overrides the input array's inferred data type.
+	*/
+	dtype: 'generic';
 }
 
 /**
@@ -494,6 +522,56 @@ declare function empty( shape: Shape | number, options: Uint8COptions ): uint8cn
 *
 * @param shape - array shape
 * @param options - options
+* @param options.dtype - underlying data type
+* @param options.order - specifies whether an array is row-major (C-style) or column-major (Fortran-style) (default: 'row-major')
+* @param options.mode - specifies how to handle a linear index which exceeds array dimensions
+* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @returns zero-filled array
+*
+* @example
+* var arr = empty( [ 2, 2 ], {
+*     'dtype': bool'
+* });
+* // returns <ndarray>
+*
+* var sh = arr.shape;
+* // returns [ 2, 2 ]
+*
+* var dt = arr.dtype;
+* // returns 'bool'
+*/
+declare function empty( shape: Shape | number, options: BoolOptions ): boolndarray;
+
+/**
+* Creates an uninitialized array having a specified shape and data type.
+*
+* @param shape - array shape
+* @param options - options
+* @param options.dtype - underlying data type
+* @param options.order - specifies whether an array is row-major (C-style) or column-major (Fortran-style) (default: 'row-major')
+* @param options.mode - specifies how to handle a linear index which exceeds array dimensions
+* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @returns zero-filled array
+*
+* @example
+* var arr = empty( [ 2, 2 ], {
+*     'dtype': generic'
+* });
+* // returns <ndarray>
+*
+* var sh = arr.shape;
+* // returns [ 2, 2 ]
+*
+* var dt = arr.dtype;
+* // returns 'generic'
+*/
+declare function empty( shape: Shape | number, options: GenericOptions ): genericndarray<number>;
+
+/**
+* Creates an uninitialized array having a specified shape and data type.
+*
+* @param shape - array shape
+* @param options - options
 * @param options.dtype - underlying data type (default: 'float64')
 * @param options.order - specifies whether an array is row-major (C-style) or column-major (Fortran-style) (default: 'row-major')
 * @param options.mode - specifies how to handle a linear index which exceeds array dimensions
@@ -533,7 +611,7 @@ declare function empty( shape: Shape | number, options?: Options ): float64ndarr
 * var dt = arr.dtype;
 * // returns 'float64'
 */
-declare function empty( shape: Shape | number, options?: OptionsWithDType ): typedndarray<number>;
+declare function empty<T = unknown>( shape: Shape | number, options?: OptionsWithDType ): typedndarray<T>;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/ndarray/empty/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/empty/docs/types/test.ts
@@ -36,7 +36,7 @@ import empty = require( './index' );
 	empty( [ 2, 2 ], { 'dtype': 'uint16' } ); // $ExpectType uint16ndarray
 	empty( [ 2, 2 ], { 'dtype': 'uint8' } ); // $ExpectType uint8ndarray
 	empty( [ 2, 2 ], { 'dtype': 'uint8c' } ); // $ExpectType uint8cndarray
-	empty( [ 2, 2 ], { 'dtype': 'generic' } ); // $ExpectType typedndarray<number>
+	empty( [ 2, 2 ], { 'dtype': 'generic' } ); // $ExpectType genericndarray<number>
 }
 
 // The compiler throws an error if the function is not provided a valid shape for the first argument...

--- a/lib/node_modules/@stdlib/ndarray/empty/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/empty/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var Buffer = require( '@stdlib/buffer/ctor' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
 var ndarray = require( '@stdlib/ndarray/ctor' );
@@ -725,6 +726,42 @@ tape( 'the function returns an uninitialized array (dtype=complex64, order=colum
 	t.strictEqual( arr.dtype, opts.dtype, 'returns expected value' );
 	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
 	t.strictEqual( instanceOf( arr.data, Complex64Array ), true, 'returns expected value' );
+	t.strictEqual( arr.order, opts.order, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns an uninitialized array (dtype=bool, order=row-major)', function test( t ) {
+	var opts;
+	var arr;
+
+	opts = {
+		'dtype': 'bool',
+		'order': 'row-major'
+	};
+	arr = empty( [ 2, 2 ], opts );
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( arr.dtype, opts.dtype, 'returns expected value' );
+	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( arr.data, BooleanArray ), true, 'returns expected value' );
+	t.strictEqual( arr.order, opts.order, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns an uninitialized array (dtype=bool, order=column-major)', function test( t ) {
+	var opts;
+	var arr;
+
+	opts = {
+		'dtype': 'bool',
+		'order': 'column-major'
+	};
+	arr = empty( [ 2, 2 ], opts );
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( arr.dtype, opts.dtype, 'returns expected value' );
+	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( arr.data, BooleanArray ), true, 'returns expected value' );
 	t.strictEqual( arr.order, opts.order, 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/ndarray/zeros-like/README.md
+++ b/lib/node_modules/@stdlib/ndarray/zeros-like/README.md
@@ -62,7 +62,7 @@ var dt = y.dtype;
 
 The function supports the following `options`:
 
--   **dtype**: output [ndarray][@stdlib/ndarray/ctor] [data type][@stdlib/ndarray/dtypes]. Overrides the input ndarray's inferred [data type][@stdlib/ndarray/dtypes].
+-   **dtype**: output [ndarray][@stdlib/ndarray/ctor] [data type][@stdlib/ndarray/dtypes]. Must be a numeric [data type][@stdlib/ndarray/dtypes] or "generic". Overrides the input ndarray's inferred [data type][@stdlib/ndarray/dtypes].
 -   **shape**: output [ndarray][@stdlib/ndarray/ctor] shape. Overrides the input ndarray's inferred shape.
 -   **order**: specifies whether the output [ndarray][@stdlib/ndarray/ctor] should be `'row-major'` (C-style) or `'column-major'` (Fortran-style). Overrides the input ndarray's inferred order.
 -   **mode**: specifies how to handle indices which exceed array dimensions (see [`ndarray`][@stdlib/ndarray/ctor]). Default: `'throw'`.
@@ -118,7 +118,7 @@ var zeros = require( '@stdlib/ndarray/zeros' );
 var zerosLike = require( '@stdlib/ndarray/zeros-like' );
 
 // Get a list of data types:
-var dt = dtypes();
+var dt = dtypes( 'numeric' );
 
 // Generate zero-filled arrays...
 var x;

--- a/lib/node_modules/@stdlib/ndarray/zeros-like/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/zeros-like/docs/types/index.d.ts
@@ -22,7 +22,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { Shape, Order, ndarray, typedndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, complex128ndarray, complex64ndarray, DataType, Mode } from '@stdlib/types/ndarray';
+import { Shape, Order, ndarray, typedndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, genericndarray, complex128ndarray, complex64ndarray, NumericAndGenericDataType, Mode } from '@stdlib/types/ndarray';
 
 /**
 * Interface describing function options.
@@ -219,6 +219,20 @@ interface Uint8COptions extends Options {
 /**
 * Interface describing function options.
 */
+interface GenericOptions extends Options {
+	/**
+	* Underlying data type.
+	*
+	* ## Notes
+	*
+	* -   This option overrides the input array's inferred data type.
+	*/
+	dtype: 'generic';
+}
+
+/**
+* Interface describing function options.
+*/
 interface OptionsWithDType extends Options {
 	/**
 	* Underlying data type.
@@ -227,7 +241,7 @@ interface OptionsWithDType extends Options {
 	*
 	* -   This option overrides the input array's inferred data type.
 	*/
-	dtype: DataType;
+	dtype: NumericAndGenericDataType;
 }
 
 /**
@@ -636,6 +650,43 @@ declare function zerosLike( x: uint8ndarray, options?: Options ): uint8ndarray;
 * // returns 'uint8c'
 */
 declare function zerosLike( x: uint8cndarray, options?: Options ): uint8cndarray;
+
+/**
+* Creates a zero-filled array having the same shape and data type as a provided input ndarray.
+*
+* @param x - input array
+* @param options - options
+* @param options.order - specifies whether the output array is 'row-major' (C-style) or 'column-major' (Fortran-style)
+* @param options.shape - output array shape
+* @param options.mode - specifies how to handle a linear index which exceeds array dimensions
+* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @param options.readonly - boolean indicating whether an array should be read-only
+* @returns zero-filled array
+*
+* @example
+* var zeros = require( '@stdlib/ndarray/zeros' );
+*
+* var x = zeros( [ 2, 2 ], {
+*     'dtype': 'generic'
+* });
+* // returns <ndarray>
+*
+* var sh = x.shape;
+* // returns [ 2, 2 ]
+*
+* var dt = x.dtype;
+* // returns 'generic'
+*
+* var y = zerosLike( x );
+* // returns <ndarray>
+*
+* sh = y.shape;
+* // returns [ 2, 2 ]
+*
+* dt = y.dtype;
+* // returns 'generic'
+*/
+declare function zerosLike( x: genericndarray<any>, options?: Options ): genericndarray<number>;
 
 /**
 * Creates a zero-filled double-precision floating-point array having the same shape as a provided input ndarray.
@@ -1076,6 +1127,46 @@ declare function zerosLike( x: ndarray, options: Uint8Options ): uint8ndarray;
 * // returns 'uint8c'
 */
 declare function zerosLike( x: ndarray, options: Uint8COptions ): uint8cndarray;
+
+/**
+* Creates a zero-filled generic array having the same shape as a provided input ndarray.
+*
+* @param x - input array
+* @param options - options
+* @param options.dtype - output array data type
+* @param options.order - specifies whether the output array is 'row-major' (C-style) or 'column-major' (Fortran-style)
+* @param options.shape - output array shape
+* @param options.mode - specifies how to handle a linear index which exceeds array dimensions
+* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @param options.readonly - boolean indicating whether an array should be read-only
+* @returns zero-filled array
+*
+* @example
+* var zeros = require( '@stdlib/ndarray/zeros' );
+*
+* var x = zeros( [ 2, 2 ], {
+*     'dtype': 'float64'
+* });
+* // returns <ndarray>
+*
+* var sh = x.shape;
+* // returns [ 2, 2 ]
+*
+* var dt = x.dtype;
+* // returns 'float64'
+*
+* var y = zerosLike( x, {
+*     'dtype': 'generic'
+* });
+* // returns <ndarray>
+*
+* sh = y.shape;
+* // returns [ 2, 2 ]
+*
+* dt = y.dtype;
+* // returns 'generic'
+*/
+declare function zerosLike( x: ndarray, options: GenericOptions ): genericndarray<number>;
 
 /**
 * Creates a zero-filled array having the same shape and data type as a provided input ndarray.

--- a/lib/node_modules/@stdlib/ndarray/zeros-like/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/zeros-like/docs/types/test.ts
@@ -38,7 +38,7 @@ import zerosLike = require( './index' );
 	zerosLike( zeros( 'uint16', sh, ord ) ); // $ExpectType uint16ndarray
 	zerosLike( zeros( 'uint8', sh, ord ) ); // $ExpectType uint8ndarray
 	zerosLike( zeros( 'uint8c', sh, ord ) ); // $ExpectType uint8cndarray
-	zerosLike( zeros( 'generic', sh, ord ) ); // $ExpectType typedndarray<number>
+	zerosLike( zeros( 'generic', sh, ord ) ); // $ExpectType genericndarray<number>
 
 
 	zerosLike( zeros( 'float64', sh, ord ), {} ); // $ExpectType float64ndarray
@@ -52,7 +52,7 @@ import zerosLike = require( './index' );
 	zerosLike( zeros( 'uint16', sh, ord ), {} ); // $ExpectType uint16ndarray
 	zerosLike( zeros( 'uint8', sh, ord ), {} ); // $ExpectType uint8ndarray
 	zerosLike( zeros( 'uint8c', sh, ord ), {} ); // $ExpectType uint8cndarray
-	zerosLike( zeros( 'generic', sh, ord ), {} ); // $ExpectType typedndarray<number>
+	zerosLike( zeros( 'generic', sh, ord ), {} ); // $ExpectType genericndarray<number>
 
 
 	zerosLike( zeros( 'float64', sh, ord ), { 'shape': [ 2, 2, 2 ] } ); // $ExpectType float64ndarray
@@ -66,7 +66,7 @@ import zerosLike = require( './index' );
 	zerosLike( zeros( 'uint16', sh, ord ), { 'shape': [ 2, 2, 2 ] } ); // $ExpectType uint16ndarray
 	zerosLike( zeros( 'uint8', sh, ord ), { 'shape': [ 2, 2, 2 ] } ); // $ExpectType uint8ndarray
 	zerosLike( zeros( 'uint8c', sh, ord ), { 'shape': [ 2, 2, 2 ] } ); // $ExpectType uint8cndarray
-	zerosLike( zeros( 'generic', sh, ord ), { 'shape': [ 2, 2, 2 ] } ); // $ExpectType typedndarray<number>
+	zerosLike( zeros( 'generic', sh, ord ), { 'shape': [ 2, 2, 2 ] } ); // $ExpectType genericndarray<number>
 
 
 	zerosLike( zeros( 'float64', sh, ord ), { 'order': 'column-major' } ); // $ExpectType float64ndarray
@@ -80,7 +80,7 @@ import zerosLike = require( './index' );
 	zerosLike( zeros( 'uint16', sh, ord ), { 'order': 'column-major' } ); // $ExpectType uint16ndarray
 	zerosLike( zeros( 'uint8', sh, ord ), { 'order': 'column-major' } ); // $ExpectType uint8ndarray
 	zerosLike( zeros( 'uint8c', sh, ord ), { 'order': 'column-major' } ); // $ExpectType uint8cndarray
-	zerosLike( zeros( 'generic', sh, ord ), { 'order': 'column-major' } ); // $ExpectType typedndarray<number>
+	zerosLike( zeros( 'generic', sh, ord ), { 'order': 'column-major' } ); // $ExpectType genericndarray<number>
 
 
 	zerosLike( zeros( 'generic', sh, ord ), { 'dtype': 'float64' } ); // $ExpectType float64ndarray
@@ -94,7 +94,7 @@ import zerosLike = require( './index' );
 	zerosLike( zeros( 'generic', sh, ord ), { 'dtype': 'uint16' } ); // $ExpectType uint16ndarray
 	zerosLike( zeros( 'generic', sh, ord ), { 'dtype': 'uint8' } ); // $ExpectType uint8ndarray
 	zerosLike( zeros( 'generic', sh, ord ), { 'dtype': 'uint8c' } ); // $ExpectType uint8cndarray
-	zerosLike( zeros( 'generic', sh, ord ), { 'dtype': 'generic' } ); // $ExpectType typedndarray<number>
+	zerosLike( zeros( 'generic', sh, ord ), { 'dtype': 'generic' } ); // $ExpectType genericndarray<number>
 }
 
 // The compiler throws an error if the function is provided a first argument is not an ndarray which has a recognized/supported data type...

--- a/lib/node_modules/@stdlib/ndarray/zeros-like/examples/index.js
+++ b/lib/node_modules/@stdlib/ndarray/zeros-like/examples/index.js
@@ -23,7 +23,7 @@ var zeros = require( '@stdlib/ndarray/zeros' );
 var zerosLike = require( './../lib' );
 
 // Get a list of data types:
-var dt = dtypes();
+var dt = dtypes( 'numeric' );
 
 // Generate zero-filled arrays...
 var x;

--- a/lib/node_modules/@stdlib/ndarray/zeros-like/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/zeros-like/test/test.js
@@ -32,10 +32,8 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
-var BooleanArray = require( '@stdlib/array/bool' );
 var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
 var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
-var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
 var ndarray = require( '@stdlib/ndarray/ctor' );
 var zeros = require( '@stdlib/ndarray/base/zeros' );
@@ -820,50 +818,6 @@ tape( 'the function returns a zero-filled array (dtype=complex64, options)', fun
 	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
 	t.strictEqual( instanceOf( arr.data, Complex64Array ), true, 'returns expected value' );
 	t.deepEqual( reinterpret64( arr.data, 0 ), expected, 'returns expected value' );
-	t.strictEqual( arr.order, 'column-major', 'returns expected value' );
-
-	t.end();
-});
-
-tape( 'the function returns a zero-filled array (dtype=bool, inferred)', function test( t ) {
-	var expected;
-	var arr;
-	var x;
-
-	expected = new Uint8Array( [ 0, 0, 0, 0 ] );
-
-	x = zeros( 'bool', [ 2, 2 ], 'row-major' );
-	arr = zerosLike( x );
-
-	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
-	t.strictEqual( arr.dtype, 'bool', 'returns expected value' );
-	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
-	t.strictEqual( instanceOf( arr.data, BooleanArray ), true, 'returns expected value' );
-	t.deepEqual( reinterpretBoolean( arr.data, 0 ), expected, 'returns expected value' );
-	t.strictEqual( arr.order, 'row-major', 'returns expected value' );
-
-	t.end();
-});
-
-tape( 'the function returns a zero-filled array (dtype=bool, options)', function test( t ) {
-	var expected;
-	var arr;
-	var x;
-
-	expected = new Uint8Array( [ 0, 0, 0, 0 ] );
-
-	x = zeros( 'generic', [ 4 ], 'row-major' );
-	arr = zerosLike( x, {
-		'shape': [ 2, 2 ],
-		'dtype': 'bool',
-		'order': 'column-major'
-	});
-
-	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
-	t.strictEqual( arr.dtype, 'bool', 'returns expected value' );
-	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
-	t.strictEqual( instanceOf( arr.data, BooleanArray ), true, 'returns expected value' );
-	t.deepEqual( reinterpretBoolean( arr.data, 0 ), expected, 'returns expected value' );
 	t.strictEqual( arr.order, 'column-major', 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/ndarray/zeros-like/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/zeros-like/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2022 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -32,8 +32,10 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
 var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
+var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
 var ndarray = require( '@stdlib/ndarray/ctor' );
 var zeros = require( '@stdlib/ndarray/base/zeros' );
@@ -818,6 +820,50 @@ tape( 'the function returns a zero-filled array (dtype=complex64, options)', fun
 	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
 	t.strictEqual( instanceOf( arr.data, Complex64Array ), true, 'returns expected value' );
 	t.deepEqual( reinterpret64( arr.data, 0 ), expected, 'returns expected value' );
+	t.strictEqual( arr.order, 'column-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a zero-filled array (dtype=bool, inferred)', function test( t ) {
+	var expected;
+	var arr;
+	var x;
+
+	expected = new Uint8Array( [ 0, 0, 0, 0 ] );
+
+	x = zeros( 'bool', [ 2, 2 ], 'row-major' );
+	arr = zerosLike( x );
+
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( arr.dtype, 'bool', 'returns expected value' );
+	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( arr.data, BooleanArray ), true, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( arr.data, 0 ), expected, 'returns expected value' );
+	t.strictEqual( arr.order, 'row-major', 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a zero-filled array (dtype=bool, options)', function test( t ) {
+	var expected;
+	var arr;
+	var x;
+
+	expected = new Uint8Array( [ 0, 0, 0, 0 ] );
+
+	x = zeros( 'generic', [ 4 ], 'row-major' );
+	arr = zerosLike( x, {
+		'shape': [ 2, 2 ],
+		'dtype': 'bool',
+		'order': 'column-major'
+	});
+
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( arr.dtype, 'bool', 'returns expected value' );
+	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( arr.data, BooleanArray ), true, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( arr.data, 0 ), expected, 'returns expected value' );
 	t.strictEqual( arr.order, 'column-major', 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/ndarray/zeros/README.md
+++ b/lib/node_modules/@stdlib/ndarray/zeros/README.md
@@ -70,7 +70,7 @@ var dt = arr.dtype;
 
 The function accepts the following `options`:
 
--   **dtype**: underlying [data type][@stdlib/ndarray/dtypes]. Default: `'float64'`.
+-   **dtype**: underlying [data type][@stdlib/ndarray/dtypes]. Must be a numeric [data type][@stdlib/ndarray/dtypes] or "generic". Default: `'float64'`.
 -   **order**: specifies whether an [ndarray][@stdlib/ndarray/ctor] is `'row-major'` (C-style) or `'column-major'` (Fortran-style). Default: `'row-major'`.
 -   **mode**: specifies how to handle indices which exceed array dimensions (see [`ndarray`][@stdlib/ndarray/ctor]). Default: `'throw'`.
 -   **submode**: a mode array which specifies for each dimension how to handle subscripts which exceed array dimensions  (see [`ndarray`][@stdlib/ndarray/ctor]). If provided fewer modes than dimensions, the constructor recycles modes using modulo arithmetic. Default: `[ options.mode ]`.
@@ -116,7 +116,7 @@ var dtypes = require( '@stdlib/ndarray/dtypes' );
 var zeros = require( '@stdlib/ndarray/zeros' );
 
 // Get a list of data types:
-var dt = dtypes();
+var dt = dtypes( 'numeric' );
 
 // Generate zero-filled arrays...
 var arr;

--- a/lib/node_modules/@stdlib/ndarray/zeros/docs/repl.txt
+++ b/lib/node_modules/@stdlib/ndarray/zeros/docs/repl.txt
@@ -11,7 +11,8 @@
         Options.
 
     options.dtype: string (optional)
-        Underlying data type. Default: 'float64'.
+        Underlying data type. Must be a numeric data type or "generic". Default:
+        'float64'.
 
     options.order: string (optional)
         Specifies whether an array is row-major (C-style) or column-major

--- a/lib/node_modules/@stdlib/ndarray/zeros/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/zeros/docs/types/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { Shape, Order, typedndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, genericndarray, complex128ndarray, complex64ndarray, DataType, Mode } from '@stdlib/types/ndarray';
+import { Shape, Order, typedndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, genericndarray, complex128ndarray, complex64ndarray, NumericAndGenericDataType, Mode } from '@stdlib/types/ndarray';
 
 /**
 * Interface describing function options.
@@ -244,7 +244,7 @@ interface OptionsWithDType extends Options {
 	*
 	* -   This option overrides the input array's inferred data type.
 	*/
-	dtype: DataType;
+	dtype: NumericAndGenericDataType;
 }
 
 /**

--- a/lib/node_modules/@stdlib/ndarray/zeros/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/zeros/docs/types/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { Shape, Order, typedndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, complex128ndarray, complex64ndarray, DataType, Mode } from '@stdlib/types/ndarray';
+import { Shape, Order, typedndarray, float64ndarray, float32ndarray, int32ndarray, int16ndarray, int8ndarray, uint32ndarray, uint16ndarray, uint8ndarray, uint8cndarray, genericndarray, complex128ndarray, complex64ndarray, DataType, Mode } from '@stdlib/types/ndarray';
 
 /**
 * Interface describing function options.
@@ -203,6 +203,34 @@ interface Uint8COptions extends Options {
 	* -   This option overrides the input array's inferred data type.
 	*/
 	dtype: 'uint8c';
+}
+
+/**
+* Interface describing function options.
+*/
+interface Uint8COptions extends Options {
+	/**
+	* Underlying data type.
+	*
+	* ## Notes
+	*
+	* -   This option overrides the input array's inferred data type.
+	*/
+	dtype: 'uint8c';
+}
+
+/**
+* Interface describing function options.
+*/
+interface GenericOptions extends Options {
+	/**
+	* Underlying data type.
+	*
+	* ## Notes
+	*
+	* -   This option overrides the input array's inferred data type.
+	*/
+	dtype: 'generic';
 }
 
 /**
@@ -504,6 +532,32 @@ declare function zeros( shape: Shape | number, options: Uint8Options ): uint8nda
 * // returns 'uint8c'
 */
 declare function zeros( shape: Shape | number, options: Uint8COptions ): uint8cndarray;
+
+/**
+* Creates a zero-filled array having a specified shape and data type.
+*
+* @param shape - array shape
+* @param options - options
+* @param options.dtype - underlying data type
+* @param options.order - specifies whether an array is row-major (C-style) or column-major (Fortran-style) (default: 'row-major')
+* @param options.mode - specifies how to handle a linear index which exceeds array dimensions
+* @param options.submode - specifies how to handle subscripts which exceed array dimensions on a per dimension basis
+* @param options.readonly - boolean indicating whether an array should be read-only
+* @returns zero-filled array
+*
+* @example
+* var arr = zeros( [ 2, 2 ], {
+*     'dtype': generic'
+* });
+* // returns <ndarray>
+*
+* var sh = arr.shape;
+* // returns [ 2, 2 ]
+*
+* var dt = arr.dtype;
+* // returns 'generic'
+*/
+declare function zeros( shape: Shape | number, options: GenericOptions ): genericndarray<number>;
 
 /**
 * Creates a zero-filled array having a specified shape and data type.

--- a/lib/node_modules/@stdlib/ndarray/zeros/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/zeros/docs/types/test.ts
@@ -36,7 +36,7 @@ import zeros = require( './index' );
 	zeros( [ 2, 2 ], { 'dtype': 'uint16' } ); // $ExpectType uint16ndarray
 	zeros( [ 2, 2 ], { 'dtype': 'uint8' } ); // $ExpectType uint8ndarray
 	zeros( [ 2, 2 ], { 'dtype': 'uint8c' } ); // $ExpectType uint8cndarray
-	zeros( [ 2, 2 ], { 'dtype': 'generic' } ); // $ExpectType typedndarray<number>
+	zeros( [ 2, 2 ], { 'dtype': 'generic' } ); // $ExpectType genericndarray<number>
 }
 
 // The compiler throws an error if the function is not provided a valid shape for the first argument...

--- a/lib/node_modules/@stdlib/ndarray/zeros/examples/index.js
+++ b/lib/node_modules/@stdlib/ndarray/zeros/examples/index.js
@@ -22,7 +22,7 @@ var dtypes = require( '@stdlib/ndarray/dtypes' );
 var zeros = require( './../lib' );
 
 // Get a list of data types:
-var dt = dtypes();
+var dt = dtypes( 'numeric' );
 
 // Generate zero-filled arrays...
 var arr;

--- a/lib/node_modules/@stdlib/ndarray/zeros/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/zeros/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2022 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -32,8 +32,10 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
+var BooleanArray = require( '@stdlib/array/bool' );
 var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
 var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
+var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
 var ndarray = require( '@stdlib/ndarray/ctor' );
 var zeros = require( './../lib' );
@@ -861,6 +863,50 @@ tape( 'the function returns a zero-filled array (dtype=complex64, order=column-m
 	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
 	t.strictEqual( instanceOf( arr.data, Complex64Array ), true, 'returns expected value' );
 	t.deepEqual( reinterpret64( arr.data, 0 ), expected, 'returns expected value' );
+	t.strictEqual( arr.order, opts.order, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a zero-filled array (dtype=bool, order=row-major)', function test( t ) {
+	var expected;
+	var opts;
+	var arr;
+
+	expected = new Uint8Array( [ 0, 0, 0, 0 ] );
+
+	opts = {
+		'dtype': 'bool',
+		'order': 'row-major'
+	};
+	arr = zeros( [ 2, 2 ], opts );
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( arr.dtype, opts.dtype, 'returns expected value' );
+	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( arr.data, BooleanArray ), true, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( arr.data, 0 ), expected, 'returns expected value' );
+	t.strictEqual( arr.order, opts.order, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a zero-filled array (dtype=bool, order=column-major)', function test( t ) {
+	var expected;
+	var opts;
+	var arr;
+
+	expected = new Uint8Array( [ 0, 0, 0, 0 ] );
+
+	opts = {
+		'dtype': 'bool',
+		'order': 'column-major'
+	};
+	arr = zeros( [ 2, 2 ], opts );
+	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
+	t.strictEqual( arr.dtype, opts.dtype, 'returns expected value' );
+	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
+	t.strictEqual( instanceOf( arr.data, BooleanArray ), true, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( arr.data, 0 ), expected, 'returns expected value' );
 	t.strictEqual( arr.order, opts.order, 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/ndarray/zeros/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/zeros/test/test.js
@@ -32,10 +32,8 @@ var Uint8Array = require( '@stdlib/array/uint8' );
 var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
-var BooleanArray = require( '@stdlib/array/bool' );
 var reinterpret64 = require( '@stdlib/strided/base/reinterpret-complex64' );
 var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
-var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
 var instanceOf = require( '@stdlib/assert/instance-of' );
 var ndarray = require( '@stdlib/ndarray/ctor' );
 var zeros = require( './../lib' );
@@ -863,50 +861,6 @@ tape( 'the function returns a zero-filled array (dtype=complex64, order=column-m
 	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
 	t.strictEqual( instanceOf( arr.data, Complex64Array ), true, 'returns expected value' );
 	t.deepEqual( reinterpret64( arr.data, 0 ), expected, 'returns expected value' );
-	t.strictEqual( arr.order, opts.order, 'returns expected value' );
-
-	t.end();
-});
-
-tape( 'the function returns a zero-filled array (dtype=bool, order=row-major)', function test( t ) {
-	var expected;
-	var opts;
-	var arr;
-
-	expected = new Uint8Array( [ 0, 0, 0, 0 ] );
-
-	opts = {
-		'dtype': 'bool',
-		'order': 'row-major'
-	};
-	arr = zeros( [ 2, 2 ], opts );
-	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
-	t.strictEqual( arr.dtype, opts.dtype, 'returns expected value' );
-	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
-	t.strictEqual( instanceOf( arr.data, BooleanArray ), true, 'returns expected value' );
-	t.deepEqual( reinterpretBoolean( arr.data, 0 ), expected, 'returns expected value' );
-	t.strictEqual( arr.order, opts.order, 'returns expected value' );
-
-	t.end();
-});
-
-tape( 'the function returns a zero-filled array (dtype=bool, order=column-major)', function test( t ) {
-	var expected;
-	var opts;
-	var arr;
-
-	expected = new Uint8Array( [ 0, 0, 0, 0 ] );
-
-	opts = {
-		'dtype': 'bool',
-		'order': 'column-major'
-	};
-	arr = zeros( [ 2, 2 ], opts );
-	t.strictEqual( instanceOf( arr, ndarray ), true, 'returns expected value' );
-	t.strictEqual( arr.dtype, opts.dtype, 'returns expected value' );
-	t.deepEqual( arr.shape, [ 2, 2 ], 'returns expected value' );
-	t.strictEqual( instanceOf( arr.data, BooleanArray ), true, 'returns expected value' );
-	t.deepEqual( reinterpretBoolean( arr.data, 0 ), expected, 'returns expected value' );
 	t.strictEqual( arr.order, opts.order, 'returns expected value' );
 
 	t.end();


### PR DESCRIPTION
Resolves: Subtask of #2547

## Description

> What is the purpose of this pull request?

This pull request:

-  This PR updates the test file of the below mentioned packages:
- [x] `@stdlib/ndarray/base/zeros`
- [x] `@stdlib/ndarray/base/zeros-like`
- [x] `@stdlib/ndarray/base/empty`
- [x] `@stdlib/ndarray/base/empty-like`
- [x] `@stdlib/ndarray/zeros`
- [x] `@stdlib/ndarray/zeros-like`
- [x] `@stdlib/ndarray/empty`
- [x] `@stdlib/ndarray/empty-like`

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
