### PR TITLE
docs: fix REPL examples in `stats/ttest`

### DIFF
--- a/lib/node_modules/@stdlib/stats/ttest/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/ttest/docs/repl.txt
@@ -128,7 +128,7 @@
     significance level
 
     // Choose custom significance level:
-    > arr = [ 2, 4, 3, 1, 0 ];
+    > var arr = [ 2, 4, 3, 1, 0 ];
     > out = {{alias}}( arr, { 'alpha': 0.01 } );
     > table = out.print()
     One-sample t-test
@@ -144,7 +144,7 @@
     significance level
 
     // Test for a mean equal to five:
-    > var arr = [ 4, 4, 6, 6, 5 ];
+    > arr = [ 4, 4, 6, 6, 5 ];
     > out = {{alias}}( arr, { 'mu': 5 } )
     {
         rejected: false,


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   fixes incorrect REPL example code

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   was discovered in #2273

## Questions

> Any questions for reviewers of this pull request?

While trying to commit, I encountered a bunch of REPL lint errors.

```json
{
  "file": "/workspaces/stdlib/lib/node_modules/@stdlib/stats/ttest/docs/repl.txt",
  "errors": [
    {
      "id": "@stdlib/_tools/repl-txt/rules/doctest",
      "severity": "error",
      "message": "Malformed return annotation. Encountered error while parsing: Bad object",
      "start": 81,
      "end": 184
    },
    {
      "id": "@stdlib/_tools/repl-txt/rules/doctest",
      "severity": "error",
      "message": "Malformed return annotation. Encountered error while parsing: Bad object",
      "start": 81,
      "end": 184
    },
    {
      "id": "@stdlib/_tools/repl-txt/rules/doctest",
      "severity": "error",
      "message": "`Paired t-test` should be wrapped in single quotes",
      "start": 81,
      "end": 184
    },
    {
      "id": "@stdlib/_tools/repl-txt/rules/doctest",
      "severity": "error",
      "message": "`One-sample t-test` should be wrapped in single quotes",
      "start": 81,
      "end": 184
    },
    {
      "id": "@stdlib/_tools/repl-txt/rules/doctest",
      "severity": "error",
      "message": "Malformed return annotation. Encountered error while parsing: Bad object",
      "start": 81,
      "end": 184
    },
    {
      "id": "@stdlib/_tools/repl-txt/rules/doctest",
      "severity": "error",
      "message": "`One-sample t-test` should be wrapped in single quotes",
      "start": 81,
      "end": 184
    },
    {
      "id": "@stdlib/_tools/repl-txt/rules/doctest",
      "severity": "error",
      "message": "`One-sample t-test` should be wrapped in single quotes",
      "start": 81,
      "end": 184
    },
    {
      "id": "@stdlib/_tools/repl-txt/rules/code-semicolons",
      "severity": "error",
      "message": "Semicolons must not be omitted if output is suppressed",
      "start": 81,
      "end": 184
    },
    {
      "id": "@stdlib/_tools/repl-txt/rules/code-semicolons",
      "severity": "error",
      "message": "Semicolons must not be omitted if output is suppressed",
      "start": 81,
      "end": 184
    }
  ]
}
```
I am to be blamed for the error due to `code-semicolons` rule originating in #2435. The updated rule doesn't work for multi-line inputs, as it's checking line by line. For instance, the line `for ( i = 0; i < 20; i++ ) {` doesn't have both the output and semicolon.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
