### PR TITLE
feat: add C implementation for `math/base/special/powm1`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/powm1/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/powm1/README.md
@@ -113,6 +113,99 @@ for ( i = 0; i < 100; i++ ) {
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/math/base/special/powm1.h"
+```
+
+#### stdlib_base_powm1( base, exponent )
+
+Evaluates `bˣ - 1`.
+
+```c
+double out = stdlib_base_powm1( 3.141592653589793, 5.0 );
+// returns ~305.0197
+
+out = stdlib_base_powm1( 4.0, 0.5 );
+// returns 1.0
+```
+
+The function accepts the following arguments:
+
+-   **base**: `[in] double` base.
+-   **exponent**: `[in] double` exponent.
+
+```c
+double stdlib_base_powm1( const double base, const double exponent );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/math/base/special/powm1.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+int main( void ) {
+    double out;
+    double b;
+    double x;
+    int i;
+
+    for ( i = 0; i < 100; i++ ) {
+        b = ( ( (double)rand() / (double)RAND_MAX ) * 10.0 );
+        x = ( ( (double)rand() / (double)RAND_MAX ) * 10.0 ) - 5.0;
+        out = stdlib_base_powm1( b, x );
+        printf( "powm1(%lf, %lf) = %lf\n", b, x, out );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/math/base/special/powm1/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/powm1/benchmark/benchmark.native.js
@@ -1,0 +1,62 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var powm1 = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( powm1 instanceof Error )
+};
+
+
+// MAIN //
+
+bench( pkg+'::native', opts, function benchmark( b ) {
+	var x;
+	var y;
+	var z;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		x = ( randu() * 2.0 ) - 0.0;
+		y = ( randu() * 100.0 ) - 50.0;
+		z = powm1( x, y );
+		if ( isnan( z ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnan( z ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/powm1/benchmark/c/native/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/powm1/benchmark/c/native/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/powm1/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/powm1/benchmark/c/native/benchmark.c
@@ -16,9 +16,6 @@
 * limitations under the License.
 */
 
-/**
-* Benchmark `powm1`.
-*/
 #include "stdlib/math/base/special/powm1.h"
 #include <stdlib.h>
 #include <stdio.h>
@@ -33,7 +30,7 @@
 /**
 * Prints the TAP version.
 */
-void print_version() {
+static void print_version( void ) {
 	printf( "TAP version 13\n" );
 }
 
@@ -43,7 +40,7 @@ void print_version() {
 * @param total     total number of tests
 * @param passing   total number of passing tests
 */
-void print_summary( int total, int passing ) {
+static void print_summary( int total, int passing ) {
 	printf( "#\n" );
 	printf( "1..%d\n", total ); // TAP plan
 	printf( "# total %d\n", total );
@@ -57,7 +54,7 @@ void print_summary( int total, int passing ) {
 *
 * @param elapsed   elapsed time in seconds
 */
-void print_results( double elapsed ) {
+static void print_results( double elapsed ) {
 	double rate = (double)ITERATIONS / elapsed;
 	printf( "  ---\n" );
 	printf( "  iterations: %d\n", ITERATIONS );
@@ -71,7 +68,7 @@ void print_results( double elapsed ) {
 *
 * @return clock time
 */
-double tic() {
+static double tic( void ) {
 	struct timeval now;
 	gettimeofday( &now, NULL );
 	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
@@ -82,7 +79,7 @@ double tic() {
 *
 * @return random number
 */
-double rand_double() {
+static double rand_double( void ) {
 	int r = rand();
 	return (double)r / ( (double)RAND_MAX + 1.0 );
 }
@@ -92,7 +89,7 @@ double rand_double() {
 *
 * @return elapsed time in seconds
 */
-double benchmark() {
+static double benchmark( void ) {
 	double elapsed;
 	double b;
 	double x;

--- a/lib/node_modules/@stdlib/math/base/special/powm1/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/powm1/benchmark/c/native/benchmark.c
@@ -1,0 +1,138 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/**
+* Benchmark `powm1`.
+*/
+#include "stdlib/math/base/special/powm1.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "powm1"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+void print_version() {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+double tic() {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1].
+*
+* @return random number
+*/
+double rand_double() {
+	int r = rand();
+	return (double)r / ( (double)RAND_MAX + 1.0 );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+double benchmark() {
+	double elapsed;
+	double b;
+	double x;
+	double y;
+	double t;
+	int i;
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		b = ( rand_double() * 2.0 ) - 0.0;
+		x = ( rand_double() * 100.0 ) - 50.0;
+		y = stdlib_base_powm1( b, x );
+		if ( y != y ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( y != y ) {
+		printf( "should not return NaN\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::native::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/math/base/special/powm1/binding.gyp
+++ b/lib/node_modules/@stdlib/math/base/special/powm1/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/math/base/special/powm1/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/powm1/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/powm1/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/powm1/examples/c/example.c
@@ -1,0 +1,35 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/powm1.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+int main( void ) {
+	double out;
+	double b;
+	double x;
+	int i;
+
+	for ( i = 0; i < 100; i++ ) {
+		b = ( ( (double)rand() / (double)RAND_MAX ) * 10.0 );
+		x = ( ( (double)rand() / (double)RAND_MAX ) * 10.0 ) - 5.0;
+		out = stdlib_base_powm1( b, x );
+		printf( "powm1(%lf, %lf) = %lf\n", b, x, out );
+	}
+}

--- a/lib/node_modules/@stdlib/math/base/special/powm1/include.gypi
+++ b/lib/node_modules/@stdlib/math/base/special/powm1/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/math/base/special/powm1/include/stdlib/math/base/special/powm1.h
+++ b/lib/node_modules/@stdlib/math/base/special/powm1/include/stdlib/math/base/special/powm1.h
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_MATH_BASE_SPECIAL_POWM1_H
+#define STDLIB_MATH_BASE_SPECIAL_POWM1_H
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Evaluates `bˣ - 1`.
+*/
+double stdlib_base_powm1( const double base, const double exponent );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_MATH_BASE_SPECIAL_POWM1_H

--- a/lib/node_modules/@stdlib/math/base/special/powm1/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/powm1/lib/native.js
@@ -1,0 +1,75 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Evaluates `bˣ - 1`.
+*
+* @private
+* @param {number} b - base
+* @param {number} x - exponent
+* @returns {number} function value
+*
+* @example
+* var y = powm1( 2.0, 3.0 );
+* // returns 7.0
+*
+* @example
+* var y = powm1( 4.0, 0.5 );
+* // returns 1.0
+*
+* @example
+* var y = powm1( 0.0, 100.0 );
+* // returns -1.0
+*
+* @example
+* var y = powm1( 100.0, 0.0 );
+* // returns 0.0
+*
+* @example
+* var y = powm1( 0.0, 0.0 );
+* // returns 0.0
+*
+* @example
+* var y = powm1( 3.141592653589793, 5.0 );
+* // returns ~305.0197
+*
+* @example
+* var y = powm1( NaN, 3.0 );
+* // returns NaN
+*
+* @example
+* var y = powm1( 5.0, NaN );
+* // returns NaN
+*/
+function powm1( b, x ) {
+	return addon( b, x );
+}
+
+
+// EXPORTS //
+
+module.exports = powm1;

--- a/lib/node_modules/@stdlib/math/base/special/powm1/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/powm1/manifest.json
@@ -1,0 +1,94 @@
+{
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/napi/binary",
+        "@stdlib/math/base/special/abs",
+        "@stdlib/math/base/special/expm1",
+        "@stdlib/math/base/special/ln",
+        "@stdlib/math/base/special/pow",
+        "@stdlib/math/base/special/trunc",
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/assert/is-infinite",
+        "@stdlib/math/base/special/fmod"
+
+      ]
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/abs",
+        "@stdlib/math/base/special/expm1",
+        "@stdlib/math/base/special/ln",
+        "@stdlib/math/base/special/pow",
+        "@stdlib/math/base/special/trunc",
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/assert/is-infinite",
+        "@stdlib/math/base/special/fmod"
+      ]
+    },
+    {
+      "task": "examples",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/abs",
+        "@stdlib/math/base/special/expm1",
+        "@stdlib/math/base/special/ln",
+        "@stdlib/math/base/special/pow",
+        "@stdlib/math/base/special/trunc",
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/assert/is-infinite",
+        "@stdlib/math/base/special/fmod"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/special/powm1/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/powm1/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/powm1/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/powm1/src/addon.c
@@ -1,0 +1,22 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/powm1.h"
+#include "stdlib/math/base/napi/binary.h"
+
+STDLIB_MATH_BASE_NAPI_MODULE_DD_D( stdlib_base_powm1 )

--- a/lib/node_modules/@stdlib/math/base/special/powm1/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/powm1/src/main.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -29,104 +29,67 @@
 * ```
 */
 
-'use strict';
-
-// MODULES //
-
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var isinfinite = require( '@stdlib/math/base/assert/is-infinite' );
-var abs = require( '@stdlib/math/base/special/abs' );
-var expm1 = require( '@stdlib/math/base/special/expm1' );
-var ln = require( '@stdlib/math/base/special/ln' );
-var pow = require( '@stdlib/math/base/special/pow' );
-var trunc = require( '@stdlib/math/base/special/trunc' );
-
-
-// MAIN //
+#include "stdlib/math/base/special/powm1.h"
+#include "stdlib/math/base/special/abs.h"
+#include "stdlib/math/base/special/expm1.h"
+#include "stdlib/math/base/special/ln.h"
+#include "stdlib/math/base/special/pow.h"
+#include "stdlib/math/base/special/trunc.h"
+#include "stdlib/math/base/assert/is_nan.h"
+#include "stdlib/math/base/assert/is_infinite.h"
+#include "stdlib/math/base/special/fmod.h"
 
 /**
 * Evaluates `bˣ - 1`.
 *
-* @param {number} b - base
-* @param {number} x - exponent
-* @returns {number} function value
+* @param x    base
+* @param y    exponent
+* @return     function value
 *
 * @example
-* var y = powm1( 2.0, 3.0 );
+* double out = stdlib_base_powm1( 2.0, 3.0 );
 * // returns 7.0
 *
 * @example
-* var y = powm1( 4.0, 0.5 );
+* double out = stdlib_base_powm1( 4.0, 0.5 );
 * // returns 1.0
-*
-* @example
-* var y = powm1( 0.0, 100.0 );
-* // returns -1.0
-*
-* @example
-* var y = powm1( 100.0, 0.0 );
-* // returns 0.0
-*
-* @example
-* var y = powm1( 0.0, 0.0 );
-* // returns 0.0
-*
-* @example
-* var y = powm1( 3.141592653589793, 5.0 );
-* // returns ~305.0197
-*
-* @example
-* var y = powm1( NaN, 3.0 );
-* // returns NaN
-*
-* @example
-* var y = powm1( 5.0, NaN );
-* // returns NaN
 */
-function powm1( b, x ) {
-	var result;
-	var y;
-	if (
-		isnan( b ) ||
-		isnan( x )
-	) {
-		return NaN;
+double stdlib_base_powm1( const double b, const double x ) {
+	double result;
+	double bc;
+	double y;
+
+	if ( stdlib_base_is_nan( b ) || stdlib_base_is_nan( x ) ) {
+		return 0.0 / 0.0; // NaN
 	}
-	if ( x === 0.0 ) {
+	if ( x == 0.0 ) {
 		// Any number raised to zero (including 0) is always 1 => b^0 - 1 = 0
 		return 0.0;
 	}
-	if ( b === 0.0 ) {
+	if ( b == 0.0 ) {
 		// Zero raised to any number (except 0) is always zero => 0^x - 1 = -1
 		return -1.0;
 	}
-	if ( b < 0.0 && x%2.0 === 0 ) {
+	bc = b;
+	if ( b < 0.0 && stdlib_base_fmod( x, 2.0 ) == 0 ) {
 		// If `x` is even, recognize that `(-b)**x == (b)**x`...
-		b = -b;
+		bc = -b;
 	}
-	if ( b > 0.0 ) {
-		if (
-			abs( x*(b-1.0) ) < 0.5 ||
-			abs( x ) < 0.2
-		) {
+	if ( bc > 0.0 ) {
+		if ( stdlib_base_abs( x * ( bc - 1.0 ) ) < 0.5 || stdlib_base_abs( x ) < 0.2 ) {
 			// No good/quick approximation for ln(b)*x, so we have to evaluate...
-			y = ln( b ) * x;
+			y = stdlib_base_ln( bc ) * x;
 			if ( y < 0.5 ) {
-				return expm1( y );
+				return stdlib_base_expm1( y );
 			}
 		}
-	} else if ( trunc( x ) !== x ) {
+	} else if ( stdlib_base_trunc( x ) != x ) {
 		// Exponentiation would yield a complex result...
-		return NaN;
+		return 0.0 / 0.0; // NaN
 	}
-	result = pow( b, x ) - 1.0;
-	if ( isinfinite( result ) || isnan( result ) ) {
+	result = stdlib_base_pow( bc, x ) - 1.0;
+	if ( stdlib_base_is_infinite( result ) || stdlib_base_is_nan( result ) ) {
 		return 0.0 / 0.0; // NaN
 	}
 	return result;
 }
-
-
-// EXPORTS //
-
-module.exports = powm1;

--- a/lib/node_modules/@stdlib/math/base/special/powm1/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/powm1/test/test.native.js
@@ -1,0 +1,152 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var randu = require( '@stdlib/random/base/randu' );
+var abs = require( '@stdlib/math/base/special/abs' );
+var expm1 = require( '@stdlib/math/base/special/expm1' );
+var ln = require( '@stdlib/math/base/special/ln' );
+var EPS = require( '@stdlib/constants/float64/eps' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// FIXTURES //
+
+var data = require( './fixtures/cpp/output.json' );
+
+
+// VARIABLES //
+
+var powm1 = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( powm1 instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof powm1, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function accepts two parameters: a base and an exponent', opts, function test( t ) {
+	t.equal( powm1.length, 2, 'arity is 2' );
+	t.end();
+});
+
+tape( 'if provided an exponent equal to `0`, the function returns `0`', opts, function test( t ) {
+	var i;
+	for ( i = -100; i < 100; i++ ) {
+		t.equal( powm1( i, 0.0 ), 0.0, 'returns -1' );
+		t.equal( powm1( ( randu()*10.0 ) - 5.0, 0.0 ), 0.0, 'returns 0' );
+	}
+	t.end();
+});
+
+tape( 'if provided a base equal to `0`, the function returns `-1` (except when the base is 0)', opts, function test( t ) {
+	var i;
+	for ( i = -100; i < 100; i++ ) {
+		if ( i === 0 ) {
+			t.equal( powm1( 0.0, i ), 0.0, 'returns 0' );
+			continue;
+		}
+		t.equal( powm1( 0.0, i ), -1.0, 'returns -1' );
+		t.equal( powm1( 0.0, ( randu()*10.0 ) - 5.0 ), -1.0, 'returns -1' );
+	}
+	t.end();
+});
+
+tape( 'the function evaluates `bˣ - 1` (tested against Boost)', opts, function test( t ) {
+	var expected;
+	var delta;
+	var tol;
+	var b;
+	var x;
+	var y;
+	var i;
+
+	b = data.b;
+	x = data.x;
+	expected = data.expected;
+
+	for ( i = 0; i < b.length; i++ ) {
+		y = powm1( b[ i ], x[ i ] );
+		delta = abs( y - expected[ i ] );
+		tol = 2.0 * EPS * abs( expected[ i ] );
+		t.ok( delta <= tol, 'within tolerance. b: ' + b[ i ] + 'x: ' + x[ i ] + '. actual: ' + y + '. E: ' + expected[ i ] + '. tol: ' + tol + '. Δ: ' + delta + '.' );
+	}
+	t.end();
+});
+
+tape( 'the function evaluates `bˣ - 1`', opts, function test( t ) {
+	t.equal( powm1( 2.0, 3.0 ), 7.0, '2^3-1 = 7' );
+	t.equal( powm1( -5.0, 3.0 ), -126.0, '(-5)^3-1 = -126' );
+	t.equal( powm1( -5.0, 2.0 ), 24.0, '(-5)^2-1 = 24' );
+	t.equal( powm1( 1.0e6, 0.1 ), 2.9810717055349727, '1e6^0.1-1 ~ 2.981' );
+	t.end();
+});
+
+tape( 'the function evaluates `bˣ - 1` as expm1( ln(b) * x ) for sufficiently small b or x', opts, function test( t ) {
+	var expected;
+	var actual;
+
+	expected = expm1( ln(4.0)*1.0e-3 );
+	actual = powm1( 4.0, 1.0e-3 );
+	t.equal( actual, expected, '4**(1e-3) = exp( ln(4)*1e-3 )' );
+
+	expected = expm1( ln(1.1)*0.4 );
+	actual = powm1( 1.1, 0.4 );
+	t.equal( actual, expected, '1.1**(0.4) = exp( ln(1.1)*0.4 )' );
+
+	t.end();
+});
+
+tape( 'the function returns `NaN` if provided a negative base and a exponent which is not an integer', opts, function test( t ) {
+	var y;
+
+	y = powm1( -125.0, 1.0/3.0 );
+	t.equal( isnan( y ), true, 'returns expected value' );
+
+	y = powm1( -16.0, -0.5 );
+	t.equal( isnan( y ), true, 'returns expected value' );
+
+	y = powm1( -2.0, -1.25 );
+	t.equal( isnan( y ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `NaN` if provided a `NaN` for the exponent', opts, function test( t ) {
+	var y = powm1( -3.0, NaN );
+	t.equal( isnan( y ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `NaN` if provided a `NaN` for the base', opts, function test( t ) {
+	var y = powm1( NaN, 5.0 );
+	t.equal( isnan( y ), true, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds `C` implementation for [`math/base/special/powm1`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/powm1).

```c
double stdlib_base_powm1( const double b, const double x );
```

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves a part of #649.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

I've checked the implementation with the latest boost implementation, and have made some changes.

Older version: https://www.boost.org/doc/libs/1_60_0/boost/math/special_functions/powm1.hpp
Latest version: https://www.boost.org/doc/libs/1_85_0/boost/math/special_functions/powm1.hpp

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
