### PR TITLE
feat: add C implementation for `math/base/special/sincospi`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/sincospi/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/sincospi/README.md
@@ -90,6 +90,96 @@ for ( i = 0; i < x.length; i++ ) {
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/math/base/special/sincospi.h"
+```
+
+#### stdlib_base_sincospi( x, &sine, &cosine )
+
+Simultaneously computes the [sine][@stdlib/math/base/special/sin] and [cosine][@stdlib/math/base/special/cos] of a `number` times [π][@stdlib/constants/float64/pi] more accurately than `sincos(pi*x)`, especially for large `x`.
+
+```c
+double cosine;
+double sine;
+
+stdlib_base_sincospi( 4.0, &sine, &cosine );
+```
+
+The function accepts the following arguments:
+
+-   **x**:      `[in] double` input value.
+-   **sine**:   `[out] double*` destination for the sine.
+-   **cosine**: `[out] double*` destination for the cosine.
+
+```c
+void stdlib_base_sincospi( const double x, double *sine, double *cosine );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/math/base/special/sincospi.h"
+#include <stdio.h>
+
+int main( void ) {
+    const double x[] = { 0.0, 1.57, 3.14, 6.28 };
+
+    double cosine;
+    double sine;
+    int i;
+    for ( i = 0; i < 4; i++ ) {
+        stdlib_base_sincospi( x[ i ], &sine, &cosine );
+        printf( "x: %lf => sine: %lf, cosine: %lf\n", x[ i ], sine, cosine );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/math/base/special/sincospi/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/sincospi/benchmark/benchmark.native.js
@@ -1,0 +1,60 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var sincospi = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( sincospi instanceof Error )
+};
+
+
+// MAIN //
+
+bench( pkg+'::native', opts, function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		x = ( randu() * 20.0 ) - 10.0;
+		y = sincospi( x );
+		if ( isnan( y[ 0 ] ) || isnan( y[ 1 ] ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnan( y[ 0 ] ) || isnan( y[ 1 ] ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/sincospi/benchmark/c/native/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/sincospi/benchmark/c/native/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/sincospi/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/sincospi/benchmark/c/native/benchmark.c
@@ -1,0 +1,134 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/sincospi.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "sincospi"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+static void print_version( void ) {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+static void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+static void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+static double tic( void ) {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec / 1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1).
+*
+* @return random number
+*/
+static double rand_double( void ) {
+	int r = rand();
+	return (double)r / ( (double)RAND_MAX + 1.0 );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+static double benchmark( void ) {
+	double elapsed;
+	double cosine;
+	double sine;
+	double x;
+	double t;
+	int i;
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		x = ( 20.0 * rand_double() ) - 10.0;
+		stdlib_base_sincospi( x, &sine, &cosine );
+		if ( cosine != cosine || sine != sine) {
+			printf( "unexpected results\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( cosine != cosine || sine != sine) {
+		printf( "unexpected results\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::native::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/math/base/special/sincospi/binding.gyp
+++ b/lib/node_modules/@stdlib/math/base/special/sincospi/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/math/base/special/sincospi/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/sincospi/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/sincospi/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/sincospi/examples/c/example.c
@@ -1,0 +1,32 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/sincospi.h"
+#include <stdio.h>
+
+int main( void ) {
+	const double x[] = { 0.0, 1.57, 3.14, 6.28 };
+
+	double cosine;
+	double sine;
+	int i;
+	for ( i = 0; i < 4; i++ ) {
+		stdlib_base_sincospi( x[ i ], &sine, &cosine );
+		printf( "x: %lf => sine: %lf, cosine: %lf\n", x[ i ], sine, cosine );
+	}
+}

--- a/lib/node_modules/@stdlib/math/base/special/sincospi/include.gypi
+++ b/lib/node_modules/@stdlib/math/base/special/sincospi/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/math/base/special/sincospi/include/stdlib/math/base/special/sincospi.h
+++ b/lib/node_modules/@stdlib/math/base/special/sincospi/include/stdlib/math/base/special/sincospi.h
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_MATH_BASE_SPECIAL_SINCOSPI_H
+#define STDLIB_MATH_BASE_SPECIAL_SINCOSPI_H
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Simultaneously computes the sine and cosine of a number times π.
+*/
+void stdlib_base_sincospi( const double x, double *sine, double *cosine );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_MATH_BASE_SPECIAL_SINCOSPI_H

--- a/lib/node_modules/@stdlib/math/base/special/sincospi/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/sincospi/lib/native.js
@@ -1,0 +1,61 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var Float64Array = require( '@stdlib/array/float64' );
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Simultaneously computes the sine and cosine of a number times π.
+*
+* @private
+* @param {number} x - input value
+* @returns {Array<number>} two-element array containing sin(πx) and cos(πx)
+*
+* @example
+* var v = sincospi( 0.0 );
+* // returns <Float64Array>[ 0.0, 1.0 ]
+*
+* @example
+* var v = sincospi( 0.5 );
+* // returns <Float64Array>[ 1.0, 0.0 ]
+*
+* @example
+* var v = sincospi( 0.1 );
+* // returns <Float64Array>[ ~0.309, ~0.951 ]
+*
+* @example
+* var v = sincospi( NaN );
+* // returns <Float64Array>[ NaN, NaN ]
+*/
+function sincospi( x ) {
+	var out = new Float64Array( 2 );
+	addon( x, out );
+	return out;
+}
+
+
+// EXPORTS //
+
+module.exports = sincospi;

--- a/lib/node_modules/@stdlib/math/base/special/sincospi/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/sincospi/manifest.json
@@ -1,0 +1,96 @@
+{
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/napi/argv",
+        "@stdlib/napi/argv-double",
+        "@stdlib/napi/argv-float64array",
+        "@stdlib/napi/export",
+        "@stdlib/math/base/special/abs",
+        "@stdlib/math/base/special/sincos",
+        "@stdlib/math/base/special/floor",
+        "@stdlib/math/base/special/copysign",
+        "@stdlib/math/base/special/fmod",
+        "@stdlib/math/base/assert/is-infinite",
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/pi"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/abs",
+        "@stdlib/math/base/special/sincos",
+        "@stdlib/math/base/special/floor",
+        "@stdlib/math/base/special/copysign",
+        "@stdlib/math/base/special/fmod",
+        "@stdlib/math/base/assert/is-infinite",
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/pi"
+      ]
+    },
+    {
+      "task": "examples",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "s@tdlib/math/base/special/abs",
+        "@stdlib/math/base/special/sincos",
+        "@stdlib/math/base/special/floor",
+        "@stdlib/math/base/special/copysign",
+        "@stdlib/math/base/special/fmod",
+        "@stdlib/math/base/assert/is-infinite",
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/pi"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/special/sincospi/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/sincospi/manifest.json
@@ -82,7 +82,7 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-        "s@tdlib/math/base/special/abs",
+        "@stdlib/math/base/special/abs",
         "@stdlib/math/base/special/sincos",
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/copysign",

--- a/lib/node_modules/@stdlib/math/base/special/sincospi/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/sincospi/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/sincospi/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/sincospi/src/addon.c
@@ -1,0 +1,41 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/sincospi.h"
+#include "stdlib/napi/argv.h"
+#include "stdlib/napi/argv_double.h"
+#include "stdlib/napi/argv_float64array.h"
+#include "stdlib/napi/export.h"
+#include <node_api.h>
+
+/**
+* Receives JavaScript callback invocation data.
+*
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @return       Node-API value
+*/
+static napi_value addon( napi_env env, napi_callback_info info ) {
+	STDLIB_NAPI_ARGV( env, info, argv, argc, 2 );
+	STDLIB_NAPI_ARGV_DOUBLE( env, x, argv, 0 );
+	STDLIB_NAPI_ARGV_FLOAT64ARRAY( env, y, ylen, argv, 1 );
+	stdlib_base_sincospi( x, &y[ 0 ], &y[ 1 ] );
+	return NULL;
+}
+
+STDLIB_NAPI_MODULE_EXPORT_FCN( addon )

--- a/lib/node_modules/@stdlib/math/base/special/sincospi/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/sincospi/src/main.c
@@ -1,0 +1,92 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/sincospi.h"
+#include "stdlib/math/base/special/abs.h"
+#include "stdlib/math/base/special/sincos.h"
+#include "stdlib/math/base/special/floor.h"
+#include "stdlib/math/base/special/copysign.h"
+#include "stdlib/math/base/special/fmod.h"
+#include "stdlib/math/base/assert/is_infinite.h"
+#include "stdlib/math/base/assert/is_nan.h"
+#include "stdlib/constants/float64/pi.h"
+#include <stdint.h>
+
+/**
+* Simultaneously computes the sine and cosine of a number times π.
+*
+* @param x         input value
+* @param sine      destination to store the sine
+* @param cosine    destination to store the cosine
+*
+* @example
+* double x = 0.0;
+*
+* double cosine;
+* double sine;
+* stdlib_base_sincospi( x, &sine, &cosine );
+*/
+void stdlib_base_sincospi( const double x, double* sine, double* cosine ) {
+	double tmp;
+	double ix;
+	double ar;
+	double r;
+
+	if ( stdlib_base_is_nan( x ) || stdlib_base_is_infinite( x ) ) {
+		*sine = 0.0 / 0.0; // NaN
+		*cosine = 0.0 / 0.0; // NaN
+		return;
+	}
+	r = stdlib_base_fmod( x, 2.0 );
+	ar = stdlib_base_abs( r );
+	if ( ar == 0.0 || ar == 1.0 ) {
+		ix = stdlib_base_floor( ar );
+		*sine = stdlib_base_copysign( 0.0, r );
+		*cosine = ( stdlib_base_fmod( ix, 2.0 ) == 1 ) ? -1.0 : 1.0;
+		return;
+	}
+	if ( ar < 0.25 ) {
+		stdlib_base_sincos( STDLIB_CONSTANT_FLOAT64_PI * r, sine, cosine );
+		return;
+	}
+	if ( ar < 0.75 ) {
+		ar = 0.5 - ar;
+		stdlib_base_sincos( STDLIB_CONSTANT_FLOAT64_PI * ar, sine, cosine );
+		tmp = *sine;
+		*sine = stdlib_base_copysign( *cosine, r );
+		*cosine = tmp;
+		return;
+	}
+	if ( ar < 1.25 ) {
+		r = stdlib_base_copysign( 1.0, r ) - r;
+		stdlib_base_sincos( STDLIB_CONSTANT_FLOAT64_PI * r, sine, cosine );
+		*cosine *= -1;
+		return;
+	}
+	if ( ar < 1.75 ) {
+		ar -= 1.5;
+		stdlib_base_sincos( STDLIB_CONSTANT_FLOAT64_PI * ar, sine, cosine );
+		tmp = *sine;
+		*sine = -stdlib_base_copysign( *cosine, r );
+		*cosine = tmp;
+		return;
+	}
+	r -= stdlib_base_copysign( 2.0, r );
+	stdlib_base_sincos( STDLIB_CONSTANT_FLOAT64_PI * r, sine, cosine );
+	return;
+}

--- a/lib/node_modules/@stdlib/math/base/special/sincospi/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/sincospi/test/test.native.js
@@ -1,0 +1,151 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+var EPS = require( '@stdlib/constants/float64/eps' );
+var abs = require( '@stdlib/math/base/special/abs' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var sincospi = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( sincospi instanceof Error )
+};
+
+
+// FIXTURES //
+
+var integers = require( './fixtures/julia/integers.json' );
+var decimals = require( './fixtures/julia/decimals.json' );
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof sincospi, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'if provided negative infinity, the function returns `[NaN,NaN]`', opts, function test( t ) {
+	var y = sincospi( NINF );
+	t.equal( isnan( y[ 0 ] ), true, 'returns expected value when provided negative infinity' );
+	t.equal( isnan( y[ 1 ] ), true, 'returns expected value when provided negative infinity' );
+	t.end();
+});
+
+tape( 'if provided positive infinity, the function returns `[NaN,NaN]`', opts, function test( t ) {
+	var y = sincospi( PINF );
+	t.equal( isnan( y[ 0 ] ), true, 'returns expected value when provided positive infinity' );
+	t.equal( isnan( y[ 1 ] ), true, 'returns expected value when provided positive infinity' );
+	t.end();
+});
+
+tape( 'if provided `NaN`, the function returns `[NaN,NaN]`', opts, function test( t ) {
+	var y = sincospi( NaN );
+	t.equal( isnan( y[ 0 ] ), true, 'returns expected value when provided NaN' );
+	t.equal( isnan( y[ 1 ] ), true, 'returns expected value when provided NaN' );
+	t.end();
+});
+
+tape( 'the function computes sin(πx) and cos(πx) for integer input', opts, function test( t ) {
+	var c;
+	var s;
+	var x;
+	var y;
+	var i;
+
+	x = integers.x;
+	s = integers.sin;
+	c = integers.cos;
+	for ( i = 0; i < x.length; i++ ) {
+		y = sincospi( x[ i ] );
+		t.equal( y[ 0 ], s[ i ], 'returns '+s[ i ] );
+		t.equal( y[ 1 ], c[ i ], 'returns '+c[ i ] );
+	}
+	t.end();
+});
+
+tape( 'if provided a value exceeding `2**53` (max (unsafe) float64 integer), the function returns [0,1]', opts, function test( t ) {
+	var x;
+	var y;
+	var i;
+
+	x = pow( 2.0, 53 ) + 1.0;
+	for ( i = 0; i < 100; i++ ) {
+		y = sincospi( x+i );
+		t.equal( y[ 0 ], 0.0, 'returns 0.0' );
+		t.equal( y[ 1 ], 1.0, 'returns 1.0' );
+	}
+	t.end();
+});
+
+tape( 'the function computes the sin(πx) and cos(πx) for fractional part equal to 1/2', opts, function test( t ) {
+	var x;
+	var y;
+	var i;
+
+	for ( i = -100; i <= 100; i++ ) {
+		x = 0.5 + ( 1.0 * i );
+		y = sincospi( x );
+		t.equal( y[ 0 ], ( (i%2 === 0) ? 1.0 : -1.0 ), 'x: '+x+'. Expected: 0' );
+		t.equal( y[ 1 ], 0.0, 'x: '+x+'. Expected: 0' );
+	}
+	t.end();
+});
+
+tape( 'the function computes the sin(πx) and cos(πx) for decimal input', opts, function test( t ) {
+	var delta;
+	var x;
+	var y;
+	var i;
+	var s;
+	var c;
+
+	x = decimals.x;
+	s = decimals.sin;
+	c = decimals.cos;
+	for ( i = 0; i < x.length; i++ ) {
+		y = sincospi( x[ i ] );
+
+		if ( y[ 0 ] === s[ i ] ) {
+			t.equal( y[ 0 ], s[ i ], 'x: '+x[ i ]+'. Expected: '+s[ i ] );
+		} else {
+			delta = abs( y[ 0 ] - s[ i ] );
+			t.ok( delta <= EPS, 'within tolerance. x: '+x[ i ]+'. Value: '+y[ 0 ]+'. Expected: '+s[ i ]+'. Tolerance: '+EPS+'.' );
+		}
+		if ( y[ 1 ] === c[ i ] ) {
+			t.equal( y[ 1 ], c[ i ], 'x: '+x[ i ]+'. Expected: '+c[ i ] );
+		} else {
+			delta = abs( y[ 1 ] - c[ i ] );
+			t.ok( delta <= EPS, 'within tolerance. x: '+x[ i ]+'. Value: '+y[ 1 ]+'. Expected: '+c[ i ]+'. Tolerance: '+EPS+'.' );
+		}
+	}
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds `C` implementation for [`math/base/special/sincospi`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/sincospi).

```c
void stdlib_base_sincospi( const double x, double* sine, double* cosine );
```

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves a part of #649.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
