### PR TITLE
docs: remove `stdint` include, return `Float64Array` in `math/base/special/sincospi`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/sincospi/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/sincospi/lib/native.js
@@ -31,7 +31,7 @@ var addon = require( './../src/addon.node' );
 *
 * @private
 * @param {number} x - input value
-* @returns {Array<number>} two-element array containing sin(πx) and cos(πx)
+* @returns {Float64Array} two-element array containing sin(πx) and cos(πx)
 *
 * @example
 * var v = sincospi( 0.0 );

--- a/lib/node_modules/@stdlib/math/base/special/sincospi/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/sincospi/src/main.c
@@ -25,7 +25,6 @@
 #include "stdlib/math/base/assert/is_infinite.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/constants/float64/pi.h"
-#include <stdint.h>
 
 /**
 * Simultaneously computes the sine and cosine of a number times π.


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   addresses https://github.com/stdlib-js/stdlib/commit/f5d15f7e0d12169f3016f1d499674b0ce9b2e0ea#r144735243 and https://github.com/stdlib-js/stdlib/commit/f5d15f7e0d12169f3016f1d499674b0ce9b2e0ea#r144735169
-   removes `include <stdint>` from `main.c`.
-   set the return value as `Float64Array` in `native.js`.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
