### PR TITLE
feat: add `math/base/special/roundf`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/roundf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/README.md
@@ -1,0 +1,212 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# Round
+
+> Round a numeric value to the nearest integer.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var roundf = require( '@stdlib/math/base/special/roundf' );
+```
+
+#### roundf( x )
+
+Rounds a `numeric` value to the nearest `integer`.
+
+```javascript
+var v = roundf( -4.2 );
+// returns -4.0
+
+v = roundf( -4.5 );
+// returns -4.0
+
+v = roundf( -4.6 );
+// returns -5.0
+
+v = roundf( 9.99999 );
+// returns 10.0
+
+v = roundf( 9.5 );
+// returns 10.0
+
+v = roundf( 9.2 );
+// returns 9.0
+
+v = roundf( 0.0 );
+// returns 0.0
+
+v = roundf( -0.0 );
+// returns -0.0
+
+v = roundf( Infinity );
+// returns Infinity
+
+v = roundf( -Infinity );
+// returns -Infinity
+
+v = roundf( NaN );
+// returns NaN
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   Ties are rounded toward positive infinity.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var randu = require( '@stdlib/random/base/randu' );
+var roundf = require( '@stdlib/math/base/special/roundf' );
+
+var x;
+var i;
+
+for ( i = 0; i < 100; i++ ) {
+    x = ( randu() * 100.0 ) - 50.0;
+    console.log( 'Value: %d. Rounded: %d.', x, roundf( x ) );
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/math/base/special/roundf.h"
+```
+
+#### stdlib_base_roundf( x )
+
+Rounds a `numeric` value to the nearest `integer`.
+
+```c
+float out = stdlib_base_roundf( -4.2f );
+// returns -4.0f
+```
+
+The function accepts the following arguments:
+
+-   **x**: `[in] float` input value.
+
+```c
+float stdlib_base_roundf( const float x );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/math/base/special/roundf.h"
+#include <stdio.h>
+
+int main( void ) {
+    const float x[] = { -5.0f, -3.89f, -2.78f, -1.67f, -0.56f, 0.56f, 1.67f, 2.78f, 3.89f, 5.0f };
+    
+    float v;
+    int i;
+    for ( i = 0; i < 10; i++ ) {
+        v = stdlib_base_roundf( x[ i ] );
+        printf( "roundf(%f) = %f\n", x[ i ], v );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/math/base/special/roundf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Round
 
-> Round a numeric value to the nearest integer.
+> Round a single-precision floating-point number to the nearest integer.
 
 <section class="usage">
 
@@ -32,7 +32,7 @@ var roundf = require( '@stdlib/math/base/special/roundf' );
 
 #### roundf( x )
 
-Rounds a `numeric` value to the nearest `integer`.
+Rounds a single-precision floating-point number value to the nearest `integer`.
 
 ```javascript
 var v = roundf( -4.2 );
@@ -134,7 +134,7 @@ for ( i = 0; i < 100; i++ ) {
 
 #### stdlib_base_roundf( x )
 
-Rounds a `numeric` value to the nearest `integer`.
+Rounds a single-precision floating-point number value to the nearest `integer`.
 
 ```c
 float out = stdlib_base_roundf( -4.2f );

--- a/lib/node_modules/@stdlib/math/base/special/roundf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/README.md
@@ -32,7 +32,7 @@ var roundf = require( '@stdlib/math/base/special/roundf' );
 
 #### roundf( x )
 
-Rounds a single-precision floating-point number value to the nearest `integer`.
+Rounds a single-precision floating-point number to the nearest `integer`.
 
 ```javascript
 var v = roundf( -4.2 );
@@ -134,7 +134,7 @@ for ( i = 0; i < 100; i++ ) {
 
 #### stdlib_base_roundf( x )
 
-Rounds a single-precision floating-point number value to the nearest `integer`.
+Rounds a single-precision floating-point number to the nearest `integer`.
 
 ```c
 float out = stdlib_base_roundf( -4.2f );

--- a/lib/node_modules/@stdlib/math/base/special/roundf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/benchmark/benchmark.js
@@ -1,0 +1,51 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var pkg = require( './../package.json' ).name;
+var roundf = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		x = ( randu() * 1000.0 ) - 500.0;
+		y = roundf( x );
+		if ( isnanf( y ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnanf( y ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/roundf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/benchmark/benchmark.native.js
@@ -1,0 +1,60 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var isnanf = require( '@stdlib/math/base/assert/is-nan' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var roundf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( roundf instanceof Error )
+};
+
+
+// MAIN //
+
+bench( pkg+'::native', opts, function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		x = ( randu() * 1000.0 ) - 500.0;
+		y = roundf( x );
+		if ( isnanf( y ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnanf( y ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/roundf/benchmark/c/native/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/benchmark/c/native/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/roundf/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/benchmark/c/native/benchmark.c
@@ -1,0 +1,133 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/roundf.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "roundf"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+static void print_version( void ) {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+static void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+static void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+static double tic( void ) {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1).
+*
+* @return random number
+*/
+static float rand_float( void ) {
+	int r = rand();
+	return (float)r / ( (float)RAND_MAX + 1.0f );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+static double benchmark( void ) {
+	double elapsed;
+	double t;
+	float x;
+	float y;
+	int i;
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		x = ( 1000.0f * rand_float() ) - 500.0f;
+		y = roundf( x );
+		if ( y != y ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( y != y ) {
+		printf( "should not return NaN\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::native::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/math/base/special/roundf/binding.gyp
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/math/base/special/roundf/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/docs/repl.txt
@@ -1,0 +1,32 @@
+
+{{alias}}( x )
+    Rounds a numeric value to the nearest integer.
+
+    Ties are rounded toward positive infinity.
+
+    Parameters
+    ----------
+    x: number
+        Input value.
+
+    Returns
+    -------
+    y: number
+        Rounded value.
+
+    Examples
+    --------
+    > var y = {{alias}}( 3.14 )
+    3.0
+    > y = {{alias}}( -4.2 )
+    -4.0
+    > y = {{alias}}( -4.6 )
+    -5.0
+    > y = {{alias}}( 9.5 )
+    10.0
+    > y = {{alias}}( -0.0 )
+    -0.0
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/math/base/special/roundf/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/docs/repl.txt
@@ -1,6 +1,6 @@
 
 {{alias}}( x )
-    Rounds a numeric value to the nearest integer.
+    Rounds a single-precision floating-point number to the nearest integer.
 
     Ties are rounded toward positive infinity.
 

--- a/lib/node_modules/@stdlib/math/base/special/roundf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/docs/types/index.d.ts
@@ -1,0 +1,80 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Rounds a numeric value to the nearest integer.
+*
+* ## Notes
+*
+* -   Ties are rounded toward positive infinity.
+*
+* @param x - input value
+* @returns function value
+*
+* @example
+* var v = roundf( -4.2 );
+* // returns -4.0
+*
+* @example
+* var v = roundf( -4.5 );
+* // returns -4.0
+*
+* @example
+* var v = roundf( -4.6 );
+* // returns -5.0
+*
+* @example
+* var v = roundf( 9.99999 );
+* // returns 10.0
+*
+* @example
+* var v = roundf( 9.5 );
+* // returns 10.0
+*
+* @example
+* var v = roundf( 9.2 );
+* // returns 9.0
+*
+* @example
+* var v = roundf( 0.0 );
+* // returns 0.0
+*
+* @example
+* var v = roundf( -0.0 );
+* // returns -0.0
+*
+* @example
+* var v = roundf( Infinity );
+* // returns Infinity
+*
+* @example
+* var v = roundf( -Infinity );
+* // returns -Infinity
+*
+* @example
+* var v = roundf( NaN );
+* // returns NaN
+*/
+declare function roundf( x: number ): number;
+
+
+// EXPORTS //
+
+export = roundf;

--- a/lib/node_modules/@stdlib/math/base/special/roundf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/docs/types/index.d.ts
@@ -19,7 +19,7 @@
 // TypeScript Version: 4.1
 
 /**
-* Rounds a numeric value to the nearest integer.
+* Rounds a single-precision floating-point number to the nearest integer.
 *
 * ## Notes
 *

--- a/lib/node_modules/@stdlib/math/base/special/roundf/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/docs/types/test.ts
@@ -1,0 +1,44 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import roundf = require( './index' );
+
+
+// TESTS //
+
+// The function returns a number...
+{
+	roundf( 2.86 ); // $ExpectType number
+}
+
+// The compiler throws an error if the function is provided a value other than a number...
+{
+	roundf( true ); // $ExpectError
+	roundf( false ); // $ExpectError
+	roundf( null ); // $ExpectError
+	roundf( undefined ); // $ExpectError
+	roundf( '5' ); // $ExpectError
+	roundf( [] ); // $ExpectError
+	roundf( {} ); // $ExpectError
+	roundf( ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided insufficient arguments...
+{
+	roundf(); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/math/base/special/roundf/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/roundf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/examples/c/example.c
@@ -1,0 +1,31 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/roundf.h"
+#include <stdio.h>
+
+int main( void ) {
+    const float x[] = { -5.0f, -3.89f, -2.78f, -1.67f, -0.56f, 0.56f, 1.67f, 2.78f, 3.89f, 5.0f };
+
+    float v;
+    int i;
+    for ( i = 0; i < 1; i++ ) {
+        v = stdlib_base_roundf( x[ i ] );
+        printf( "roundf(%f) = %f\n", x[ i ], v );
+    }
+}

--- a/lib/node_modules/@stdlib/math/base/special/roundf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/examples/index.js
@@ -1,0 +1,30 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var randu = require( '@stdlib/random/base/randu' );
+var roundf = require( './../lib' );
+
+var x;
+var i;
+
+for ( i = 0; i < 100; i++ ) {
+	x = ( randu() * 100.0) - 50.0;
+	console.log( 'Value: %d. Rounded: %d.', x, roundf( x ) );
+}

--- a/lib/node_modules/@stdlib/math/base/special/roundf/include.gypi
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/math/base/special/roundf/include/stdlib/math/base/special/roundf.h
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/include/stdlib/math/base/special/roundf.h
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 /**
-* Rounds a numeric value to the nearest integer.
+* Rounds a single-precision floating-point number to the nearest integer.
 */
 float stdlib_base_roundf( const float x );
 

--- a/lib/node_modules/@stdlib/math/base/special/roundf/include/stdlib/math/base/special/roundf.h
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/include/stdlib/math/base/special/roundf.h
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_MATH_BASE_SPECIAL_ROUNDF_H
+#define STDLIB_MATH_BASE_SPECIAL_ROUNDF_H
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Rounds a numeric value to the nearest integer.
+*/
+float stdlib_base_roundf( const float x );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_MATH_BASE_SPECIAL_ROUNDF_H

--- a/lib/node_modules/@stdlib/math/base/special/roundf/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/lib/index.js
@@ -1,0 +1,70 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Round a numeric value to the nearest integer.
+*
+* @module @stdlib/math/base/special/roundf
+*
+* @example
+* var roundf = require( '@stdlib/math/base/special/roundf' );
+*
+* var v = roundf( -4.2 );
+* // returns -4.0
+*
+* v = roundf( -4.5 );
+* // returns -4.0
+*
+* v = roundf( -4.6 );
+* // returns -5.0
+*
+* v = roundf( 9.99999 );
+* // returns 10.0
+*
+* v = roundf( 9.5 );
+* // returns 10.0
+*
+* v = roundf( 9.2 );
+* // returns 9.0
+*
+* v = roundf( 0.0 );
+* // returns 0.0
+*
+* v = roundf( -0.0 );
+* // returns -0.0
+*
+* v = roundf( Infinity );
+* // returns Infinity
+*
+* v = roundf( -Infinity );
+* // returns -Infinity
+*
+* v = roundf( NaN );
+* // returns NaN
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/math/base/special/roundf/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Round a numeric value to the nearest integer.
+* Round a single-precision floating-point number to the nearest integer.
 *
 * @module @stdlib/math/base/special/roundf
 *

--- a/lib/node_modules/@stdlib/math/base/special/roundf/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/lib/main.js
@@ -29,7 +29,7 @@ var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
 // MAIN //
 
 /**
-* Rounds a numeric value to the nearest integer.
+* Rounds a single-precision floating-point number to the nearest integer.
 *
 * @param {number} x - input value
 * @returns {number} output value

--- a/lib/node_modules/@stdlib/math/base/special/roundf/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/lib/main.js
@@ -1,0 +1,102 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var floorf = require( '@stdlib/math/base/special/floorf' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
+
+
+// MAIN //
+
+/**
+* Rounds a numeric value to the nearest integer.
+*
+* @param {number} x - input value
+* @returns {number} output value
+*
+* @example
+* var v = roundf( -4.2 );
+* // returns -4.0
+*
+* @example
+* var v = roundf( -4.5 );
+* // returns -4.0
+*
+* @example
+* var v = roundf( -4.6 );
+* // returns -5.0
+*
+* @example
+* var v = roundf( 9.99999 );
+* // returns 10.0
+*
+* @example
+* var v = roundf( 9.5 );
+* // returns 10.0
+*
+* @example
+* var v = roundf( 9.2 );
+* // returns 9.0
+*
+* @example
+* var v = roundf( 0.0 );
+* // returns 0.0
+*
+* @example
+* var v = roundf( -0.0 );
+* // returns -0.0
+*
+* @example
+* var v = roundf( Infinity );
+* // returns Infinity
+*
+* @example
+* var v = roundf( -Infinity );
+* // returns -Infinity
+*
+* @example
+* var v = roundf( NaN );
+* // returns NaN
+*/
+function roundf( x ) {
+	if ( isnanf( x ) ) {
+		return NaN;
+	}
+	if ( isNegativeZerof( x ) || ( x >= -0.5 && x < 0.0 ) ) {
+		return -0.0; // -0
+	}
+	if ( x > 0.0 && x < 0.5 ) {
+		return 0.0; // 0
+	}
+
+	// If the magnitude is big enough, there's no place for the fraction part. If we try to add 0.5 to this number, 1.0 will be added instead...
+	if ( x >= 8388608.0 || x <= -8388608.0 ) {
+		return x;
+	}
+	return floorf( float64ToFloat32( x + 0.5 ) );
+}
+
+
+// EXPORTS //
+
+module.exports = roundf;

--- a/lib/node_modules/@stdlib/math/base/special/roundf/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/lib/native.js
@@ -1,0 +1,86 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Rounds a numeric value to the nearest integer.
+*
+* @private
+* @param {number} x - input value
+* @returns {number} function value
+*
+* @example
+* var v = roundf( -4.2 );
+* // returns -4.0
+*
+* @example
+* var v = roundf( -4.5 );
+* // returns -4.0
+*
+* @example
+* var v = roundf( -4.6 );
+* // returns -5.0
+*
+* @example
+* var v = roundf( 9.99999 );
+* // returns 10.0
+*
+* @example
+* var v = roundf( 9.5 );
+* // returns 10.0
+*
+* @example
+* var v = roundf( 9.2 );
+* // returns 9.0
+*
+* @example
+* var v = roundf( 0.0 );
+* // returns 0.0
+*
+* @example
+* var v = roundf( -0.0 );
+* // returns -0.0
+*
+* @example
+* var v = roundf( Infinity );
+* // returns Infinity
+*
+* @example
+* var v = roundf( -Infinity );
+* // returns -Infinity
+*
+* @example
+* var v = roundf( NaN );
+* // returns NaN
+*/
+function roundf( x ) {
+	return addon( x );
+}
+
+
+// EXPORTS //
+
+module.exports = roundf;

--- a/lib/node_modules/@stdlib/math/base/special/roundf/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/lib/native.js
@@ -26,7 +26,7 @@ var addon = require( './../src/addon.node' );
 // MAIN //
 
 /**
-* Rounds a numeric value to the nearest integer.
+* Rounds a single-precision floating-point number to the nearest integer.
 *
 * @private
 * @param {number} x - input value

--- a/lib/node_modules/@stdlib/math/base/special/roundf/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/manifest.json
@@ -1,0 +1,78 @@
+{
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/napi/unary",
+        "@stdlib/math/base/special/floorf",
+        "@stdlib/math/base/assert/is-nanf",
+        "@stdlib/math/base/assert/is-negative-zerof"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/floorf",
+        "@stdlib/math/base/assert/is-nanf",
+        "@stdlib/math/base/assert/is-negative-zerof"
+      ]
+    },
+    {
+      "task": "examples",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/floorf",
+        "@stdlib/math/base/assert/is-nanf",
+        "@stdlib/math/base/assert/is-negative-zerof"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/special/roundf/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/math/base/special/roundf",
   "version": "0.0.0",
-  "description": "Round a numeric value to the nearest integer.",
+  "description": "Round a single-precision floating-point number to the nearest integer.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/math/base/special/roundf/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@stdlib/math/base/special/roundf",
+  "version": "0.0.0",
+  "description": "Round a numeric value to the nearest integer.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "gypfile": true,
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "src": "./src",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
+    "math.round",
+    "roundf",
+    "integer",
+    "nearest",
+    "number"
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/special/roundf/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/roundf/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/src/addon.c
@@ -1,0 +1,23 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/roundf.h"
+#include "stdlib/math/base/napi/unary.h"
+
+// cppcheck-suppress shadowFunction
+STDLIB_MATH_BASE_NAPI_MODULE_F_F( stdlib_base_roundf )

--- a/lib/node_modules/@stdlib/math/base/special/roundf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/src/main.c
@@ -22,7 +22,7 @@
 #include "stdlib/math/base/assert/is_negative_zerof.h"
 
 /**
-* Rounds a numeric value to the nearest integer.
+* Rounds a single-precision floating-point number to the nearest integer.
 *
 * @param x    input value
 * @return     output value

--- a/lib/node_modules/@stdlib/math/base/special/roundf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/src/main.c
@@ -28,7 +28,7 @@
 * @return     output value
 *
 * @example
-* double out = stdlib_base_roundf( -4.2 );
+* float out = stdlib_base_roundf( -4.2 );
 * // returns -4.0
 */
 float stdlib_base_roundf( const float x ) {

--- a/lib/node_modules/@stdlib/math/base/special/roundf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/src/main.c
@@ -1,0 +1,50 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/roundf.h"
+#include "stdlib/math/base/special/floorf.h"
+#include "stdlib/math/base/assert/is_nanf.h"
+#include "stdlib/math/base/assert/is_negative_zerof.h"
+
+/**
+* Rounds a numeric value to the nearest integer.
+*
+* @param x    input value
+* @return     output value
+*
+* @example
+* double out = stdlib_base_roundf( -4.2 );
+* // returns -4.0
+*/
+float stdlib_base_roundf( const float x ) {
+	if ( stdlib_base_is_nanf( x ) ) {
+		return 0.0f / 0.0f; // NaN
+	}
+	if ( stdlib_base_is_negative_zerof( x ) || ( x >= -0.5f && x < 0.0f ) ) {
+		return -0.0f; // -0
+	}
+	if ( x > 0.0f && x < 0.5f ) {
+		return 0.0f; // 0
+	}
+
+	// If the magnitude is big enough, there's no place for the fraction part. If we try to add 0.5 to this number, 1.0 will be added instead...
+	if ( x >= 8388608.0f || x <= -8388608.0f ) {
+		return x;
+	}
+	return stdlib_base_floorf( x + 0.5f );
+}

--- a/lib/node_modules/@stdlib/math/base/special/roundf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/test/test.js
@@ -36,7 +36,7 @@ tape( 'main export is a function', function test( t ) {
 	t.end();
 });
 
-tape( 'the function rounds a numeric value to the nearest integer', function test( t ) {
+tape( 'the function rounds a single-precision floating-point number to the nearest integer', function test( t ) {
 	t.strictEqual( roundf( -4.2 ), -4.0, 'equals -4' );
 	t.strictEqual( roundf( -4.5 ), -4.0, 'equals -4' );
 	t.strictEqual( roundf( -4.8 ), -5.0, 'equals -5' );

--- a/lib/node_modules/@stdlib/math/base/special/roundf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/test/test.js
@@ -1,0 +1,97 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var NINF = require( '@stdlib/constants/float32/ninf' );
+var PINF = require( '@stdlib/constants/float32/pinf' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
+var roundf = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof roundf, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function rounds a numeric value to the nearest integer', function test( t ) {
+	t.strictEqual( roundf( -4.2 ), -4.0, 'equals -4' );
+	t.strictEqual( roundf( -4.5 ), -4.0, 'equals -4' );
+	t.strictEqual( roundf( -4.8 ), -5.0, 'equals -5' );
+	t.strictEqual( roundf( 4.2 ), 4.0, 'equals 4' );
+	t.strictEqual( roundf( 4.5 ), 5.0, 'equals 5' );
+	t.strictEqual( roundf( 9.99999 ), 10.0, 'equals 10' );
+	t.strictEqual( roundf( 9.5 ), 10.0, 'equals 10' );
+	t.strictEqual( roundf( 9.4 ), 9.0, 'equals 10' );
+	t.strictEqual( roundf( 0.0 ), 0.0, 'equals 0' );
+	t.strictEqual( roundf( 0.2 ), 0.0, 'equals 0' );
+	t.end();
+});
+
+tape( 'the function returns `-0` if provided `-0`', function test( t ) {
+	var v = roundf( -0.0 );
+	t.strictEqual( isNegativeZerof( v ), true, 'returns -0' );
+	t.end();
+});
+
+tape( 'the function returns `NaN` if provided a `NaN`', function test( t ) {
+	var v = roundf( NaN );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `+infinity` if provided a `+infinity`', function test( t ) {
+	var v = roundf( PINF );
+	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.end();
+});
+
+tape( 'the function returns `-infinity` if provided a `-infinity`', function test( t ) {
+	var v = roundf( NINF );
+	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.end();
+});
+
+tape( 'the function returns the correct result for large positive non-decimal values', function test( t ) {
+	var start = 8388608;
+	var end = 8390000;
+	var i;
+
+	for ( i = start; i < end; i++ ) {
+		t.strictEqual( roundf( i ), i, 'returns '+i );
+	}
+	t.end();
+});
+
+tape( 'the function returns the correct result for large negative non-decimal values', function test( t ) {
+	var start = -8390000;
+	var end = -8388608;
+	var i;
+
+	for ( i = start; i < end; i++ ) {
+		t.strictEqual( roundf( i ), i, 'returns '+i );
+	}
+	t.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/roundf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/test/test.native.js
@@ -1,0 +1,106 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var NINF = require( '@stdlib/constants/float32/ninf' );
+var PINF = require( '@stdlib/constants/float32/pinf' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var roundf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( roundf instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof roundf, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function rounds a numeric value to the nearest integer', opts, function test( t ) {
+	t.strictEqual( roundf( -4.2 ), -4.0, 'equals -4' );
+	t.strictEqual( roundf( -4.5 ), -4.0, 'equals -4' );
+	t.strictEqual( roundf( -4.8 ), -5.0, 'equals -5' );
+	t.strictEqual( roundf( 4.2 ), 4.0, 'equals 4' );
+	t.strictEqual( roundf( 4.5 ), 5.0, 'equals 5' );
+	t.strictEqual( roundf( 9.99999 ), 10.0, 'equals 10' );
+	t.strictEqual( roundf( 9.5 ), 10.0, 'equals 10' );
+	t.strictEqual( roundf( 9.4 ), 9.0, 'equals 10' );
+	t.strictEqual( roundf( 0.0 ), 0.0, 'equals 0' );
+	t.strictEqual( roundf( 0.2 ), 0.0, 'equals 0' );
+	t.end();
+});
+
+tape( 'the function returns `-0` if provided `-0`', opts, function test( t ) {
+	var v = roundf( -0.0 );
+	t.strictEqual( isNegativeZerof( v ), true, 'returns -0' );
+	t.end();
+});
+
+tape( 'the function returns `NaN` if provided a `NaN`', opts, function test( t ) {
+	var v = roundf( NaN );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `+infinity` if provided a `+infinity`', opts, function test( t ) {
+	var v = roundf( PINF );
+	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.end();
+});
+
+tape( 'the function returns `-infinity` if provided a `-infinity`', opts, function test( t ) {
+	var v = roundf( NINF );
+	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.end();
+});
+
+tape( 'the function returns the correct result for large positive non-decimal values', opts, function test( t ) {
+	var start = 8388608;
+	var end = 8390000;
+	var i;
+
+	for ( i = start; i < end; i++ ) {
+		t.strictEqual( roundf( i ), i, 'returns '+i );
+	}
+	t.end();
+});
+
+tape( 'the function returns the correct result for large negative non-decimal values', opts, function test( t ) {
+	var start = -8390000;
+	var end = -8388608;
+	var i;
+
+	for ( i = start; i < end; i++ ) {
+		t.strictEqual( roundf( i ), i, 'returns '+i );
+	}
+	t.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/roundf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/test/test.native.js
@@ -45,7 +45,7 @@ tape( 'main export is a function', opts, function test( t ) {
 	t.end();
 });
 
-tape( 'the function rounds a numeric value to the nearest integer', opts, function test( t ) {
+tape( 'the function rounds a single-precision floating-point number to the nearest integer', opts, function test( t ) {
 	t.strictEqual( roundf( -4.2 ), -4.0, 'equals -4' );
 	t.strictEqual( roundf( -4.5 ), -4.0, 'equals -4' );
 	t.strictEqual( roundf( -4.8 ), -5.0, 'equals -5' );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds `math/base/special/roundf`, which would be the single-precision equivalent for [`math/base/special/round`](https://github.com/stdlib-js/stdlib/tree/19abe4839bccbe8b48fbe92f5fe9737f304a5cd9/lib/node_modules/@stdlib/math/base/special/round).

```c
float stdlib_base_roundf( const float x );
```

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves a part of #649.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

- I have emulated the logic of the `C` implementation of [`math/base/special/round`](https://github.com/stdlib-js/stdlib/tree/19abe4839bccbe8b48fbe92f5fe9737f304a5cd9/lib/node_modules/@stdlib/math/base/special/round) in the `javascript` implementation of `roundf` as well, rather than using a built-in function. I believe it would be great if we update `math/base/special/round` too, thus avoiding the built-in function. 
- I have used `8388608.0` as we're dealing with `float`, rather than `4503599627370496.0` as the extreme value.
- Coverage report:

<img width="1710" alt="Screenshot 2024-08-01 at 23 55 00" src="https://github.com/user-attachments/assets/945f6c32-dd1f-4992-b29c-ba8fabbbb6d4">

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
