### PR TITLE
feat: Add Rice Distribution Base Package

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/rice/Readme.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/rice/Readme.md
@@ -1,0 +1,72 @@
+# Rice Distribution
+
+This package implements the Rice distribution for the `@stdlib` library.
+
+## Overview
+
+The Rice distribution is a continuous probability distribution. This package provides the following primary functions:
+
+- **PDF (Probability Density Function)**
+- **CDF (Cumulative Distribution Function)**
+
+## Installation
+
+```bash
+npm install @stdlib/stats-base-dists-rice
+```
+
+## Usage
+
+### PDF
+
+The PDF function evaluates the probability density function for given `x`, `nu`, and `sigma`.
+
+#### Syntax
+
+```javascript
+var pdf = require('@stdlib/stats/base/dists/rice/pdf');
+
+pdf(x, nu, sigma);
+```
+
+#### Example
+
+```javascript
+var pdf = require('@stdlib/stats/base/dists/rice/pdf');
+
+var y = pdf(2, 1, 1);
+console.log(y);  // returns the PDF value at x=2 for nu=1 and sigma=1
+```
+
+### CDF
+
+The CDF function evaluates the cumulative distribution function for given `x`, `nu`, and `sigma`.
+
+#### Syntax
+
+```javascript
+var cdf = require('@stdlib/stats/base/dists/rice/cdf');
+
+cdf(x, nu, sigma);
+```
+
+#### Example
+
+```javascript
+var cdf = require('@stdlib/stats/base/dists/rice/cdf');
+
+var y = cdf(2, 1, 1);
+console.log(y);  // returns the CDF value at x=2 for nu=1 and sigma=1
+```
+
+## Testing
+
+To run the tests, use the following commands:
+
+```bash
+npm install
+npm test
+```
+
+
+

--- a/lib/node_modules/@stdlib/stats/base/dists/rice/lib/cdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rice/lib/cdf.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * Evaluates the cumulative distribution function (CDF) for a Rice distribution.
+ *
+ * @param {number} x - input value
+ * @param {number} nu - noncentrality parameter
+ * @param {number} sigma - scale parameter
+ * @returns {number} evaluated CDF
+ */
+function cdf(x, nu, sigma) {
+    if (sigma <= 0) {
+        throw new Error('Scale parameter `sigma` must be positive');
+    }
+    const z = x / sigma;
+    const bessel = require('@stdlib/math/base/special/besseli');
+    const normal = require('@stdlib/stats/base/dists/normal/cdf');
+    return normal.cdf(z, nu / sigma, 1) - Math.exp(-z * z / 2 - nu * nu / (2 * sigma * sigma)) * bessel(z * nu / sigma, 1);
+}
+
+module.exports = cdf;

--- a/lib/node_modules/@stdlib/stats/base/dists/rice/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rice/lib/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var pdf = require('./pdf');
+var cdf = require('./cdf');
+
+module.exports = {
+    pdf: pdf,
+    cdf: cdf
+};

--- a/lib/node_modules/@stdlib/stats/base/dists/rice/lib/pdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rice/lib/pdf.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * Evaluates the probability density function (PDF) for a Rice distribution.
+ *
+ * @param {number} x - input value
+ * @param {number} nu - noncentrality parameter
+ * @param {number} sigma - scale parameter
+ * @returns {number} evaluated PDF
+ */
+function pdf(x, nu, sigma) {
+    if (sigma <= 0) {
+        throw new Error('Scale parameter `sigma` must be positive');
+    }
+    const factor = x / (sigma * sigma);
+    const expFactor = Math.exp(-((x*x + nu*nu) / (2 * sigma * sigma)));
+    const bessel = require('@stdlib/math/base/special/bessel0');
+    return factor * expFactor * bessel(x * nu / (sigma * sigma));
+}
+
+module.exports = pdf;

--- a/lib/node_modules/@stdlib/stats/base/dists/rice/test/test.cdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rice/test/test.cdf.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var tape = require('tape');
+var cdf = require('./../lib/cdf');
+
+tape('CDF of Rice distribution', function (t) {
+    t.equal(cdf(2, 1, 1), /* expected value */);
+    t.end();
+});

--- a/lib/node_modules/@stdlib/stats/base/dists/rice/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rice/test/test.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var tape = require('tape');
+var rice = require('./../lib');
+
+tape('main export is an object', function (t) {
+    t.equal(typeof rice, 'object', 'main export is an object');
+    t.end();
+});

--- a/lib/node_modules/@stdlib/stats/base/dists/rice/test/test.pdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rice/test/test.pdf.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var tape = require('tape');
+var pdf = require('./../lib/pdf');
+
+tape('PDF of Rice distribution', function (t) {
+    t.equal(pdf(2, 1, 1), /* expected value */);
+    t.end();
+});


### PR DESCRIPTION
# Issue
- [Link to issue #178]

# Description
This pull request implements the base package for the Rice distribution in the `@stdlib/stats/base/dists/rice` namespace. The base package includes the essential functions such as the probability density function (PDF) and cumulative distribution function (CDF) for the Rice distribution. This serves as the foundational implementation, and additional functions will be added in subsequent PRs as per the guidelines.

## File Structure
```
@stdlib/
└── stats/
    └── base/
        └── dists/
            └── rice/
                ├── README.md
                ├── package.json
                ├── lib/
                │   ├── index.js
                │   ├── cdf.js
                │   └── pdf.js
                └── test/
                    ├── test.js
                    ├── test.cdf.js
                    └── test.pdf.js
```

## Checklist
- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

## Other Information
- Reference implementation from SciPy.
- Future enhancements will include additional functions like the quantile function, mean, and median.

## References
- [Rice Distribution on Wikipedia](https://en.wikipedia.org/wiki/Rice_distribution)
- [SciPy Documentation for Rice Distribution](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.rice.html)