### PR TITLE
feat: add C implementation for `math/base/special/fresnel`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/fresnel/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/fresnel/README.md
@@ -116,6 +116,96 @@ for ( i = 0; i < x.length; i++ ) {
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/math/base/special/fresnel.h"
+```
+
+#### stdlib_base_fresnel( x, &S, &C )
+
+Simultaneously computes the [Fresnel integrals][fresnel-integral] S(x) and C(x).
+
+```c
+double S;
+double C;
+
+stdlib_base_fresnel( 4.0, &S, &C );
+```
+
+The function accepts the following arguments:
+
+-   **x**: `[in] double` input value.
+-   **S**: `[out] double*` destination for S(x).
+-   **C**: `[out] double*` destination for C(x).
+
+```c
+void stdlib_base_fresnel( const double x, double *S, double *C );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/math/base/special/fresnel.h"
+#include <stdio.h>
+
+int main( void ) {
+    const double x[] = { 0.0, 1.57, 3.14, 6.28 };
+
+    double S;
+    double C;
+    int i;
+    for ( i = 0; i < 4; i++ ) {
+        stdlib_base_fresnel( x[ i ], &S, &C );
+        printf( "x: %lf => S(x): %lf, C(x): %lf\n", x[ i ], S, C );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/math/base/special/fresnel/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/fresnel/benchmark/benchmark.native.js
@@ -1,0 +1,60 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var fresnel = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( fresnel instanceof Error )
+};
+
+
+// MAIN //
+
+bench( pkg+'::native', opts, function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		x = ( randu() * 20.0 ) - 10.0;
+		y = fresnel( x );
+		if ( isnan( y[0] ) || isnan( y[1] ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnan( y[0] ) || isnan( y[1] ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/fresnel/benchmark/c/native/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/fresnel/benchmark/c/native/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/fresnel/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/fresnel/benchmark/c/native/benchmark.c
@@ -1,0 +1,134 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/fresnel.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "fresnel"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+static void print_version( void ) {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+static void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+static void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+static double tic( void ) {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec / 1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1).
+*
+* @return random number
+*/
+static double rand_double( void ) {
+	int r = rand();
+	return (double)r / ( (double)RAND_MAX + 1.0 );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+static double benchmark( void ) {
+	double elapsed;
+	double C;
+	double S;
+	double x;
+	double t;
+	int i;
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		x = ( 20.0 * rand_double() ) - 10.0;
+		stdlib_base_fresnel( x, &S, &C );
+		if ( C != C || S != S) {
+			printf( "unexpected results\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( C != C || S != S) {
+		printf( "unexpected results\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::native::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/math/base/special/fresnel/binding.gyp
+++ b/lib/node_modules/@stdlib/math/base/special/fresnel/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/math/base/special/fresnel/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/fresnel/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/fresnel/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/fresnel/examples/c/example.c
@@ -1,0 +1,32 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/fresnel.h"
+#include <stdio.h>
+
+int main( void ) {
+	const double x[] = { 0.0, 1.57, 3.14, 6.28 };
+
+	double C;
+	double S;
+	int i;
+	for ( i = 0; i < 4; i++ ) {
+		stdlib_base_fresnel( x[ i ], &S, &C );
+		printf( "x: %lf => S(x): %lf, C(x): %lf\n", x[ i ], S, C );
+	}
+}

--- a/lib/node_modules/@stdlib/math/base/special/fresnel/include.gypi
+++ b/lib/node_modules/@stdlib/math/base/special/fresnel/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/math/base/special/fresnel/include/stdlib/math/base/special/fresnel.h
+++ b/lib/node_modules/@stdlib/math/base/special/fresnel/include/stdlib/math/base/special/fresnel.h
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_MATH_BASE_SPECIAL_FRESNEL_H
+#define STDLIB_MATH_BASE_SPECIAL_FRESNEL_H
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Computes the Fresnel integrals S(x) and C(x).
+*/
+void stdlib_base_fresnel( const double x, double *S, double *C );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_MATH_BASE_SPECIAL_FRESNEL_H

--- a/lib/node_modules/@stdlib/math/base/special/fresnel/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/fresnel/lib/native.js
@@ -1,0 +1,65 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var Float64Array = require( '@stdlib/array/float64' );
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Computes the Fresnel integrals S(x) and C(x).
+*
+* @private
+* @param {number} x - input value
+* @returns {Array<number>} S(x) and C(x)
+*
+* @example
+* var v = fresnel( 0.0 );
+* // returns <Float64Array>[ 0.0, 0.0 ]
+*
+* @example
+* var v = fresnel( 1.0 );
+* // returns <Float64Array>[ ~0.438, ~0.780 ]
+*
+* @example
+* var v = fresnel( Infinity );
+* // returns <Float64Array>[ ~0.5, ~0.5 ]
+*
+* @example
+* var v = fresnel( -Infinity );
+* // returns <Float64Array>[ ~-0.5, ~-0.5 ]
+*
+* @example
+* var v = fresnel( NaN );
+* // returns <Float64Array>[ NaN, NaN ]
+*/
+function fresnel( x ) {
+	var out = new Float64Array( 2 );
+	addon( x, out );
+	return out;
+}
+
+
+// EXPORTS //
+
+module.exports = fresnel;

--- a/lib/node_modules/@stdlib/math/base/special/fresnel/lib/rational_pcqc.js
+++ b/lib/node_modules/@stdlib/math/base/special/fresnel/lib/rational_pcqc.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2022 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 // MAIN //
 
 /**
-* Evaluates a rational function, i.e., the ratio of two polynomials described by the coefficients stored in \\(P\\) and \\(Q\\).
+* Evaluates a rational function (i.e., the ratio of two polynomials described by the coefficients stored in \\(P\\) and \\(Q\\)).
 *
 * ## Notes
 *

--- a/lib/node_modules/@stdlib/math/base/special/fresnel/lib/rational_pfqf.js
+++ b/lib/node_modules/@stdlib/math/base/special/fresnel/lib/rational_pfqf.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2022 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 // MAIN //
 
 /**
-* Evaluates a rational function, i.e., the ratio of two polynomials described by the coefficients stored in \\(P\\) and \\(Q\\).
+* Evaluates a rational function (i.e., the ratio of two polynomials described by the coefficients stored in \\(P\\) and \\(Q\\)).
 *
 * ## Notes
 *

--- a/lib/node_modules/@stdlib/math/base/special/fresnel/lib/rational_pgqg.js
+++ b/lib/node_modules/@stdlib/math/base/special/fresnel/lib/rational_pgqg.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2022 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 // MAIN //
 
 /**
-* Evaluates a rational function, i.e., the ratio of two polynomials described by the coefficients stored in \\(P\\) and \\(Q\\).
+* Evaluates a rational function (i.e., the ratio of two polynomials described by the coefficients stored in \\(P\\) and \\(Q\\)).
 *
 * ## Notes
 *

--- a/lib/node_modules/@stdlib/math/base/special/fresnel/lib/rational_psqs.js
+++ b/lib/node_modules/@stdlib/math/base/special/fresnel/lib/rational_psqs.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2022 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 // MAIN //
 
 /**
-* Evaluates a rational function, i.e., the ratio of two polynomials described by the coefficients stored in \\(P\\) and \\(Q\\).
+* Evaluates a rational function (i.e., the ratio of two polynomials described by the coefficients stored in \\(P\\) and \\(Q\\)).
 *
 * ## Notes
 *

--- a/lib/node_modules/@stdlib/math/base/special/fresnel/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/fresnel/manifest.json
@@ -1,0 +1,81 @@
+{
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/napi/unary",
+        "@stdlib/math/base/special/abs",
+        "@stdlib/math/base/special/sincos",
+        "@stdlib/constants/float64/pi",
+        "@stdlib/constants/float64/half-pi"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/abs",
+        "@stdlib/math/base/special/sincos",
+        "@stdlib/constants/float64/pi",
+        "@stdlib/constants/float64/half-pi"
+      ]
+    },
+    {
+      "task": "examples",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/abs",
+        "@stdlib/math/base/special/sincos",
+        "@stdlib/constants/float64/pi",
+        "@stdlib/constants/float64/half-pi"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/special/fresnel/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/fresnel/manifest.json
@@ -36,7 +36,10 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-        "@stdlib/math/base/napi/unary",
+        "@stdlib/napi/argv",
+        "@stdlib/napi/argv-double",
+        "@stdlib/napi/argv-float64array",
+        "@stdlib/napi/export",
         "@stdlib/math/base/special/abs",
         "@stdlib/math/base/special/sincos",
         "@stdlib/constants/float64/pi",

--- a/lib/node_modules/@stdlib/math/base/special/fresnel/scripts/evalrational.js
+++ b/lib/node_modules/@stdlib/math/base/special/fresnel/scripts/evalrational.js
@@ -24,10 +24,15 @@
 // MODULES //
 
 var resolve = require( 'path' ).resolve;
+var readFileSync = require( '@stdlib/fs/read-file' ).sync;
 var writeFileSync = require( '@stdlib/fs/write-file' ).sync;
 var currentYear = require( '@stdlib/time/current-year' );
 var licenseHeader = require( '@stdlib/_tools/licenses/header' );
 var compile = require( '@stdlib/math/base/tools/evalrational-compile' );
+var compileC = require( '@stdlib/math/base/tools/evalrational-compile-c' );
+var substringBefore = require( '@stdlib/string/substring-before' );
+var substringAfter = require( '@stdlib/string/substring-after' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -144,6 +149,33 @@ var header = licenseHeader( 'Apache-2.0', 'js', {
 header += '\n/* This is a generated file. Do not edit directly. */\n';
 
 
+// FUNCTIONS //
+
+/**
+* Inserts a compiled function into file content.
+*
+* @private
+* @param {string} text - source content
+* @param {string} id - function identifier
+* @param {string} str - function string
+* @returns {string} updated content
+*/
+function insert( text, id, str ) {
+	var before;
+	var after;
+	var begin;
+	var end;
+
+	begin = '// BEGIN: '+id;
+	end = '// END: '+id;
+
+	before = substringBefore( text, begin );
+	after = substringAfter( text, end );
+
+	return format( '%s// BEGIN: %s\n\n%s\n%s%s', before, id, str, end, after );
+}
+
+
 // MAIN //
 
 /**
@@ -153,7 +185,9 @@ header += '\n/* This is a generated file. Do not edit directly. */\n';
 */
 function main() {
 	var fpath;
+	var copts;
 	var opts;
+	var file;
 	var str;
 
 	opts = {
@@ -175,6 +209,32 @@ function main() {
 	fpath = resolve( __dirname, '..', 'lib', 'rational_pgqg.js' );
 	str = header + compile( PG, QG );
 	writeFileSync( fpath, str, opts );
+
+	copts = {
+		'dtype': 'double',
+		'name': ''
+	};
+
+	fpath = resolve( __dirname, '..', 'src', 'main.c' );
+	file = readFileSync( fpath, opts );
+
+	copts.name = 'rational_psqs';
+	str = compileC( PS, QS, copts );
+	file = insert( file, copts.name, str );
+
+	copts.name = 'rational_pcqc';
+	str = compileC( PC, QC, copts );
+	file = insert( file, copts.name, str );
+
+	copts.name = 'rational_pfqf';
+	str = compileC( PF, QF, copts );
+	file = insert( file, copts.name, str );
+
+	copts.name = 'rational_pgqg';
+	str = compileC( PG, QG, copts );
+	file = insert( file, copts.name, str );
+
+	writeFileSync( fpath, file, opts );
 }
 
 main();

--- a/lib/node_modules/@stdlib/math/base/special/fresnel/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/fresnel/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/fresnel/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/fresnel/src/addon.c
@@ -1,0 +1,41 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/fresnel.h"
+#include "stdlib/napi/argv.h"
+#include "stdlib/napi/argv_double.h"
+#include "stdlib/napi/argv_float64array.h"
+#include "stdlib/napi/export.h"
+#include <node_api.h>
+
+/**
+* Receives JavaScript callback invocation data.
+*
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @return       Node-API value
+*/
+static napi_value addon( napi_env env, napi_callback_info info ) {
+	STDLIB_NAPI_ARGV( env, info, argv, argc, 2 );
+	STDLIB_NAPI_ARGV_DOUBLE( env, x, argv, 0 );
+	STDLIB_NAPI_ARGV_FLOAT64ARRAY( env, y, ylen, argv, 1 );
+	stdlib_base_fresnel( x, &y[ 0 ], &y[ 1 ] );
+	return NULL;
+}
+
+STDLIB_NAPI_MODULE_EXPORT_FCN( addon )

--- a/lib/node_modules/@stdlib/math/base/special/fresnel/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/fresnel/src/main.c
@@ -1,0 +1,288 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*
+* ## Notice
+*
+* The original C code, long comment, copyright, license, and constants are from [Cephes]{@link http://www.netlib.org/cephes}. The implementation follows the original, but has been modified for JavaScript.
+*
+* ```text
+* Copyright 1984, 1987, 1989, 2000 by Stephen L. Moshier
+*
+* Some software in this archive may be from the book _Methods and Programs for Mathematical Functions_ (Prentice-Hall or Simon & Schuster International, 1989) or from the Cephes Mathematical Library, a commercial product. In either event, it is copyrighted by the author. What you see here may be used freely but it comes with no support or guarantee.
+*
+* Stephen L. Moshier
+* moshier@na-net.ornl.gov
+* ```
+*/
+
+#include "stdlib/math/base/special/fresnel.h"
+#include "stdlib/math/base/special/sincos.h"
+#include "stdlib/math/base/special/abs.h"
+#include "stdlib/constants/float64/half_pi.h"
+#include "stdlib/constants/float64/pi.h"
+
+/* Begin auto-generated functions. The following functions are auto-generated. Do not edit directly. */
+
+// BEGIN: rational_psqs
+
+/**
+* Evaluates a rational function (i.e., the ratio of two polynomials described by the coefficients stored in \\(P\\) and \\(Q\\)).
+*
+* ## Notes
+*
+* -   Coefficients should be sorted in ascending degree.
+* -   The implementation uses [Horner's rule][horners-method] for efficient computation.
+*
+* [horners-method]: https://en.wikipedia.org/wiki/Horner%27s_method
+*
+* @param x    value at which to evaluate the rational function
+* @return     evaluated rational function
+*/
+static double rational_psqs( const double x ) {
+	double ax;
+	double ix;
+	double s1;
+	double s2;
+	if ( x == 0.0 ) {
+		return 0.5235987755982989;
+	}
+	if ( x < 0.0 ) {
+		ax = -x;
+	} else {
+		ax = x;
+	}
+	if ( ax <= 1.0 ) {
+		s1 = 318016297876.5678 + (x * (-44297951805.96978 + (x * (2548908805.7337637 + (x * (-62974148.62058625 + (x * (708840.0452577386 + (x * (-2991.8191940101983 + (x * 0.0)))))))))));
+		s2 = 607366389490.0846 + (x * (22441179564.534092 + (x * (419320245.8981112 + (x * (5173438.887700964 + (x * (45584.78108065326 + (x * (281.3762688899943 + (x * 1.0)))))))))));
+	} else {
+		ix = 1.0 / x;
+		s1 = 0.0 + (ix * (-2991.8191940101983 + (ix * (708840.0452577386 + (ix * (-62974148.62058625 + (ix * (2548908805.7337637 + (ix * (-44297951805.96978 + (ix * 318016297876.5678)))))))))));
+		s2 = 1.0 + (ix * (281.3762688899943 + (ix * (45584.78108065326 + (ix * (5173438.887700964 + (ix * (419320245.8981112 + (ix * (22441179564.534092 + (ix * 607366389490.0846)))))))))));
+	}
+	return s1 / s2;
+}
+
+// END: rational_psqs
+
+// BEGIN: rational_pcqc
+
+/**
+* Evaluates a rational function (i.e., the ratio of two polynomials described by the coefficients stored in \\(P\\) and \\(Q\\)).
+*
+* ## Notes
+*
+* -   Coefficients should be sorted in ascending degree.
+* -   The implementation uses [Horner's rule][horners-method] for efficient computation.
+*
+* [horners-method]: https://en.wikipedia.org/wiki/Horner%27s_method
+*
+* @param x    value at which to evaluate the rational function
+* @return     evaluated rational function
+*/
+static double rational_pcqc( const double x ) {
+	double ax;
+	double ix;
+	double s1;
+	double s2;
+	if ( x == 0.0 ) {
+		return 1.0;
+	}
+	if ( x < 0.0 ) {
+		ax = -x;
+	} else {
+		ax = x;
+	}
+	if ( ax <= 1.0 ) {
+		s1 = 1.0 + (x * (-0.20552590095501388 + (x * (0.018884331939670384 + (x * (-0.0006451914356839651 + (x * (0.000009504280628298596 + (x * (-4.9884311457357354e-8 + (x * 0.0)))))))))));
+		s2 = 1.0 + (x * (0.04121420907221998 + (x * (0.0008680295429417843 + (x * (0.000012226278902417902 + (x * (1.2500186247959882e-7 + (x * (9.154392157746574e-10 + (x * 3.99982968972496e-12)))))))))));
+	} else {
+		ix = 1.0 / x;
+		s1 = 0.0 + (ix * (-4.9884311457357354e-8 + (ix * (0.000009504280628298596 + (ix * (-0.0006451914356839651 + (ix * (0.018884331939670384 + (ix * (-0.20552590095501388 + (ix * 1.0)))))))))));
+		s2 = 3.99982968972496e-12 + (ix * (9.154392157746574e-10 + (ix * (1.2500186247959882e-7 + (ix * (0.000012226278902417902 + (ix * (0.0008680295429417843 + (ix * (0.04121420907221998 + (ix * 1.0)))))))))));
+	}
+	return s1 / s2;
+}
+
+// END: rational_pcqc
+
+// BEGIN: rational_pfqf
+
+/**
+* Evaluates a rational function (i.e., the ratio of two polynomials described by the coefficients stored in \\(P\\) and \\(Q\\)).
+*
+* ## Notes
+*
+* -   Coefficients should be sorted in ascending degree.
+* -   The implementation uses [Horner's rule][horners-method] for efficient computation.
+*
+* [horners-method]: https://en.wikipedia.org/wiki/Horner%27s_method
+*
+* @param x    value at which to evaluate the rational function
+* @return     evaluated rational function
+*/
+static double rational_pfqf( const double x ) {
+	double ax;
+	double ix;
+	double s1;
+	double s2;
+	if ( x == 0.0 ) {
+		return 2.999999999999634;
+	}
+	if ( x < 0.0 ) {
+		ax = -x;
+	} else {
+		ax = x;
+	}
+	if ( ax <= 1.0 ) {
+		s1 = 3.763297112699879e-20 + (x * (1.3428327623306275e-16 + (x * (1.7201074326816183e-13 + (x * (1.0230451416490724e-10 + (x * (3.055689837902576e-8 + (x * (0.0000046361374928786735 + (x * (0.000345017939782574 + (x * (0.011522095507358577 + (x * (0.1434079197807589 + (x * (0.4215435550436775 + (x * 0.0)))))))))))))))))));
+		s2 = 1.2544323709001127e-20 + (x * (4.5200143407412973e-17 + (x * (5.887545336215784e-14 + (x * (3.6014002958937136e-11 + (x * (1.1269922476399903e-8 + (x * (0.0000018462756734893055 + (x * (0.00015593440916415301 + (x * (0.0064405152650885865 + (x * (0.11688892585919138 + (x * (0.7515863983533789 + (x * 1.0)))))))))))))))))));
+	} else {
+		ix = 1.0 / x;
+		s1 = 0.0 + (ix * (0.4215435550436775 + (ix * (0.1434079197807589 + (ix * (0.011522095507358577 + (ix * (0.000345017939782574 + (ix * (0.0000046361374928786735 + (ix * (3.055689837902576e-8 + (ix * (1.0230451416490724e-10 + (ix * (1.7201074326816183e-13 + (ix * (1.3428327623306275e-16 + (ix * 3.763297112699879e-20)))))))))))))))))));
+		s2 = 1.0 + (ix * (0.7515863983533789 + (ix * (0.11688892585919138 + (ix * (0.0064405152650885865 + (ix * (0.00015593440916415301 + (ix * (0.0000018462756734893055 + (ix * (1.1269922476399903e-8 + (ix * (3.6014002958937136e-11 + (ix * (5.887545336215784e-14 + (ix * (4.5200143407412973e-17 + (ix * 1.2544323709001127e-20)))))))))))))))))));
+	}
+	return s1 / s2;
+}
+
+// END: rational_pfqf
+
+// BEGIN: rational_pgqg
+
+/**
+* Evaluates a rational function (i.e., the ratio of two polynomials described by the coefficients stored in \\(P\\) and \\(Q\\)).
+*
+* ## Notes
+*
+* -   Coefficients should be sorted in ascending degree.
+* -   The implementation uses [Horner's rule][horners-method] for efficient computation.
+*
+* [horners-method]: https://en.wikipedia.org/wiki/Horner%27s_method
+*
+* @param x    value at which to evaluate the rational function
+* @return     evaluated rational function
+*/
+static double rational_pgqg( const double x ) {
+	double ax;
+	double ix;
+	double s1;
+	double s2;
+	if ( x == 0.0 ) {
+		return 1.0;
+	}
+	if ( x < 0.0 ) {
+		ax = -x;
+	} else {
+		ax = x;
+	}
+	if ( ax <= 1.0 ) {
+		s1 = 1.8695871016278324e-22 + (x * (8.363544356306774e-19 + (x * (1.375554606332618e-15 + (x * (1.0826804113902088e-12 + (x * (4.4534441586175015e-10 + (x * (9.828524436884223e-8 + (x * (0.000011513882611188428 + (x * (0.0006840793809153931 + (x * (0.018764858409257526 + (x * (0.1971028335255234 + (x * (0.5044420736433832 + (x * 0.0)))))))))))))))))))));
+		s2 = 1.8695871016278324e-22 + (x * (8.391588162831187e-19 + (x * (1.3879653125957886e-15 + (x * (1.1027321506624028e-12 + (x * (4.6068072814652043e-10 + (x * (1.0431458965757199e-7 + (x * (0.000012754507566772912 + (x * (0.0008146791071843061 + (x * (0.02536037414203388 + (x * (0.33774898912002 + (x * (1.4749575992512833 + (x * 1.0)))))))))))))))))))));
+	} else {
+		ix = 1.0 / x;
+		s1 = 0.0 + (ix * (0.5044420736433832 + (ix * (0.1971028335255234 + (ix * (0.018764858409257526 + (ix * (0.0006840793809153931 + (ix * (0.000011513882611188428 + (ix * (9.828524436884223e-8 + (ix * (4.4534441586175015e-10 + (ix * (1.0826804113902088e-12 + (ix * (1.375554606332618e-15 + (ix * (8.363544356306774e-19 + (ix * 1.8695871016278324e-22)))))))))))))))))))));
+		s2 = 1.0 + (ix * (1.4749575992512833 + (ix * (0.33774898912002 + (ix * (0.02536037414203388 + (ix * (0.0008146791071843061 + (ix * (0.000012754507566772912 + (ix * (1.0431458965757199e-7 + (ix * (4.6068072814652043e-10 + (ix * (1.1027321506624028e-12 + (ix * (1.3879653125957886e-15 + (ix * (8.391588162831187e-19 + (ix * 1.8695871016278324e-22)))))))))))))))))))));
+	}
+	return s1 / s2;
+}
+
+// END: rational_pgqg
+
+/* End auto-generated functions. */
+
+/**
+* Computes the Fresnel integrals S(x) and C(x) and assigns results to a provided output array.
+*
+* ## Method
+*
+* Evaluates the Fresnel integrals
+*
+* ```tex
+* \begin{align*}
+* \operatorname{S}(x) &= \int_0^x \sin\left(\frac{\pi}{2} t^2\right)\,\mathrm{d}t, \\
+* \operatorname{C}(x) &= \int_0^x \cos\left(\frac{\pi}{2} t^2\right)\,\mathrm{d}t.
+* \end{align*}
+* ```
+*
+* The integrals are evaluated by a power series for \\( x < 1 \\). For \\( x >= 1 \\) auxiliary functions \\( f(x) \\) and \\( g(x) \\) are employed such that
+*
+* ```tex
+* \begin{align*}
+* \operatorname{C}(x) &= \frac{1}{2} + f(x) \sin\left( \frac{\pi}{2} x^2 \right) - g(x) \cos\left( \frac{\pi}{2} x^2 \right), \\
+* \operatorname{S}(x) &= \frac{1}{2} - f(x) \cos\left( \frac{\pi}{2} x^2 \right) - g(x) \sin\left( \frac{\pi}{2} x^2 \right).
+* \end{align*}
+* ```
+*
+* ## Notes
+*
+* -   Relative error on test interval \\( \[0,10\] \\):
+*
+*     | arithmetic | function | # trials | peak    | rms     |
+*     |:----------:|:--------:|:--------:|:-------:|:-------:|
+*     | IEEE       | S(x)     | 10000    | 2.0e-15 | 3.2e-16 |
+*     | IEEE       | C(x)     | 10000    | 1.8e-15 | 3.3e-16 |
+*
+* @param x    input value
+* @param S    destination to store S(x)
+* @param C    destination to store C(x)
+*
+* @example
+* double x = 0.0;
+*
+* double S;
+* double C;
+* stdlib_base_fresnel( x, &S, &C );
+*/
+void stdlib_base_fresnel( const double x, double* S, double* C ) {
+	double x2;
+	double xa;
+	double f;
+	double g;
+	double t;
+	double u;
+	double s;
+	double c;
+
+	xa = stdlib_base_abs( x );
+	x2 = xa * xa;
+	if ( x2 < 2.5625 ) {
+		t = x2 * x2;
+		*S = xa * x2 * rational_psqs( t );
+		*C = xa * rational_pcqc( t );
+	} else if ( xa > 36974.0 ) {
+		*C = 0.5;
+		*S = 0.5;
+	} else {
+		// Asymptotic power series auxiliary functions for large arguments...
+		x2 = xa * xa;
+		t = STDLIB_CONSTANT_FLOAT64_PI * x2;
+		u = 1.0 / ( t * t );
+		t = 1.0 / t;
+		f = 1.0 - ( u * rational_pfqf( u ) );
+		g = t * rational_pgqg( u );
+		t = STDLIB_CONSTANT_FLOAT64_HALF_PI * x2;
+		stdlib_base_sincos( t, &s, &c );
+		t = STDLIB_CONSTANT_FLOAT64_PI * xa;
+		*C = 0.5 + ( ( ( f * s ) - ( g * c ) ) / t );
+		*S = 0.5 - ( ( ( f * c ) + ( g * s ) ) / t );
+	}
+	if ( x < 0.0 ) {
+		*C = -*C;
+		*S = -*S;
+	}
+	return;
+}

--- a/lib/node_modules/@stdlib/math/base/special/fresnel/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/fresnel/test/test.native.js
@@ -1,0 +1,226 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+var EPS = require( '@stdlib/constants/float64/eps' );
+var abs = require( '@stdlib/math/base/special/abs' );
+var randu = require( '@stdlib/random/base/randu' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var fresnel = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( fresnel instanceof Error )
+};
+
+
+// FIXTURES //
+
+var smallPositive = require( './fixtures/c/cephes/small.json' );
+var mediumPositive = require( './fixtures/c/cephes/medium.json' );
+var largePositive = require( './fixtures/c/cephes/large.json' );
+var hugePositive = require( './fixtures/c/cephes/huge.json' );
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof fresnel, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function computes Fresnel integrals (small positive values)', opts, function test( t ) {
+	var delta;
+	var tol;
+	var C;
+	var S;
+	var x;
+	var y;
+	var i;
+
+	x = smallPositive.x;
+	S = smallPositive.S;
+	C = smallPositive.C;
+
+	for ( i = 0; i < x.length; i++ ) {
+		y = fresnel( x[i] );
+		if ( y[0] === S[i] ) {
+			t.equal( y[0], S[i], 'x: '+x[i]+'. Expected: '+S[i] );
+		} else {
+			delta = abs( y[0] - S[i] );
+			tol = 4.0 * EPS * abs( S[i] );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. S: '+y[0]+'. Expected: '+S[i]+'. tol: '+tol+'. delta: '+delta+'.' );
+		}
+		if ( y[1] === C[i] ) {
+			t.equal( y[1], C[i], 'x: '+x[i]+'. Expected: '+C[i] );
+		} else {
+			delta = abs( y[1] - C[i] );
+			tol = 4.0 * EPS * abs( C[i] );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. C: '+y[1]+'. Expected: '+C[i]+'. tol: '+tol+'. delta: '+delta+'.' );
+		}
+	}
+	t.end();
+});
+
+tape( 'the function computes Fresnel integrals (medium positive values)', opts, function test( t ) {
+	var delta;
+	var tol;
+	var C;
+	var S;
+	var x;
+	var y;
+	var i;
+
+	x = mediumPositive.x;
+	S = mediumPositive.S;
+	C = mediumPositive.C;
+
+	for ( i = 0; i < x.length; i++ ) {
+		y = fresnel( x[i] );
+		if ( y[0] === S[i] ) {
+			t.equal( y[0], S[i], 'x: '+x[i]+'. Expected: '+S[i] );
+		} else {
+			delta = abs( y[0] - S[i] );
+			tol = 1.5 * EPS * abs( S[i] );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. S: '+y[0]+'. Expected: '+S[i]+'. tol: '+tol+'. delta: '+delta+'.' );
+		}
+		if ( y[1] === C[i] ) {
+			t.equal( y[1], C[i], 'x: '+x[i]+'. Expected: '+C[i] );
+		} else {
+			delta = abs( y[1] - C[i] );
+			tol = 1.5 * EPS * abs( C[i] );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. C: '+y[1]+'. Expected: '+C[i]+'. tol: '+tol+'. delta: '+delta+'.' );
+		}
+	}
+	t.end();
+});
+
+tape( 'the function computes Fresnel integrals (large positive values)', opts, function test( t ) {
+	var delta;
+	var tol;
+	var C;
+	var S;
+	var x;
+	var y;
+	var i;
+
+	x = largePositive.x;
+	S = largePositive.S;
+	C = largePositive.C;
+
+	for ( i = 0; i < x.length; i++ ) {
+		y = fresnel( x[i] );
+		if ( y[0] === S[i] ) {
+			t.equal( y[0], S[i], 'x: '+x[i]+'. Expected: '+S[i] );
+		} else {
+			delta = abs( y[0] - S[i] );
+			tol = 1.5 * EPS * abs( S[i] );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. S: '+y[0]+'. Expected: '+S[i]+'. tol: '+tol+'. delta: '+delta+'.' );
+		}
+		if ( y[1] === C[i] ) {
+			t.equal( y[1], C[i], 'x: '+x[i]+'. Expected: '+C[i] );
+		} else {
+			delta = abs( y[1] - C[i] );
+			tol = 1.5 * EPS * abs( C[i] );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. C: '+y[1]+'. Expected: '+C[i]+'. tol: '+tol+'. delta: '+delta+'.' );
+		}
+	}
+	t.end();
+});
+
+tape( 'the function computes Fresnel integrals (very large positive values)', opts, function test( t ) {
+	var delta;
+	var tol;
+	var C;
+	var S;
+	var x;
+	var y;
+	var i;
+
+	x = hugePositive.x;
+	S = hugePositive.S;
+	C = hugePositive.C;
+
+	for ( i = 0; i < x.length; i++ ) {
+		y = fresnel( x[i] );
+		if ( y[0] === S[i] ) {
+			t.equal( y[0], S[i], 'x: '+x[i]+'. Expected: '+S[i] );
+		} else {
+			delta = abs( y[0] - S[i] );
+			tol = 1.5 * EPS * abs( S[i] );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. S: '+y[0]+'. Expected: '+S[i]+'. tol: '+tol+'. delta: '+delta+'.' );
+		}
+		if ( y[1] === C[i] ) {
+			t.equal( y[1], C[i], 'x: '+x[i]+'. Expected: '+C[i] );
+		} else {
+			delta = abs( y[1] - C[i] );
+			tol = 1.5 * EPS * abs( C[i] );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. C: '+y[1]+'. Expected: '+C[i]+'. tol: '+tol+'. delta: '+delta+'.' );
+		}
+	}
+	t.end();
+});
+
+tape( 'the function is an odd function of x', opts, function test( t ) {
+	var yn;
+	var yp;
+	var x;
+	var i;
+
+	for ( i = 0; i < 500; i++ ) {
+		x = randu() * 10000.0;
+		yn = fresnel( -x );
+		yp = fresnel( x );
+
+		t.equal( yp[0], -yn[0], 'S(x) = -S(-x)' );
+		t.equal( yp[1], -yn[1], 'C(x) = -C(-x)' );
+	}
+	t.end();
+});
+
+tape( 'the function returns `[0.5, 0.5]` if provided `+infinity`', opts, function test( t ) {
+	var v = fresnel( PINF );
+	t.equal( v[0], 0.5, 'returns 0.5' );
+	t.equal( v[1], 0.5, 'returns 0.5' );
+	t.end();
+});
+
+tape( 'the function returns `[-0.5, -0.5]` if provided `-infinity`', opts, function test( t ) {
+	var v = fresnel( NINF );
+	t.equal( v[0], -0.5, 'returns -0.5' );
+	t.equal( v[1], -0.5, 'returns -0.5' );
+	t.end();
+});
+
+tape( 'the function returns `[NaN, NaN]` if provided a `NaN`', opts, function test( t ) {
+	var v = fresnel( NaN );
+	t.equal( isnan( v[0] ), true, 'returns expected value' );
+	t.equal( isnan( v[1] ), true, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds `C` implementation for [`math/base/special/fresnel`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/fresnel).

```c
void stdlib_base_fresnel( const double x, double* S, double* C );
```

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves a part of #649.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
