### PR TITLE
fix: remove unused include in `math/base/special/factorial`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/factorial/include/stdlib/math/base/special/factorial.h
+++ b/lib/node_modules/@stdlib/math/base/special/factorial/include/stdlib/math/base/special/factorial.h
@@ -19,8 +19,6 @@
 #ifndef STDLIB_MATH_BASE_SPECIAL_FACTORIAL_H
 #define STDLIB_MATH_BASE_SPECIAL_FACTORIAL_H
 
-#include <stdint.h>
-
 /*
 * If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
 */


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   addresses https://github.com/stdlib-js/stdlib/commit/cc98b20ab91590c526896d547e447f107fc714aa#r144361923
-   removes unused `include <stdint.h>` from [`factorial.h`](https://github.com/stdlib-js/stdlib/blob/develop/lib/node_modules/%40stdlib/math/base/special/factorial/include/stdlib/math/base/special/factorial.h#L22).

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
