### PR TITLE
refactor: remove extra `if` block, use `b` instead of `base` in `math/base/special/floorsd`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/floorsd/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/floorsd/lib/main.js
@@ -64,11 +64,7 @@ function floorsd( x, n, b ) {
 		isnan( x ) ||
 		isnan( n ) ||
 		n < 1 ||
-		isInfinite( n )
-	) {
-		return NaN;
-	}
-	if (
+		isInfinite( n ) ||
 		isnan( b ) ||
 		b <= 0 ||
 		isInfinite( b )

--- a/lib/node_modules/@stdlib/math/base/special/floorsd/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/floorsd/src/main.c
@@ -55,10 +55,10 @@ double stdlib_base_floorsd( const double x, const int32_t n, const int32_t b ) {
 	} else if ( b == 2 ) {
 		exp = stdlib_base_float64_exponent( stdlib_base_abs( x ) );
 	} else {
-		exp = stdlib_base_ln( stdlib_base_abs( x ) ) / stdlib_base_ln( b );
+		exp = stdlib_base_ln( stdlib_base_abs( x ) ) / stdlib_base_ln( (double)b );
 	}
 	exp = stdlib_base_floor( exp - n + 1.0 );
-	s = stdlib_base_pow( b, stdlib_base_abs( exp ) );
+	s = stdlib_base_pow( (double)b, stdlib_base_abs( exp ) );
 
 	// Check for overflow:
 	if ( stdlib_base_is_infinite( s ) ) {

--- a/lib/node_modules/@stdlib/math/base/special/floorsd/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/floorsd/src/main.c
@@ -40,7 +40,6 @@
 * // returns 0.03125
 */
 double stdlib_base_floorsd( const double x, const int32_t n, const int32_t b ) {
-	int32_t base;
 	double exp;
 	double s;
 	double y;
@@ -48,19 +47,18 @@ double stdlib_base_floorsd( const double x, const int32_t n, const int32_t b ) {
 	if ( stdlib_base_is_nan( x ) || n < 1 || b <= 0 ) {
 		return 0.0 / 0.0; // NaN
 	}
-	base = b;
 	if ( stdlib_base_is_infinite( x ) || x == 0.0 ) {
 		return x;
 	}
-	if ( base == 10 ) {
+	if ( b == 10 ) {
 		exp = stdlib_base_log10( stdlib_base_abs( x ) );
-	} else if ( base == 2 ) {
+	} else if ( b == 2 ) {
 		exp = stdlib_base_float64_exponent( stdlib_base_abs( x ) );
 	} else {
-		exp = stdlib_base_ln( stdlib_base_abs( x ) ) / stdlib_base_ln( base );
+		exp = stdlib_base_ln( stdlib_base_abs( x ) ) / stdlib_base_ln( b );
 	}
 	exp = stdlib_base_floor( exp - n + 1.0 );
-	s = stdlib_base_pow( base, stdlib_base_abs( exp ) );
+	s = stdlib_base_pow( b, stdlib_base_abs( exp ) );
 
 	// Check for overflow:
 	if ( stdlib_base_is_infinite( s ) ) {


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   removes extra `if` block, and checks the conditions for `b` in the initial `if` block itself, as the return value in both of them is the same, in the `javascript` implementation.
-   removes the `base` variable in `C` implementation, we can directly use `b`.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
