### PR TITLE
feat: add C implementation for `math/base/special/gamma-delta-ratio`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/README.md
@@ -74,6 +74,99 @@ for ( i = 0; i < 100; i++ ) {
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/math/base/special/gamma_delta_ratio.h"
+```
+
+#### stdlib_base_gamma_delta_ratio( z, delta )
+
+Computes the ratio of two [gamma functions][@stdlib/math/base/special/gamma]. Specifically, the function evaluates `Γ( z ) / Γ( z + delta )`.
+
+```c
+double out = stdlib_base_gamma_delta_ratio( 2.0, 3.0 );
+// returns ~0.042
+
+out = stdlib_base_gamma_delta_ratio( 4.0, 0.5 );
+// returns ~0.516
+```
+
+The function accepts the following arguments:
+
+-   **z**: `[in] double` first gamma parameter.
+-   **delta**: `[in] double` difference.
+
+```c
+double stdlib_base_gamma_delta_ratio( const double z, const double delta );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/math/base/special/gamma_delta_ratio.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+int main( void ) {
+    double delta;
+    double out;
+    double z;
+    int i;
+
+    for ( i = 0; i < 100; i++ ) {
+        z = (double)rand() * 10.0;
+        delta = (double)rand() * 10.0;
+        out = stdlib_base_gamma_delta_ratio( z, delta );
+        printf( "gamma_delta_ratio(%lf, %lf) = %lf\n", z, delta, out );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/benchmark/benchmark.native.js
@@ -1,0 +1,86 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var gamma = require( '@stdlib/math/base/special/gamma' );
+var randu = require( '@stdlib/random/base/randu' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var gammaDeltaRatio = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( gammaDeltaRatio instanceof Error )
+};
+
+
+// MAIN //
+
+bench( pkg+'::native', opts, function benchmark( b ) {
+	var delta;
+	var z;
+	var y;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		z = randu() * 100.0;
+		delta = randu() * 100.0;
+		y = gammaDeltaRatio( z, delta );
+		if ( isnan( y ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnan( y ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::native,naive', function benchmark( b ) {
+	var delta;
+	var z;
+	var y;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		z = randu() * 100.0;
+		delta = randu() * 100.0;
+		y = gamma( z ) / gamma( z + delta );
+		if ( isnan( y ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnan( y ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/benchmark/c/native/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/benchmark/c/native/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/benchmark/c/native/benchmark.c
@@ -16,9 +16,6 @@
 * limitations under the License.
 */
 
-/**
-* Benchmark `gamma_delta_ratio`.
-*/
 #include "stdlib/math/base/special/gamma_delta_ratio.h"
 #include <stdlib.h>
 #include <stdio.h>
@@ -33,7 +30,7 @@
 /**
 * Prints the TAP version.
 */
-void print_version() {
+static void print_version( void ) {
 	printf( "TAP version 13\n" );
 }
 
@@ -43,7 +40,7 @@ void print_version() {
 * @param total     total number of tests
 * @param passing   total number of passing tests
 */
-void print_summary( int total, int passing ) {
+static void print_summary( int total, int passing ) {
 	printf( "#\n" );
 	printf( "1..%d\n", total ); // TAP plan
 	printf( "# total %d\n", total );
@@ -57,7 +54,7 @@ void print_summary( int total, int passing ) {
 *
 * @param elapsed   elapsed time in seconds
 */
-void print_results( double elapsed ) {
+static void print_results( double elapsed ) {
 	double rate = (double)ITERATIONS / elapsed;
 	printf( "  ---\n" );
 	printf( "  iterations: %d\n", ITERATIONS );
@@ -71,7 +68,7 @@ void print_results( double elapsed ) {
 *
 * @return clock time
 */
-double tic() {
+static double tic( void ) {
 	struct timeval now;
 	gettimeofday( &now, NULL );
 	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
@@ -82,7 +79,7 @@ double tic() {
 *
 * @return random number
 */
-double rand_double() {
+static double rand_double( void ) {
 	int r = rand();
 	return (double)r / ( (double)RAND_MAX + 1.0 );
 }
@@ -92,7 +89,7 @@ double rand_double() {
 *
 * @return elapsed time in seconds
 */
-double benchmark() {
+static double benchmark( void ) {
 	double elapsed;
 	double delta;
 	double z;

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/benchmark/c/native/benchmark.c
@@ -1,0 +1,138 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/**
+* Benchmark `gamma_delta_ratio`.
+*/
+#include "stdlib/math/base/special/gamma_delta_ratio.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "gamma-delta-ratio"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+void print_version() {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+double tic() {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1].
+*
+* @return random number
+*/
+double rand_double() {
+	int r = rand();
+	return (double)r / ( (double)RAND_MAX + 1.0 );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+double benchmark() {
+	double elapsed;
+	double delta;
+	double z;
+	double y;
+	double t;
+	int i;
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		z = ( rand_double() * 100.0 );
+		delta = ( rand_double() * 100.0 );
+		y = stdlib_base_gamma_delta_ratio( z, delta );
+		if ( y != y ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( y != y ) {
+		printf( "should not return NaN\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::native::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/binding.gyp
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/examples/c/example.c
@@ -1,0 +1,35 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/gamma_delta_ratio.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+int main( void ) {
+	double delta;
+	double out;
+	double z;
+	int i;
+
+	for ( i = 0; i < 100; i++ ) {
+		z = (double)rand() * 10.0;
+		delta = (double)rand() * 10.0;
+		out = stdlib_base_gamma_delta_ratio( z, delta );
+		printf( "gamma_delta_ratio(%lf, %lf) = %lf\n", z, delta, out );
+	}
+}

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/include.gypi
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/include/stdlib/math/base/special/gamma_delta_ratio.h
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/include/stdlib/math/base/special/gamma_delta_ratio.h
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_MATH_BASE_SPECIAL_GAMMA_DELTA_RATIO_H
+#define STDLIB_MATH_BASE_SPECIAL_GAMMA_DELTA_RATIO_H
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Computes the ratio of two gamma functions.
+*/
+double stdlib_base_gamma_delta_ratio( const double z, const double delta );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_MATH_BASE_SPECIAL_GAMMA_DELTA_RATIO_H

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/lib/gamma_delta_ratio_lanczos.js
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/lib/gamma_delta_ratio_lanczos.js
@@ -90,8 +90,8 @@ function gammaDeltaRatioLanczos( z, delta ) {
 	}
 	zgh = z + G - 0.5;
 	if ( z + delta === z ) {
-		if ( abs(delta) < 10.0 ) {
-			result = exp( ( 0.5-z ) * log1p( delta/zgh ) );
+		if ( abs( delta / zgh ) < EPSILON ) {
+			result = exp( -delta );
 		} else {
 			result = 1.0;
 		}

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/lib/gamma_delta_ratio_lanczos.js
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/lib/gamma_delta_ratio_lanczos.js
@@ -45,11 +45,11 @@ var pow = require( '@stdlib/math/base/special/pow' );
 var EPSILON = require( '@stdlib/constants/float64/eps' );
 var E = require( '@stdlib/constants/float64/e' );
 var G = require( '@stdlib/constants/float64/gamma-lanczos-g' );
+var MAX_FACTORIAL = require( '@stdlib/constants/float64/max-safe-nth-factorial' );
 
 
 // VARIABLES //
 
-var MAX_FACTORIAL = 170; // TODO: consider moving to pkg
 var FACTORIAL_169 = 4.269068009004705e+304;
 
 

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/lib/gamma_delta_ratio_lanczos.js
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/lib/gamma_delta_ratio_lanczos.js
@@ -80,7 +80,7 @@ function gammaDeltaRatioLanczos( z, delta ) {
 	var zgh;
 
 	if ( z < EPSILON ) {
-		if ( delta > MAX_FACTORIAL ) {
+		if ( delta >= MAX_FACTORIAL ) {
 			ratio = gammaDeltaRatioLanczos( delta, MAX_FACTORIAL-delta );
 			ratio *= z;
 			ratio *= FACTORIAL_169;

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/lib/main.js
@@ -40,12 +40,8 @@ var abs = require( '@stdlib/math/base/special/abs' );
 var floor = require( '@stdlib/math/base/special/floor' );
 var gamma = require( '@stdlib/math/base/special/gamma' );
 var factorial = require( '@stdlib/math/base/special/factorial' );
+var MAX_FACTORIAL = require( '@stdlib/constants/float64/max-safe-nth-factorial' );
 var gammaDeltaRatioLanczos = require( './gamma_delta_ratio_lanczos.js' );
-
-
-// VARIABLES //
-
-var MAX_FACTORIAL = 170; // TODO: consider moving to pkg
 
 
 // MAIN //

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/lib/main.js
@@ -18,7 +18,7 @@
 *
 * ## Notice
 *
-* The original C++ code and copyright notice are from the [Boost library]{@link http://www.boost.org/doc/libs/1_64_0/boost/math/special_functions/gamma.hpp}. The implementation has been modified for JavaScript.
+* The original C++ code and copyright notice are from the [Boost library]{@link http://www.boost.org/doc/libs/1_85_0/boost/math/special_functions/gamma.hpp}. The implementation has been modified for JavaScript.
 *
 * ```text
 * Copyright John Maddock 2006-7, 2013-14.

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/lib/native.js
@@ -1,0 +1,55 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Computes the ratio of two gamma functions.
+*
+* @private
+* @param {number} z - first gamma parameter
+* @param {number} delta - difference
+* @returns {number} gamma ratio
+*
+* @example
+* var y = gammaDeltaRatio( 2.0, 3.0 );
+* // returns ~0.042
+*
+* @example
+* var y = gammaDeltaRatio( 4.0, 0.5 );
+* // returns ~0.516
+*
+* @example
+* var y = gammaDeltaRatio( 100.0, 0.0 );
+* // returns 1.0
+*/
+function gammaDeltaRatio( z, delta ) {
+	return addon( z, delta );
+}
+
+
+// EXPORTS //
+
+module.exports = gammaDeltaRatio;

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/manifest.json
@@ -1,0 +1,105 @@
+{
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/napi/binary",
+        "@stdlib/math/base/special/abs",
+        "@stdlib/math/base/special/floor",
+        "@stdlib/math/base/special/gamma",
+        "@stdlib/math/base/special/factorial",
+        "@stdlib/math/base/special/gamma-lanczos-sum",
+        "@stdlib/math/base/special/log1p",
+        "@stdlib/math/base/special/exp",
+        "@stdlib/math/base/special/pow",
+        "@stdlib/constants/float64/max-safe-nth-factorial",
+        "@stdlib/constants/float64/eps",
+        "@stdlib/constants/float64/e",
+        "@stdlib/constants/float64/gamma-lanczos-g"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/abs",
+        "@stdlib/math/base/special/floor",
+        "@stdlib/math/base/special/gamma",
+        "@stdlib/math/base/special/factorial",
+        "@stdlib/math/base/special/gamma-lanczos-sum",
+        "@stdlib/math/base/special/log1p",
+        "@stdlib/math/base/special/exp",
+        "@stdlib/math/base/special/pow",
+        "@stdlib/constants/float64/max-safe-nth-factorial",
+        "@stdlib/constants/float64/eps",
+        "@stdlib/constants/float64/e",
+        "@stdlib/constants/float64/gamma-lanczos-g"
+      ]
+    },
+    {
+      "task": "examples",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/abs",
+        "@stdlib/math/base/special/floor",
+        "@stdlib/math/base/special/gamma",
+        "@stdlib/math/base/special/factorial",
+        "@stdlib/math/base/special/gamma-lanczos-sum",
+        "@stdlib/math/base/special/log1p",
+        "@stdlib/math/base/special/exp",
+        "@stdlib/math/base/special/pow",
+        "@stdlib/constants/float64/max-safe-nth-factorial",
+        "@stdlib/constants/float64/eps",
+        "@stdlib/constants/float64/e",
+        "@stdlib/constants/float64/gamma-lanczos-g"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/src/addon.c
@@ -1,0 +1,23 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/gamma_delta_ratio.h"
+#include "stdlib/math/base/napi/binary.h"
+
+// cppcheck-suppress shadowFunction
+STDLIB_MATH_BASE_NAPI_MODULE_DD_D( stdlib_base_gamma_delta_ratio )

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/src/main.c
@@ -18,7 +18,7 @@
 *
 * ## Notice
 *
-* The original C++ code and copyright notice are from the [Boost library]{@link http://www.boost.org/doc/libs/1_64_0/boost/math/special_functions/gamma.hpp}. The implementation has been modified for JavaScript.
+* The original C++ code and copyright notice are from the [Boost library]{@link http://www.boost.org/doc/libs/1_85_0/boost/math/special_functions/gamma.hpp}. The implementation has been modified for JavaScript.
 *
 * ```text
 * Copyright John Maddock 2006-7, 2013-14.

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/src/main.c
@@ -18,7 +18,7 @@
 *
 * ## Notice
 *
-* The original C++ code and copyright notice are from the [Boost library]{@link http://www.boost.org/doc/libs/1_85_0/boost/math/special_functions/gamma.hpp}. The implementation has been modified for JavaScript.
+* The original C++ code and copyright notice are from the [Boost library]{@link http://www.boost.org/doc/libs/1_85_0/boost/math/special_functions/gamma.hpp}. The implementation has been modified for use in stdlib.
 *
 * ```text
 * Copyright John Maddock 2006-7, 2013-14.

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/src/main.c
@@ -62,7 +62,6 @@ static const double FACTORIAL_169 = 4.269068009004705e+304;
 *     \end{align*}
 *     ```
 *
-* @private
 * @param z        first gamma parameter
 * @param delta    difference
 * @returns        gamma ratio

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/src/main.c
@@ -82,8 +82,8 @@ static double gammaDeltaRatioLanczos( const double z, const double delta ) {
 	}
 	zgh = z + STDLIB_CONSTANT_FLOAT64_GAMMA_LANCZOS_G - 0.5;
 	if ( z + delta == z ) {
-		if ( stdlib_base_abs( delta ) < 10.0 ) {
-			result = stdlib_base_exp( ( 0.5 - z ) * stdlib_base_log1p( delta / zgh ) );
+		if ( stdlib_base_abs( delta / zgh ) < STDLIB_CONSTANT_FLOAT64_EPS ) {
+			result = stdlib_base_exp( -delta );
 		} else {
 			result = 1.0;
 		}

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/src/main.c
@@ -72,7 +72,7 @@ static double gammaDeltaRatioLanczos( const double z, const double delta ) {
 	double zgh;
 
 	if ( z < STDLIB_CONSTANT_FLOAT64_EPS ) {
-		if ( delta > STDLIB_CONSTANT_FLOAT64_MAX_SAFE_NTH_FACTORIAL ) {
+		if ( delta >= STDLIB_CONSTANT_FLOAT64_MAX_SAFE_NTH_FACTORIAL ) {
 			ratio = gammaDeltaRatioLanczos( delta, STDLIB_CONSTANT_FLOAT64_MAX_SAFE_NTH_FACTORIAL - delta );
 			ratio *= z;
 			ratio *= FACTORIAL_169;

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/src/main.c
@@ -1,0 +1,172 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*
+* ## Notice
+*
+* The original C++ code and copyright notice are from the [Boost library]{@link http://www.boost.org/doc/libs/1_64_0/boost/math/special_functions/gamma.hpp}. The implementation has been modified for JavaScript.
+*
+* ```text
+* Copyright John Maddock 2006-7, 2013-14.
+* Copyright Paul A. Bristow 2007, 2013-14.
+* Copyright Nikhar Agrawal 2013-14.
+* Copyright Christopher Kormanyos 2013-14.
+*
+* Use, modification and distribution are subject to the
+* Boost Software License, Version 1.0. (See accompanying file
+* LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+* ```
+*/
+
+#include "stdlib/math/base/special/gamma_delta_ratio.h"
+#include "stdlib/math/base/special/abs.h"
+#include "stdlib/math/base/special/floor.h"
+#include "stdlib/math/base/special/gamma.h"
+#include "stdlib/math/base/special/factorial.h"
+#include "stdlib/constants/float64/max_safe_nth_factorial.h"
+#include "stdlib/math/base/special/gamma_lanczos_sum.h"
+#include "stdlib/math/base/special/log1p.h"
+#include "stdlib/math/base/special/exp.h"
+#include "stdlib/math/base/special/pow.h"
+#include "stdlib/constants/float64/eps.h"
+#include "stdlib/constants/float64/e.h"
+#include "stdlib/constants/float64/gamma_lanczos_g.h"
+
+static const double FACTORIAL_169 = 4.269068009004705e+304;
+
+/**
+* Calculates the ratio of two gamma functions via Lanczos approximation.
+*
+* ## Notes
+*
+* -   When \\( z < \epsilon \\), we get spurious numeric overflow unless we're very careful. This can occur either inside `lanczosSum(z)` or in the final combination of terms. To avoid this, split the product up into 2 (or 3) parts:
+*
+*     ```tex
+*     \begin{align*}
+*     G(z) / G(L) &= 1 / (z \cdot G(L)) ; z < \eps, L = z + \delta = \delta \\
+*     z * G(L) &= z * G(lim) \cdot (G(L)/G(lim)) ; lim = \text{largest factorial}
+*     \end{align*}
+*     ```
+*
+* @private
+* @param z        first gamma parameter
+* @param delta    difference
+* @returns        gamma ratio
+*/
+static double gammaDeltaRatioLanczos( const double z, const double delta ) {
+	double result;
+	double ratio;
+	double zgh;
+
+	if ( z < STDLIB_CONSTANT_FLOAT64_EPS ) {
+		if ( delta > STDLIB_CONSTANT_FLOAT64_MAX_SAFE_NTH_FACTORIAL ) {
+			ratio = gammaDeltaRatioLanczos( delta, STDLIB_CONSTANT_FLOAT64_MAX_SAFE_NTH_FACTORIAL - delta );
+			ratio *= z;
+			ratio *= FACTORIAL_169;
+			return 1.0 / ratio;
+		}
+		return 1.0 / ( z * stdlib_base_gamma( z + delta ) );
+	}
+	zgh = z + STDLIB_CONSTANT_FLOAT64_GAMMA_LANCZOS_G - 0.5;
+	if ( z + delta == z ) {
+		if ( stdlib_base_abs( delta ) < 10.0 ) {
+			result = stdlib_base_exp( ( 0.5 - z ) * stdlib_base_log1p( delta / zgh ) );
+		} else {
+			result = 1.0;
+		}
+	} else {
+		if ( stdlib_base_abs( delta ) < 10.0 ) {
+			result = stdlib_base_exp( ( 0.5 - z ) * stdlib_base_log1p( delta / zgh ) );
+		} else {
+			result = stdlib_base_pow( zgh / ( zgh + delta ), z - 0.5 );
+		}
+		// Split up the calculation to avoid spurious overflow:
+		result *= stdlib_base_gamma_lanczos_sum( z ) / stdlib_base_gamma_lanczos_sum( z + delta );
+	}
+	result *= stdlib_base_pow( STDLIB_CONSTANT_FLOAT64_E / ( zgh + delta ), delta );
+	return result;
+}
+
+/**
+* Computes the ratio of two gamma functions.
+*
+* ## Notes
+*
+* -   Specifically, the function evaluates
+*
+*     ```tex
+*     \frac{ \Gamma( z ) }{ \Gamma( z + \delta ) }
+*     ```
+*
+* @param z        first gamma parameter
+* @param delta    difference
+* @return         gamma ratio
+*
+* @example
+* double out = stdlib_base_gamma_delta_ratio( 2.0, 3.0 );
+* // returns ~0.042
+*/
+double stdlib_base_gamma_delta_ratio( const double z, const double delta ) {
+	double deltac;
+	double result;
+	double idelta;
+	double zc;
+	double iz;
+
+	if ( z <= 0.0 || z + delta <= 0.0 ) {
+		// This isn't very sophisticated, or accurate, but it does work:
+		return stdlib_base_gamma( z ) / stdlib_base_gamma( z + delta );
+	}
+	idelta = stdlib_base_floor( delta );
+	if ( idelta == delta ) {
+		iz = stdlib_base_floor( z );
+		if ( iz == z ) {
+			// As both `z` and `delta` are integers, see if we can use a table lookup:
+			if ( z <= STDLIB_CONSTANT_FLOAT64_MAX_SAFE_NTH_FACTORIAL && ( z + delta <= STDLIB_CONSTANT_FLOAT64_MAX_SAFE_NTH_FACTORIAL ) ) {
+				return stdlib_base_factorial( iz - 1.0 ) / stdlib_base_factorial( idelta + iz - 1.0 );
+			}
+		}
+		if ( stdlib_base_abs( delta ) < 20.0 ) {
+			// As `delta` is a small integer, we can use a finite product:
+			if ( delta == 0.0 ) {
+				return 1.0;
+			}
+			zc = z;
+			deltac = delta;
+			if ( deltac < 0.0 ) {
+				zc -= 1.0;
+				result = zc;
+				deltac += 1.0;
+				while ( deltac != 0.0 ) {
+					zc -= 1.0;
+					result *= zc;
+					deltac += 1.0;
+				}
+				return result;
+			}
+			result = 1.0 / zc;
+			deltac -= 1.0;
+			while ( deltac != 0.0 ) {
+				zc += 1.0;
+				result /= zc;
+				deltac -= 1.0;
+			}
+			return result;
+		}
+	}
+	return gammaDeltaRatioLanczos( z, delta );
+}

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/test/test.js
@@ -87,7 +87,7 @@ tape( 'the function evaluates the ratio of two gamma functions (decimals)', func
 	for ( i = 0; i < z.length; i++ ) {
 		v = gammaDeltaRatio( z[ i ], diff[ i ] );
 		delta = abs( v - expected[ i ] );
-		tol = 350.0 * EPS * abs( expected[ i ] );
+		tol = 337.0 * EPS * abs( expected[ i ] );
 		t.ok( delta <= tol, 'within tolerance. z: '+z[i]+'. delta: '+diff[i]+'. v: '+v+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
 	}
 	t.end();
@@ -108,7 +108,7 @@ tape( 'the function evaluates the ratio of two gamma functions (small integers)'
 	for ( i = 0; i < z.length; i++ ) {
 		v = gammaDeltaRatio( z[ i ], diff[ i ] );
 		delta = abs( v - expected[ i ] );
-		tol = 10.0 * EPS * abs( expected[ i ] );
+		tol = 1.1 * EPS * abs( expected[ i ] );
 		t.ok( delta <= tol, 'within tolerance. z: '+z[i]+'. delta: '+diff[i]+'. v: '+v+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
 	}
 	t.end();
@@ -129,7 +129,7 @@ tape( 'the function evaluates the ratio of two gamma functions (large integers)'
 	for ( i = 0; i < z.length; i++ ) {
 		v = gammaDeltaRatio( z[ i ], diff[ i ] );
 		delta = abs( v - expected[ i ] );
-		tol = 150.0 * EPS * abs( expected[ i ] );
+		tol = 129.0 * EPS * abs( expected[ i ] );
 		t.ok( delta <= tol, 'within tolerance. z: '+z[i]+'. delta: '+diff[i]+'. v: '+v+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
 	}
 	t.end();
@@ -150,7 +150,7 @@ tape( 'the function evaluates the ratio of two gamma functions (non-integer `z`,
 	for ( i = 0; i < z.length; i++ ) {
 		v = gammaDeltaRatio( z[ i ], diff[ i ] );
 		delta = abs( v - expected[ i ] );
-		tol = 150.0 * EPS * abs( expected[ i ] );
+		tol = 129.0 * EPS * abs( expected[ i ] );
 		t.ok( delta <= tol, 'within tolerance. z: '+z[i]+'. delta: '+diff[i]+'. v: '+v+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
 	}
 	t.end();
@@ -171,7 +171,7 @@ tape( 'the function evaluates the ratio of two gamma functions (tiny `z`, large 
 	for ( i = 0; i < z.length; i++ ) {
 		v = gammaDeltaRatio( z[ i ], diff[ i ] );
 		delta = abs( v - expected[ i ] );
-		tol = 100.0 * EPS * abs( expected[ i ] );
+		tol = 3.3 * EPS * abs( expected[ i ] );
 
 		// Handle cases where either the expected value is zero or `v` is zero and the expected value is very small...
 		if ( tol < 1.0e-300 ) {

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/test/test.native.js
@@ -1,0 +1,213 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var abs = require( '@stdlib/math/base/special/abs' );
+var EPS = require( '@stdlib/constants/float64/eps' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var gammaDeltaRatio = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( gammaDeltaRatio instanceof Error )
+};
+
+
+// FIXTURES //
+
+var decimalsIntegers = require( './fixtures/cpp/decimals_integers.json' );
+var largeIntegers = require( './fixtures/cpp/large_integers.json' );
+var smallIntegers = require( './fixtures/cpp/small_integers.json' );
+var largeTiny = require( './fixtures/cpp/large_tiny.json' );
+var tinyLarge = require( './fixtures/cpp/tiny_large.json' );
+var decimals = require( './fixtures/cpp/decimals.json' );
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof gammaDeltaRatio, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `NaN` if provided `NaN` for either parameter', opts, function test( t ) {
+	var v;
+
+	v = gammaDeltaRatio( NaN, 5.0 );
+	t.equal( isnan( v ), true, 'returns expected value' );
+
+	v = gammaDeltaRatio( 1.0, NaN );
+	t.equal( isnan( v ), true, 'returns expected value' );
+
+	v = gammaDeltaRatio( NaN, NaN );
+	t.equal( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `0` for very large `z` and negligible `delta`', opts, function test( t ) {
+	var v;
+
+	v = gammaDeltaRatio( 1.0e100, 20.7 );
+	t.equal( v, 0.0, 'returns 0' );
+
+	v = gammaDeltaRatio( 1.0e120, 100.1 );
+	t.equal( v, 0.0, 'returns 0' );
+
+	t.end();
+});
+
+tape( 'the function evaluates the ratio of two gamma functions (decimals)', opts, function test( t ) {
+	var expected;
+	var delta;
+	var diff;
+	var tol;
+	var v;
+	var i;
+	var z;
+
+	z = decimals.z;
+	diff = decimals.delta;
+	expected = decimals.expected;
+	for ( i = 0; i < z.length; i++ ) {
+		v = gammaDeltaRatio( z[ i ], diff[ i ] );
+		delta = abs( v - expected[ i ] );
+		tol = 350.0 * EPS * abs( expected[ i ] );
+		t.ok( delta <= tol, 'within tolerance. z: '+z[i]+'. delta: '+diff[i]+'. v: '+v+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+	}
+	t.end();
+});
+
+tape( 'the function evaluates the ratio of two gamma functions (small integers)', opts, function test( t ) {
+	var expected;
+	var delta;
+	var diff;
+	var tol;
+	var v;
+	var i;
+	var z;
+
+	z = smallIntegers.z;
+	diff = smallIntegers.delta;
+	expected = smallIntegers.expected;
+	for ( i = 0; i < z.length; i++ ) {
+		v = gammaDeltaRatio( z[ i ], diff[ i ] );
+		delta = abs( v - expected[ i ] );
+		tol = 10.0 * EPS * abs( expected[ i ] );
+		t.ok( delta <= tol, 'within tolerance. z: '+z[i]+'. delta: '+diff[i]+'. v: '+v+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+	}
+	t.end();
+});
+
+tape( 'the function evaluates the ratio of two gamma functions (large integers)', opts, function test( t ) {
+	var expected;
+	var delta;
+	var diff;
+	var tol;
+	var v;
+	var i;
+	var z;
+
+	z = largeIntegers.z;
+	diff = largeIntegers.delta;
+	expected = largeIntegers.expected;
+	for ( i = 0; i < z.length; i++ ) {
+		v = gammaDeltaRatio( z[ i ], diff[ i ] );
+		delta = abs( v - expected[ i ] );
+		tol = 150.0 * EPS * abs( expected[ i ] );
+		t.ok( delta <= tol, 'within tolerance. z: '+z[i]+'. delta: '+diff[i]+'. v: '+v+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+	}
+	t.end();
+});
+
+tape( 'the function evaluates the ratio of two gamma functions (non-integer `z`, integer `delta`)', opts, function test( t ) {
+	var expected;
+	var delta;
+	var diff;
+	var tol;
+	var v;
+	var i;
+	var z;
+
+	z = decimalsIntegers.z;
+	diff = decimalsIntegers.delta;
+	expected = decimalsIntegers.expected;
+	for ( i = 0; i < z.length; i++ ) {
+		v = gammaDeltaRatio( z[ i ], diff[ i ] );
+		delta = abs( v - expected[ i ] );
+		tol = 150.0 * EPS * abs( expected[ i ] );
+		t.ok( delta <= tol, 'within tolerance. z: '+z[i]+'. delta: '+diff[i]+'. v: '+v+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+	}
+	t.end();
+});
+
+tape( 'the function evaluates the ratio of two gamma functions (tiny `z`, large `delta`)', opts, function test( t ) {
+	var expected;
+	var delta;
+	var diff;
+	var tol;
+	var v;
+	var i;
+	var z;
+
+	z = tinyLarge.z;
+	diff = tinyLarge.delta;
+	expected = tinyLarge.expected;
+	for ( i = 0; i < z.length; i++ ) {
+		v = gammaDeltaRatio( z[ i ], diff[ i ] );
+		delta = abs( v - expected[ i ] );
+		tol = 100.0 * EPS * abs( expected[ i ] );
+
+		// Handle cases where either the expected value is zero or `v` is zero and the expected value is very small...
+		if ( tol < 1.0e-300 ) {
+			tol = 1.0e-300;
+		}
+		t.ok( delta <= tol, 'within tolerance. z: '+z[i]+'. delta: '+diff[i]+'. v: '+v+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+	}
+	t.end();
+});
+
+tape( 'the function evaluates the ratio of two gamma functions (large `z`, tiny `delta`)', opts, function test( t ) {
+	var expected;
+	var delta;
+	var diff;
+	var tol;
+	var v;
+	var i;
+	var z;
+
+	z = largeTiny.z;
+	diff = largeTiny.delta;
+	expected = largeTiny.expected;
+	for ( i = 0; i < z.length; i++ ) {
+		v = gammaDeltaRatio( z[ i ], diff[ i ] );
+		delta = abs( v - expected[ i ] );
+		tol = 1.0 * EPS * abs( expected[ i ] );
+		t.ok( delta <= tol, 'within tolerance. z: '+z[i]+'. delta: '+diff[i]+'. v: '+v+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
+	}
+	t.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/test/test.native.js
@@ -96,7 +96,7 @@ tape( 'the function evaluates the ratio of two gamma functions (decimals)', opts
 	for ( i = 0; i < z.length; i++ ) {
 		v = gammaDeltaRatio( z[ i ], diff[ i ] );
 		delta = abs( v - expected[ i ] );
-		tol = 350.0 * EPS * abs( expected[ i ] );
+		tol = 337.0 * EPS * abs( expected[ i ] );
 		t.ok( delta <= tol, 'within tolerance. z: '+z[i]+'. delta: '+diff[i]+'. v: '+v+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
 	}
 	t.end();
@@ -117,7 +117,7 @@ tape( 'the function evaluates the ratio of two gamma functions (small integers)'
 	for ( i = 0; i < z.length; i++ ) {
 		v = gammaDeltaRatio( z[ i ], diff[ i ] );
 		delta = abs( v - expected[ i ] );
-		tol = 10.0 * EPS * abs( expected[ i ] );
+		tol = 1.1 * EPS * abs( expected[ i ] );
 		t.ok( delta <= tol, 'within tolerance. z: '+z[i]+'. delta: '+diff[i]+'. v: '+v+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
 	}
 	t.end();
@@ -138,7 +138,7 @@ tape( 'the function evaluates the ratio of two gamma functions (large integers)'
 	for ( i = 0; i < z.length; i++ ) {
 		v = gammaDeltaRatio( z[ i ], diff[ i ] );
 		delta = abs( v - expected[ i ] );
-		tol = 150.0 * EPS * abs( expected[ i ] );
+		tol = 129.0 * EPS * abs( expected[ i ] );
 		t.ok( delta <= tol, 'within tolerance. z: '+z[i]+'. delta: '+diff[i]+'. v: '+v+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
 	}
 	t.end();
@@ -159,7 +159,7 @@ tape( 'the function evaluates the ratio of two gamma functions (non-integer `z`,
 	for ( i = 0; i < z.length; i++ ) {
 		v = gammaDeltaRatio( z[ i ], diff[ i ] );
 		delta = abs( v - expected[ i ] );
-		tol = 150.0 * EPS * abs( expected[ i ] );
+		tol = 129.0 * EPS * abs( expected[ i ] );
 		t.ok( delta <= tol, 'within tolerance. z: '+z[i]+'. delta: '+diff[i]+'. v: '+v+'. E: '+expected[i]+'. Δ: '+delta+'. tol: '+tol );
 	}
 	t.end();
@@ -180,7 +180,7 @@ tape( 'the function evaluates the ratio of two gamma functions (tiny `z`, large 
 	for ( i = 0; i < z.length; i++ ) {
 		v = gammaDeltaRatio( z[ i ], diff[ i ] );
 		delta = abs( v - expected[ i ] );
-		tol = 100.0 * EPS * abs( expected[ i ] );
+		tol = 3.3 * EPS * abs( expected[ i ] );
 
 		// Handle cases where either the expected value is zero or `v` is zero and the expected value is very small...
 		if ( tol < 1.0e-300 ) {


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds `C` implementation for [`math/base/special/gamma-delta-ratio`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/gamma-delta-ratio).
-   replaces a variable declared in `main.js` for `MAX_FACTORIAL`, by importing it.

```c
double stdlib_base_gamma_delta_ratio( const double z, const double delta );
```

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves a part of #649.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
