### PR TITLE
refactor: correct return value in `math/base/special/sincos`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/sincos/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/sincos/src/main.c
@@ -125,7 +125,8 @@ void stdlib_base_sincos( const double x, double* sine, double* cosine ) {
 				*cosine = 0.0;
 			}
 		}
-		return kernelSincos( x, 0.0, sine, cosine );
+		kernelSincos( x, 0.0, sine, cosine );
+		return;
 	}
 
 	// Case: x is NaN or infinity


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   corrects the return value in the[ `stdlib_base_sincos`](https://github.com/stdlib-js/stdlib/blob/develop/lib/node_modules/%40stdlib/math/base/special/sincos/src/main.c#L128) function. As the return type of `kernelSincos` and `stdlib_base_sincos` is `void`, we return nothing.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
