### PR TITLE
feat: add `copyWithin`, `entries`, `forEach` to `array/bool`

### DIFF
--- a/lib/node_modules/@stdlib/array/bool/README.md
+++ b/lib/node_modules/@stdlib/array/bool/README.md
@@ -366,6 +366,88 @@ v = arr.at( -100 );
 // returns undefined
 ```
 
+<a name="method-copy-within"></a>
+
+#### BooleanArray.prototype.copyWithin( target, start\[, end] )
+
+Copies a sequence of elements within the array starting at `start` and ending at `end` (non-inclusive) to the position starting at `target`.
+
+```javascript
+var arr = new BooleanArray( 4 );
+
+arr.set( true, 0 );
+arr.set( false, 1 );
+arr.set( false, 2 );
+arr.set( true, 3 );
+
+var v = arr.get( 0 );
+// returns true
+
+v = arr.get( 1 );
+// returns false
+
+// Copy the last two elements to the first two elements:
+arr.copyWithin( 0, 2 );
+
+v = arr.get( 0 );
+// returns false
+
+v = arr.get( 1 );
+// returns true
+```
+
+By default, `end` equals the number of array elements (i.e., one more than the last array index). To limit the sequence length, provide an `end` argument.
+
+```javascript
+var arr = new BooleanArray( 4 );
+
+arr.set( true, 0 );
+arr.set( false, 1 );
+arr.set( false, 2 );
+arr.set( true, 3 );
+
+var v = arr.get( 2 );
+// returns false
+
+v = arr.get( 3 );
+// returns true
+
+// Copy the first two elements to the last two elements:
+arr.copyWithin( 2, 0, 2 );
+
+v = arr.get( 2 );
+// returns true
+
+v = arr.get( 3 );
+// returns false
+```
+
+When a `target`, `start`, and/or `end` index is negative, the respective index is determined relative to the last array element. The following example achieves the same behavior as the previous example:
+
+```javascript
+var arr = new BooleanArray( 4 );
+
+arr.set( true, 0 );
+arr.set( false, 1 );
+arr.set( false, 2 );
+arr.set( true, 3 );
+
+var v = arr.get( 2 );
+// returns false
+
+v = arr.get( 3 );
+// returns true
+
+// Copy the first two elements to the last two elements using negative indices:
+arr.copyWithin( -2, -4, -2 );
+
+v = arr.get( 2 );
+// returns true
+
+v = arr.get( 3 );
+// returns false
+```
+
 <a name="method-entries"></a>
 
 #### Complex64Array.prototype.entries()

--- a/lib/node_modules/@stdlib/array/bool/README.md
+++ b/lib/node_modules/@stdlib/array/bool/README.md
@@ -450,7 +450,7 @@ v = arr.get( 3 );
 
 <a name="method-entries"></a>
 
-#### Complex64Array.prototype.entries()
+#### BooleanArray.prototype.entries()
 
 Returns an iterator for iterating over array key-value pairs.
 

--- a/lib/node_modules/@stdlib/array/bool/README.md
+++ b/lib/node_modules/@stdlib/array/bool/README.md
@@ -366,6 +366,39 @@ v = arr.at( -100 );
 // returns undefined
 ```
 
+<a name="method-entries"></a>
+
+#### Complex64Array.prototype.entries()
+
+Returns an iterator for iterating over array key-value pairs.
+
+```javascript
+var arr = new BooleanArray( 3 );
+
+arr.set( true, 0 );
+arr.set( false, 1 );
+arr.set( true, 2 );
+
+var it = arr.entries();
+
+var v = it.next().value;
+// returns [ 0, true ]
+
+v = it.next().value;
+// returns [ 1, false ]
+
+v = it.next().value;
+// returns [ 2, true ]
+
+var bool = it.next().done;
+// returns true
+```
+
+The returned [iterator][mdn-iterator-protocol] protocol-compliant object has the following properties:
+
+-   **next**: function which returns an [iterator][mdn-iterator-protocol] protocol-compliant object containing the next iterated value (if one exists) assigned to a `value` property and a `done` property having a `boolean` value indicating whether the [iterator][mdn-iterator-protocol] is finished.
+-   **return**: function which closes an [iterator][mdn-iterator-protocol] and returns a single (optional) argument in an [iterator][mdn-iterator-protocol] protocol-compliant object.
+
 <a name="method-every"></a>
 
 #### BooleanArray.prototype.every( predicate\[, thisArg] )

--- a/lib/node_modules/@stdlib/array/bool/README.md
+++ b/lib/node_modules/@stdlib/array/bool/README.md
@@ -861,6 +861,66 @@ var count = context.count;
 // returns 3
 ```
 
+<a name="method-for-each"></a>
+
+#### BooleanArray.prototype.forEach( callbackFn\[, thisArg] )
+
+Invokes a function once for each array element.
+
+```javascript
+function log( v, i ) {
+    console.log( '%s: %s', i, v.toString() );
+}
+
+var arr = new BooleanArray( 3 );
+
+arr.set( true, 0 );
+arr.set( false, 1 );
+arr.set( true, 2 );
+
+arr.forEach( log );
+/* =>
+    0: true
+    1: false
+    2: true
+*/
+```
+
+The invoked function is provided three arguments:
+
+-   **value**: current array element.
+-   **index**: current array element index.
+-   **arr**: the array on which this method was called.
+
+To set the function execution context, provide a `thisArg`.
+
+```javascript
+function fcn( v, i ) {
+    this.count += 1;
+    console.log( '%s: %s', i, v.toString() );
+}
+
+var arr = new BooleanArray( 3 );
+
+var context = {
+    'count': 0
+};
+
+arr.set( true, 0 );
+arr.set( false, 1 );
+arr.set( true, 2 );
+
+arr.forEach( fcn, context );
+/* =>
+    0: 1 + 1i
+    1: 2 + 2i
+    2: 3 + 3i
+*/
+
+var count = context.count;
+// returns 3
+```
+
 <a name="method-get"></a>
 
 #### BooleanArray.prototype.get( i )

--- a/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.copy_within.js
+++ b/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.copy_within.js
@@ -1,0 +1,56 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pkg = require( './../package.json' ).name;
+var BooleanArray = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg+':copyWithin', function benchmark( b ) {
+	var arr;
+	var buf;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < 5; i++ ) {
+		arr.push( i%2 );
+	}
+	arr = new BooleanArray( arr );
+	buf = arr.buffer;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		buf[ 0 ] = i%2;
+		arr = arr.copyWithin( 1, 0 );
+		if ( buf[ 0 ] !== i%2 ) {
+			b.fail( 'unexpected result' );
+		}
+	}
+	b.toc();
+	if ( buf[ 0 ] !== buf[ 0 ] ) {
+		b.fail( 'should not be NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.copy_within.length.js
+++ b/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.copy_within.length.js
@@ -1,0 +1,103 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var pkg = require( './../package.json' ).name;
+var BooleanArray = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var arr;
+	var buf;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < len+1; i++ ) {
+		arr.push( i%2 );
+	}
+	arr = new BooleanArray( arr );
+	buf = arr.buffer;
+
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			buf[ 0 ] = i%2;
+			arr.copyWithin( 1, 0 );
+			if ( buf[ 0 ] !== i%2 ) {
+				b.fail( 'unexpected result' );
+			}
+		}
+		b.toc();
+		if ( buf[ 0 ] !== buf[ 0 ] ) {
+			b.fail( 'should not be NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':copyWithin:len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.entries.js
+++ b/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.entries.js
@@ -1,0 +1,54 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pkg = require( './../package.json' ).name;
+var BooleanArray = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg+':entries', function benchmark( b ) {
+	var iter;
+	var arr;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < 10; i++ ) {
+		arr.push( true );
+	}
+	arr = new BooleanArray( arr );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		iter = arr.entries();
+		if ( typeof iter !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+	if ( typeof iter !== 'object' || typeof iter.next !== 'function' ) {
+		b.fail( 'should return an iterator protocol-compliant object' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.for_each.js
+++ b/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.for_each.js
@@ -1,0 +1,56 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var pkg = require( './../package.json' ).name;
+var BooleanArray = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg+':forEach', function benchmark( b ) {
+	var arr;
+	var i;
+
+	arr = new BooleanArray( [ true, false, false, true ] );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr.forEach( check );
+		if ( arr.length !== 4 ) {
+			b.fail( 'should not change an array length' );
+		}
+	}
+	b.toc();
+	if ( arr.length !== 4 ) {
+		b.fail( 'should not change an array length' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+
+	function check( v ) {
+		if ( !isBoolean( v ) ) {
+			b.fail( 'should be a boolean' );
+		}
+	}
+});

--- a/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.for_each.length.js
+++ b/lib/node_modules/@stdlib/array/bool/benchmark/benchmark.for_each.length.js
@@ -1,0 +1,106 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var pkg = require( './../package.json' ).name;
+var BooleanArray = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var arr;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < len; i++ ) {
+		arr.push( true );
+	}
+	arr = new BooleanArray( arr );
+
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			arr.forEach( callback );
+			if ( arr.length !== len ) {
+				b.fail( 'should not change an array length' );
+			}
+		}
+		b.toc();
+		if ( arr.length !== len ) {
+			b.fail( 'should not change an array length' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+
+		function callback( value ) {
+			if ( value !== true ) {
+				throw new Error( 'something went wrong' );
+			}
+		}
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':forEach:len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/bool/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/bool/docs/repl.txt
@@ -313,6 +313,29 @@
     true
 
 
+{{alias}}.prototype.entries()
+    Returns an iterator for iterating over array key-value pairs.
+
+    Returns
+    -------
+    iterator: Iterator
+        Iterator for iterating over array key-value pairs.
+
+    Examples
+    --------
+    > var arr = new {{alias}}( [ true, false, true ] )
+    <BooleanArray>
+    > var it = arr.entries();
+    > var v = it.next().value
+    [ 0, true ]
+    > v = it.next().value
+    [ 1, false ]
+    > v = it.next().value
+    [ 2, true ]
+    > var bool = it.next().done
+    true
+
+
 {{alias}}.prototype.every( predicate[, thisArg] )
     Returns a boolean indicating whether all elements in the array pass a test.
 

--- a/lib/node_modules/@stdlib/array/bool/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/bool/docs/repl.txt
@@ -617,6 +617,34 @@
     2
 
 
+{{alias}}.prototype.forEach( clbk[, thisArg] )
+    Invokes a function once for each array element.
+
+    A callback function is provided the following arguments:
+
+    - value: current array element.
+    - index: current array element index.
+    - arr: the array on which the method was called.
+
+    Parameters
+    ----------
+    clbk: Function
+        Function to invoke for each array element.
+
+    thisArg: Any (optional)
+        Execution context.
+    
+    Examples
+    --------
+    > var str = '%';
+    > function clbk( v ) { str += v.toString() + '%'; };
+    > var arr = new {{alias}}( [ true, false, false, true ] )
+    <BooleanArray>
+    > arr.forEach( clbk );
+    > str
+    '%true%false%false%true%'
+
+
 {{alias}}.prototype.get( i )
     Returns an array element located at integer position (index) `i`.
 

--- a/lib/node_modules/@stdlib/array/bool/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/bool/docs/repl.txt
@@ -313,6 +313,38 @@
     true
 
 
+{{alias}}.prototype.copyWithin( target, start[, end] )
+    Copies a sequence of elements within the array starting at `start` and
+    ending at `end` (non-inclusive) to the position starting at `target`.
+
+    Parameters
+    ----------
+    target: integer
+        Target start index position.
+    
+    start: integer
+        Source start index position.
+    
+    end: integer (optional)
+        Source end index position. Default: out.length.
+
+    Returns
+    -------
+    out: BooleanArray
+        Modified array.
+    
+    Examples
+    --------
+    > var arr = new {{alias}}( [ true, false, false, true ] )
+    <BooleanArray>
+    > arr.copyWithin( 0, 2 )
+    <BooleanArray>
+    > var v = arr.get( 0 )
+    false
+    > v = arr.get( 1 )
+    true
+
+
 {{alias}}.prototype.entries()
     Returns an iterator for iterating over array key-value pairs.
 

--- a/lib/node_modules/@stdlib/array/bool/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/bool/docs/types/index.d.ts
@@ -119,6 +119,50 @@ type Predicate<U> = NullaryPredicate<U> | UnaryPredicate<U> | BinaryPredicate<U>
 /**
 * Callback invoked for each element in an array.
 *
+* @returns undefined
+*/
+type NullaryCallback<U> = ( this: U ) => void;
+
+/**
+* Callback invoked for each element in an array.
+*
+* @param value - current array element
+* @returns undefined
+*/
+type UnaryCallback<U> = ( this: U, value: boolean ) => void;
+
+/**
+* Callback invoked for each element in an array.
+*
+* @param value - current array element
+* @param index - current array element index
+* @returns undefined
+*/
+type BinaryCallback<U> = ( this: U, value: boolean, index: number ) => void;
+
+/**
+* Callback invoked for each element in an array.
+*
+* @param value - current array element
+* @param index - current array element index
+* @param arr - array on which the method was called
+* @returns undefined
+*/
+type TernaryCallback<U> = ( this: U, value: boolean, index: number, arr: BooleanArray ) => void;
+
+/**
+* Callback invoked for each element in an array.
+*
+* @param value - current array element
+* @param index - current array element index
+* @param arr - array on which the method was called
+* @returns undefined
+*/
+type Callback<U> = NullaryCallback<U> | UnaryCallback<U> | BinaryCallback<U> | TernaryCallback<U>;
+
+/**
+* Callback invoked for each element in an array.
+*
 * @returns returned value
 */
 type NullaryMapFcn<U> = ( this: U ) => any;
@@ -585,6 +629,31 @@ declare class BooleanArray implements BooleanArrayInterface {
 	* // returns 2
 	*/
 	findLastIndex<U = unknown>( predicate: Predicate<U>, thisArg?: ThisParameterType<Predicate<U>> ): number;
+
+	/**
+	* Invokes a function once for each array element.
+	*
+	* @param fcn - function to invoke
+	* @param thisArg - execution context
+	* @returns undefined
+	*
+	* @example
+	* function log( v, i ) {
+	*     console.log( '%s: %s', i, v.toString() );
+	* }
+	*
+	* var arr = new BooleanArray( 3 );
+	*
+	* arr.set( true, 0 );
+	* arr.set( false, 1 );
+	* arr.set( true, 2 );
+	*
+	* arr.forEach( log );
+	* // => 0: true
+	* // => 1: false
+	* // => 2: true
+	*/
+	forEach<U = unknown>( fcn: Callback<U>, thisArg?: ThisParameterType<Callback<U>> ): void;
 
 	/**
 	* Returns an array element.

--- a/lib/node_modules/@stdlib/array/bool/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/bool/docs/types/index.d.ts
@@ -22,12 +22,22 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { Iterator as Iter, IterableIterator } from '@stdlib/types/iter';
+import { Iterator as Iter, IterableIterator, TypedIterator } from '@stdlib/types/iter';
 import { ArrayLike, BooleanArray as BooleanArrayInterface } from '@stdlib/types/array';
 import ArrayBuffer = require( '@stdlib/array/buffer' );
 
 // Define a union type representing both iterable and non-iterable iterators:
 type Iterator = Iter | IterableIterator;
+
+/**
+* Locale-specific configuration options.
+*/
+interface LocaleOptions<T = unknown> {
+	/**
+	* Configuration property.
+	*/
+	[ key: string | symbol | number ]: T | undefined;
+};
 
 /**
 * Callback invoked for each element in a source object.
@@ -349,6 +359,33 @@ declare class BooleanArray implements BooleanArrayInterface {
 	* // returns 10
 	*/
 	readonly length: number;
+
+	/**
+	* Copies a sequence of elements within the array to the position starting at `target`.
+	*
+	* @param target - index at which to start copying elements
+	* @param start - source index at which to copy elements from
+	* @param end - source index at which to stop copying elements from
+	* @returns modified array
+	*
+	* @example
+	* var arr = new BooleanArray( 4 );
+	*
+	* arr.set( true, 0 );
+	* arr.set( false, 1 );
+	* arr.set( false, 2 );
+	* arr.set( true, 3 );
+	*
+	* // Copy the first two elements to the last two elements:
+	* arr.copyWithin( 2, 0, 2 );
+	*
+	* var v = arr.get( 2 );
+	* // returns true
+	*
+	* v = arr.get( 3 );
+	* // returns false
+	*/
+	copyWithin( target: number, start: number, end?: number ): BooleanArray;
 
 	/**
 	* Returns an iterator for iterating over array key-value pairs.

--- a/lib/node_modules/@stdlib/array/bool/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/bool/docs/types/index.d.ts
@@ -351,6 +351,34 @@ declare class BooleanArray implements BooleanArrayInterface {
 	readonly length: number;
 
 	/**
+	* Returns an iterator for iterating over array key-value pairs.
+	*
+	* @returns iterator
+	*
+	* @example
+	* var arr = new BooleanArray( 3 );
+	*
+	* arr.set( true, 0 );
+	* arr.set( false, 1 );
+	* arr.set( true, 2 );
+	*
+	* var it = arr.entries();
+	*
+	* var v = it.next().value;
+	* // returns [ 0, true ]
+	*
+	* v = it.next().value;
+	* // returns [ 1, false ]
+	*
+	* v = it.next().value;
+	* // returns [ 2, true ]
+	*
+	* var bool = it.next().done;
+	* // returns true
+	*/
+	entries(): TypedIterator<[number, boolean]>;
+
+	/**
 	* Tests whether all elements in an array pass a test implemented by a predicate function.
 	*
 	* @param predicate - predicate function

--- a/lib/node_modules/@stdlib/array/bool/lib/main.js
+++ b/lib/node_modules/@stdlib/array/bool/lib/main.js
@@ -1025,6 +1025,46 @@ setReadOnly( BooleanArray.prototype, 'findLastIndex', function findLastIndex( pr
 });
 
 /**
+* Invokes a function once for each array element.
+*
+* @name forEach
+* @memberof BooleanArray.prototype
+* @type {Function}
+* @param {Function} fcn - function to invoke
+* @param {*} [thisArg] - function invocation context
+* @throws {TypeError} `this` must be a boolean array
+* @throws {TypeError} first argument must be a function
+*
+* @example
+* function log( v, i ) {
+*     console.log( '%s: %s', i, v.toString() );
+* }
+*
+* var arr = new BooleanArray( 3 );
+*
+* arr.set( true, 0 );
+* arr.set( false, 1 );
+* arr.set( true, 2 );
+*
+* arr.forEach( log );
+*/
+setReadOnly( BooleanArray.prototype, 'forEach', function forEach( fcn, thisArg ) {
+	var buf;
+	var i;
+
+	if ( !isBooleanArray( this ) ) {
+		throw new TypeError( 'invalid invocation. `this` is not a boolean array.' );
+	}
+	if ( !isFunction( fcn ) ) {
+		throw new TypeError( format( 'invalid argument. First argument must be a function. Value: `%s`.', fcn ) );
+	}
+	buf = this._buffer;
+	for ( i = 0; i < this._length; i++ ) {
+		fcn.call( thisArg, Boolean( buf[ i ] ), i, this );
+	}
+});
+
+/**
 * Returns an array element.
 *
 * @name get

--- a/lib/node_modules/@stdlib/array/bool/lib/main.js
+++ b/lib/node_modules/@stdlib/array/bool/lib/main.js
@@ -502,6 +502,114 @@ setReadOnlyAccessor( BooleanArray.prototype, 'byteOffset', function get() {
 setReadOnly( BooleanArray.prototype, 'BYTES_PER_ELEMENT', BooleanArray.BYTES_PER_ELEMENT );
 
 /**
+* Returns an iterator for iterating over array key-value pairs.
+*
+* @name entries
+* @memberof BooleanArray.prototype
+* @type {Function}
+* @throws {TypeError} `this` must be a boolean array
+* @returns {Iterator} iterator
+*
+* @example
+* var arr = new BooleanArray( 3 );
+*
+* arr.set( true, 0 );
+* arr.set( false, 1 );
+* arr.set( true, 2 );
+*
+* var it = arr.entries();
+*
+* var v = it.next().value;
+* // returns [ 0, true ]
+*
+* v = it.next().value;
+* // returns [ 1, false ]
+*
+* v = it.next().value;
+* // returns [ 2, true ]
+*
+* var bool = it.next().done;
+* // returns true
+*/
+setReadOnly( BooleanArray.prototype, 'entries', function entries() {
+	var self;
+	var iter;
+	var len;
+	var buf;
+	var FLG;
+	var i;
+
+	if ( !isBooleanArray( this ) ) {
+		throw new TypeError( 'invalid invocation. `this` is not a boolean array.' );
+	}
+	self = this;
+	buf = this._buffer;
+	len = this._length;
+
+	// Initialize an iteration index:
+	i = -1;
+
+	// Create an iterator protocol-compliant object:
+	iter = {};
+	setReadOnly( iter, 'next', next );
+	setReadOnly( iter, 'return', end );
+
+	if ( ITERATOR_SYMBOL ) {
+		setReadOnly( iter, ITERATOR_SYMBOL, factory );
+	}
+	return iter;
+
+	/**
+	* Returns an iterator protocol-compliant object containing the next iterated value.
+	*
+	* @private
+	* @returns {Object} iterator protocol-compliant object
+	*/
+	function next() {
+		i += 1;
+		if ( FLG || i >= len ) {
+			return {
+				'done': true
+			};
+		}
+		return {
+			'value': [ i, Boolean( buf[ i ] ) ],
+			'done': false
+		};
+	}
+
+	/**
+	* Finishes an iterator.
+	*
+	* @private
+	* @param {*} [value] - value to return
+	* @returns {Object} iterator protocol-compliant object
+	*/
+	function end( value ) {
+		FLG = true;
+		if ( arguments.length ) {
+			return {
+				'value': value,
+				'done': true
+			};
+		}
+		return {
+			'done': true
+		};
+	}
+
+	/**
+	* Returns a new iterator.
+	*
+	* @private
+	* @returns {Iterator} iterator
+	*/
+	function factory() {
+		return self.entries();
+	}
+});
+
+/**
 * Tests whether all elements in an array pass a test implemented by a predicate function.
 *
 * @name every

--- a/lib/node_modules/@stdlib/array/bool/lib/main.js
+++ b/lib/node_modules/@stdlib/array/bool/lib/main.js
@@ -502,6 +502,48 @@ setReadOnlyAccessor( BooleanArray.prototype, 'byteOffset', function get() {
 setReadOnly( BooleanArray.prototype, 'BYTES_PER_ELEMENT', BooleanArray.BYTES_PER_ELEMENT );
 
 /**
+* Copies a sequence of elements within the array to the position starting at `target`.
+*
+* @name copyWithin
+* @memberof BooleanArray.prototype
+* @type {Function}
+* @param {integer} target - index at which to start copying elements
+* @param {integer} start - source index at which to copy elements from
+* @param {integer} [end] - source index at which to stop copying elements from
+* @throws {TypeError} `this` must be a boolean array
+* @returns {BooleanArray} modified array
+*
+* @example
+* var arr = new BooleanArray( 4 );
+*
+* arr.set( true, 0 );
+* arr.set( false, 1 );
+* arr.set( false, 2 );
+* arr.set( true, 3 );
+*
+* // Copy the first two elements to the last two elements:
+* arr.copyWithin( 2, 0, 2 );
+*
+* var v = arr.get( 2 );
+* // returns true
+*
+* v = arr.get( 3 );
+* // returns false
+*/
+setReadOnly( BooleanArray.prototype, 'copyWithin', function copyWithin( target, start ) {
+	if ( !isBooleanArray( this ) ) {
+		throw new TypeError( 'invalid invocation. `this` is not a boolean array.' );
+	}
+	// FIXME: prefer a functional `copyWithin` implementation which addresses lack of universal browser support (e.g., IE11 and Safari) or ensure that typed arrays are polyfilled
+	if ( arguments.length === 2 ) {
+		this._buffer.copyWithin( target, start );
+	} else {
+		this._buffer.copyWithin( target, start, arguments[2] );
+	}
+	return this;
+});
+
+/**
 * Returns an iterator for iterating over array key-value pairs.
 *
 * @name entries

--- a/lib/node_modules/@stdlib/array/bool/test/test.copy_within.js
+++ b/lib/node_modules/@stdlib/array/bool/test/test.copy_within.js
@@ -1,0 +1,215 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
+var Uint8Array = require( '@stdlib/array/uint8' );
+var BooleanArray = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof BooleanArray, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the main export is a `copyWithin` method for copying a sequence of array elements within a boolean array', function test( t ) {
+	t.strictEqual( hasOwnProp( BooleanArray.prototype, 'copyWithin' ), true, 'has property' );
+	t.strictEqual( isFunction( BooleanArray.prototype.copyWithin ), true, 'has method' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a boolean array instance', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new BooleanArray( 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[]
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.copyWithin.call( value, 3, 0 );
+		};
+	}
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a boolean array instance (end)', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new BooleanArray( 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[]
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.copyWithin.call( value, 3, 0, 5 );
+		};
+	}
+});
+
+tape( 'the method copies a sequence of elements within an array', function test( t ) {
+	var expected;
+	var arr;
+
+	arr = new BooleanArray( [ true, false, false, true, true, false, false, true ] );
+	arr.copyWithin( 0, 5 );
+
+	expected = new Uint8Array( [ 0, 0, 1, 1, 1, 0, 0, 1 ] );
+
+	t.deepEqual( reinterpretBoolean( arr, 0 ), expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the method copies a sequence of elements within an array (negative target)', function test( t ) {
+	var expected;
+	var arr;
+
+	arr = new BooleanArray( [ true, false, false, true, true, false, false, true ] );
+	arr.copyWithin( -arr.length, 5 );
+
+	expected = new Uint8Array( [ 0, 0, 1, 1, 1, 0, 0, 1 ] );
+
+	t.deepEqual( reinterpretBoolean( arr, 0 ), expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the method copies a sequence of elements within an array (negative start)', function test( t ) {
+	var expected;
+	var arr;
+
+	arr = new BooleanArray( [ true, false, false, true, true, false, false, true ] );
+	arr.copyWithin( 0, -3 );
+
+	expected = new Uint8Array( [ 0, 0, 1, 1, 1, 0, 0, 1 ] );
+
+	t.deepEqual( reinterpretBoolean( arr, 0 ), expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the method copies a sequence of elements within an array (end=length)', function test( t ) {
+	var expected;
+	var arr;
+
+	arr = new BooleanArray( [ true, false, false, true, true, false, false, true ] );
+	arr.copyWithin( 0, 5, arr.length );
+
+	expected = new Uint8Array( [ 0, 0, 1, 1, 1, 0, 0, 1 ] );
+
+	t.deepEqual( reinterpretBoolean( arr, 0 ), expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the method copies a sequence of elements within an array (non-inclusive end)', function test( t ) {
+	var expected;
+	var arr;
+
+	arr = new BooleanArray( [ true, false, false, true, true, false, false, true ] );
+	arr.copyWithin( 2, 0, 4 );
+
+	expected = new Uint8Array( [ 1, 0, 1, 0, 0, 1, 0, 1 ] );
+
+	t.deepEqual( reinterpretBoolean( arr, 0 ), expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the method copies a sequence of elements within an array (negative end)', function test( t ) {
+	var expected;
+	var arr;
+
+	arr = new BooleanArray( [ true, false, false, true, true, false, false, true ] );
+	arr.copyWithin( 2, 0, -4 );
+
+	expected = new Uint8Array( [ 1, 0, 1, 0, 0, 1, 0, 1 ] );
+
+	t.deepEqual( reinterpretBoolean( arr, 0 ), expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the method copies a sequence of elements within an array (target >= length)', function test( t ) {
+	var expected;
+	var arr;
+
+	arr = new BooleanArray( [ true, false, false, true, true, false, false, true ] );
+	arr.copyWithin( arr.length, 5 );
+
+	expected = new Uint8Array( [ 1, 0, 0, 1, 1, 0, 0, 1 ] );
+
+	t.deepEqual( reinterpretBoolean( arr, 0 ), expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the method copies a sequence of elements within an array (target > start)', function test( t ) {
+	var expected;
+	var arr;
+
+	arr = new BooleanArray( [ true, false, false, true, true, false, false, true ] );
+	arr.copyWithin( 2, 0 );
+
+	expected = new Uint8Array( [ 1, 0, 1, 0, 0, 1, 1, 0 ] );
+
+	t.deepEqual( reinterpretBoolean( arr, 0 ), expected, 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/array/bool/test/test.entries.js
+++ b/lib/node_modules/@stdlib/array/bool/test/test.entries.js
@@ -1,0 +1,237 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var proxyquire = require( 'proxyquire' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var isArray = require( '@stdlib/assert/is-array' );
+var isBoolean = require( '@stdlib/assert/is-boolean' );
+var ITERATOR_SYMBOL = require( '@stdlib/symbol/iterator' );
+var BooleanArray = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof BooleanArray, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the main export is an `entries` method for returning an iterator for iterating over array key-value pairs', function test( t ) {
+	t.strictEqual( hasOwnProp( BooleanArray.prototype, 'entries' ), true, 'has property' );
+	t.strictEqual( isFunction( BooleanArray.prototype.entries ), true, 'has method' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a boolean array instance', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new BooleanArray( 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[]
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.entries.call( value );
+		};
+	}
+});
+
+tape( 'the method returns an iterator protocol-compliant object', function test( t ) {
+	var buf;
+	var arr;
+	var it;
+	var v;
+	var i;
+
+	buf = [ true, false, false, true ];
+	arr = new BooleanArray( buf );
+
+	it = arr.entries();
+	t.strictEqual( it.next.length, 0, 'has zero arity' );
+
+	for ( i = 0; i < arr.length; i++ ) {
+		v = it.next();
+		t.strictEqual( isArray( v.value ), true, 'returns expected value' );
+		t.strictEqual( v.value[ 0 ], i, 'returns expected value' );
+		t.strictEqual( isBoolean( v.value[ 1 ] ), true, 'returns expected value' );
+		t.strictEqual( v.value[ 1 ], buf[ i ], 'returns expected value' );
+		t.strictEqual( typeof v.done, 'boolean', 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the method returns an iterator which has a `return` method for closing an iterator (no argument)', function test( t ) {
+	var buf;
+	var arr;
+	var it;
+	var v;
+
+	buf = [ true, false, false, true ];
+	arr = new BooleanArray( buf );
+
+	it = arr.entries();
+
+	v = it.next();
+	t.strictEqual( v.value[ 1 ], buf[ 0 ], 'returns expected value' );
+	t.strictEqual( v.done, false, 'returns expected value' );
+
+	v = it.next();
+	t.strictEqual( v.value[ 1 ], buf[ 1 ], 'returns expected value' );
+	t.strictEqual( v.done, false, 'returns expected value' );
+
+	v = it.return();
+	t.strictEqual( v.value, void 0, 'returns expected value' );
+	t.strictEqual( v.done, true, 'returns expected value' );
+
+	v = it.next();
+	t.strictEqual( v.value, void 0, 'returns expected value' );
+	t.strictEqual( v.done, true, 'returns expected value' );
+
+	v = it.next();
+	t.strictEqual( v.value, void 0, 'returns expected value' );
+	t.strictEqual( v.done, true, 'returns expected value' );
+
+	v = it.next();
+	t.strictEqual( v.value, void 0, 'returns expected value' );
+	t.strictEqual( v.done, true, 'returns expected value' );
+
+	v = it.next();
+	t.strictEqual( v.value, void 0, 'returns expected value' );
+	t.strictEqual( v.done, true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the method returns an iterator which has a `return` method for closing an iterator (argument)', function test( t ) {
+	var buf;
+	var arr;
+	var it;
+	var v;
+
+	buf = [ true, false, false, true ];
+	arr = new BooleanArray( buf );
+
+	it = arr.entries();
+
+	v = it.next();
+	t.strictEqual( v.value[ 1 ], buf[ 0 ], 'returns expected value' );
+	t.strictEqual( v.done, false, 'returns expected value' );
+
+	v = it.next();
+	t.strictEqual( v.value[ 1 ], buf[ 1 ], 'returns expected value' );
+	t.strictEqual( v.done, false, 'returns expected value' );
+
+	v = it.return( 'finished' );
+	t.strictEqual( v.value, 'finished', 'returns expected value' );
+	t.strictEqual( v.done, true, 'returns expected value' );
+
+	v = it.next();
+	t.strictEqual( v.value, void 0, 'returns expected value' );
+	t.strictEqual( v.done, true, 'returns expected value' );
+
+	v = it.next();
+	t.strictEqual( v.value, void 0, 'returns expected value' );
+	t.strictEqual( v.done, true, 'returns expected value' );
+
+	v = it.next();
+	t.strictEqual( v.value, void 0, 'returns expected value' );
+	t.strictEqual( v.done, true, 'returns expected value' );
+
+	v = it.next();
+	t.strictEqual( v.value, void 0, 'returns expected value' );
+	t.strictEqual( v.done, true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if an environment supports `Symbol.iterator`, the method returns an iterable', function test( t ) {
+	var BooleanArray;
+	var arr;
+	var buf;
+	var it1;
+	var it2;
+	var v1;
+	var v2;
+	var i;
+
+	BooleanArray = proxyquire( './../lib/main.js', {
+		'@stdlib/symbol/iterator': '__ITERATOR_SYMBOL__'
+	});
+
+	buf = [ true, false, false, true ];
+	arr = new BooleanArray( buf );
+
+	it1 = arr.entries();
+	t.strictEqual( typeof it1[ '__ITERATOR_SYMBOL__' ], 'function', 'has method' );
+	t.strictEqual( it1[ '__ITERATOR_SYMBOL__' ].length, 0, 'has zero arity' );
+
+	it2 = it1[ '__ITERATOR_SYMBOL__' ]();
+	t.strictEqual( typeof it2, 'object', 'returns an object' );
+	t.strictEqual( typeof it2.next, 'function', 'has `next` method' );
+	t.strictEqual( typeof it2.return, 'function', 'has `return` method' );
+
+	for ( i = 0; i < arr.length; i++ ) {
+		v1 = it1.next().value;
+		v2 = it2.next().value;
+		t.strictEqual( v1[ 0 ], v2[ 0 ], 'returns expected value' );
+		t.strictEqual( v1[ 1 ], v2[ 1 ], 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'if an environment does not support `Symbol.iterator`, the method does not return an "iterable"', function test( t ) {
+	var BooleanArray;
+	var arr;
+	var buf;
+	var it;
+
+	BooleanArray = proxyquire( './../lib/main.js', {
+		'@stdlib/symbol/iterator': false
+	});
+
+	buf = [ true, false, false, true ];
+	arr = new BooleanArray( buf );
+
+	it = arr.entries();
+	t.strictEqual( it[ ITERATOR_SYMBOL ], void 0, 'does not have property' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/array/bool/test/test.for_each.js
+++ b/lib/node_modules/@stdlib/array/bool/test/test.for_each.js
@@ -1,0 +1,176 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var BooleanArray = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof BooleanArray, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the main export is a `forEach` method', function test( t ) {
+	t.strictEqual( hasOwnProp( BooleanArray.prototype, 'forEach' ), true, 'has property' );
+	t.strictEqual( isFunction( BooleanArray.prototype.forEach ), true, 'has method' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a boolean array instance', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new BooleanArray( 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.forEach.call( value, fcn );
+		};
+	}
+
+	function fcn( v ) {
+		if ( !isBoolean( v ) ) {
+			t.fail( 'should be a boolean' );
+		}
+	}
+});
+
+tape( 'the method throws an error if provided a first argument which is not a function', function test( t ) {
+	var values;
+	var arr;
+	var i;
+
+	arr = new BooleanArray( 10 );
+
+	values = [
+		'5',
+		3.14,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[]
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.forEach( value );
+		};
+	}
+});
+
+tape( 'the method should not invoke a provided callback function if operating on an empty boolean array', function test( t ) {
+	var arr;
+
+	arr = new BooleanArray();
+	arr.forEach( fcn );
+
+	t.end();
+
+	function fcn() {
+		t.fail( 'should not be invoked' );
+	}
+});
+
+tape( 'the method returns `undefined`', function test( t ) {
+	var arr;
+	var out;
+
+	arr = new BooleanArray( [ true, false, false, true ] );
+	out = arr.forEach( fcn );
+
+	t.strictEqual( out, void 0, 'returns expected value' );
+	t.end();
+
+	function fcn( v ) {
+		if ( !isBoolean( v ) ) {
+			t.fail( 'should be a boolean' );
+		}
+	}
+});
+
+tape( 'the method invokes a provided function for each element in an array', function test( t ) {
+	var expected;
+	var arr;
+
+	expected = [];
+	arr = new BooleanArray( [ true, false, false, true ] );
+	arr.forEach( fcn );
+	expected = new BooleanArray( expected );
+
+	t.deepEqual( reinterpretBoolean( expected, 0 ), reinterpretBoolean( arr, 0 ), 'returns expected value' );
+	t.end();
+
+	function fcn( v ) {
+		expected.push( v );
+	}
+});
+
+tape( 'the method supports providing an execution context', function test( t ) {
+	var ctx;
+	var arr;
+
+	ctx = {
+		'count': 0
+	};
+	arr = new BooleanArray( [ true, false, false, true ] );
+	arr.forEach( fcn, ctx );
+
+	t.strictEqual( ctx.count, 4, 'returns expected value' );
+
+	t.end();
+
+	function fcn() {
+		this.count += 1; // eslint-disable-line no-invalid-this
+	}
+});

--- a/lib/node_modules/@stdlib/array/bool/test/test.for_each.js
+++ b/lib/node_modules/@stdlib/array/bool/test/test.for_each.js
@@ -23,7 +23,6 @@
 var tape = require( 'tape' );
 var hasOwnProp = require( '@stdlib/assert/has-own-property' );
 var isFunction = require( '@stdlib/assert/is-function' );
-var reinterpretBoolean = require( '@stdlib/strided/base/reinterpret-boolean' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var BooleanArray = require( './../lib' );
 
@@ -152,8 +151,7 @@ tape( 'the method invokes a provided function for each element in an array', fun
 	arr = new BooleanArray( [ true, false, false, true ] );
 	arr.forEach( fcn );
 
-	values = new BooleanArray( values );
-	t.deepEqual( reinterpretBoolean( values, 0 ), reinterpretBoolean( arr, 0 ), 'returns expected value' );
+	t.deepEqual( values, [ true, false, false, true ], 'returns expected value' );
 	t.deepEqual( indices, [ 0, 1, 2, 3 ], 'returns expected value' );
 	t.strictEqual( arrays[ 0 ], arr, 'returns expected value' );
 	t.strictEqual( arrays[ 1 ], arr, 'returns expected value' );

--- a/lib/node_modules/@stdlib/array/bool/test/test.for_each.js
+++ b/lib/node_modules/@stdlib/array/bool/test/test.for_each.js
@@ -140,19 +140,20 @@ tape( 'the method returns `undefined`', function test( t ) {
 });
 
 tape( 'the method invokes a provided function for each element in an array', function test( t ) {
-	var expected;
+	var actual;
 	var arr;
 
-	expected = [];
+	actual = [];
+
 	arr = new BooleanArray( [ true, false, false, true ] );
 	arr.forEach( fcn );
-	expected = new BooleanArray( expected );
 
-	t.deepEqual( reinterpretBoolean( expected, 0 ), reinterpretBoolean( arr, 0 ), 'returns expected value' );
+	actual = new BooleanArray( actual );
+	t.deepEqual( reinterpretBoolean( actual, 0 ), reinterpretBoolean( arr, 0 ), 'returns expected value' );
 	t.end();
 
 	function fcn( v ) {
-		expected.push( v );
+		actual.push( v );
 	}
 });
 

--- a/lib/node_modules/@stdlib/array/bool/test/test.for_each.js
+++ b/lib/node_modules/@stdlib/array/bool/test/test.for_each.js
@@ -140,20 +140,32 @@ tape( 'the method returns `undefined`', function test( t ) {
 });
 
 tape( 'the method invokes a provided function for each element in an array', function test( t ) {
-	var actual;
+	var indices;
+	var values;
+	var arrays;
 	var arr;
 
-	actual = [];
+	indices = [];
+	values = [];
+	arrays = [];
 
 	arr = new BooleanArray( [ true, false, false, true ] );
 	arr.forEach( fcn );
 
-	actual = new BooleanArray( actual );
-	t.deepEqual( reinterpretBoolean( actual, 0 ), reinterpretBoolean( arr, 0 ), 'returns expected value' );
+	values = new BooleanArray( values );
+	t.deepEqual( reinterpretBoolean( values, 0 ), reinterpretBoolean( arr, 0 ), 'returns expected value' );
+	t.deepEqual( indices, [ 0, 1, 2, 3 ], 'returns expected value' );
+	t.strictEqual( arrays[ 0 ], arr, 'returns expected value' );
+	t.strictEqual( arrays[ 1 ], arr, 'returns expected value' );
+	t.strictEqual( arrays[ 2 ], arr, 'returns expected value' );
+	t.strictEqual( arrays[ 3 ], arr, 'returns expected value' );
+
 	t.end();
 
-	function fcn( v ) {
-		actual.push( v );
+	function fcn( v, i, arr ) {
+		values.push( v );
+		indices.push( i );
+		arrays.push( arr );
 	}
 });
 


### PR DESCRIPTION
Resolves: Subtask of #2304 

## Description

> What is the purpose of this pull request?

This pull request:

-  Adds the typed array `copyWithin`, `forEach` and `entries` methods to prototype of `BooleanArray`

## Related Issues

> Does this pull request have any related issues?

This pull request:

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
