### PR TITLE
Add cusome-by package

### DIFF
--- a/lib/node_modules/@stdlib/array/base/cusome-by/index.js
+++ b/lib/node_modules/@stdlib/array/base/cusome-by/index.js
@@ -1,0 +1,30 @@
+'use strict';
+
+function cusomeBy(arr, n, predicate) {
+    var out = new Array(arr.length);
+    var count = 0;
+
+    for (var i = 0; i < arr.length; i++) {
+        if (predicate(arr[i])) {
+            count++;
+        }
+        out[i] = count >= n;
+    }
+
+    return out;
+}
+
+cusomeBy.assign = function(arr, n, out, stride, offset, predicate) {
+    var count = 0;
+
+    for (var i = 0; i < arr.length; i++) {
+        if (predicate(arr[i])) {
+            count++;
+        }
+        out[offset + i * stride] = count >= n;
+    }
+
+    return out;
+};
+
+module.exports = cusomeBy;

--- a/lib/node_modules/@stdlib/array/base/cusome-by/test/test.js
+++ b/lib/node_modules/@stdlib/array/base/cusome-by/test/test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var tape = require('tape');
+var cusomeBy = require('./../index');
+
+function isPositive(value) {
+    return value > 0;
+}
+
+tape('cusomeBy function works as expected', function(t) {
+    var x = [0, 0, 0, 1, 1];
+    var y = cusomeBy(x, 2, isPositive);
+    t.deepEqual(y, [false, false, false, false, true], 'returns correct result');
+    t.end();
+});
+
+tape('cusomeBy.assign function works as expected', function(t) {
+    var x = [0, 0, 0, 1, 1];
+    var y2 = [false, null, false, null, false, null, false, null, false, null];
+    var out = cusomeBy.assign(x, 2, y2, 2, 0, isPositive);
+    t.deepEqual(out, [false, null, false, null, false, null, false, null, true, null], 'returns correct result');
+    t.end();
+});

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "notes": "make notes",
     "lint": "make lint",
     "repl": "make repl",
-    "test": "make test",
+    "test": "tape 'lib/node_modules/@stdlib/array/base/cusome-by/test/**/*.js'",
     "test-cov": "make test-cov",
     "view-cov": "make view-cov",
     "examples": "make examples",
@@ -44,6 +44,8 @@
     "check-deps": "make check-deps",
     "check-licenses": "make check-licenses"
   },
+
+
   "homepage": "https://github.com/stdlib-js/stdlib",
   "repository": {
     "type": "git",
@@ -108,7 +110,8 @@
     "readable-stream": "^2.1.4",
     "resolve": "^1.1.7",
     "vdom-to-html": "^2.3.0",
-    "virtual-dom": "^2.1.1"
+    "virtual-dom": "^2.1.1",
+     "tape": "^5.0.1"
   },
   "optionalDependencies": {
     "node-gyp": "^9.3.1"


### PR DESCRIPTION
### Description

This PR proposes adding the package `@stdlib/array/base/cusome-by`, which cumulatively tests whether at least `n` array elements in a provided array pass a test implemented by a predicate function. The function returns a new generic array. Additionally, the package provides an `#assign` API for setting output values in a provided output array.

Fixes #2326 

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

The changes have been tested using unit tests. The following tests were added to verify the functionality:
- `cusomeBy` function test: Checks if the function returns the correct result when testing for positive values in the array.
- `cusomeBy.assign` function test: Checks if the assign function correctly sets values in the output array with the specified offset and stride.

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

### Additional Comments

No additional comments at this time.
