### PR TITLE
refactor: use `max-safe-nth-factorial` package in `math/base/special/factorial`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/factorial/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/factorial/lib/main.js
@@ -24,12 +24,8 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isInteger = require( '@stdlib/math/base/assert/is-integer' );
 var gamma = require( '@stdlib/math/base/special/gamma' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
+var FLOAT64_MAX_SAFE_NTH_FACTORIAL = require( '@stdlib/constants/float64/max-safe-nth-factorial' );
 var FACTORIALS = require( './factorials.json' );
-
-
-// VARIABLES //
-
-var MAX_FACTORIAL = 170; // TODO: consider extracting as a constant
 
 
 // MAIN //
@@ -76,7 +72,7 @@ function factorial( x ) {
 		if ( x < 0 ) {
 			return NaN;
 		}
-		if ( x <= MAX_FACTORIAL ) {
+		if ( x <= FLOAT64_MAX_SAFE_NTH_FACTORIAL ) {
 			return FACTORIALS[ x ];
 		}
 		return PINF;

--- a/lib/node_modules/@stdlib/math/base/special/factorial/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/factorial/manifest.json
@@ -40,7 +40,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-integer",
         "@stdlib/math/base/special/gamma",
-        "@stdlib/constants/float64/pinf"
+        "@stdlib/constants/float64/pinf",
+        "@stdlib/constants/float64/max-safe-nth-factorial"
       ]
     },
     {
@@ -57,7 +58,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-integer",
         "@stdlib/math/base/special/gamma",
-        "@stdlib/constants/float64/pinf"
+        "@stdlib/constants/float64/pinf",
+        "@stdlib/constants/float64/max-safe-nth-factorial"
       ]
     },
     {
@@ -74,7 +76,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-integer",
         "@stdlib/math/base/special/gamma",
-        "@stdlib/constants/float64/pinf"
+        "@stdlib/constants/float64/pinf",
+        "@stdlib/constants/float64/max-safe-nth-factorial"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/factorial/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/factorial/src/main.c
@@ -21,9 +21,9 @@
 #include "stdlib/math/base/assert/is_integer.h"
 #include "stdlib/math/base/special/gamma.h"
 #include "stdlib/constants/float64/pinf.h"
+#include "stdlib/constants/float64/max_safe_nth_factorial.h"
 #include <stdint.h>
 
-static const double MAX_FACTORIAL = 170.0;
 static const double FACTORIALS[ 171 ] = {
 	1.0,
 	1.0,
@@ -217,7 +217,7 @@ double stdlib_base_factorial( const double x ) {
 		if ( x < 0.0 ) {
 			return 0.0 / 0.0; // NaN
 		}
-		if ( x <= MAX_FACTORIAL ) {
+		if ( x <= STDLIB_CONSTANT_FLOAT64_MAX_SAFE_NTH_FACTORIAL ) {
 			return FACTORIALS[ (int32_t)x ];
 		}
 		return STDLIB_CONSTANT_FLOAT64_PINF;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-  uses [`max-safe-nth-factorial`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/constants/float64/max-safe-nth-factorial) package instead of explicitly declaring a variable in [`math/base/special/factorial`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/factorial).

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

I've used the full name, i.e., `FLOAT64_MAX_SAFE_NTH_FACTORIAL` instead of `MAX_FACTORIAL`, in the `javascript` implementation as well.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
