### PR TITLE
docs: add missing `stdint` includes in examples in `math/base/napi/binary`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/napi/binary/README.md
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/README.md
@@ -621,6 +621,8 @@ When used, this macro should be used **instead of** `NAPI_MODULE`. The macro inc
 Macro for registering a Node-API module exporting an interface for invoking a binary function accepting and returning signed 32-bit integers.
 
 ```c
+#include <stdint.h>
+
 static int32_t add( const int32_t x, const int32_t y ) {
     return x + y;
 }
@@ -642,6 +644,8 @@ When used, this macro should be used **instead of** `NAPI_MODULE`. The macro inc
 Macro for registering a Node-API module exporting an interface for invoking a binary function accepting signed 32-bit integers and returning a double-precision floating-point number.
 
 ```c
+#include <stdint.h>
+
 static double add( const int32_t x, const int32_t y ) {
     return x + y;
 }

--- a/lib/node_modules/@stdlib/math/base/napi/binary/README.md
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/README.md
@@ -955,7 +955,7 @@ static double fcn( const int64_t x, const int64_t y ) {
 // ...
 
 // Register a Node-API module:
-STDLIB_MATH_BASE_NAPI_MODULE_II_D( fcn );
+STDLIB_MATH_BASE_NAPI_MODULE_LL_D( fcn );
 ```
 
 The macro expects the following arguments:

--- a/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary.h
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary.h
@@ -70,6 +70,8 @@
 * @param fcn   binary function
 *
 * @example
+* #include <stdint.h>
+*
 * static int_32 add( const int_32 x, const int_32 y ) {
 *     return x + y;
 * }
@@ -110,6 +112,8 @@
 * @param fcn   binary function
 *
 * @example
+* #include <stdint.h>
+*
 * static double add( const int_32 x, const int_32 y ) {
 *     return x + y;
 * }


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds missing `stdint` includes in examples in [`math/base/napi/binary`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/napi/binary).
-   addresses https://github.com/stdlib-js/stdlib/pull/2726#pullrequestreview-2213917275.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
