### PR TITLE
feat: add C implementation for `math/base/special/truncb`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/truncb/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/truncb/README.md
@@ -93,6 +93,96 @@ for ( i = 0; i < 100; i++ ) {
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/math/base/special/truncb.h"
+```
+
+#### stdlib_base_truncb( x, n, b )
+
+Rounds a `numeric` value to the nearest multiple of `b^n` toward zero.
+
+```c
+double out = stdlib_base_truncb( 3.141592653589793, -4, 10 );
+// returns 3.1415
+```
+
+The function accepts the following arguments:
+
+-   **x**: `[in] double` input value.
+-   **n**: `[in] int32_t` power.
+-   **b**: `[in] int32_t` base.
+
+```c
+double stdlib_base_truncb( const double x, const int32_t n, const int32_t b );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/math/base/special/truncb.h"
+#include <stdio.h>
+#include <stdint.h>
+
+int main( void ) {
+    const double x[] = { -5.0, -3.89, -2.78, -1.67, -0.56, 0.56, 1.67, 2.78, 3.89, 5.0 };
+    const int32_t n[] = { -4, -3, -2, -1, 0, 1, 2, 3, 4, 5 };
+    const int32_t b[] = { 20, 19, 18, 17, 16, 15, 14, 13, 12, 11 };
+
+    double v;
+    int i;
+    for ( i = 0; i < 10; i++ ) {
+        v = stdlib_base_truncb( x[ i ], n[ i ], b[ i ] );
+        printf( "truncb(%lf, %d, %d) = %lf\n", x[ i ], n[ i ], b[ i ], v );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/math/base/special/truncb/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/truncb/benchmark/benchmark.native.js
@@ -1,0 +1,60 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var truncb = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( truncb instanceof Error )
+};
+
+
+// MAIN //
+
+bench( pkg+'::native', opts, function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		x = ( randu() * 1.0e7 ) - 5.0e6;
+		y = truncb( x, 2, 20 );
+		if ( isnan( y ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnan( y ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/truncb/benchmark/c/native/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/truncb/benchmark/c/native/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/truncb/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/truncb/benchmark/c/native/benchmark.c
@@ -1,0 +1,136 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/**
+* Benchmark `truncb`.
+*/
+#include "stdlib/math/base/special/truncb.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "truncb"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+void print_version() {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+double tic() {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1].
+*
+* @return random number
+*/
+double rand_double() {
+	int r = rand();
+	return (double)r / ( (double)RAND_MAX + 1.0 );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+double benchmark() {
+	double elapsed;
+	double x;
+	double y;
+	double t;
+	int i;
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		x = ( 1.0e7 * rand_double() ) - 5.0e6;
+		y = stdlib_base_truncb( x, 2, 20 );
+		if ( y != y ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( y != y ) {
+		printf( "should not return NaN\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::native::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/math/base/special/truncb/binding.gyp
+++ b/lib/node_modules/@stdlib/math/base/special/truncb/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/math/base/special/truncb/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/truncb/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/truncb/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/truncb/examples/c/example.c
@@ -1,0 +1,34 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/truncb.h"
+#include <stdio.h>
+#include <stdint.h>
+
+int main( void ) {
+	const double x[] = { -5.0, -3.89, -2.78, -1.67, -0.56, 0.56, 1.67, 2.78, 3.89, 5.0 };
+	const int32_t n[] = { -4, -3, -2, -1, 0, 1, 2, 3, 4, 5 };
+	const int32_t b[] = { 20, 19, 18, 17, 16, 15, 14, 13, 12, 11 };
+
+	double v;
+	int i;
+	for ( i = 0; i < 10; i++ ) {
+		v = stdlib_base_truncb( x[ i ], n[ i ], b[ i ] );
+		printf( "truncb(%lf, %d, %d) = %lf\n", x[ i ], n[ i ], b[ i ], v );
+	}
+}

--- a/lib/node_modules/@stdlib/math/base/special/truncb/include.gypi
+++ b/lib/node_modules/@stdlib/math/base/special/truncb/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/math/base/special/truncb/include/stdlib/math/base/special/truncb.h
+++ b/lib/node_modules/@stdlib/math/base/special/truncb/include/stdlib/math/base/special/truncb.h
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_MATH_BASE_SPECIAL_TRUNCB_H
+#define STDLIB_MATH_BASE_SPECIAL_TRUNCB_H
+
+#include <stdint.h>
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Rounds a numeric value to the nearest multiple of \\(b^n\\) toward zero.
+*/
+double stdlib_base_truncb( const double x, const int32_t n, const int32_t b );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_MATH_BASE_SPECIAL_TRUNCB_H

--- a/lib/node_modules/@stdlib/math/base/special/truncb/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/truncb/lib/native.js
@@ -1,0 +1,59 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Rounds a numeric value to the nearest multiple of \\(b^n\\) toward zero.
+*
+* @private
+* @param {number} x - input value
+* @param {integer} n - integer power
+* @param {PositiveInteger} b - base
+* @returns {number} rounded value
+*
+* @example
+* // Round a value to 4 decimal places:
+* var v = truncb( 3.141592653589793, -4, 10 );
+* // returns 3.1415
+*
+* @example
+* // If n = 0 or b = 1, `truncb` behaves like `trunc`:
+* var v = truncb( 3.141592653589793, 0, 2 );
+* // returns 3.0
+*
+* @example
+* // Round a value to the nearest multiple of two toward zero:
+* var v = truncb( 5.0, 1, 2 );
+* // returns 4.0
+*/
+function truncb( x, n, b ) {
+	return addon( x, n, b );
+}
+
+
+// EXPORTS //
+
+module.exports = truncb;

--- a/lib/node_modules/@stdlib/math/base/special/truncb/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/truncb/manifest.json
@@ -1,0 +1,84 @@
+{
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/napi/ternary",
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/assert/is-infinite",
+        "@stdlib/math/base/special/trunc",
+        "@stdlib/math/base/special/truncn",
+        "@stdlib/math/base/special/pow"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/assert/is-infinite",
+        "@stdlib/math/base/special/trunc",
+        "@stdlib/math/base/special/truncn",
+        "@stdlib/math/base/special/pow"
+      ]
+    },
+    {
+      "task": "examples",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/assert/is-infinite",
+        "@stdlib/math/base/special/trunc",
+        "@stdlib/math/base/special/truncn",
+        "@stdlib/math/base/special/pow"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/special/truncb/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/truncb/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/truncb/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/truncb/src/addon.c
@@ -1,0 +1,23 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/truncb.h"
+#include "stdlib/math/base/napi/ternary.h"
+
+// cppcheck-suppress shadowFunction
+STDLIB_MATH_BASE_NAPI_MODULE_DII_D( stdlib_base_truncb )

--- a/lib/node_modules/@stdlib/math/base/special/truncb/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/truncb/src/main.c
@@ -1,0 +1,68 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/truncb.h"
+#include "stdlib/math/base/assert/is_nan.h"
+#include "stdlib/math/base/assert/is_infinite.h"
+#include "stdlib/math/base/special/trunc.h"
+#include "stdlib/math/base/special/truncn.h"
+#include "stdlib/math/base/special/pow.h"
+#include <stdint.h>
+
+/**
+* Rounds a numeric value to the nearest multiple of \\(b^n\\) toward zero.
+*
+* @param x    input value
+* @param n    integer power
+* @param b    base
+* @return     rounded value
+*
+* @example
+* double out = stdlib_base_truncb( 3.141592653589793, -4, 10 );
+* // returns 3.1415
+*/
+double stdlib_base_truncb( const double x, const int32_t n, const int32_t b ) {
+	double y;
+	double s;
+
+	if ( stdlib_base_is_nan( x ) || b <= 0 ) {
+		return 0.0 / 0.0; // NaN
+	}
+	if ( stdlib_base_is_infinite( x ) || x == 0.0 ) {
+		return x;
+	}
+	if ( b == 10 ) {
+		return stdlib_base_truncn( x, n );
+	}
+	if ( n == 0 || b == 1 ) {
+		return stdlib_base_trunc( x );
+	}
+	s = stdlib_base_pow( b, -n );
+
+	// Check for overflow:
+	if ( stdlib_base_is_infinite( s ) ) {
+		return x;
+	}
+	y = stdlib_base_trunc( x * s ) / s;
+
+	// Check for overflow:
+	if ( stdlib_base_is_infinite( y ) ) {
+		return x;
+	}
+	return y;
+}

--- a/lib/node_modules/@stdlib/math/base/special/truncb/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/truncb/src/main.c
@@ -52,7 +52,7 @@ double stdlib_base_truncb( const double x, const int32_t n, const int32_t b ) {
 	if ( n == 0 || b == 1 ) {
 		return stdlib_base_trunc( x );
 	}
-	s = stdlib_base_pow( b, -n );
+	s = stdlib_base_pow( (double)b, -(double)n );
 
 	// Check for overflow:
 	if ( stdlib_base_is_infinite( s ) ) {

--- a/lib/node_modules/@stdlib/math/base/special/truncb/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/truncb/test/test.native.js
@@ -1,0 +1,313 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var PI = require( '@stdlib/constants/float64/pi' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+var EPS = require( '@stdlib/constants/float64/eps' );
+var randu = require( '@stdlib/random/base/randu' );
+var round = require( '@stdlib/math/base/special/round' );
+var trunc = require( '@stdlib/math/base/special/trunc' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var abs = require( '@stdlib/math/base/special/abs' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
+var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var truncb = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( truncb instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof truncb, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `NaN` if provided `NaN`', opts, function test( t ) {
+	var v;
+
+	v = truncb( NaN, -2, 1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `NaN` if provided `b <= 0`', opts, function test( t ) {
+	var v;
+
+	v = truncb( PI, 5, 0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	v = truncb( PI, 5, -1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `+infinity` if provided `+infinity`', opts, function test( t ) {
+	var v = truncb( PINF, 5, 10 );
+	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.end();
+});
+
+tape( 'the function returns `-infinity` if provided `-infinity`', opts, function test( t ) {
+	var v = truncb( NINF, -3, 10 );
+	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.end();
+});
+
+tape( 'the function returns `-0` if provided `-0`', opts, function test( t ) {
+	var v;
+
+	v = truncb( -0.0, 0, 10 );
+	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+
+	v = truncb( -0.0, -2, 10 );
+	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+
+	v = truncb( -0.0, 2, 10 );
+	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+
+	t.end();
+});
+
+tape( 'the function returns `+0` if provided `+0`', opts, function test( t ) {
+	var v;
+
+	v = truncb( 0.0, 0, 10 );
+	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+
+	v = truncb( +0.0, -2, 10 );
+	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+
+	v = truncb( +0.0, 2, 10 );
+	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+
+	t.end();
+});
+
+tape( 'the function supports rounding a numeric value to a desired number of decimals', opts, function test( t ) {
+	t.strictEqual( truncb( PI, -2, 10 ), 3.14, 'returns expected value' );
+	t.strictEqual( truncb( -PI, -2, 10 ), -3.14, 'returns expected value' );
+	t.strictEqual( truncb( 9.99999, -2, 10 ), 9.99, 'returns expected value' );
+	t.strictEqual( truncb( -9.99999, -2, 10 ), -9.99, 'returns expected value' );
+	t.strictEqual( truncb( 0.0, 2, 10 ), 0.0, 'returns expected value' );
+	t.strictEqual( truncb( 12368.0, -3, 10 ), 12368.0, 'returns expected value' );
+	t.strictEqual( truncb( -12368.0, -3, 10 ), -12368.0, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports rounding a numeric value to a desired number of digits', opts, function test( t ) {
+	t.strictEqual( truncb( PI, 3, 10 ), 0.0, 'returns expected value' );
+	t.strictEqual( truncb( 12368.0, 3, 10 ), 12000.0, 'returns expected value' );
+	t.strictEqual( truncb( 12368.0, 1, 10 ), 12360.0, 'returns expected value' );
+	t.strictEqual( isNegativeZero( truncb( -PI, 3, 10 ) ), true, 'returns expected value' );
+	t.strictEqual( truncb( -12368.0, 3, 10 ), -12000.0, 'returns expected value' );
+	t.strictEqual( truncb( -12368.0, 1, 10 ), -12360.0, 'returns expected value' );
+	t.end();
+});
+
+tape( 'if `x` is too large a double to have decimals and `n < 0`, the input value is returned', opts, function test( t ) {
+	var sign;
+	var exp;
+	var x;
+	var n;
+	var v;
+	var i;
+	for ( i = 0; i < 100; i++ ) {
+		sign = ( randu()<0.5 ) ? -1.0 : 1.0;
+		exp = 54 + round( randu()*254.0 );
+		x = sign * (1.0+randu()) * pow( 10.0, exp );
+		n = -( round( randu()*324.0) );
+		v = truncb( x, n, 10 );
+		t.strictEqual( x, v, ' returns input value when provided x='+x+', n='+n+'.' );
+	}
+	t.end();
+});
+
+tape( 'if `b^n` is too large and `x < 0`, the function returns `-0`', opts, function test( t ) {
+	var exp;
+	var x;
+	var n;
+	var v;
+	var i;
+	for ( i = 0; i < 100; i++ ) {
+		exp = round( randu()*307.0 );
+		x = -(1.0+randu()) * pow( 10.0, exp );
+		n = round( randu()*100.0 ) + 309;
+		v = truncb( x, n, 10 );
+		t.strictEqual( isNegativeZero( v ), true, ' returns -0 when provided x='+x+', n='+n+'.' );
+	}
+	t.end();
+});
+
+tape( 'if `b^n` is too large and `x > 0`, the function returns `+0`', opts, function test( t ) {
+	var exp;
+	var x;
+	var n;
+	var v;
+	var i;
+	for ( i = 0; i < 100; i++ ) {
+		exp = round( randu()*307.0 );
+		x = (1.0+randu()) * pow( 10.0, exp );
+		n = round( randu()*100.0 ) + 309;
+		v = truncb( x, n, 10 );
+		t.strictEqual( isPositiveZero( v ), true, ' returns +0 when provided x='+x+', n='+n+'.' );
+	}
+	t.end();
+});
+
+tape( 'the function supports rounding very small numbers (including subnormals)', opts, function test( t ) {
+	var expected;
+	var delta;
+	var tol;
+	var x;
+	var n;
+	var v;
+	var i;
+
+	x = 3.1468234343023397 * pow( 10.0, -308 );
+
+	n = [];
+	for ( i = -308; i > -325; i-- ) {
+		n.push( i );
+	}
+	expected = [
+		3e-308,
+		3.1e-308,
+		3.14e-308,
+		3.146e-308,
+		3.1468e-308,
+		3.14682e-308,
+		3.146823e-308,
+		3.1468234e-308,
+		3.14682343e-308,
+		3.146823434e-308,
+		3.1468234343e-308,
+		3.14682343430e-308,
+		3.146823434302e-308,
+		3.1468234343023e-308,
+		3.14682343430234e-308, // 3.1468234343023397e-308 * 1e308 = 3.14682343430234
+		3.146823434302340e-308,  // 3.1468234343023397e-308 * 1e308 = 3.14682343430234
+		3.1468234343023397e-308
+	];
+
+	for ( i = 0; i < n.length; i++ ) {
+		v = truncb( x, n[i], 10 );
+		if ( v === expected[i] ) {
+			t.strictEqual( v, expected[ i ], 'returns '+expected[i]+' when provided x='+x+' and n='+n[i]+'.' );
+		} else {
+			delta = abs( v - expected[i] );
+			tol = EPS * abs( expected[i] );
+			t.strictEqual( delta <= tol, true, 'x: '+x+'. n: '+n[i]+'. v: '+v+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol );
+		}
+	}
+	t.end();
+});
+
+tape( 'if the function encounters overflow, the function returns the input value', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = 3.1468234343023397;
+	v = truncb( x, -314, 10 );
+	t.strictEqual( v, x, 'returns the input value' );
+
+	x = -3.1468234343023397;
+	v = truncb( x, -314, 10 );
+	t.strictEqual( v, x, 'returns the input value' );
+
+	x = 9007199254740000;
+	v = truncb( x, -300, 10 );
+	t.strictEqual( v, x, 'returns the input value' );
+
+	x = -9007199254740000;
+	v = truncb( x, -300, 10 );
+	t.strictEqual( v, x, 'returns the input value' );
+
+	t.end();
+});
+
+tape( 'if `n = 0`, the function exhibits standard truncate behavior', opts, function test( t ) {
+	var x;
+	var v;
+	var i;
+
+	for ( i = 0; i < 200; i++ ) {
+		x = (randu()*1000.0) - 500.0;
+		v = truncb( x, 0, 2 );
+		t.strictEqual( v, trunc( x ), 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'if `b = 1`, the function exhibits standard truncate behavior', opts, function test( t ) {
+	var x;
+	var v;
+	var i;
+
+	for ( i = 0; i < 200; i++ ) {
+		x = (randu()*1000.0) - 500.0;
+		v = truncb( x, 100, 1 );
+		t.strictEqual( v, trunc( x ), 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function supports arbitrary rounding', opts, function test( t ) {
+	t.strictEqual( truncb( 5.0, 1, 2 ), 4.0, 'returns expected value' );
+	t.strictEqual( truncb( 38.5, 1, 6 ), 36.0, 'returns expected value' );
+	t.strictEqual( truncb( 0.425, -2, 2 ), 0.25, 'returns expected value' );
+	t.strictEqual( truncb( 60.0, 1, 40.0 ), 40.0, 'returns expected value' );
+	t.strictEqual( truncb( -21.54, -1, 5 ), -21.4, 'returns expected value' );
+	t.strictEqual( truncb( 35.037, -4, 2 ), 35.0, 'returns expected value' );
+	t.end();
+});
+
+tape( 'if the function overflows, the function returns the input value', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = 12.5;
+	v = truncb( x, -308, 10 );
+	t.strictEqual( v, x, 'returns expected value' );
+
+	x = 12.5;
+	v = truncb( x, -1022, 2 );
+	t.strictEqual( v, x, 'returns expected value' );
+
+	x = 12.5;
+	v = truncb( x, -1074, 2 );
+	t.strictEqual( v, x, 'returns expected value' );
+
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds C implementation for [`math/base/special/truncb`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/truncb).

```c
double stdlib_base_truncb( const double x, const int32_t n, const int32_t b );
```

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves a part of #649.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

I haven't added some of the test cases to `test.native.js`, as they are not relevant for the `C` implementation ( test cases which sets `n` and `b` as `NaN` and `infinite` ).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
