### PR TITLE
docs: use `native` in `benchmark.native.js` in `math/base/special/gcd`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/gcd/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/gcd/benchmark/benchmark.native.js
@@ -38,7 +38,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg, opts, function benchmark( b ) {
+bench( pkg+'::native', opts, function benchmark( b ) {
 	var x;
 	var y;
 	var z;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds the missing `native` in [`math/base/special/gcd/benchmark/benchmark.native.js`](https://github.com/stdlib-js/stdlib/blob/develop/lib/node_modules/%40stdlib/math/base/special/gcd/benchmark/benchmark.native.js#L41).

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
