### PR TITLE
feat: add `iter/cunone`

### DIFF
--- a/lib/node_modules/@stdlib/iter/cunone/README.md
+++ b/lib/node_modules/@stdlib/iter/cunone/README.md
@@ -1,0 +1,146 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# iterCuNone
+
+> Create an [iterator][mdn-iterator-protocol] which cumulatively tests whether every iterated value is falsy.
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+```javascript
+var iterCuNone = require( '@stdlib/iter/cunone' );
+```
+```javascript
+iterCuNone( iterator )
+Returns an iterator which cumulatively tests whether every iterated value is falsy.
+javascriptvar array2iterator = require( '@stdlib/array/to-iterator' );
+
+var arr = array2iterator( [ false, null, undefined, '', 0, NaN, true ] );
+
+var it = iterCuNone( arr );
+// returns <Object>
+
+var v = it.next().value;
+// returns true
+
+v = it.next().value;
+// returns true
+
+v = it.next().value;
+// returns true
+
+v = it.next().value;
+// returns true
+
+v = it.next().value;
+// returns true
+
+v = it.next().value;
+// returns true
+
+v = it.next().value;
+// returns false
+
+var bool = it.next().done;
+// returns true
+```
+The returned iterator protocol-compliant object has the following properties:
+
+next: function which returns an iterator protocol-compliant object containing the next iterated value (if one exists) assigned to a value property and a done property having a boolean value indicating whether the iterator is finished.
+return: function which closes an iterator and returns a single (optional) argument in an iterator protocol-compliant object.
+
+</section>
+<!-- /.usage -->
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+<section class="notes">
+
+## Notes
+
+
+
+- If an environment supports `Symbol.iterator` and the provided iterator is iterable, the returned iterator is iterable.
+- In JavaScript, falsy values are `false`, `null`, `undefined`, `0`, `NaN`, and an empty string (`""`).
+
+</section>
+<!-- /.notes -->
+<!-- Package usage examples. -->
+<section class="examples">
+
+## Examples
+<!-- eslint no-undef: "error" -->
+```javascript
+
+var randu = require( '@stdlib/random/iter/randu' );
+var iterMap = require( '@stdlib/iter/map' );
+var iterCuNone = require( '@stdlib/iter/cunone' );
+
+// Create an iterator which generates uniformly distributed pseudorandom numbers:
+var rand = randu({
+    'iter': 100
+});
+
+// Create an iterator which applies a threshold to generated numbers:
+var it = iterMap( rand, function threshold( r ) {
+    return ( r > 0.95 );
+});
+
+// Create an iterator which cumulatively tests whether all values are "falsy":
+var result = iterCuNone( it );
+
+// Perform manual iteration...
+var v;
+while ( true ) {
+    v = result.next();
+    if ( v.done ) {
+        break;
+    }
+    console.log( v.value );
+}
+```
+</section>
+<!-- /.examples -->
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+<section class="references">
+</section>
+<!-- /.references -->
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+<section class="related">
+
+
+
+</section>
+<!-- /.related -->
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+<section class="links">
+<!-- <related-links> -->
+<!-- </related-links> -->
+</section>
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/iter/cunone/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/cunone/benchmark/benchmark.js
@@ -1,0 +1,96 @@
+/** * @license Apache-2.0 
+ * * * Copyright (c) 2024 The Stdlib Authors. * * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * * you may not use this file except in compliance with the License. 
+ * * You may obtain a copy of the License at * * http://www.apache.org/licenses/LICENSE-2.0 *
+ *  * Unless required by applicable law or agreed to in writing, software 
+ * * distributed under the License is distributed on an "AS IS" BASIS, * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  either express or implied. * See the License for the specific language governing permissions and * limitations under the License. */
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isBoolean = require( '@stdlib/assert-is-boolean' ).isPrimitive;
+var isIteratorLike = require( '@stdlib/assert-is-iterator-like' );
+var pkg = require( './../package.json' ).name;
+var iterCuNone = require( './../lib' );
+
+// FUNCTIONS //
+
+function createIterator( arr ) {
+	var len;
+	var it;
+	var i;
+
+	len = arr.length;
+	i = -1;
+	it = {};
+	it.next = next;
+	it.reset = reset;
+
+	return it;
+
+	function next() {
+		i += 1;
+		if ( i < len ) {
+			return { 'value': arr[ i ], 'done': false };
+		}
+		return { 'done': true };
+	}
+
+	function reset() {
+		i = -1;
+	}
+}
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var iter;
+	var arr;
+	var i;
+
+	arr = [ 0, 0, 0, 0, 0, 1 ];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		iter = iterCuNone( createIterator( arr ) );
+		if ( typeof iter !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+
+	if ( !isIteratorLike( iter ) ) {
+		b.fail( 'should return an iterator protocol-compliant object' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::iteration', function benchmark( b ) {
+	var iter;
+	var arr;
+	var i;
+	var v;
+
+	arr = [ 0, 0, 0, 0, 0, 1 ];
+	iter = iterCuNone( createIterator( arr ) );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		v = iter.next().value;
+		if ( typeof v !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+
+	if ( !isBoolean( v ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/iter/cunone/docs/repl.txt
+++ b/lib/node_modules/@stdlib/iter/cunone/docs/repl.txt
@@ -1,0 +1,53 @@
+{{alias}}( iterator )
+    Returns an iterator which cumulatively tests whether every iterated value is
+    falsy.
+
+    The returned iterator immediately returns `false` upon encountering a truthy
+    value, for all subsequent iterations.
+
+    If provided an iterator which does not return any iterated values, the
+    returned iterator returns `true`.
+
+    Parameters
+    ----------
+    iterator: Object
+        Input iterator over which to iterate.
+
+    Returns
+    -------
+    iterator: Object
+        Iterator.
+
+    Iterator Protocol
+    -----------------
+    The returned iterator protocol-compliant object has the following properties:
+
+    next: Function
+        Returns an iterator protocol-compliant object containing the next
+        iterated value (if one exists) assigned to a `value` property and a
+        `done` property having a boolean value indicating whether the iterator
+        is finished.
+
+    return: Function
+        Finishes an iterator and returns a single (optional) argument in an
+        iterator protocol-compliant object.
+
+    Examples
+    --------
+    > var arr = {{alias:@stdlib/array/to-iterator}}( [ 0, 0, 0, 0, 1 ] );
+    > var it = {{alias}}( arr )
+    > var v = it.next().value
+    true
+    > v = it.next().value
+    true
+    > v = it.next().value
+    true
+    > v = it.next().value
+    true
+    > v = it.next().value
+    false
+    > var bool = it.next().done
+    true
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/iter/cunone/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/iter/cunone/docs/types/index.d.ts
@@ -1,0 +1,69 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { Iterator as Iter, IterableIterator } from '@stdlib/types/iter';
+
+// Define a union type representing both iterable and non-iterable iterators:
+type Iterator = Iter | IterableIterator;
+
+/**
+* Returns an iterator which cumulatively tests whether every iterated value is falsy.
+*
+* @param iterator - input iterator
+* @returns iterator
+*
+* @example
+* var array2iterator = require( '@stdlib/array-to-iterator' );
+*
+* var it = iterCuNone( array2iterator( [ false, null, undefined, '', 0, NaN, true ] ) );
+* // returns <Object>
+*
+* var v = it.next().value;
+* // returns true
+*
+* v = it.next().value;
+* // returns true
+*
+* v = it.next().value;
+* // returns true
+*
+* v = it.next().value;
+* // returns true
+*
+* v = it.next().value;
+* // returns true
+*
+* v = it.next().value;
+* // returns true
+*
+* v = it.next().value;
+* // returns false
+*
+* var bool = it.next().done;
+* // returns true
+*/
+declare function iterCuNone( iterator: Iterator ): Iterator;
+
+
+// EXPORTS //
+
+export = iterCuNone;

--- a/lib/node_modules/@stdlib/iter/cunone/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/iter/cunone/docs/types/test.ts
@@ -1,0 +1,68 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import iterCuNone = require( './index' );
+
+/**
+* Returns an iterator protocol-compliant object.
+*
+* @returns iterator protocol-compliant object
+*/
+function iterator() {
+    return {
+        'next': next
+    };
+
+    /**
+    * Implements the iterator protocol `next` method.
+    *
+    * @returns iterator protocol-compliant object
+    */
+    function next() {
+        return {
+            'value': true,
+            'done': false
+        };
+    }
+}
+
+
+// TESTS //
+
+// The function returns an iterator...
+{
+    iterCuNone( iterator() ); // $ExpectType Iterator
+}
+
+// The compiler throws an error if the function is provided a value other than an iterator protocol-compliant object...
+{
+    iterCuNone( '5' ); // $ExpectError
+    iterCuNone( 5 ); // $ExpectError
+    iterCuNone( true ); // $ExpectError
+    iterCuNone( false ); // $ExpectError
+    iterCuNone( null ); // $ExpectError
+    iterCuNone( undefined ); // $ExpectError
+    iterCuNone( [] ); // $ExpectError
+    iterCuNone( {} ); // $ExpectError
+    iterCuNone( ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided insufficient arguments...
+{
+    iterCuNone(); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/iter/cunone/examples/index.js
+++ b/lib/node_modules/@stdlib/iter/cunone/examples/index.js
@@ -1,0 +1,46 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var randu = require( '@stdlib/random-iter-randu' );
+var iterMap = require( '@stdlib/iter-map' );
+var iterCuNone = require( './../lib' );
+
+// Create an iterator which generates uniformly distributed pseudorandom numbers:
+var rand = randu({
+    'iter': 100
+});
+
+// Create an iterator which applies a threshold to generated numbers:
+var it = iterMap( rand, function threshold( r ) {
+    return ( r > 0.95 );
+});
+
+// Create an iterator which cumulatively tests whether all values are "falsy":
+var result = iterCuNone( it );
+
+// Perform manual iteration...
+var v;
+while ( true ) {
+    v = result.next();
+    if ( v.done ) {
+        break;
+    }
+    console.log( v.value );
+}

--- a/lib/node_modules/@stdlib/iter/cunone/lib/index.js
+++ b/lib/node_modules/@stdlib/iter/cunone/lib/index.js
@@ -1,0 +1,65 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Create an iterator which cumulatively tests whether every iterated value is falsy.
+*
+* @module @stdlib/iter-cunone
+*
+* @example
+* var array2iterator = require( '@stdlib/array-to-iterator' );
+* var iterCuNone = require( '@stdlib/iter-cunone' );
+*
+* var it = iterCuNone( array2iterator( [ false, null, undefined, '', 0, NaN, true ] ) );
+* // returns <Object>
+*
+* var v = it.next().value;
+* // returns true
+*
+* v = it.next().value;
+* // returns true
+*
+* v = it.next().value;
+* // returns true
+*
+* v = it.next().value;
+* // returns true
+*
+* v = it.next().value;
+* // returns true
+*
+* v = it.next().value;
+* // returns true
+*
+* v = it.next().value;
+* // returns false
+*
+* var bool = it.next().done;
+* // returns true
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/iter/cunone/lib/main.js
+++ b/lib/node_modules/@stdlib/iter/cunone/lib/main.js
@@ -1,0 +1,145 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
+var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var iteratorSymbol = require( '@stdlib/symbol-iterator' );
+var format = require( '@stdlib/string/format' );
+
+
+// MAIN //
+
+/**
+* Returns an iterator which cumulatively tests whether every iterated value is falsy.
+*
+* @param {Iterator} iterator - input iterator
+* @throws {TypeError} must provide an iterator
+* @returns {Iterator} iterator
+*
+* @example
+* var array2iterator = require( '@stdlib/array-to-iterator' );
+*
+* var it = iterCuNone( array2iterator( [ false, null, undefined, '', 0, NaN, true ] ) );
+* // returns <Object>
+*
+* var v = it.next().value;
+* // returns true
+*
+* v = it.next().value;
+* // returns true
+*
+* v = it.next().value;
+* // returns true
+*
+* v = it.next().value;
+* // returns true
+*
+* v = it.next().value;
+* // returns true
+*
+* v = it.next().value;
+* // returns true
+*
+* v = it.next().value;
+* // returns false
+*
+* var bool = it.next().done;
+* // returns true
+*/
+function iterCuNone( iterator ) {
+	var iter;
+	var FLG;
+	if ( !isIteratorLike( iterator ) ) {
+		throw new TypeError( format( 'invalid argument. Must provide an iterator. Value: `%s`.', iterator ) );
+	}
+	// Create a new iterator:
+	iter = {
+		'next': next
+	};
+	setReadOnly( iter, 'return', finish );
+
+	// If an environment supports `Symbol.iterator`, make the iterator iterable:
+	if ( iteratorSymbol && isFunction( iterator[ iteratorSymbol ] ) ) {
+		setReadOnly( iter, iteratorSymbol, factory );
+	}
+	return iter;
+
+	/**
+	* Returns an iterator protocol-compliant object containing the next iterated value.
+	*
+	* @private
+	* @returns {Object} iterator protocol-compliant object
+	*/
+	function next() {
+		var v;
+		var result;
+	
+		v = iterator.next();
+		if (v.done) {
+			return v;
+		}
+		if (FLG === false && v.value) {
+			FLG = true;
+		}
+		result = !FLG;
+		return {
+			'value': !FLG,
+			'done': false
+		};
+	}
+
+	/**
+	* Finishes an iterator.
+	*
+	* @private
+	* @param {*} [value] - value to return
+	* @returns {Object} iterator protocol-compliant object
+	*/
+	function finish( value ) {
+		FLG = true;
+		if ( arguments.length ) {
+			return {
+				'value': value,
+				'done': true
+			};
+		}
+		return {
+			'done': true
+		};
+	}
+
+	/**
+	* Returns a new iterator.
+	*
+	* @private
+	* @returns {Iterator} iterator
+	*/
+	function factory() {
+		return iterCuNone( iterator[ iteratorSymbol ]() );
+	}
+}
+
+
+// EXPORTS //
+
+module.exports = iterCuNone;

--- a/lib/node_modules/@stdlib/iter/cunone/package.json
+++ b/lib/node_modules/@stdlib/iter/cunone/package.json
@@ -1,0 +1,85 @@
+{
+    "name": "@stdlib/iter/cunone",
+    "version": "0.0.0",
+    "description": "Create an iterator which cumulatively tests whether every iterated value is falsy.",
+    "license": "Apache-2.0",
+    "author": {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    },
+    "contributors": [
+      {
+        "name": "The Stdlib Authors",
+        "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+      }
+    ],
+    "main": "./lib",
+    "directories": {
+      "benchmark": "./benchmark",
+      "doc": "./docs",
+      "example": "./examples",
+      "lib": "./lib",
+      "test": "./test"
+    },
+    "types": "./docs/types",
+    "scripts": {
+      "test": "make test",
+      "test-cov": "make test-cov",
+      "examples": "make examples",
+      "benchmark": "make benchmark"
+    },
+    "homepage": "https://stdlib.io",
+    "repository": {
+      "type": "git",
+      "url": "git://github.com/stdlib-js/iter-cunone.git"
+    },
+    "bugs": {
+      "url": "https://github.com/stdlib-js/stdlib/issues"
+    },
+    "dependencies": {
+      "@stdlib/assert-is-iterator-like": "^0.0.x",
+      "@stdlib/symbol-iterator": "^0.0.x",
+      "@stdlib/types": "^0.0.x",
+      "@stdlib/utils-define-nonenumerable-read-only-property": "^0.0.x",
+      "@stdlib/error-tools-fmtprodmsg": "^0.0.x"
+    },
+    "devDependencies": {
+      "@stdlib/array-to-iterator": "^0.0.x",
+      "@stdlib/assert-is-boolean": "^0.0.x",
+      "@stdlib/random-iter-randu": "^0.0.x",
+      "tape": "git+https://github.com/kgryte/tape.git#fix/globby",
+      "istanbul": "^0.4.1",
+      "tap-min": "git+https://github.com/Planeshifter/tap-min.git"
+    },
+    "engines": {
+      "node": ">=0.10.0",
+      "npm": ">2.7.0"
+    },
+    "os": [
+      "aix",
+      "darwin",
+      "freebsd",
+      "linux",
+      "macos",
+      "openbsd",
+      "sunos",
+      "win32",
+      "windows"
+    ],
+    "keywords": [
+      "stdlib",
+      "stditer",
+      "iterator",
+      "iterable",
+      "iterate",
+      "cumulative",
+      "none",
+      "false",
+      "falsy"
+    ],
+    "__stdlib__": {},
+    "funding": {
+      "type": "opencollective",
+      "url": "https://opencollective.com/stdlib"
+    }
+  }

--- a/lib/node_modules/@stdlib/iter/cunone/test/test.js
+++ b/lib/node_modules/@stdlib/iter/cunone/test/test.js
@@ -1,0 +1,260 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var proxyquire = require( 'proxyquire' );
+var isBoolean = require( '@stdlib/assert-is-boolean' ).isPrimitive;
+var isIteratorLike = require( '@stdlib/assert-is-iterator-like' );
+var array2iterator = require( '@stdlib/array-to-iterator' );
+var iterCuNone = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof iterCuNone, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function throws an error if provided an iterator argument which is not an iterator protocol-compliant object', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			iterCuNone( value );
+		};
+	}
+});
+
+tape( 'the function returns an iterator protocol-compliant object', function test( t ) {
+	var it;
+	var r;
+	var i;
+
+	it = iterCuNone( array2iterator( [ 1, 2, 3 ] ) );
+	t.equal( it.next.length, 0, 'has zero arity' );
+
+	for ( i = 0; i < 100; i++ ) {
+		r = it.next();
+		t.equal( typeof r.value, 'boolean', 'returns a boolean' );
+		t.equal( typeof r.done, 'boolean', 'returns a boolean' );
+	}
+	t.end();
+});
+
+tape( 'the function returns an iterator which cumulatively tests whether every iterated value is falsy', function test( t ) {
+	var expected;
+	var values;
+	var it;
+	var i;
+
+	values = [ false, null, void 0, '', 0, NaN, true, 'abc', 5 ];
+	expected = [ true, true, true, true, true, true, false, false, false ];
+
+	it = iterCuNone( array2iterator( values ) );
+	t.equal( isIteratorLike( it ), true, 'returns an iterator' );
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.equal( it.next().value, expected[ i ], 'returns expected value' );
+	}
+	t.equal( it.next().done, true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns an iterator which returns `true` if all iterated values are falsy', function test( t ) {
+	var it;
+	var r;
+
+	it = iterCuNone( array2iterator( [ false, null, void 0, '', 0, NaN ] ) );
+	t.equal( isIteratorLike( it ), true, 'returns an iterator' );
+
+	r = it.next();
+	t.equal( r.value, true, 'returns expected value' );
+	t.equal( r.done, false, 'returns expected value' );
+
+	r = it.next();
+	t.equal( r.value, true, 'returns expected value' );
+	t.equal( r.done, false, 'returns expected value' );
+
+	r = it.next();
+	t.equal( r.value, true, 'returns expected value' );
+	t.equal( r.done, false, 'returns expected value' );
+
+	r = it.next();
+	t.equal( r.value, true, 'returns expected value' );
+	t.equal( r.done, false, 'returns expected value' );
+
+	r = it.next();
+	t.equal( r.value, true, 'returns expected value' );
+	t.equal( r.done, false, 'returns expected value' );
+
+	r = it.next();
+	t.equal( r.value, true, 'returns expected value' );
+	t.equal( r.done, false, 'returns expected value' );
+
+	r = it.next();
+	t.equal( r.value, void 0, 'returns expected value' );
+	t.equal( r.done, true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns an iterator which returns `true` if provided an "empty" iterator', function test( t ) {
+	var it;
+	var r;
+
+	it = iterCuNone( array2iterator( [] ) );
+	t.equal( isIteratorLike( it ), true, 'returns an iterator' );
+
+	r = it.next();
+	t.equal( r.value, void 0, 'returns expected value' );
+	t.equal( r.done, true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the returned iterator has a `return` method for closing an iterator (no argument)', function test( t ) {
+	var it;
+	var r;
+
+	it = iterCuNone( array2iterator( [ 1, 2, 3, 4 ] ) );
+
+	r = it.next();
+	t.equal( isBoolean( r.value ), true, 'returns a boolean' );
+	t.equal( r.done, false, 'returns expected value' );
+
+	r = it.next();
+	t.equal( isBoolean( r.value ), true, 'returns a boolean' );
+	t.equal( r.done, false, 'returns expected value' );
+
+	r = it.return();
+	t.equal( r.value, void 0, 'returns expected value' );
+	t.equal( r.done, true, 'returns expected value' );
+
+	r = it.next();
+	t.equal( r.value, void 0, 'returns expected value' );
+	t.equal( r.done, true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the returned iterator has a `return` method for closing an iterator (argument)', function test( t ) {
+	var it;
+	var r;
+
+	it = iterCuNone( array2iterator( [ 1, 2, 3, 4 ] ) );
+
+	r = it.next();
+	t.equal( isBoolean( r.value ), true, 'returns a boolean' );
+	t.equal( r.done, false, 'returns expected value' );
+
+	r = it.next();
+	t.equal( isBoolean( r.value ), true, 'returns a boolean' );
+	t.equal( r.done, false, 'returns expected value' );
+
+	r = it.return( 'finished' );
+	t.equal( r.value, 'finished', 'returns expected value' );
+	t.equal( r.done, true, 'returns expected value' );
+
+	r = it.next();
+	t.equal( r.value, void 0, 'returns expected value' );
+	t.equal( r.done, true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if an environment supports `Symbol.iterator` and the provided iterator is iterable, the returned iterator is iterable', function test( t ) {
+	var iterCuNone;
+	var opts;
+	var rand;
+	var it1;
+	var it2;
+	var i;
+
+	iterCuNone = proxyquire( './../lib/main.js', {
+		'@stdlib/symbol-iterator': '__ITERATOR_SYMBOL__'
+	});
+
+	opts = {
+		'seed': 12345
+	};
+	rand = {
+		'next': function next() {
+			return {
+				'value': ( opts.iter += 1 ),
+				'done': false
+			};
+		}
+	};
+	rand[ '__ITERATOR_SYMBOL__' ] = function iterator() {
+		return rand;
+	};
+
+	it1 = iterCuNone( rand );
+	t.equal( typeof it1[ '__ITERATOR_SYMBOL__' ], 'function', 'has method' );
+	t.equal( it1[ '__ITERATOR_SYMBOL__' ].length, 0, 'has zero arity' );
+
+	it2 = it1[ '__ITERATOR_SYMBOL__' ]();
+	t.equal( typeof it2, 'object', 'returns an object' );
+	t.equal( typeof it2.next, 'function', 'has method' );
+	t.equal( typeof it2.return, 'function', 'has method' );
+
+	for ( i = 0; i < 100; i++ ) {
+		t.equal( it2.next().value, it1.next().value, 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'if an environment does not support `Symbol.iterator`, the returned iterator is not "iterable"', function test( t ) {
+    var iterCuNone;
+    var it;
+
+    iterCuNone = proxyquire( './../lib/main.js', {
+        '@stdlib/symbol-iterator': false
+    });
+
+    it = iterCuNone( array2iterator( [ 1, 2, 3, 4 ] ) );
+    t.equal( it[ iteratorSymbol ], void 0, 'does not have property' );
+
+    t.end();
+});

--- a/lib/node_modules/@stdlib/iter/none/package.json
+++ b/lib/node_modules/@stdlib/iter/none/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@stdlib/iter/none",
+  "name": "@stdlib/iter/cunone",
   "version": "0.0.0",
-  "description": "Test whether all iterated values are falsy.",
+  "description": "Create an iterator which cumulatively tests whether every iterated value is falsy.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",
@@ -50,19 +50,13 @@
   ],
   "keywords": [
     "stdlib",
-    "stdutils",
-    "stdutil",
-    "utilities",
-    "utility",
-    "utils",
-    "util",
-    "test",
-    "none",
-    "all",
-    "every",
-    "iterate",
+    "stditer",
     "iterator",
-    "iter",
-    "validate"
+    "iterable",
+    "iterate",
+    "cumulative",
+    "none",
+    "false",
+    "falsy"
   ]
 }


### PR DESCRIPTION
Resolves #2333.

## Description
> What is the purpose of this pull request?

This pull request:
- Implements a new iterator function `itercunone`
- Adds functionality to cumulatively test whether every iterated value is falsy
- Enhances the stdlib iterator ecosystem

## Related Issues
> Does this pull request have any related issues?

This pull request:
- resolves #2333

## Questions
> Any questions for reviewers of this pull request?

No.

## Other
> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

This implementation:
- Takes an input iterator
- Returns a new iterator that yields boolean values
- Continues yielding `true` while all values are falsy
- Yields `false` once a truthy value is encountered and for all subsequent iterations
- Handles both iterable and non-iterable input iterators

## Checklist
> Please ensure the following tasks are completed before submitting this pull request.

- [X] Read, understood, and followed the [contributing guidelines][contributing].

***
@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md