### PR TITLE
feat: add `keys`, `values` and `with` methods to `array/bool`

### DIFF
--- a/lib/node_modules/@stdlib/array/bool/README.md
+++ b/lib/node_modules/@stdlib/array/bool/README.md
@@ -710,6 +710,35 @@ var str = arr.join( '|' );
 // returns 'true|false|true'
 ```
 
+<a name="method-keys"></a>
+
+#### BooleanArray.prototype.keys()
+
+Returns an iterator for iterating over each index key in a typed array.
+
+```javascript
+var arr = new BooleanArray( 2 );
+
+arr.set( true, 0 );
+arr.set( false, 1 );
+
+var iter = arr.keys();
+
+var v = iter.next().value;
+// returns 0
+
+v = iter.next().value;
+// returns 1
+
+var bool = iter.next().done;
+// returns true
+```
+
+The returned [iterator][mdn-iterator-protocol] protocol-compliant object has the following properties:
+
+-   **next**: function which returns an [iterator][mdn-iterator-protocol] protocol-compliant object containing the next iterated value (if one exists) assigned to a `value` property and a `done` property having a `boolean` value indicating whether the [iterator][mdn-iterator-protocol] is finished.
+-   **return**: function which closes an [iterator][mdn-iterator-protocol] and returns a single (optional) argument in an [iterator][mdn-iterator-protocol] protocol-compliant object.
+
 <a name="method-last-index-of"></a>
 
 #### BooleanArray.prototype.lastIndexOf( searchElement\[, fromIndex] )
@@ -1337,6 +1366,55 @@ var str = arr.toString();
 // returns 'true,false,true'
 ```
 
+<a name="method-values"></a>
+
+#### BooleanArray.prototype.values()
+
+Returns an iterator for iterating over each value in a typed array.
+
+```javascript
+var arr = new BooleanArray( 2 );
+
+arr.set( true, 0 );
+arr.set( false, 1 );
+
+var iter = arr.values();
+
+var v = iter.next().value;
+// returns true
+
+v = iter.next().value;
+// returns false
+
+var bool = iter.next().done;
+// returns true
+```
+
+The returned [iterator][mdn-iterator-protocol] protocol-compliant object has the following properties:
+
+-   **next**: function which returns an [iterator][mdn-iterator-protocol] protocol-compliant object containing the next iterated value (if one exists) assigned to a `value` property and a `done` property having a `boolean` value indicating whether the [iterator][mdn-iterator-protocol] is finished.
+-   **return**: function which closes an [iterator][mdn-iterator-protocol] and returns a single (optional) argument in an [iterator][mdn-iterator-protocol] protocol-compliant object.
+
+<a name="method-with"></a>
+
+#### BooleanArray.prototype.with( index, value )
+
+Returns a new typed array with the element at a provided index replaced with a provided value.
+
+```javascript
+var arr = new BooleanArray( 3 );
+
+arr.set( true, 0 );
+arr.set( false, 1 );
+arr.set( true, 1 );
+
+var out = arr.with( 0, false );
+// returns <BooleanArray>
+
+var v = out.get( 0 );
+// returns false
+```
+
 </section>
 
 <!-- /.usage -->
@@ -1418,6 +1496,8 @@ console.log( '%s', false );
 <!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 
 <section class="links">
+
+[mdn-iterator-protocol]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#The_iterator_protocol
 
 [@stdlib/array/typed]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/typed
 

--- a/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.keys.js
+++ b/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.keys.js
@@ -1,0 +1,51 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var pkg = require( './../package.json' ).name;
+var BooleanArray = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg+':keys', function benchmark( b ) {
+	var iter;
+	var arr;
+	var i;
+
+	arr = new BooleanArray( [ true, false ] );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		iter = arr.keys();
+		if ( typeof iter !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+	if ( !isIteratorLike( iter ) ) {
+		b.fail( 'should return an iterator protocol-compliant object' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.keys.length.js
+++ b/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.keys.length.js
@@ -1,0 +1,102 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var pkg = require( './../package.json' ).name;
+var BooleanArray = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var arr;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < len; i++ ) {
+		arr.push( true );
+	}
+	arr = new BooleanArray( arr );
+
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var iter;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			iter = arr.keys();
+			if ( typeof iter !== 'object' ) {
+				b.fail( 'should return an object' );
+			}
+		}
+		b.toc();
+		if ( !isIteratorLike( iter ) ) {
+			b.fail( 'should return an iterator protocol-compliant object' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':keys:len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.values.js
+++ b/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.values.js
@@ -1,0 +1,51 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var pkg = require( './../package.json' ).name;
+var BooleanArray = require('./../lib');
+
+
+// MAIN //
+
+bench( pkg+':values', function benchmark( b ) {
+	var iter;
+	var arr;
+	var i;
+
+	arr = new BooleanArray( [ true, false ] );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		iter = arr.values();
+		if ( typeof iter !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+	if ( !isIteratorLike( iter ) ) {
+		b.fail( 'should return an iterator protocol-compliant object' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.values.length.js
+++ b/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.values.length.js
@@ -1,0 +1,102 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var pkg = require( './../package.json' ).name;
+var BooleanArray = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var arr;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < len; i++ ) {
+		arr.push( true );
+	}
+	arr = new BooleanArray( arr );
+
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var iter;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			iter = arr.values();
+			if ( typeof iter !== 'object' ) {
+				b.fail( 'should return an object' );
+			}
+		}
+		b.toc();
+		if ( !isIteratorLike( iter ) ) {
+			b.fail( 'should return an iterator protocol-compliant object' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':values:len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.with.js
+++ b/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.with.js
@@ -1,0 +1,56 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isBooleanArray = require( '@stdlib/assert/is-booleanarray' );
+var pkg = require( './../package.json' ).name;
+var BooleanArray = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg+':with', function benchmark( b ) {
+	var values;
+	var arr;
+	var out;
+	var i;
+
+	values = [
+		true,
+		false
+	];
+	arr = new BooleanArray( 5 );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = arr.with( i%arr.length, values[ i%values.length ] );
+		if ( typeof out !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+	if ( !isBooleanArray( out ) ) {
+		b.fail( 'should return a BooleanArray' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.with.length.js
+++ b/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.with.length.js
@@ -1,0 +1,100 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var isBooleanArray = require('@stdlib/assert/is-booleanarray' );
+var pkg = require( './../package.json' ).name;
+var BooleanArray = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var arr = new BooleanArray( len );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var values;
+		var out;
+		var i;
+
+		values = [
+			true,
+			false
+		];
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			out = arr.with( i%len, values[ i%values.length ] );
+			if ( typeof out !== 'object' ) {
+				b.fail( 'should return an object' );
+			}
+		}
+		b.toc();
+		if ( !isBooleanArray( out ) ) {
+			b.fail( 'should return a BooleanArray' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':with:len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/bool/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/bool/docs/repl.txt
@@ -566,6 +566,27 @@
     'true|false|true'
 
 
+{{alias}}.prototype.keys()
+    Returns an iterator for iterating over each index key in a typed array.
+
+    Returns
+    -------
+    iterator: Iterator
+        Iterator for iterating over array index keys.
+    
+    Examples
+    --------
+    > var arr = new {{alias}}( [ true, false ] )
+    <BooleanArray>
+    > var it = arr.keys();
+    > var v = it.next().value
+    0
+    > v = it.next().value
+    1
+    > v = it.next().done
+    true
+
+
 {{alias}}.prototype.lastIndexOf( searchElement[, fromIndex] )
     Returns the last index at which a given element can be found.
 
@@ -981,6 +1002,54 @@
     <BooleanArray>
     > var str = arr.toString()
     'true,false,true'
+
+
+{{alias}}.prototype.values()
+    Returns an iterator for iterating over each value in a typed array.
+
+    Returns
+    -------
+    iterator: Iterator
+        Iterator for iterating over array values.
+    
+    Examples
+    --------
+    > var arr = new {{alias}}( [ true, false ] )
+    <BooleanArray>
+    > var it = arr.values();
+    > var v = it.next().value
+    true
+    > v = it.next().value
+    false
+    > var bool = it.next().done
+    true
+
+
+{{alias}}.prototype.with( index, value )
+    Returns a new typed array with the element at a provided index replaced
+    with a provided value.
+
+    Parameters
+    ----------
+    index: integer
+        Element index.
+    
+    value: boolean
+        Element value.  
+
+    Returns
+    -------
+    out: BooleanArray
+        New typed array.
+    
+    Examples
+    --------
+    > var arr = new {{alias}}( [ true, false, true ] )
+    <BooleanArray>
+    > var out = arr.with( 0, false )
+    <BooleanArray>
+    > var v = out.get( 0 )
+    false
 
 
     See Also

--- a/lib/node_modules/@stdlib/array/bool/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/bool/docs/types/index.d.ts
@@ -533,6 +533,30 @@ declare class BooleanArray implements BooleanArrayInterface {
 	join( separator?: string ): string;
 
 	/**
+	* Returns an iterator for iterating over each index key in a typed array.
+	*
+	* @returns iterator
+	*
+	* @example
+	* var arr = new BooleanArray( 2 );
+	*
+	* arr.set( true, 0 );
+	* arr.set( false, 1 );
+	*
+	* var iter = arr.keys();
+	*
+	* var v = iter.next().value;
+	* // returns 0
+	*
+	* v = iter.next().value;
+	* // returns 1
+	*
+	* var bool = iter.next().done;
+	* // returns true
+	*/
+	keys(): TypedIterator<number>;
+
+	/**
 	* Returns the last index at which a given element can be found.
 	*
 	* @param searchElement - element to find
@@ -942,6 +966,55 @@ declare class BooleanArray implements BooleanArrayInterface {
 	* // returns 'true,false,true'
 	*/
 	toString(): string;
+
+	/**
+	* Returns an iterator for iterating over each value in a typed array.
+	*
+	* @returns iterator
+	*
+	* @example
+	* var arr = new BooleanArray( 2 );
+	*
+	* arr.set( true, 0 );
+	* arr.set( false, 1 );
+	*
+	* var iter = arr.values();
+	*
+	* var v = iter.next().value;
+	* // returns true
+	*
+	* v = iter.next().value;
+	* // returns false
+	*
+	* var bool = iter.next().done;
+	* // returns true
+	*/
+	values(): TypedIterator<boolean>;
+
+	/**
+	* Returns a new typed array with the element at a provided index replaced with a provided value.
+	*
+	* @param index - element index
+	* @param value - new value
+	* @throws first argument must be an integer
+	* @throws second argument must be a boolean
+	* @throws index argument is out-of-bounds
+	* @returns modified typed array
+	*
+	* @example
+	* var arr = new BooleanArray( 3 );
+	*
+	* arr.set( true, 0 );
+	* arr.set( false, 1 );
+	* arr.set( true, 2 );
+	*
+	* var out = arr.with( 0, false );
+	* // returns <BooleanArray>
+	*
+	* var v = out.get( 0 );
+	* // returns false
+	*/
+	with( index: number, value: boolean ): BooleanArray;
 }
 
 /**

--- a/lib/node_modules/@stdlib/array/bool/lib/main.js
+++ b/lib/node_modules/@stdlib/array/bool/lib/main.js
@@ -896,6 +896,108 @@ setReadOnly( BooleanArray.prototype, 'join', function join( separator ) {
 });
 
 /**
+* Returns an iterator for iterating over each index key in a typed array.
+*
+* @name keys
+* @memberof BooleanArray.prototype
+* @type {Function}
+* @throws {TypeError} `this` must be a boolean array
+* @returns {Iterator} iterator
+*
+* @example
+* var arr = new BooleanArray( 2 );
+*
+* arr.set( true, 0 );
+* arr.set( false, 1 );
+*
+* var iter = arr.keys();
+*
+* var v = iter.next().value;
+* // returns 0
+*
+* v = iter.next().value;
+* // returns 1
+*
+* var bool = iter.next().done;
+* // returns true
+*/
+setReadOnly( BooleanArray.prototype, 'keys', function keys() {
+	var self;
+	var iter;
+	var len;
+	var FLG;
+	var i;
+
+	if ( !isBooleanArray( this ) ) {
+		throw new TypeError( 'invalid invocation. `this` is not a boolean array.' );
+	}
+	self = this;
+	len = this._length;
+
+	// Initialize an iteration index:
+	i = -1;
+
+	// Create an iterator protocol-compliant object:
+	iter = {};
+	setReadOnly( iter, 'next', next );
+	setReadOnly( iter, 'return', end );
+
+	if ( ITERATOR_SYMBOL ) {
+		setReadOnly( iter, ITERATOR_SYMBOL, factory );
+	}
+	return iter;
+
+	/**
+	* Returns an iterator protocol-compliant object containing the next iterated value.
+	*
+	* @private
+	* @returns {Object} iterator protocol-compliant object
+	*/
+	function next() {
+		i += 1;
+		if ( FLG || i >= len ) {
+			return {
+				'done': true
+			};
+		}
+		return {
+			'value': i,
+			'done': false
+		};
+	}
+
+	/**
+	* Finishes an iterator.
+	*
+	* @private
+	* @param {*} [value] - value to return
+	* @returns {Object} iterator protocol-compliant object
+	*/
+	function end( value ) {
+		FLG = true;
+		if ( arguments.length ) {
+			return {
+				'value': value,
+				'done': true
+			};
+		}
+		return {
+			'done': true
+		};
+	}
+
+	/**
+	* Returns a new iterator.
+	*
+	* @private
+	* @returns {Iterator} iterator
+	*/
+	function factory() {
+		return self.keys();
+	}
+});
+
+/**
 * Returns the last index at which a given element can be found.
 *
 * @name lastIndexOf
@@ -1784,6 +1886,168 @@ setReadOnly( BooleanArray.prototype, 'toString', function toString() {
 		}
 	}
 	return out.join( ',' );
+});
+
+/**
+* Returns an iterator for iterating over each value in a typed array.
+*
+* @name values
+* @memberof BooleanArray.prototype
+* @type {Function}
+* @throws {TypeError} `this` must be a boolean array
+* @returns {Iterator} iterator
+*
+* @example
+* var arr = new BooleanArray( 2 );
+*
+* arr.set( true, 0 );
+* arr.set( false, 1 );
+*
+* var iter = arr.values();
+*
+* var v = iter.next().value;
+* // returns true
+*
+* v = iter.next().value;
+* // returns false
+*
+* var bool = iter.next().done;
+* // returns true
+*/
+setReadOnly( BooleanArray.prototype, 'values', function values() {
+	var iter;
+	var self;
+	var len;
+	var FLG;
+	var buf;
+	var i;
+
+	if ( !isBooleanArray( this ) ) {
+		throw new TypeError( 'invalid invocation. `this` is not a boolean array.' );
+	}
+	self = this;
+	buf = this._buffer;
+	len = this._length;
+
+	// Initialize an iteration index:
+	i = -1;
+
+	// Create an iterator protocol-compliant object:
+	iter = {};
+	setReadOnly( iter, 'next', next );
+	setReadOnly( iter, 'return', end );
+
+	if ( ITERATOR_SYMBOL ) {
+		setReadOnly( iter, ITERATOR_SYMBOL, factory );
+	}
+	return iter;
+
+	/**
+	* Returns an iterator protocol-compliant object containing the next iterated value.
+	*
+	* @private
+	* @returns {Object} iterator protocol-compliant object
+	*/
+	function next() {
+		i += 1;
+		if ( FLG || i >= len ) {
+			return {
+				'done': true
+			};
+		}
+		return {
+			'value': Boolean( buf[ i ] ),
+			'done': false
+		};
+	}
+
+	/**
+	* Finishes an iterator.
+	*
+	* @private
+	* @param {*} [value] - value to return
+	* @returns {Object} iterator protocol-compliant object
+	*/
+	function end( value ) {
+		FLG = true;
+		if ( arguments.length ) {
+			return {
+				'value': value,
+				'done': true
+			};
+		}
+		return {
+			'done': true
+		};
+	}
+
+	/**
+	* Returns a new iterator.
+	*
+	* @private
+	* @returns {Iterator} iterator
+	*/
+	function factory() {
+		return self.values();
+	}
+});
+
+/**
+* Returns a new typed array with the element at a provided index replaced with a provided value.
+*
+* @name with
+* @memberof BooleanArray.prototype
+* @type {Function}
+* @param {integer} index - element index
+* @param {boolean} value - new value
+* @throws {TypeError} `this` must be a boolean array
+* @throws {TypeError} first argument must be an integer
+* @throws {RangeError} index argument is out-of-bounds
+* @throws {TypeError} second argument must be a boolean
+* @returns {BooleanArray} new typed array
+*
+* @example
+* var arr = new BooleanArray( 3 );
+*
+* arr.set( true, 0 );
+* arr.set( false, 1 );
+* arr.set( true, 2 );
+*
+* var out = arr.with( 0, false );
+* // returns <BooleanArray>
+*
+* var v = out.get( 0 );
+* // returns false
+*/
+setReadOnly( BooleanArray.prototype, 'with', function copyWith( index, value ) {
+	var buf;
+	var out;
+	var len;
+
+	if ( !isBooleanArray( this ) ) {
+		throw new TypeError( 'invalid invocation. `this` is not a boolean array.' );
+	}
+	if ( !isInteger( index ) ) {
+		throw new TypeError( format( 'invalid argument. First argument must be an integer. Value: `%s`.', index ) );
+	}
+	len = this._length;
+	if ( index < 0 ) {
+		index += len;
+	}
+	if ( index < 0 || index >= len ) {
+		throw new RangeError( format( 'invalid argument. Index argument is out-of-bounds. Value: `%s`.', index ) );
+	}
+	if ( !isBoolean( value ) ) {
+		throw new TypeError( format( 'invalid argument. Second argument must be a boolean. Value: `%s`.', value ) );
+	}
+	out = new this.constructor( this._buffer );
+	buf = out._buffer; // eslint-disable-line no-underscore-dangle
+	if ( value ) {
+		buf[ index ] = 1;
+	} else {
+		buf[ index ] = 0;
+	}
+	return out;
 });
 
 

--- a/lib/node_modules/@stdlib/array/bool/test/test.keys.js
+++ b/lib/node_modules/@stdlib/array/bool/test/test.keys.js
@@ -1,0 +1,261 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var proxyquire = require( 'proxyquire' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var ITERATOR_SYMBOL = require( '@stdlib/symbol/iterator' );
+var BooleanArray = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof BooleanArray, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the main export is a `keys` method', function test( t ) {
+	t.strictEqual( hasOwnProp( BooleanArray.prototype, 'keys' ), true, 'has property' );
+	t.strictEqual( isFunction( BooleanArray.prototype.keys ), true, 'has method' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a boolean array instance', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new BooleanArray( 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.keys.call( value );
+		};
+	}
+});
+
+tape( 'the method returns an iterator protocol-compliant object', function test( t ) {
+	var expected;
+	var arr;
+	var it;
+	var i;
+	var r;
+	var e;
+
+	arr = new BooleanArray( [ true, false ] );
+	expected = [
+		{
+			'value': 0,
+			'done': false
+		},
+		{
+			'value': 1,
+			'done': false
+		},
+		{
+			'done': true
+		}
+	];
+	it = arr.keys();
+
+	t.strictEqual( typeof it, 'object', 'returns an object' );
+	t.strictEqual( typeof it.next, 'function', 'has next method' );
+
+	for ( i = 0; i < expected.length; i++ ) {
+		r = it.next();
+		e = expected[ i ];
+		if ( e.value === void 0 ) {
+			t.deepEqual( r, e, 'returns expected value' );
+		} else {
+			t.strictEqual( r.value, e.value, 'returns expected value' );
+			t.strictEqual( r.done, e.done, 'returns expected value' );
+		}
+	}
+
+	t.end();
+});
+
+tape( 'the method returns an iterator which does not iterate over empty arrays', function test( t ) {
+	var expected;
+	var arr;
+	var it;
+	var i;
+	var v;
+
+	arr = new BooleanArray( [] );
+	expected = [
+		{
+			'done': true
+		},
+		{
+			'done': true
+		},
+		{
+			'done': true
+		}
+	];
+	it = arr.keys();
+
+	t.strictEqual( typeof it, 'object', 'returns an object' );
+	t.strictEqual( typeof it.next, 'function', 'has next method' );
+
+	for ( i = 0; i < expected.length; i++ ) {
+		v = it.next();
+		t.deepEqual( v, expected[ i ], 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the returned iterator has a `return` method for closing an iterator (no argument)', function test( t ) {
+	var arr;
+	var it;
+	var v;
+
+	arr = new BooleanArray( [ true, false, true ] );
+	it = arr.keys();
+
+	v = it.next();
+	t.strictEqual( v.value, 0, 'returns expected value' );
+	t.strictEqual( v.done, false, 'returns expected value' );
+
+	v = it.next();
+	t.strictEqual( v.value, 1, 'returns expected value' );
+	t.strictEqual( v.done, false, 'returns expected value' );
+
+	v = it.return();
+	t.strictEqual( v.value, void 0, 'returns expected value' );
+	t.strictEqual( v.done, true, 'returns expected value' );
+
+	v = it.next();
+	t.strictEqual( v.value, void 0, 'returns expected value' );
+	t.strictEqual( v.done, true, 'returns expected value' );
+
+	v = it.next();
+	t.strictEqual( v.value, void 0, 'returns expected value' );
+	t.strictEqual( v.done, true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the returned iterator has a `return` method for closing an iterator (argument)', function test( t ) {
+	var arr;
+	var it;
+	var v;
+
+	arr = new BooleanArray( [ true, false, true ] );
+	it = arr.keys();
+
+	v = it.next();
+	t.strictEqual( v.value, 0, 'returns expected value' );
+	t.strictEqual( v.done, false, 'returns expected value' );
+
+	v = it.next();
+	t.strictEqual( v.value, 1, 'returns expected value' );
+	t.strictEqual( v.done, false, 'returns expected value' );
+
+	v = it.return( 'beep' );
+	t.strictEqual( v.value, 'beep', 'returns expected value' );
+	t.strictEqual( v.done, true, 'returns expected value' );
+
+	v = it.next();
+	t.strictEqual( v.value, void 0, 'returns expected value' );
+	t.strictEqual( v.done, true, 'returns expected value' );
+
+	v = it.next();
+	t.strictEqual( v.value, void 0, 'returns expected value' );
+	t.strictEqual( v.done, true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if an environment supports `Symbol.iterator`, the method returns an iterable', function test( t ) {
+	var BooleanArray;
+	var arr;
+	var buf;
+	var it1;
+	var it2;
+	var v1;
+	var v2;
+	var i;
+
+	BooleanArray = proxyquire( './../lib/main.js', {
+		'@stdlib/symbol/iterator': '__ITERATOR_SYMBOL__'
+	});
+
+	buf = [ 1, 0, 0, 1 ];
+	arr = new BooleanArray( buf );
+
+	it1 = arr.keys();
+	t.strictEqual( typeof it1[ '__ITERATOR_SYMBOL__' ], 'function', 'has method' );
+	t.strictEqual( it1[ '__ITERATOR_SYMBOL__' ].length, 0, 'has zero arity' );
+
+	it2 = it1[ '__ITERATOR_SYMBOL__' ]();
+	t.strictEqual( typeof it2, 'object', 'returns an object' );
+	t.strictEqual( typeof it2.next, 'function', 'has `next` method' );
+	t.strictEqual( typeof it2.return, 'function', 'has `return` method' );
+
+	for ( i = 0; i < arr.length; i++ ) {
+		v1 = it1.next().value;
+		v2 = it2.next().value;
+		t.strictEqual( v1, v2, 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'if an environment does not support `Symbol.iterator`, the method does not return an "iterable"', function test( t ) {
+	var BooleanArray;
+	var arr;
+	var buf;
+	var it;
+
+	BooleanArray = proxyquire( './../lib/main.js', {
+		'@stdlib/symbol/iterator': false
+	});
+
+	buf = [ 1, 0, 0, 1 ];
+	arr = new BooleanArray( buf );
+
+	it = arr.keys();
+	t.strictEqual( it[ ITERATOR_SYMBOL ], void 0, 'does not have property' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/array/bool/test/test.values.js
+++ b/lib/node_modules/@stdlib/array/bool/test/test.values.js
@@ -1,0 +1,263 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var proxyquire = require( 'proxyquire' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var ITERATOR_SYMBOL = require( '@stdlib/symbol/iterator' );
+var BooleanArray = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof BooleanArray, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the main export is a `values` method', function test( t ) {
+	t.strictEqual( hasOwnProp( BooleanArray.prototype, 'values' ), true, 'has property' );
+	t.strictEqual( isFunction( BooleanArray.prototype.values ), true, 'has method' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a boolean array instance', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new BooleanArray( 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.values.call( value );
+		};
+	}
+});
+
+tape( 'the method returns an iterator protocol-compliant object', function test( t ) {
+	var expected;
+	var arr;
+	var it;
+	var i;
+	var r;
+	var e;
+
+	arr = new BooleanArray( [ true, false ] );
+	expected = [
+		{
+			'value': true,
+			'done': false
+		},
+		{
+			'value': false,
+			'done': false
+		},
+		{
+			'done': true
+		}
+	];
+	it = arr.values();
+
+	t.strictEqual( typeof it, 'object', 'returns an object' );
+	t.strictEqual( typeof it.next, 'function', 'has next method' );
+
+	for ( i = 0; i < expected.length; i++ ) {
+		r = it.next();
+		e = expected[ i ];
+		if ( e.value === void 0 ) {
+			t.deepEqual( r, e, 'returns expected value' );
+		} else {
+			t.strictEqual( isBoolean( r.value ), true, 'returns expected value' );
+			t.strictEqual( r.value, e.value, 'returns expected value' );
+			t.strictEqual( r.done, e.done, 'returns expected value' );
+		}
+	}
+
+	t.end();
+});
+
+tape( 'the method returns an iterator which does not iterate over empty arrays', function test( t ) {
+	var expected;
+	var arr;
+	var it;
+	var i;
+	var v;
+
+	arr = new BooleanArray( [] );
+	expected = [
+		{
+			'done': true
+		},
+		{
+			'done': true
+		},
+		{
+			'done': true
+		}
+	];
+	it = arr.values();
+
+	t.strictEqual( typeof it, 'object', 'returns an object' );
+	t.strictEqual( typeof it.next, 'function', 'has next method' );
+
+	for ( i = 0; i < expected.length; i++ ) {
+		v = it.next();
+		t.deepEqual( v, expected[ i ], 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the returned iterator has a `return` method for closing an iterator (no argument)', function test( t ) {
+	var arr;
+	var it;
+	var v;
+
+	arr = new BooleanArray( [ true, false, true ] );
+	it = arr.values();
+
+	v = it.next();
+	t.strictEqual( v.value, true, 'returns expected value' );
+	t.strictEqual( v.done, false, 'returns expected value' );
+
+	v = it.next();
+	t.strictEqual( v.value, false, 'returns expected value' );
+	t.strictEqual( v.done, false, 'returns expected value' );
+
+	v = it.return();
+	t.strictEqual( v.value, void 0, 'returns expected value' );
+	t.strictEqual( v.done, true, 'returns expected value' );
+
+	v = it.next();
+	t.strictEqual( v.value, void 0, 'returns expected value' );
+	t.strictEqual( v.done, true, 'returns expected value' );
+
+	v = it.next();
+	t.strictEqual( v.value, void 0, 'returns expected value' );
+	t.strictEqual( v.done, true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the returned iterator has a `return` method for closing an iterator (argument)', function test( t ) {
+	var arr;
+	var it;
+	var v;
+
+	arr = new BooleanArray( [ true, false, true ] );
+	it = arr.values();
+
+	v = it.next();
+	t.strictEqual( v.value, true, 'returns expected value' );
+	t.strictEqual( v.done, false, 'returns expected value' );
+
+	v = it.next();
+	t.strictEqual( v.value, false, 'returns expected value' );
+	t.strictEqual( v.done, false, 'returns expected value' );
+
+	v = it.return( 'beep' );
+	t.strictEqual( v.value, 'beep', 'returns expected value' );
+	t.strictEqual( v.done, true, 'returns expected value' );
+
+	v = it.next();
+	t.strictEqual( v.value, void 0, 'returns expected value' );
+	t.strictEqual( v.done, true, 'returns expected value' );
+
+	v = it.next();
+	t.strictEqual( v.value, void 0, 'returns expected value' );
+	t.strictEqual( v.done, true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if an environment supports `Symbol.iterator`, the method returns an iterable', function test( t ) {
+	var BooleanArray;
+	var arr;
+	var buf;
+	var it1;
+	var it2;
+	var v1;
+	var v2;
+	var i;
+
+	BooleanArray = proxyquire( './../lib/main.js', {
+		'@stdlib/symbol/iterator': '__ITERATOR_SYMBOL__'
+	});
+
+	buf = [ 1, 0, 0, 1 ];
+	arr = new BooleanArray( buf );
+
+	it1 = arr.values();
+	t.strictEqual( typeof it1[ '__ITERATOR_SYMBOL__' ], 'function', 'has method' );
+	t.strictEqual( it1[ '__ITERATOR_SYMBOL__' ].length, 0, 'has zero arity' );
+
+	it2 = it1[ '__ITERATOR_SYMBOL__' ]();
+	t.strictEqual( typeof it2, 'object', 'returns an object' );
+	t.strictEqual( typeof it2.next, 'function', 'has `next` method' );
+	t.strictEqual( typeof it2.return, 'function', 'has `return` method' );
+
+	for ( i = 0; i < arr.length; i++ ) {
+		v1 = it1.next().value;
+		v2 = it2.next().value;
+		t.strictEqual( v1, v2, 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'if an environment does not support `Symbol.iterator`, the method does not return an "iterable"', function test( t ) {
+	var BooleanArray;
+	var arr;
+	var buf;
+	var it;
+
+	BooleanArray = proxyquire( './../lib/main.js', {
+		'@stdlib/symbol/iterator': false
+	});
+
+	buf = [ true, false, false, true ];
+	arr = new BooleanArray( buf );
+
+	it = arr.values();
+	t.strictEqual( it[ ITERATOR_SYMBOL ], void 0, 'does not have property' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/array/bool/test/test.with.js
+++ b/lib/node_modules/@stdlib/array/bool/test/test.with.js
@@ -1,0 +1,200 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var Uint8Array = require( '@stdlib/array/uint8' );
+var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
+var BooleanArray = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof BooleanArray, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the main export is a `with` method', function test( t ) {
+	t.strictEqual( hasOwnProp( BooleanArray.prototype, 'with' ), true, 'has property' );
+	t.strictEqual( isFunction( BooleanArray.prototype.with ), true, 'has method' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a boolean array instance', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new BooleanArray( 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.with.call( value, 0, true );
+		};
+	}
+});
+
+tape( 'the method throws an error if provided a first argument which is not an integer', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new BooleanArray( 5 );
+
+	values = [
+		'5',
+		3.14,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.with( value, true );
+		};
+	}
+});
+
+tape( 'the method throws an error if provided a first argument which is not in bounds', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new BooleanArray( 10 );
+
+	values = [
+		-11,
+		-12,
+		11,
+		12
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), RangeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.with( value, false );
+		};
+	}
+});
+
+tape( 'the method throws an error if provided a second argument which is not a boolean', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new BooleanArray( 10 );
+
+	values = [
+		'5',
+		3.14,
+		NaN,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.with( 0, value );
+		};
+	}
+});
+
+tape( 'the method does not change the array length', function test( t ) {
+	var arr;
+	var out;
+
+	arr = new BooleanArray( 10 );
+	out = arr.with( 5, true );
+
+	t.strictEqual( out.length, 10, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method returns a new boolean array with the element at a provided index replaced with a provided value', function test( t ) {
+	var expected;
+	var arr;
+	var out;
+
+	arr = new BooleanArray( [ true, false, false, false ] );
+	expected = new Uint8Array( [ 1, 0, 0, 1 ] );
+	out = arr.with( 3, true );
+
+	t.strictEqual( out instanceof BooleanArray, true, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
+	t.notEqual( out, arr, 'returns new instance' );
+	t.end();
+});
+
+tape( 'the method supports negative indices', function test( t ) {
+	var expected;
+	var arr;
+	var out;
+
+	arr = new BooleanArray( [ true, false, false ] );
+	expected = new Uint8Array( [ 1, 0, 1 ] );
+
+	out = arr.with( -1, true );
+
+	t.strictEqual( out instanceof BooleanArray, true, 'returns expected value' );
+	t.deepEqual( reinterpretBoolean( out, 0 ), expected, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
Resolves: Subtask of #2304 

## Description

> What is the purpose of this pull request?

This pull request:

-  Adds the typed array `keys`, `values` and `with` methods to prototype of `BooleanArray`

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
