### PR TITLE
test: add tests to `ndarray/base/nullary`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/nullary/test/test.10d.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nullary/test/test.10d.js
@@ -679,7 +679,7 @@ tape( 'the function applies a nullary callback to each indexed element of a 10-d
 	dt = 'complex128';
 	ord = 'row-major';
 	sh = [ 1, 1, 1, 1, 1, 1, 2, 2, 1, 2 ];
-	st = [ 8, 8, 8, 8, 8, 8, 4, 2, 2, 1 ];
+	st = [ -8, -8, -8, -8, -8, -8, -4, -2, -2, -1 ];
 	o = strides2offset( sh, st );
 
 	x = ndarray( dt, zeros( numel( sh ), dt ), sh, st, o, ord );

--- a/lib/node_modules/@stdlib/ndarray/base/nullary/test/test.10d.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nullary/test/test.10d.js
@@ -32,6 +32,9 @@ var ndarray = require( '@stdlib/ndarray/ctor' );
 var shape2strides = require( '@stdlib/ndarray/base/shape2strides' );
 var strides2offset = require( '@stdlib/ndarray/base/strides2offset' );
 var numel = require( '@stdlib/ndarray/base/numel' );
+var dfill = require( '@stdlib/blas/ext/base/dfill' );
+var gfill = require( '@stdlib/blas/ext/base/gfill' );
+var blockSize = require( '@stdlib/ndarray/base/nullary-tiling-block-size' );
 var nullary = require( './../lib' );
 
 
@@ -107,6 +110,25 @@ tape( 'the function applies a nullary callback to each indexed element of a 10-d
 	t.end();
 });
 
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (row-major, empty)', function test( t ) {
+	var expected;
+	var x;
+
+	x = ndarray( 'float64', zeros( 4, 'float64' ), [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ], [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ], 0, 'row-major' );
+
+	nullary( [ x ], constantFunction( 10.0 ) );
+
+	expected = new Float64Array([
+		0.0,
+		0.0,
+		0.0,
+		0.0
+	]);
+	t.strictEqual( isSameFloat64Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (row-major, contiguous)', function test( t ) {
 	var expected;
 	var ord;
@@ -120,6 +142,40 @@ tape( 'the function applies a nullary callback to each indexed element of a 10-d
 	ord = 'row-major';
 	sh = [ 1, 1, 1, 1, 1, 1, 2, 2, 1, 2 ];
 	st = shape2strides( sh, ord );
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh ), dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( 10.0 ) );
+
+	expected = new Float64Array([
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0
+	]);
+	t.strictEqual( isSameFloat64Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (row-major, contiguous, negative strides)', function test( t ) {
+	var expected;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'float64';
+	ord = 'row-major';
+	sh = [ 1, 1, 1, 1, 1, 1, 2, 2, 1, 2 ];
+	st = [ -8, -8, -8, -8, -8, -8, -4, -2, -2, -1 ];
 	o = strides2offset( sh, st );
 
 	x = ndarray( dt, zeros( numel( sh ), dt ), sh, st, o, ord );
@@ -225,6 +281,350 @@ tape( 'the function applies a nullary callback to each indexed element of a 10-d
 	t.end();
 });
 
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (row-major, non-contiguous, large arrays)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'float64';
+	ord = 'row-major';
+
+	bsize = blockSize( dt );
+	sh = [ bsize*2, 2, 1, 1, 2, 1, 2, 1, 1, 2 ];
+	st = [ 32, 16, 16, -16, 8, 8, -4, 4, 4, 2 ];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( 10.0 ) );
+
+	expected = new Float64Array( x.length*2 );
+	dfill( x.length, 10.0, expected, st[ 9 ] );
+
+	t.strictEqual( isSameFloat64Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (row-major, non-contiguous, large arrays)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'float64';
+	ord = 'row-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, bsize*2, 2, 1, 2, 1, 2, 1, 1, 2 ];
+	st = [ bsize*64, 32, 16, -16, 8, 8, -4, 4, 4, 2 ];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( 10.0 ) );
+
+	expected = new Float64Array( x.length*2 );
+	dfill( x.length, 10.0, expected, st[ 9 ] );
+
+	t.strictEqual( isSameFloat64Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (row-major, non-contiguous, large arrays)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'float64';
+	ord = 'row-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 2, bsize*2, 2, 1, 1, 2, 1, 1, 2 ];
+	st = [ bsize*64, bsize*32, 16, -8, 8, 8, -4, 4, 4, 2 ];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( 10.0 ) );
+
+	expected = new Float64Array( x.length*2 );
+	dfill( x.length, 10.0, expected, st[ 9 ] );
+
+	t.strictEqual( isSameFloat64Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (row-major, non-contiguous, large arrays)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'float64';
+	ord = 'row-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 1, 2, bsize*2, 2, 1, 2, 1, 1, 2 ];
+	st = [ bsize*64, bsize*64, bsize*32, -16, 8, 8, -4, 4, 4, 2 ];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( 10.0 ) );
+
+	expected = new Float64Array( x.length*2 );
+	dfill( x.length, 10.0, expected, st[ 9 ] );
+
+	t.strictEqual( isSameFloat64Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (row-major, non-contiguous, large arrays)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'float64';
+	ord = 'row-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 1, 1, 2, bsize*2, 2, 1, 1, 1, 2 ];
+	st = [ bsize*32, bsize*32, bsize*32, -bsize*16, 8, 4, -4, 4, 4, 2 ];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( 10.0 ) );
+
+	expected = new Float64Array( x.length*2 );
+	dfill( x.length, 10.0, expected, st[ 9 ] );
+
+	t.strictEqual( isSameFloat64Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (row-major, non-contiguous, large arrays)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'float64';
+	ord = 'row-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 1, 1, 1, 2, bsize*2, 2, 1, 1, 2 ];
+	st = [ bsize*32, bsize*32, bsize*32, -bsize*32, bsize*16, 8, -4, 4, 4, 2 ];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( 10.0 ) );
+
+	expected = new Float64Array( x.length*2 );
+	dfill( x.length, 10.0, expected, st[ 9 ] );
+
+	t.strictEqual( isSameFloat64Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (row-major, non-contiguous, large arrays)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'float64';
+	ord = 'row-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 1, 2, 1, 1, 2, bsize*2, 2, 1, 2 ];
+	st = [
+		bsize*64,
+		bsize*64,
+		bsize*32,
+		-bsize*32,
+		bsize*32,
+		bsize*16,
+		-8,
+		4,
+		4,
+		2
+	];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( 10.0 ) );
+
+	expected = new Float64Array( x.length*2 );
+	dfill( x.length, 10.0, expected, st[ 9 ] );
+
+	t.strictEqual( isSameFloat64Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (row-major, non-contiguous, large arrays)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'float64';
+	ord = 'row-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 1, 2, 1, 1, 1, 2, bsize*2, 2, 2 ];
+	st = [
+		bsize*64,
+		bsize*64,
+		bsize*32,
+		-bsize*32,
+		bsize*32,
+		bsize*32,
+		-bsize*16,
+		8,
+		4,
+		2
+	];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( 10.0 ) );
+
+	expected = new Float64Array( x.length*2 );
+	dfill( x.length, 10.0, expected, st[ 9 ] );
+
+	t.strictEqual( isSameFloat64Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (row-major, non-contiguous, large arrays)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'float64';
+	ord = 'row-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 1, 2, 1, 2, 1, 1, 2, bsize*2, 2 ];
+	st = [
+		bsize*64,
+		bsize*64,
+		bsize*32,
+		-bsize*32,
+		bsize*16,
+		bsize*16,
+		-bsize*16,
+		bsize*8,
+		4,
+		2
+	];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( 10.0 ) );
+
+	expected = new Float64Array( x.length*2 );
+	dfill( x.length, 10.0, expected, st[ 9 ] );
+
+	t.strictEqual( isSameFloat64Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (row-major, non-contiguous, large arrays)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'float64';
+	ord = 'row-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 1, 2, 1, 2, 1, 1, 1, 2, bsize*2 ];
+	st = [
+		bsize*32,
+		bsize*32,
+		bsize*16,
+		-bsize*16,
+		bsize*8,
+		bsize*8,
+		-bsize*8,
+		bsize*8,
+		bsize*4,
+		2
+	];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( 10.0 ) );
+
+	expected = new Float64Array( x.length*2 );
+	dfill( x.length, 10.0, expected, st[ 9 ] );
+
+	t.strictEqual( isSameFloat64Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (row-major, contiguous, accessors)', function test( t ) {
 	var expected;
 	var ord;
@@ -238,6 +638,48 @@ tape( 'the function applies a nullary callback to each indexed element of a 10-d
 	ord = 'row-major';
 	sh = [ 1, 1, 1, 1, 1, 1, 2, 2, 1, 2 ];
 	st = shape2strides( sh, ord );
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh ), dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( new Complex128( 10.0, 10.0 ) ) );
+
+	expected = new Complex128Array( [
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0
+	] );
+	t.strictEqual( isSameComplex128Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (row-major, contiguous, accessors, negative strides)', function test( t ) {
+	var expected;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'complex128';
+	ord = 'row-major';
+	sh = [ 1, 1, 1, 1, 1, 1, 2, 2, 1, 2 ];
+	st = [ 8, 8, 8, 8, 8, 8, 4, 2, 2, 1 ];
 	o = strides2offset( sh, st );
 
 	x = ndarray( dt, zeros( numel( sh ), dt ), sh, st, o, ord );
@@ -383,6 +825,350 @@ tape( 'the function applies a nullary callback to each indexed element of a 10-d
 	t.end();
 });
 
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (row-major, non-contiguous, large arrays, accessors)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'complex128';
+	ord = 'row-major';
+
+	bsize = blockSize( dt );
+	sh = [ bsize*2, 2, 1, 1, 2, 1, 2, 1, 1, 2 ];
+	st = [ 32, 16, 16, -16, 8, 8, -4, 4, 4, 2 ];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( new Complex128( 10.0, 10.0 ) ) );
+
+	expected = new Complex128Array( x.length*2 );
+	gfill( x.length, new Complex128( 10.0, 10.0 ), expected, st[ 9 ] );
+
+	t.strictEqual( isSameComplex128Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (row-major, non-contiguous, large arrays, accessors)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'complex128';
+	ord = 'row-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, bsize*2, 2, 1, 2, 1, 2, 1, 1, 2 ];
+	st = [ bsize*64, 32, 16, -16, 8, 8, -4, 4, 4, 2 ];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( new Complex128( 10.0, 10.0 ) ) );
+
+	expected = new Complex128Array( x.length*2 );
+	gfill( x.length, new Complex128( 10.0, 10.0 ), expected, st[ 9 ] );
+
+	t.strictEqual( isSameComplex128Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (row-major, non-contiguous, large arrays, accessors)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'complex128';
+	ord = 'row-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 2, bsize*2, 2, 1, 1, 2, 1, 1, 2 ];
+	st = [ bsize*64, bsize*32, 16, -8, 8, 8, -4, 4, 4, 2 ];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( new Complex128( 10.0, 10.0 ) ) );
+
+	expected = new Complex128Array( x.length*2 );
+	gfill( x.length, new Complex128( 10.0, 10.0 ), expected, st[ 9 ] );
+
+	t.strictEqual( isSameComplex128Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (row-major, non-contiguous, large arrays, accessors)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'complex128';
+	ord = 'row-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 1, 2, bsize*2, 2, 1, 2, 1, 1, 2 ];
+	st = [ bsize*64, bsize*64, bsize*32, -16, 8, 8, -4, 4, 4, 2 ];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( new Complex128( 10.0, 10.0 ) ) );
+
+	expected = new Complex128Array( x.length*2 );
+	gfill( x.length, new Complex128( 10.0, 10.0 ), expected, st[ 9 ] );
+
+	t.strictEqual( isSameComplex128Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (row-major, non-contiguous, large arrays, accessors)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'complex128';
+	ord = 'row-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 1, 1, 2, bsize*2, 2, 1, 1, 1, 2 ];
+	st = [ bsize*32, bsize*32, bsize*32, -bsize*16, 8, 4, -4, 4, 4, 2 ];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( new Complex128( 10.0, 10.0 ) ) );
+
+	expected = new Complex128Array( x.length*2 );
+	gfill( x.length, new Complex128( 10.0, 10.0 ), expected, st[ 9 ] );
+
+	t.strictEqual( isSameComplex128Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (row-major, non-contiguous, large arrays, accessors)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'complex128';
+	ord = 'row-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 1, 1, 1, 2, bsize*2, 2, 1, 1, 2 ];
+	st = [ bsize*32, bsize*32, bsize*32, -bsize*32, bsize*16, 8, -4, 4, 4, 2 ];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( new Complex128( 10.0, 10.0 ) ) );
+
+	expected = new Complex128Array( x.length*2 );
+	gfill( x.length, new Complex128( 10.0, 10.0 ), expected, st[ 9 ] );
+
+	t.strictEqual( isSameComplex128Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (row-major, non-contiguous, large arrays, accessors)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'complex128';
+	ord = 'row-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 1, 2, 1, 1, 2, bsize*2, 2, 1, 2 ];
+	st = [
+		bsize*64,
+		bsize*64,
+		bsize*32,
+		-bsize*32,
+		bsize*32,
+		bsize*16,
+		-8,
+		4,
+		4,
+		2
+	];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( new Complex128( 10.0, 10.0 ) ) );
+
+	expected = new Complex128Array( x.length*2 );
+	gfill( x.length, new Complex128( 10.0, 10.0 ), expected, st[ 9 ] );
+
+	t.strictEqual( isSameComplex128Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (row-major, non-contiguous, large arrays, accessors)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'complex128';
+	ord = 'row-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 1, 2, 1, 1, 1, 2, bsize*2, 2, 2 ];
+	st = [
+		bsize*64,
+		bsize*64,
+		bsize*32,
+		-bsize*32,
+		bsize*32,
+		bsize*32,
+		-bsize*16,
+		8,
+		4,
+		2
+	];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( new Complex128( 10.0, 10.0 ) ) );
+
+	expected = new Complex128Array( x.length*2 );
+	gfill( x.length, new Complex128( 10.0, 10.0 ), expected, st[ 9 ] );
+
+	t.strictEqual( isSameComplex128Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (row-major, non-contiguous, large arrays, accessors)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'complex128';
+	ord = 'row-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 1, 2, 1, 2, 1, 1, 2, bsize*2, 2 ];
+	st = [
+		bsize*64,
+		bsize*64,
+		bsize*32,
+		-bsize*32,
+		bsize*16,
+		bsize*16,
+		-bsize*16,
+		bsize*8,
+		4,
+		2
+	];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( new Complex128( 10.0, 10.0 ) ) );
+
+	expected = new Complex128Array( x.length*2 );
+	gfill( x.length, new Complex128( 10.0, 10.0 ), expected, st[ 9 ] );
+
+	t.strictEqual( isSameComplex128Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (row-major, non-contiguous, large arrays, accessors)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'complex128';
+	ord = 'row-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 1, 2, 1, 2, 1, 1, 1, 2, bsize*2 ];
+	st = [
+		bsize*32,
+		bsize*32,
+		bsize*16,
+		-bsize*16,
+		bsize*8,
+		bsize*8,
+		-bsize*8,
+		bsize*8,
+		bsize*4,
+		2
+	];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( new Complex128( 10.0, 10.0 ) ) );
+
+	expected = new Complex128Array( x.length*2 );
+	gfill( x.length, new Complex128( 10.0, 10.0 ), expected, st[ 9 ] );
+
+	t.strictEqual( isSameComplex128Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (column-major, singleton dimensions)', function test( t ) {
 	var expected;
 	var ord;
@@ -447,6 +1233,25 @@ tape( 'the function applies a nullary callback to each indexed element of a 10-d
 	t.end();
 });
 
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (column-major, empty)', function test( t ) {
+	var expected;
+	var x;
+
+	x = ndarray( 'float64', zeros( 4, 'float64' ), [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ], [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ], 0, 'column-major' );
+
+	nullary( [ x ], constantFunction( 10.0 ) );
+
+	expected = new Float64Array([
+		0.0,
+		0.0,
+		0.0,
+		0.0
+	]);
+	t.strictEqual( isSameFloat64Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (column-major, contiguous)', function test( t ) {
 	var expected;
 	var ord;
@@ -460,6 +1265,40 @@ tape( 'the function applies a nullary callback to each indexed element of a 10-d
 	ord = 'column-major';
 	sh = [ 1, 1, 1, 1, 1, 1, 2, 2, 1, 2 ];
 	st = shape2strides( sh, ord );
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh ), dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( 10.0 ) );
+
+	expected = new Float64Array([
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0
+	]);
+	t.strictEqual( isSameFloat64Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (column-major, contiguous, negative strides)', function test( t ) {
+	var expected;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'float64';
+	ord = 'column-major';
+	sh = [ 1, 1, 1, 1, 1, 1, 2, 2, 1, 2 ];
+	st = [ -1, -1, -1, -1, -1, -1, -1, -2, -4, -4 ];
 	o = strides2offset( sh, st );
 
 	x = ndarray( dt, zeros( numel( sh ), dt ), sh, st, o, ord );
@@ -565,6 +1404,350 @@ tape('the function applies a nullary callback to each indexed element of an 10-d
 	t.end();
 });
 
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (column-major, non-contiguous, large arrays)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'float64';
+	ord = 'column-major';
+
+	bsize = blockSize( dt );
+	sh = [ bsize*2, 2, 1, 1, 2, 1, 2, 1, 1, 2 ];
+	st = [
+		2,
+		bsize*4,
+		bsize*8,
+		-bsize*8,
+		bsize*8,
+		bsize*16,
+		bsize*16,
+		-bsize*32,
+		bsize*32,
+		bsize*32
+	];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( 10.0 ) );
+
+	expected = new Float64Array( x.length*2 );
+	dfill( x.length, 10.0, expected, st[ 0 ] );
+
+	t.strictEqual( isSameFloat64Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (column-major, non-contiguous, large arrays)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'float64';
+	ord = 'column-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, bsize*2, 2, 1, 2, 1, 2, 1, 1, 2 ];
+	st = [
+		2,
+		4,
+		bsize*8,
+		bsize*16,
+		bsize*16,
+		bsize*32,
+		bsize*32,
+		bsize*64,
+		bsize*64,
+		bsize*64
+	];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( 10.0 ) );
+
+	expected = new Float64Array( x.length*2 );
+	dfill( x.length, 10.0, expected, st[ 0 ] );
+
+	t.strictEqual( isSameFloat64Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (column-major, non-contiguous, large arrays)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'float64';
+	ord = 'column-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 2, bsize*2, 2, 1, 1, 2, 1, 1, 2 ];
+	st = [
+		2,
+		4,
+		8,
+		bsize*16,
+		bsize*32,
+		bsize*32,
+		bsize*32,
+		bsize*64,
+		bsize*64,
+		bsize*64
+	];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( 10.0 ) );
+
+	expected = new Float64Array( x.length*2 );
+	dfill( x.length, 10.0, expected, st[ 0 ] );
+
+	t.strictEqual( isSameFloat64Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (column-major, non-contiguous, large arrays)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'float64';
+	ord = 'column-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 1, 2, bsize*2, 2, 1, 2, 1, 1, 2 ];
+	st = [
+		2,
+		4,
+		4,
+		8,
+		bsize*16,
+		bsize*32,
+		bsize*32,
+		bsize*64,
+		bsize*64,
+		bsize*64
+	];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( 10.0 ) );
+
+	expected = new Float64Array( x.length*2 );
+	dfill( x.length, 10.0, expected, st[ 0 ] );
+
+	t.strictEqual( isSameFloat64Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (column-major, non-contiguous, large arrays)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'float64';
+	ord = 'column-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 1, 1, 2, bsize*2, 2, 1, 1, 1, 2 ];
+	st = [ 2, 4, 4, 4, 8, bsize*16, bsize*32, bsize*32, bsize*32, bsize*32 ];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( 10.0 ) );
+
+	expected = new Float64Array( x.length*2 );
+	dfill( x.length, 10.0, expected, st[ 0 ] );
+
+	t.strictEqual( isSameFloat64Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (column-major, non-contiguous, large arrays)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'float64';
+	ord = 'column-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 1, 1, 1, 2, bsize*2, 2, 1, 1, 2 ];
+	st = [ 2, 4, 4, 4, 4, 8, bsize*16, bsize*32, bsize*32, bsize*32 ];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( 10.0 ) );
+
+	expected = new Float64Array( x.length*2 );
+	dfill( x.length, 10.0, expected, st[ 0 ] );
+
+	t.strictEqual( isSameFloat64Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (column-major, non-contiguous, large arrays)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'float64';
+	ord = 'column-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 1, 2, 1, 1, 2, bsize*2, 2, 1, 2 ];
+	st = [ 2, 4, 4, 8, 8, 8, 16, bsize*32, bsize*64, bsize*64 ];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( 10.0 ) );
+
+	expected = new Float64Array( x.length*2 );
+	dfill( x.length, 10.0, expected, st[ 0 ] );
+
+	t.strictEqual( isSameFloat64Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (column-major, non-contiguous, large arrays)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'float64';
+	ord = 'column-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 1, 2, 1, 2, 1, 2, bsize*2, 2, 1 ];
+	st = [ 2, 4, 4, 8, 8, 16, 16, 32, bsize*64, bsize*128 ];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( 10.0 ) );
+
+	expected = new Float64Array( x.length*2 );
+	dfill( x.length, 10.0, expected, st[ 0 ] );
+
+	t.strictEqual( isSameFloat64Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (column-major, non-contiguous, large arrays)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'float64';
+	ord = 'column-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 1, 2, 1, 2, 1, 1, 2, bsize*2, 2 ];
+	st = [ 2, 4, 4, 8, 8, 16, 16, 16, 32, bsize*64 ];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( 10.0 ) );
+
+	expected = new Float64Array( x.length*2 );
+	dfill( x.length, 10.0, expected, st[ 0 ] );
+
+	t.strictEqual( isSameFloat64Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (column-major, non-contiguous, large arrays)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'float64';
+	ord = 'column-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 1, 2, 1, 2, 1, 1, 1, 2, bsize*2 ];
+	st = [ 2, 4, 4, 8, 8, 16, -16, 16, 16, 32 ];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( 10.0 ) );
+
+	expected = new Float64Array( x.length*2 );
+	dfill( x.length, 10.0, expected, st[ 0 ] );
+
+	t.strictEqual( isSameFloat64Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (column-major, contiguous, accessors)', function test( t ) {
 	var expected;
 	var ord;
@@ -578,6 +1761,48 @@ tape( 'the function applies a nullary callback to each indexed element of a 10-d
 	ord = 'column-major';
 	sh = [ 1, 1, 1, 1, 1, 2, 2, 1, 2, 1 ];
 	st = shape2strides( sh, ord );
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh ), dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( new Complex128( 10.0, 10.0 ) ) );
+
+	expected = new Complex128Array([
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0,
+		10.0
+	]);
+	t.strictEqual( isSameComplex128Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (column-major, contiguous, accessors, negative strides)', function test( t ) {
+	var expected;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'complex128';
+	ord = 'column-major';
+	sh = [ 1, 1, 1, 1, 1, 2, 2, 1, 2, 1 ];
+	st = [ -1, -1, -1, -1, -1, -1, -2, -4, -4, -8 ];
 	o = strides2offset( sh, st );
 
 	x = ndarray( dt, zeros( numel( sh ), dt ), sh, st, o, ord );
@@ -718,6 +1943,350 @@ tape( 'the function applies a nullary callback to each indexed element of a 10-d
 		0.0,
 		0.0
 	]);
+	t.strictEqual( isSameComplex128Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (column-major, non-contiguous, large arrays, accessors)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'complex128';
+	ord = 'column-major';
+
+	bsize = blockSize( dt );
+	sh = [ bsize*2, 2, 1, 1, 2, 1, 2, 1, 1, 2 ];
+	st = [
+		2,
+		bsize*4,
+		bsize*8,
+		-bsize*8,
+		bsize*8,
+		bsize*16,
+		bsize*16,
+		-bsize*32,
+		bsize*32,
+		bsize*32
+	];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( new Complex128( 10.0, 10.0 ) ) );
+
+	expected = new Complex128Array( x.length*2 );
+	gfill( x.length, new Complex128( 10.0, 10.0 ), expected, st[ 0 ] );
+
+	t.strictEqual( isSameComplex128Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (column-major, non-contiguous, large arrays, accessors)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'complex128';
+	ord = 'column-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, bsize*2, 2, 1, 2, 1, 2, 1, 1, 2 ];
+	st = [
+		2,
+		4,
+		bsize*8,
+		bsize*16,
+		bsize*16,
+		bsize*32,
+		bsize*32,
+		bsize*64,
+		bsize*64,
+		bsize*64
+	];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( new Complex128( 10.0, 10.0 ) ) );
+
+	expected = new Complex128Array( x.length*2 );
+	gfill( x.length, new Complex128( 10.0, 10.0 ), expected, st[ 0 ] );
+
+	t.strictEqual( isSameComplex128Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (column-major, non-contiguous, large arrays, accessors)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'complex128';
+	ord = 'column-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 2, bsize*2, 2, 1, 1, 2, 1, 1, 2 ];
+	st = [
+		2,
+		4,
+		8,
+		bsize*16,
+		bsize*32,
+		bsize*32,
+		bsize*32,
+		bsize*64,
+		bsize*64,
+		bsize*64
+	];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( new Complex128( 10.0, 10.0 ) ) );
+
+	expected = new Complex128Array( x.length*2 );
+	gfill( x.length, new Complex128( 10.0, 10.0 ), expected, st[ 0 ] );
+
+	t.strictEqual( isSameComplex128Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (column-major, non-contiguous, large arrays, accessors)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'complex128';
+	ord = 'column-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 1, 2, bsize*2, 2, 1, 2, 1, 1, 2 ];
+	st = [
+		2,
+		4,
+		4,
+		8,
+		bsize*16,
+		bsize*32,
+		bsize*32,
+		bsize*64,
+		bsize*64,
+		bsize*64
+	];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( new Complex128( 10.0, 10.0 ) ) );
+
+	expected = new Complex128Array( x.length*2 );
+	gfill( x.length, new Complex128( 10.0, 10.0 ), expected, st[ 0 ] );
+
+	t.strictEqual( isSameComplex128Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (column-major, non-contiguous, large arrays, accessors)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'complex128';
+	ord = 'column-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 1, 1, 2, bsize*2, 2, 1, 1, 1, 2 ];
+	st = [ 2, 4, 4, 4, 8, bsize*16, bsize*32, bsize*32, bsize*32, bsize*32 ];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( new Complex128( 10.0, 10.0 ) ) );
+
+	expected = new Complex128Array( x.length*2 );
+	gfill( x.length, new Complex128( 10.0, 10.0 ), expected, st[ 0 ] );
+
+	t.strictEqual( isSameComplex128Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (column-major, non-contiguous, large arrays, accessors)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'complex128';
+	ord = 'column-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 1, 1, 1, 2, bsize*2, 2, 1, 1, 2 ];
+	st = [ 2, 4, 4, 4, 4, 8, bsize*16, bsize*32, bsize*32, bsize*32 ];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( new Complex128( 10.0, 10.0 ) ) );
+
+	expected = new Complex128Array( x.length*2 );
+	gfill( x.length, new Complex128( 10.0, 10.0 ), expected, st[ 0 ] );
+
+	t.strictEqual( isSameComplex128Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (column-major, non-contiguous, large arrays, accessors)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'complex128';
+	ord = 'column-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 1, 2, 1, 1, 2, bsize*2, 2, 1, 2 ];
+	st = [ 2, 4, 4, 8, 8, 8, 16, bsize*32, bsize*64, bsize*64 ];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( new Complex128( 10.0, 10.0 ) ) );
+
+	expected = new Complex128Array( x.length*2 );
+	gfill( x.length, new Complex128( 10.0, 10.0 ), expected, st[ 0 ] );
+
+	t.strictEqual( isSameComplex128Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (column-major, non-contiguous, large arrays, accessors)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'complex128';
+	ord = 'column-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 1, 2, 1, 2, 1, 2, bsize*2, 2, 1 ];
+	st = [ 2, 4, 4, 8, 8, 16, 16, 32, bsize*64, bsize*128 ];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( new Complex128( 10.0, 10.0 ) ) );
+
+	expected = new Complex128Array( x.length*2 );
+	gfill( x.length, new Complex128( 10.0, 10.0 ), expected, st[ 0 ] );
+
+	t.strictEqual( isSameComplex128Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (column-major, non-contiguous, large arrays, accessors)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'complex128';
+	ord = 'column-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 1, 2, 1, 2, 1, 1, 2, bsize*2, 2 ];
+	st = [ 2, 4, 4, 8, 8, 16, 16, 16, 32, bsize*64 ];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( new Complex128( 10.0, 10.0 ) ) );
+
+	expected = new Complex128Array( x.length*2 );
+	gfill( x.length, new Complex128( 10.0, 10.0 ), expected, st[ 0 ] );
+
+	t.strictEqual( isSameComplex128Array( x.data, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (column-major, non-contiguous, large arrays, accessors)', function test( t ) {
+	var expected;
+	var bsize;
+	var ord;
+	var sh;
+	var st;
+	var dt;
+	var o;
+	var x;
+
+	dt = 'complex128';
+	ord = 'column-major';
+
+	bsize = blockSize( dt );
+	sh = [ 2, 1, 2, 1, 2, 1, 1, 1, 2, bsize*2 ];
+	st = [ 2, 4, 4, 8, 8, 16, -16, 16, 16, 32 ];
+	o = strides2offset( sh, st );
+
+	x = ndarray( dt, zeros( numel( sh )*2, dt ), sh, st, o, ord );
+
+	nullary( [ x ], constantFunction( new Complex128( 10.0, 10.0 ) ) );
+
+	expected = new Complex128Array( x.length*2 );
+	gfill( x.length, new Complex128( 10.0, 10.0 ), expected, st[ 0 ] );
+
 	t.strictEqual( isSameComplex128Array( x.data, expected ), true, 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/ndarray/base/nullary/test/test.10d.js
+++ b/lib/node_modules/@stdlib/ndarray/base/nullary/test/test.10d.js
@@ -1320,7 +1320,7 @@ tape( 'the function applies a nullary callback to each indexed element of a 10-d
 	t.end();
 });
 
-tape('the function applies a nullary callback to each indexed element of an 10-dimensional ndarray (column-major, non-contiguous, same sign strides)', function test( t ) {
+tape('the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (column-major, non-contiguous, same sign strides)', function test( t ) {
 	var expected;
 	var ord;
 	var sh;
@@ -1362,7 +1362,7 @@ tape('the function applies a nullary callback to each indexed element of an 10-d
 	t.end();
 });
 
-tape('the function applies a nullary callback to each indexed element of an 10-dimensional ndarray (column-major, non-contiguous, mixed sign strides)', function test( t ) {
+tape('the function applies a nullary callback to each indexed element of a 10-dimensional ndarray (column-major, non-contiguous, mixed sign strides)', function test( t ) {
 	var expected;
 	var ord;
 	var sh;


### PR DESCRIPTION
Resolves #2229 .

## Description

> What is the purpose of this pull request?

This pull request:

-   add tests to `@stdlib/ndarray/base/nullary/test/test.10d.js` for 100% test coverage

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #2229 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

- At first, I implemented the strides the same way I did with `9d`, i.e.  `[ 2, 1, 2, 1, bsize*2, 2, 1, 2, 1, 2 ]` (only one alternate side of the dimension `bsize*2` was non-singleton) and same as with `9d` I was getting `100%` branch coverage (screenshot below). Could you comment on why this is happening?

![cov-10-d](https://github.com/user-attachments/assets/42a55b8c-1481-4881-b4dd-ef5f55868081)


## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
