### PR TITLE
feat: add `LL_D` in `math/base/napi/binary`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/napi/binary/README.md
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/README.md
@@ -555,6 +555,46 @@ The function accepts the following arguments:
 void stdlib_math_base_napi_ci_c( napi_env env, napi_callback_info info, stdlib_complex64_t (*fcn)( stdlib_complex64_t, int32_t ) );
 ```
 
+#### stdlib_math_base_napi_ll_d( env, info, fcn )
+
+Invokes a binary function accepting signed 64-bit integers and returning a double-precision floating-point number.
+
+```c
+#include <node_api.h>
+#include <stdint.h>
+
+// ...
+
+static double fcn( const int64_t x, const int64_t y ) {
+    // ...
+}
+
+// ...
+
+/**
+* Receives JavaScript callback invocation data.
+*
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @return       Node-API value
+*/
+napi_value addon( napi_env env, napi_callback_info info ) {
+    return stdlib_math_base_napi_ll_d( env, info, fcn );
+}
+
+// ...
+```
+
+The function accepts the following arguments:
+
+-   **env**: `[in] napi_env` environment under which the function is invoked.
+-   **info**: `[in] napi_callback_info` callback data.
+-   **fcn**: `[in] double (*fcn)( int64_t, int64_t )` binary function.
+
+```c
+void stdlib_math_base_napi_ll_d( napi_env env, napi_callback_info info, double (*fcn)( int64_t, int64_t ) );
+```
+
 #### STDLIB_MATH_BASE_NAPI_MODULE_DD_D( fcn )
 
 Macro for registering a Node-API module exporting an interface for invoking a binary function accepting and returning double-precision floating-point numbers.
@@ -894,6 +934,29 @@ STDLIB_MATH_BASE_NAPI_MODULE_CF_C( add );
 The macro expects the following arguments:
 
 -   **fcn**: `stdlib_complex64_t (*fcn)( stdlib_complex64_t, float )` binary function.
+
+When used, this macro should be used **instead of** `NAPI_MODULE`. The macro includes `NAPI_MODULE`, thus ensuring Node-API module registration.
+
+#### STDLIB_MATH_BASE_NAPI_MODULE_LL_D( fcn )
+
+Macro for registering a Node-API module exporting an interface for invoking a binary function accepting signed 64-bit integers and returning a double-precision floating-point number.
+
+```c
+#include <stdint.h>
+
+static double fcn( const int64_t x, const int64_t y ) {
+    // ...
+}
+
+// ...
+
+// Register a Node-API module:
+STDLIB_MATH_BASE_NAPI_MODULE_II_D( fcn );
+```
+
+The macro expects the following arguments:
+
+-   **fcn**: `double (*fcn)( int64_t, int64_t )` binary function.
 
 When used, this macro should be used **instead of** `NAPI_MODULE`. The macro includes `NAPI_MODULE`, thus ensuring Node-API module registration.
 

--- a/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary.h
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary.h
@@ -576,6 +576,8 @@
 * @param fcn   binary function
 *
 * @example
+* #include <stdint.h>
+*
 * static double fcn( const int_64 x, const int_64 y ) {
 *     // ...
 * }

--- a/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary.h
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary.h
@@ -570,6 +570,46 @@
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_cf_c_init )
 
+/**
+* Macro for registering a Node-API module exporting an interface invoking a binary function accepting signed 64-bit integers and returning a double-precision floating-point number.
+*
+* @param fcn   binary function
+*
+* @example
+* static double fcn( const int_64 x, const int_64 y ) {
+*     // ...
+* }
+*
+* // ...
+*
+* // Register a Node-API module:
+* STDLIB_MATH_BASE_NAPI_MODULE_LL_D( fcn );
+*/
+#define STDLIB_MATH_BASE_NAPI_MODULE_LL_D( fcn )                               \
+	static napi_value stdlib_math_base_napi_ll_d_wrapper(                      \
+		napi_env env,                                                          \
+		napi_callback_info info                                                \
+	) {                                                                        \
+		return stdlib_math_base_napi_ll_d( env, info, fcn );                   \
+	};                                                                         \
+	static napi_value stdlib_math_base_napi_ll_d_init(                         \
+		napi_env env,                                                          \
+		napi_value exports                                                     \
+	) {                                                                        \
+		napi_value fcn;                                                        \
+		napi_status status = napi_create_function(                             \
+			env,                                                               \
+			"exports",                                                         \
+			NAPI_AUTO_LENGTH,                                                  \
+			stdlib_math_base_napi_ll_d_wrapper,                                \
+			NULL,                                                              \
+			&fcn                                                               \
+		);                                                                     \
+		assert( status == napi_ok );                                           \
+		return fcn;                                                            \
+	};                                                                         \
+	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_ll_d_init )
+
 /*
 * If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
 */
@@ -636,6 +676,11 @@ napi_value stdlib_math_base_napi_zd_z( napi_env env, napi_callback_info info, st
 * Invokes a binary function accepting a single-precision complex floating-point number and a single-precision floating-point number and returning a single-precision complex floating-point number.
 */
 napi_value stdlib_math_base_napi_cf_c( napi_env env, napi_callback_info info, stdlib_complex64_t (*fcn)( stdlib_complex64_t, float ) );
+
+/**
+* Invokes a binary function accepting signed 64-bit integers and returning a double-precision floating-point number.
+*/
+napi_value stdlib_math_base_napi_ll_d( napi_env env, napi_callback_info info, double (*fcn)( int64_t, int64_t ) );
 
 #ifdef __cplusplus
 }

--- a/lib/node_modules/@stdlib/math/base/napi/binary/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/src/main.c
@@ -1185,3 +1185,65 @@ napi_value stdlib_math_base_napi_cf_c( napi_env env, napi_callback_info info, st
 
 	return obj;
 }
+
+/**
+* Invokes a binary function accepting signed 64-bit integers and returning a double-precision floating-point number.
+*
+* ## Notes
+*
+* -   This function expects that the callback `info` argument provides access to the following JavaScript arguments:
+*
+*     -   `x`: input value.
+*     -   `y`: input value.
+*
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @param fcn    binary function
+* @return       function return value as a Node-API double-precision floating-point number
+*/
+napi_value stdlib_math_base_napi_ll_d( napi_env env, napi_callback_info info, double (*fcn)( int64_t, int64_t ) ) {
+	napi_status status;
+
+	size_t argc = 2;
+	napi_value argv[ 2 ];
+	status = napi_get_cb_info( env, info, &argc, argv, NULL, NULL );
+	assert( status == napi_ok );
+
+	if ( argc < 2 ) {
+		status = napi_throw_error( env, NULL, "invalid invocation. Must provide two numbers." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	napi_valuetype vtype0;
+	status = napi_typeof( env, argv[ 0 ], &vtype0 );
+	assert( status == napi_ok );
+	if ( vtype0 != napi_number ) {
+		status = napi_throw_type_error( env, NULL, "invalid argument. First argument must be a number." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	napi_valuetype vtype1;
+	status = napi_typeof( env, argv[ 1 ], &vtype1 );
+	assert( status == napi_ok );
+	if ( vtype1 != napi_number ) {
+		status = napi_throw_type_error( env, NULL, "invalid argument. Second argument must be a number." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	int64_t x;
+	status = napi_get_value_int64( env, argv[ 0 ], &x );
+	assert( status == napi_ok );
+
+	int64_t y;
+	status = napi_get_value_int64( env, argv[ 1 ], &y );
+	assert( status == napi_ok );
+
+	napi_value v;
+	status = napi_create_double( env, fcn( x, y ), &v );
+	assert( status == napi_ok );
+
+	return v;
+}


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds the function `napi_value stdlib_math_base_napi_ll_d( napi_env env, napi_callback_info info, double (*fcn)( double, int64_t, int64_t ) )` in [`math/base/napi/binary`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/@stdlib/math/base/napi/binary).

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   is a pre-requisite for #2206.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
