### PR TITLE
build: run workflow step only if user has write access

### DIFF
--- a/.github/workflows/process_metadata.yml
+++ b/.github/workflows/process_metadata.yml
@@ -92,6 +92,9 @@ jobs:
       # Check the metadata for directives to send tweets:
       - name: 'Send tweets'
 
+        # Only run this step if a user has write access:
+        if: steps.assert-write-access.outcome == 'success'
+
         # Pin action to full length commit SHA
         uses: stdlib-js/metadata-tweet-action@8e9b688c86150797c1c7f60bc8f7c9a9a30e10fe # v2.0.0
         with:


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   fixes [failing workflow](https://github.com/stdlib-js/stdlib/actions/runs/9926540978/job/27420298225)
-   skips the "Send tweets" workflow step if the user doesn't have write access as [no metadata is generated in the previous step](https://github.com/stdlib-js/metadata-tweet-action?tab=readme-ov-file#inputs).

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   adds to https://github.com/stdlib-js/stdlib/commit/bcb0fc6b43d69fe80abbbc63bbe6e93ad9cae4bb

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
