### PR TITLE
[RFC]: add @stdlib/fs/resolve-parent-paths-by

### DIFF
--- a/lib/node_modules/@stdlib/fs/resolve-parent-paths-by.js/README.md
+++ b/lib/node_modules/@stdlib/fs/resolve-parent-paths-by.js/README.md
@@ -1,0 +1,120 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# resolveParentPathsBy
+
+> Resolve paths from a set of paths by walking parent directories based on a predicate.
+
+## Overview
+
+The `resolveParentPathsBy` function resolves paths from a set of paths by walking parent directories according to a provided predicate. It supports both asynchronous and synchronous operations and allows specifying different modes of resolution.
+
+## Installation
+
+```bash
+npm install @stdlib/fs/resolve-parent-paths-by
+```
+
+## Usage
+
+```var resolveParentPathsBy = require('@stdlib/fs/resolve-parent-paths-by'); ```
+
+### Asynchronous API
+
+```resolveParentPathsBy(paths, options, callback);```
+
+### Example
+
+```
+var opts = {
+    dir: __dirname,
+    mode: 'first'
+};
+
+resolveParentPathsBy([ 'package.json', 'README.md' ], opts, function (error, paths) {
+    if (error) {
+        throw error;
+    }
+    console.log(paths);
+    // Output: ['...', '...']
+});
+```
+
+## Synchronous API
+```var paths = resolveParentPathsBy.sync(paths, options);```
+
+### Example
+
+```
+var opts = {
+    dir: __dirname,
+    mode: 'some'
+};
+
+var paths = resolveParentPathsBy.sync([ 'package.json', 'README.md' ], opts);
+console.log(paths);
+// Output: ['...', '...']
+```
+
+## Options 
+- dir: Base search directory. If not specified, the current working directory is used.
+- mode: Specifies how paths are resolved. Options include first, some, all, and each.
+
+## Notes
+
+- In some mode, the return order of resolved paths is not guaranteed.
+- This implementation performs a search by walking parent directories, which may involve filesystem access, unlike core path.resolve which performs string manipulation.
+
+## Examples
+
+```
+// Sync example
+var opts = {
+    dir: __dirname,
+    mode: 'first'
+};
+var paths = resolveParentPathsBy.sync([ 'package.json', 'README.md' ], opts);
+console.log(paths);
+// Output: ['...']
+
+// Async example
+resolveParentPathsBy([ 'package.json', 'README.md' ], opts, function (error, paths) {
+    if (error) {
+        throw error;
+    }
+    console.log(paths);
+});
+```
+
+## CLI
+### Usage
+
+``` resolve-parent-paths-by [options] <path> [<path>...]```
+
+### Options
+
+- `-h`, `--help`: Print help message.
+- `-V`, `--version`: Print the package version.
+- `--dir dir`: Base search directory.
+- `--mode mode`: Mode of operation.
+
+### Example
+
+```$ resolve-parent-paths-by package.json README.md```

--- a/lib/node_modules/@stdlib/fs/resolve-parent-paths-by.js/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/fs/resolve-parent-paths-by.js/benchmark/benchmark.js
@@ -1,0 +1,316 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var basename = require( 'path' ).basename;
+var bench = require( '@stdlib/bench' );
+var pkg = require( './../package.json' ).name;
+var resolveParentPaths = require( './../lib' );
+
+// MAIN //
+
+bench( pkg+':mode=first', function benchmark( b ) {
+    var PATHS;
+    var opts;
+    var i;
+
+    PATHS = [
+        [ 'package.json' ],
+        [ 'beep-boop!!!hello world!?!', 'package.json' ],
+        [ 'package.json', 'README.md' ]
+    ];
+    opts = {
+        'dir': __dirname,
+        'mode': 'first'
+    };
+
+    i = 0;
+    b.tic();
+
+    return next();
+
+    function next() {
+        i += 1;
+        if ( i <= b.iterations ) {
+            return resolveParentPaths( PATHS[ i % 3 ], opts, done );
+        }
+        b.toc();
+        b.pass( 'benchmark finished' );
+        b.end();
+    }
+
+    function done( error, paths ) {
+        if ( error ) {
+            b.fail( error.message );
+        }
+        if ( paths.length === 0 ) {
+            b.fail( 'should return a path' );
+        }
+        next();
+    }
+});
+
+bench( pkg+':mode=some', function benchmark( b ) {
+    var PATHS;
+    var opts;
+    var i;
+
+    PATHS = [
+        [ 'package.json' ],
+        [ 'beep-boop!!!hello world!?!', 'package.json' ],
+        [ 'package.json', 'README.md' ]
+    ];
+    opts = {
+        'dir': __dirname,
+        'mode': 'some'
+    };
+
+    i = 0;
+    b.tic();
+
+    return next();
+
+    function next() {
+        i += 1;
+        if ( i <= b.iterations ) {
+            return resolveParentPaths( PATHS[ i % 3 ], opts, done );
+        }
+        b.toc();
+        b.pass( 'benchmark finished' );
+        b.end();
+    }
+
+    function done( error, paths ) {
+        if ( error ) {
+            b.fail( error.message );
+        }
+        if ( paths.length === 0 ) {
+            b.fail( 'should return a path' );
+        }
+        next();
+    }
+});
+
+bench( pkg+':mode=all', function benchmark( b ) {
+    var PATHS;
+    var opts;
+    var i;
+
+    PATHS = [
+        [ 'package.json' ],
+        [ 'package.json', 'README.md' ]
+    ];
+    opts = {
+        'dir': __dirname,
+        'mode': 'all'
+    };
+
+    i = 0;
+    b.tic();
+
+    return next();
+
+    function next() {
+        i += 1;
+        if ( i <= b.iterations ) {
+            return resolveParentPaths( PATHS[ i % 2 ], opts, done );
+        }
+        b.toc();
+        b.pass( 'benchmark finished' );
+        b.end();
+    }
+
+    function done( error, paths ) {
+        if ( error ) {
+            b.fail( error.message );
+        }
+        if ( paths.length === 0 ) {
+            b.fail( 'should return a path' );
+        }
+        next();
+    }
+});
+
+bench( pkg+':mode=each', function benchmark( b ) {
+    var PATHS;
+    var opts;
+    var i;
+
+    PATHS = [
+        [ 'package.json' ],
+        [ 'beep-boop!!!hello world!?!', 'package.json' ],
+        [ basename( __dirname ), 'README.md' ],
+        [ 'README.md', 'package.json' ]
+    ];
+    opts = {
+        'dir': __dirname,
+        'mode': 'each'
+    };
+
+    i = 0;
+    b.tic();
+
+    return next();
+
+    function next() {
+        i += 1;
+        if ( i <= b.iterations ) {
+            return resolveParentPaths( PATHS[ i % 4 ], opts, done );
+        }
+        b.toc();
+        b.pass( 'benchmark finished' );
+        b.end();
+    }
+
+    function done( error, paths ) {
+        if ( error ) {
+            b.fail( error.message );
+        }
+        if ( paths.length === 0 ) {
+            b.fail( 'should return a path' );
+        }
+        next();
+    }
+});
+
+bench( pkg+':sync:mode=first', function benchmark( b ) {
+    var PATHS;
+    var paths;
+    var opts;
+    var i;
+
+    PATHS = [
+        [ 'package.json' ],
+        [ 'beep-boop!!!hello world!?!', 'package.json' ],
+        [ 'package.json', 'README.md' ]
+    ];
+    opts = {
+        'dir': __dirname,
+        'mode': 'first'
+    };
+
+    b.tic();
+    for ( i = 0; i < b.iterations; i++ ) {
+        paths = resolveParentPaths.sync( PATHS[ i % 3 ], opts );
+        if ( paths.length === 0 ) {
+            b.fail( 'should return a path' );
+        }
+    }
+    b.toc();
+    if ( paths.length === 0 ) {
+        b.fail( 'should return a path' );
+    }
+    b.pass( 'benchmark finished' );
+    b.end();
+});
+
+bench( pkg+':sync:mode=some', function benchmark( b ) {
+    var PATHS;
+    var paths;
+    var opts;
+    var i;
+
+    PATHS = [
+        [ 'package.json' ],
+        [ 'beep-boop!!!hello world!?!', 'package.json' ],
+        [ 'package.json', 'README.md' ]
+    ];
+    opts = {
+        'dir': __dirname,
+        'mode': 'some'
+    };
+
+    b.tic();
+    for ( i = 0; i < b.iterations; i++ ) {
+        paths = resolveParentPaths.sync( PATHS[ i % 3 ], opts );
+        if ( paths.length === 0 ) {
+            b.fail( 'should return a path' );
+        }
+    }
+    b.toc();
+    if ( paths.length === 0 ) {
+        b.fail( 'should return a path' );
+    }
+    b.pass( 'benchmark finished' );
+    b.end();
+});
+
+bench( pkg+':sync:mode=all', function benchmark( b ) {
+    var PATHS;
+    var paths;
+    var opts;
+    var i;
+
+    PATHS = [
+        [ 'package.json' ],
+        [ 'package.json', 'README.md' ]
+    ];
+    opts = {
+        'dir': __dirname,
+        'mode': 'all'
+    };
+
+    b.tic();
+    for ( i = 0; i < b.iterations; i++ ) {
+        paths = resolveParentPaths.sync( PATHS[ i % 2 ], opts );
+        if ( paths.length === 0 ) {
+            b.fail( 'should return a path' );
+        }
+    }
+    b.toc();
+    if ( paths.length === 0 ) {
+        b.fail( 'should return a path' );
+    }
+    b.pass( 'benchmark finished' );
+    b.end();
+});
+
+bench( pkg+':sync:mode=each', function benchmark( b ) {
+    var PATHS;
+    var paths;
+    var opts;
+    var i;
+
+    PATHS = [
+        [ 'package.json' ],
+        [ 'beep-boop!!!hello world!?!', 'package.json' ],
+        [ basename( __dirname ), 'README.md' ],
+        [ 'README.md', 'package.json' ]
+    ];
+    opts = {
+        'dir': __dirname,
+        'mode': 'each'
+    };
+
+    b.tic();
+    for ( i = 0; i < b.iterations; i++ ) {
+        paths = resolveParentPaths.sync( PATHS[ i % 4 ], opts );
+        if ( paths.length === 0 ) {
+            b.fail( 'should return a path' );
+        }
+    }
+    b.toc();
+    if ( paths.length === 0 ) {
+        b.fail( 'should return a path' );
+    }
+    b.pass( 'benchmark finished' );
+    b.end();
+});

--- a/lib/node_modules/@stdlib/fs/resolve-parent-paths-by.js/lib/index.js
+++ b/lib/node_modules/@stdlib/fs/resolve-parent-paths-by.js/lib/index.js
@@ -1,0 +1,71 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Resolve parent paths by predicate for multiple paths.
+*
+* @module @stdlib/fs/resolve-parent-paths-by
+*
+* @example
+* var resolveParentPathsBy = require( '@stdlib/fs/resolve-parent-paths-by' );
+*
+* function predicate( path ) {
+*     return true; // Example predicate
+* }
+*
+* var paths = [
+*     '/some/path/to/file1',
+*     '/another/path/to/file2'
+* ];
+*
+* var result = resolveParentPathsBy( paths, predicate, { mode: 'any' } );
+* console.log( result );
+*
+* @example
+* var resolveParentPathsBy = require( '@stdlib/fs/resolve-parent-paths-by' );
+*
+* function predicate( path ) {
+*     return true; // Example predicate
+* }
+*
+* var paths = [
+*     '/some/path/to/file1',
+*     '/another/path/to/file2'
+* ];
+*
+* var result = resolveParentPathsBy.sync( paths, predicate, { mode: 'all' } );
+* console.log( result );
+*/
+
+// MODULES //
+
+var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
+var main = require( './resolve-parent-paths-by.js' );
+var sync = require( './resolve-parent-paths-by.sync.js' );
+
+// MAIN //
+
+setReadOnly( main, 'sync', sync );
+
+// EXPORTS //
+
+module.exports = main;
+
+// exports: { "sync": "main.sync" }

--- a/lib/node_modules/@stdlib/fs/resolve-parent-paths-by.js/lib/main.js
+++ b/lib/node_modules/@stdlib/fs/resolve-parent-paths-by.js/lib/main.js
@@ -1,0 +1,437 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+import { resolve } from 'path';
+import { primitives as isStringArray } from '@stdlib/assert/is-string-array';
+import isArrayLikeObject from '@stdlib/assert/is-array-like-object';
+import isFunction from '@stdlib/assert/is-function';
+import cwd from '@stdlib/process/cwd';
+import exists from '@stdlib/fs/exists';
+import filled from '@stdlib/array/base/filled';
+import format from '@stdlib/string/format';
+import validate from './validate.js';
+
+
+// VARIABLES //
+
+var MODES = {
+    'first': first,
+    'some': some,
+    'all': all,
+    'each': each
+};
+
+
+// FUNCTIONS //
+
+/**
+* Asynchronously resolves the first path match from a set of paths by walking parent directories.
+*
+* @private
+* @param {Array<string>} paths - paths to resolve
+* @param {string} dir - base directory
+* @param {Function} predicate - function to test each resolved path
+* @param {Callback} done - callback to invoke after resolving paths
+* @returns {void}
+*/
+function first(paths, dir, predicate, done) {
+    var child;
+    var spath;
+    var idx;
+    var out;
+
+    out = [];
+
+    // Start at a base directory and continue moving up through each parent directory...
+    spath = resolve(dir, paths[0]);
+
+    idx = 1; // index of next path
+    exists(spath, onExists);
+
+    /**
+    * Callback invoked after checking for path existence.
+    *
+    * @private
+    * @param {(Error|null)} error - error object
+    * @param {boolean} bool - boolean indicating if a path exists
+    * @returns {void}
+    */
+    function onExists(error, bool) { // eslint-disable-line node/handle-callback-err
+        if (error) {
+            return done(error);
+        }
+        if (bool && predicate(spath)) {
+            out.push(spath);
+            return done(null, out);
+        }
+        // If we have traversed all paths at the current directory level, resolve parent directory...
+        if (idx === paths.length) {
+            // Resolve a parent directory:
+            child = dir;
+            dir = resolve(dir, '..');
+
+            // If we have already reached root, we cannot resolve any higher directories...
+            if (child === dir) {
+                return done(null, out);
+            }
+            idx = 0;
+        }
+        spath = resolve(dir, paths[idx]);
+        idx += 1;
+        exists(spath, onExists);
+    }
+}
+
+/**
+* Asynchronously resolves one or more paths from a set of paths at a directory level by walking parent directories.
+*
+* @private
+* @param {Array<string>} paths - paths to resolve
+* @param {string} dir - base directory
+* @param {Function} predicate - function to test each resolved path
+* @param {Callback} done - callback to invoke after resolving paths
+* @returns {void}
+*/
+function some(paths, dir, predicate, done) {
+    var child;
+    var spath;
+    var FLG;
+    var out;
+
+    FLG = 0; // initialize flag to track if we are done traversing a directory level
+    out = [];
+
+    // Start at a base directory and continue moving up through each parent directory...
+    return next(dir);
+
+    /**
+    * Resolves paths within a directory.
+    *
+    * @private
+    * @param {string} dir - directory to search
+    */
+    function next(dir) {
+        var i;
+        for (i = 0; i < paths.length; i++) {
+            spath = resolve(dir, paths[i]);
+            exists(spath, getCallback(spath));
+        }
+    }
+
+    /**
+    * Returns a callback to be invoked upon checking for path existence.
+    *
+    * @private
+    * @param {string} spath - resolved path
+    * @returns {Callback} callback
+    */
+    function getCallback(spath) {
+        return onExists;
+
+        /**
+        * Callback invoked after checking for path existence.
+        *
+        * @private
+        * @param {(Error|null)} error - error object
+        * @param {boolean} bool - boolean indicating if a path exists
+        * @returns {void}
+        */
+        function onExists(error, bool) { // eslint-disable-line node/handle-callback-err
+            if (error) {
+                return done(error);
+            }
+            if (bool && predicate(spath)) {
+                out.push(spath);
+            }
+            FLG += 1;
+            if (FLG === paths.length) {
+                // Check if we have resolved any paths...
+                if (out.length > 0) {
+                    return done(null, out);
+                }
+                // Resolve a parent directory:
+                child = dir;
+                dir = resolve(dir, '..');
+
+                // Reset flag:
+                FLG = 0;
+
+                // If we have already reached root, we cannot resolve any higher directories...
+                if (child === dir) {
+                    return done(null, out);
+                }
+                // Resolve paths at next directory level:
+                return next(dir);
+            }
+        }
+    }
+}
+
+/**
+* Asynchronously resolves all paths from a set of paths at a directory level by walking parent directories.
+*
+* @private
+* @param {Array<string>} paths - paths to resolve
+* @param {string} dir - base directory
+* @param {Function} predicate - function to test each resolved path
+* @param {Callback} done - callback to invoke after resolving paths
+* @returns {void}
+*/
+function all(paths, dir, predicate, done) {
+    var count;
+    var child;
+    var spath;
+    var FLG;
+    var out;
+
+    count = 0; // initialize counter to track if we are done resolving all paths
+    FLG = 0; // initialize flag to track if we are done traversing a directory level
+    out = filled(null, paths.length);
+
+    // Start at a base directory and continue moving up through each parent directory...
+    return next(dir);
+
+    /**
+    * Resolves paths within a directory.
+    *
+    * @private
+    * @param {string} dir - directory to search
+    */
+    function next(dir) {
+        var i;
+        for (i = 0; i < paths.length; i++) {
+            spath = resolve(dir, paths[i]);
+            exists(spath, getCallback(i, spath));
+        }
+    }
+
+    /**
+    * Returns a callback to be invoked upon checking for path existence.
+    *
+    * @private
+    * @param {NonNegativeInteger} idx - index
+    * @param {string} spath - resolved path
+    * @returns {Callback} callback
+    */
+    function getCallback(idx, spath) {
+        return onExists;
+
+        /**
+        * Callback invoked after checking for path existence.
+        *
+        * @private
+        * @param {(Error|null)} error - error object
+        * @param {boolean} bool - boolean indicating if a path exists
+        * @returns {void}
+        */
+        function onExists(error, bool) { // eslint-disable-line node/handle-callback-err
+            if (error) {
+                return done(error);
+            }
+            if (bool && predicate(spath)) {
+                out[idx] = spath;
+                count += 1;
+            }
+            FLG += 1;
+            if (FLG === paths.length) {
+                // Check if we have resolved all paths...
+                if (count === paths.length) {
+                    return done(null, out);
+                }
+                // Resolve a parent directory:
+                child = dir;
+                dir = resolve(dir, '..');
+
+                // Reset flag and buffers:
+                FLG = 0;
+                out = [];
+                count = 0;
+
+                // If we have already reached root, we cannot resolve any higher directories...
+                if (child === dir) {
+                    return done(null, out);
+                }
+                // Resolve paths at next directory level:
+                return next(dir);
+            }
+        }
+    }
+}
+
+/**
+* Asynchronously resolves each path from a set of paths by walking parent directories.
+*
+* @private
+* @param {Array<string>} paths - paths to resolve
+* @param {string} dir - base directory
+* @param {Function} predicate - function to test each resolved path
+* @param {Callback} done - callback to invoke after resolving paths
+* @returns {void}
+*/
+function each(paths, dir, predicate, done) {
+    var count;
+    var child;
+    var spath;
+    var out;
+    var i;
+
+    count = 0; // initialize counter to track if we are done resolving all paths
+    out = filled(null, paths.length);
+
+    // Start at a base directory and continue moving up through each parent directory...
+    for (i = 0; i < paths.length; i++) {
+        spath = resolve(dir, paths[i]);
+        exists(spath, getCallback(i, spath, dir));
+    }
+
+    /**
+    * Determines whether all paths have been resolved.
+    *
+    * @private
+    * @returns {void}
+    */
+    function next() {
+        count += 1;
+        if (count === paths.length) {
+            return done(null, out);
+        }
+    }
+
+    /**
+    * Returns a callback to be invoked upon checking for path existence.
+    *
+    * @private
+    * @param {NonNegativeInteger} idx - index
+    * @param {string} spath - resolved path
+    * @param {string} dir - base directory
+    * @returns {Callback} callback
+    */
+    function getCallback(idx, spath, dir) {
+        return onExists;
+
+        /**
+        * Callback invoked after checking for path existence.
+        *
+        * @private
+        * @param {(Error|null)} error - error object
+        * @param {boolean} bool - boolean indicating if a path exists
+        * @returns {void}
+        */
+        function onExists(error, bool) { // eslint-disable-line node/handle-callback-err
+            if (error) {
+                return done(error);
+            }
+            if (bool && predicate(spath)) {
+                out[idx] = spath;
+            } else {
+                // Resolve a parent directory:
+                child = dir;
+                dir = resolve(dir, '..');
+
+                // If we have already reached root, we cannot resolve any higher directories...
+                if (child === dir) {
+                    out[idx] = null;
+                } else {
+                    // Resolve path at next directory level:
+                    spath = resolve(dir, paths[idx]);
+                    exists(spath, getCallback(idx, spath, dir));
+                    return;
+                }
+            }
+            next();
+        }
+    }
+}
+
+
+// MAIN //
+
+/**
+* Asynchronously resolves paths from a set of paths by walking parent directories.
+*
+* @param {Array<string>} paths - paths to resolve
+* @param {Object} [options] - function options
+* @param {string} [options.dir] - base directory
+* @param {string} [options.mode] - mode of operation
+* @param {Function} [options.predicate] - function to test each resolved path
+* @param {Callback} clbk - callback to invoke after resolving paths
+* @throws {TypeError} first argument must be an array of strings
+* @throws {TypeError} callback argument must be a function
+* @throws {TypeError} options argument must be an object
+* @throws {TypeError} must provide valid options
+* @returns {void}
+*
+* @example
+* resolveParentPathsBy( [ 'package.json', 'package-lock.json' ], { predicate: (p) => p.includes('package') }, onPaths );
+*
+* function onPaths( error, paths ) {
+*     if ( error ) {
+*         throw error;
+*     }
+*     console.log( paths );
+* }
+*/
+function resolveParentPathsBy(paths, options, clbk) {
+    var opts;
+    var done;
+    var mode;
+    var dir;
+    var predicate;
+    var fcn;
+    var err;
+
+    if (!isStringArray(paths)) {
+        if (isArrayLikeObject(paths) && paths.length === 0) {
+            return [];
+        }
+        throw new TypeError(format('invalid argument. First argument must be an array of strings. Value: `%s`.', paths));
+    }
+    opts = {};
+    if (arguments.length > 2) {
+        done = clbk;
+        err = validate(opts, options);
+        if (err) {
+            throw err;
+        }
+        predicate = opts.predicate || function () { return true; };
+    } else {
+        done = options;
+        predicate = function () { return true; };
+    }
+    if (!isFunction(done)) {
+        throw new TypeError(format('invalid argument. Callback argument must be a function. Value: `%s`.', done));
+    }
+    if (opts.dir) {
+        dir = resolve(cwd(), opts.dir);
+    } else {
+        dir = cwd();
+    }
+    mode = opts.mode || 'all';
+
+    fcn = MODES[mode];
+    fcn(paths, dir, predicate, done);
+}
+
+
+// EXPORTS //
+
+export default resolveParentPathsBy;

--- a/lib/node_modules/@stdlib/fs/resolve-parent-paths-by.js/lib/sync.js
+++ b/lib/node_modules/@stdlib/fs/resolve-parent-paths-by.js/lib/sync.js
@@ -1,0 +1,238 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+import { resolve } from 'path';
+import { primitives as isStringArray } from '@stdlib/assert/is-string-array';
+import isArrayLikeObject from '@stdlib/assert/is-array-like-object';
+import cwd from '@stdlib/process/cwd';
+import { sync as exists } from '@stdlib/fs/exists';
+import filled from '@stdlib/array/base/filled';
+import format from '@stdlib/string/format';
+import validate from './validate.js';
+
+
+// VARIABLES //
+
+var MODES = {
+    'first': first,
+    'some': some,
+    'all': all,
+    'each': each
+};
+
+
+// FUNCTIONS //
+
+/**
+* Synchronously resolves the first path match from a set of paths by walking parent directories.
+*
+* @private
+* @param {Array<string>} paths - paths to resolve
+* @param {string} dir - base directory
+* @param {Function} predicate - function to test each resolved path
+* @returns {Array<string>} resolved paths
+*/
+function first(paths, dir, predicate) {
+    var child;
+    var spath;
+    var out;
+    var i;
+
+    // Start at a base directory and continue moving up through each parent directory...
+    out = [];
+    while (child !== dir) {
+        for (i = 0; i < paths.length; i++) {
+            spath = resolve(dir, paths[i]);
+            if (exists(spath) && predicate(spath)) {
+                out.push(spath);
+                return out;
+            }
+        }
+        child = dir;
+        dir = resolve(dir, '..');
+    }
+    return out;
+}
+
+/**
+* Synchronously resolves one or more paths from a set of paths at a directory level by walking parent directories.
+*
+* @private
+* @param {Array<string>} paths - paths to resolve
+* @param {string} dir - base directory
+* @param {Function} predicate - function to test each resolved path
+* @returns {Array<string>} resolved paths
+*/
+function some(paths, dir, predicate) {
+    var child;
+    var spath;
+    var out;
+    var i;
+
+    // Start at a base directory and continue moving up through each parent directory...
+    out = [];
+    while (child !== dir) {
+        for (i = 0; i < paths.length; i++) {
+            spath = resolve(dir, paths[i]);
+            if (exists(spath) && predicate(spath)) {
+                out.push(spath);
+            }
+        }
+        if (out.length > 0) {
+            return out;
+        }
+        child = dir;
+        dir = resolve(dir, '..');
+    }
+    return out;
+}
+
+/**
+* Synchronously resolves all paths from a set of paths at a directory level by walking parent directories.
+*
+* @private
+* @param {Array<string>} paths - paths to resolve
+* @param {string} dir - base directory
+* @param {Function} predicate - function to test each resolved path
+* @returns {Array<string>} resolved paths
+*/
+function all(paths, dir, predicate) {
+    var child;
+    var spath;
+    var out;
+    var i;
+
+    // Start at a base directory and continue moving up through each parent directory...
+    out = [];
+    while (child !== dir) {
+        for (i = 0; i < paths.length; i++) {
+            spath = resolve(dir, paths[i]);
+            if (exists(spath) && predicate(spath)) {
+                out.push(spath);
+            }
+        }
+        if (out.length === paths.length) {
+            return out;
+        }
+        out = [];
+        child = dir;
+        dir = resolve(dir, '..');
+    }
+    return out;
+}
+
+/**
+* Synchronously resolves each path from a set of paths by walking parent directories.
+*
+* @private
+* @param {Array<string>} paths - paths to resolve
+* @param {string} dir - base directory
+* @param {Function} predicate - function to test each resolved path
+* @returns {Array<string|null>} resolved paths
+*/
+function each(paths, dir, predicate) {
+    var count;
+    var child;
+    var spath;
+    var out;
+    var i;
+
+    count = 0;
+    out = filled(null, paths.length);
+
+    // Start at a base directory and continue moving up through each parent directory...
+    while (child !== dir) {
+        for (i = 0; i < paths.length; i++) {
+            if (out[i] !== null) {
+                continue;
+            }
+            spath = resolve(dir, paths[i]);
+            if (exists(spath) && predicate(spath)) {
+                out[i] = spath;
+                count += 1;
+            }
+        }
+        if (count === paths.length) {
+            break;
+        }
+        child = dir;
+        dir = resolve(dir, '..');
+    }
+    return out;
+}
+
+
+// MAIN //
+
+/**
+* Synchronously resolves paths from a set of paths by walking parent directories.
+*
+* @param {Array<string>} paths - paths to resolve
+* @param {Object} [options] - function options
+* @param {string} [options.dir] - base directory
+* @param {string} [options.mode='all'] - mode of operation
+* @param {Function} [options.predicate] - function to test each resolved path
+* @throws {TypeError} first argument must be an array of strings
+* @throws {TypeError} options argument must be an object
+* @throws {TypeError} must provide valid options
+* @returns {Array<string|null>} resolved paths
+*
+* @example
+* var paths = resolveParentPathsBySync( [ 'package.json', 'package-lock.json' ] );
+*/
+function resolveParentPathsBySync(paths, options) {
+    var opts;
+    var mode;
+    var dir;
+    var fcn;
+    var err;
+    var predicate;
+
+    if (!isStringArray(paths)) {
+        if (isArrayLikeObject(paths) && paths.length === 0) {
+            return [];
+        }
+        throw new TypeError(format('invalid argument. First argument must be an array of strings. Value: `%s`.', paths));
+    }
+    opts = {};
+    if (arguments.length > 1) {
+        err = validate(opts, options);
+        if (err) {
+            throw err;
+        }
+    }
+    if (opts.dir) {
+        dir = resolve(cwd(), opts.dir);
+    } else {
+        dir = cwd();
+    }
+    mode = opts.mode || 'all';
+    predicate = opts.predicate || function () { return true; };
+
+    fcn = MODES[mode];
+    return fcn(paths, dir, predicate);
+}
+
+
+// EXPORTS //
+
+export default resolveParentPathsBySync;

--- a/lib/node_modules/@stdlib/fs/resolve-parent-paths-by.js/lib/validate.js
+++ b/lib/node_modules/@stdlib/fs/resolve-parent-paths-by.js/lib/validate.js
@@ -1,0 +1,81 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isObject = require( '@stdlib/assert/is-plain-object' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
+var contains = require( '@stdlib/array/base/assert/contains' ).factory;
+var format = require( '@stdlib/string/format' );
+
+
+// VARIABLES //
+
+var isMode = contains( [ 'first', 'some', 'all', 'each' ] );
+
+
+// MAIN //
+
+/**
+* Validates function options.
+*
+* @private
+* @param {Object} opts - destination object
+* @param {Options} options - function options
+* @param {string} [options.dir] - base directory
+* @param {string} [options.mode] - operation mode
+* @returns {(Error|null)} error object or null
+*
+* @example
+* var opts = {};
+* var options = {
+*     'dir': '/foo/bar/baz',
+*     'mode': 'some'
+* };
+*
+* var err = validate( opts, options );
+* if ( err ) {
+*    throw err;
+* }
+*/
+function validate( opts, options ) {
+	if ( !isObject( options ) ) {
+		return new TypeError( format( 'invalid argument. Options argument must be an object. Value: `%s`.', options ) );
+	}
+	if ( hasOwnProp( options, 'dir' ) ) {
+		opts.dir = options.dir;
+		if ( !isString( opts.dir ) ) {
+			return new TypeError( format( 'invalid option. `%s` option must be a string. Option: `%s`.', 'dir', opts.dir ) );
+		}
+	}
+	if ( hasOwnProp( options, 'mode' ) ) {
+		opts.mode = options.mode;
+		if ( !isMode( opts.mode ) ) {
+			return new TypeError( format( 'invalid option. `%s` option must be a valid mode. Option: `%s`.', 'mode', opts.mode ) );
+		}
+	}
+	return null;
+}
+
+
+// EXPORTS //
+
+module.exports = validate;

--- a/lib/node_modules/@stdlib/fs/resolve-parent-paths-by.js/package.json
+++ b/lib/node_modules/@stdlib/fs/resolve-parent-paths-by.js/package.json
@@ -1,0 +1,86 @@
+{
+  "name": "@stdlib/fs/resolve-parent-paths-by",
+  "version": "1.0.0",
+  "description": "Resolve parent paths by predicate for multiple paths.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "bin": {
+    "resolve-parent-paths-by": "./bin/cli.js"
+  },
+  "main": "./lib/resolve-parent-paths-by.js",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./tests"
+  },
+  "types": "./docs/types",
+  "scripts": {
+    "test": "node tests/test-resolve-parent-paths-by.js",
+    "benchmark": "node benchmark/benchmark.js"
+  },
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {
+    "path": "^0.12.7",
+    "fs": "0.0.1-security"
+  },
+  "devDependencies": {
+    "benchmark": "^2.1.4"
+  },
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdfs",
+    "fs",
+    "resolve",
+    "parent",
+    "path",
+    "async",
+    "sync",
+    "file",
+    "directory",
+    "dir",
+    "find",
+    "up",
+    "findup",
+    "find-up",
+    "upsearch",
+    "search",
+    "lookup",
+    "look-up",
+    "locate",
+    "walk",
+    "filesystem"
+  ]
+}

--- a/lib/node_modules/@stdlib/fs/resolve-parent-paths-by.js/test/test.js
+++ b/lib/node_modules/@stdlib/fs/resolve-parent-paths-by.js/test/test.js
@@ -1,0 +1,60 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require('tape');
+var resolveParentPathsBy = require('./../lib');
+var sync = require('./../lib/sync').default;
+
+
+// TESTS //
+
+tape('main export is a function', function test(t) {
+    t.ok(typeof resolveParentPathsBy === 'function', 'main export is a function');
+    t.end();
+});
+
+tape('attached to the main export is a function to resolve paths synchronously', function test(t) {
+    t.equal(typeof resolveParentPathsBy.sync, 'function', 'has `sync` method');
+    t.end();
+});
+
+tape('sync method resolves paths correctly', function test(t) {
+    var opts = { dir: __dirname, mode: 'first' };
+    var paths = resolveParentPathsBy.sync([ 'package.json' ], opts);
+    
+    t.ok(Array.isArray(paths), 'returns an array');
+    t.ok(paths.length > 0, 'returns at least one path');
+    t.equal(typeof paths[0], 'string', 'paths are strings');
+    t.end();
+});
+
+tape('main export resolves paths correctly', function test(t) {
+    var opts = { dir: __dirname, mode: 'first' };
+
+    resolveParentPathsBy([ 'package.json' ], opts, function done(error, paths) {
+        t.error(error, 'does not throw error');
+        t.ok(Array.isArray(paths), 'returns an array');
+        t.ok(paths.length > 0, 'returns at least one path');
+        t.equal(typeof paths[0], 'string', 'paths are strings');
+        t.end();
+    });
+});

--- a/lib/node_modules/@stdlib/fs/resolve-parent-paths-by.js/test/test.main.js
+++ b/lib/node_modules/@stdlib/fs/resolve-parent-paths-by.js/test/test.main.js
@@ -1,0 +1,163 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var path = require('path');
+var tape = require('tape');
+var resolveParentPathsBy = require('./../lib/main.js').default; // Adjust path if needed
+var IS_BROWSER = require('@stdlib/assert/is-browser');
+var contains = require('@stdlib/assert/contains');
+var cwd = require('@stdlib/process/cwd');
+
+// VARIABLES //
+
+var opts = {
+    'skip': IS_BROWSER // Skip tests in the browser environment
+};
+
+// TESTS //
+
+tape('main export is a function', function test(t) {
+    t.ok(true, __filename);
+    t.strictEqual(typeof resolveParentPathsBy, 'function', 'main export is a function');
+    t.end();
+});
+
+tape('the function throws an error if provided an invalid `paths` argument', function test(t) {
+    var values = [
+        5,
+        NaN,
+        null,
+        undefined,
+        true,
+        {},
+        function noop() { },
+        'beep',
+        [1, 2]
+    ];
+
+    values.forEach(function (value) {
+        t.throws(badValue(value), TypeError, 'throws a type error when provided ' + value);
+    });
+
+    t.end();
+
+    function badValue(value) {
+        return function badValue() {
+            resolveParentPathsBy(value, {}, noop);
+        };
+    }
+});
+
+tape('the function throws an error if provided an invalid `options` argument', function test(t) {
+    var values = [
+        5,
+        NaN,
+        null,
+        undefined,
+        true,
+        [],
+        function noop() { },
+        'beep'
+    ];
+
+    values.forEach(function (value) {
+        t.throws(badValue(value), TypeError, 'throws a type error when provided ' + value);
+    });
+
+    t.end();
+
+    function badValue(value) {
+        return function badValue() {
+            resolveParentPathsBy(['foo'], value, noop);
+        };
+    }
+});
+
+tape('the function throws an error if provided an invalid callback', function test(t) {
+    var values = [
+        '5',
+        5,
+        NaN,
+        null,
+        undefined,
+        true,
+        [],
+        {}
+    ];
+
+    values.forEach(function (value) {
+        t.throws(badValue(value), TypeError, 'throws a type error when provided ' + value);
+    });
+
+    t.end();
+
+    function badValue(value) {
+        return function badValue() {
+            resolveParentPathsBy(['foo'], { mode: 'all' }, value);
+        };
+    }
+});
+
+tape('the function returns an empty array if no paths are resolved', function test(t) {
+    var expected = [];
+    resolveParentPathsBy(['nonexistent'], { mode: 'all' }, function onPaths(error, paths) {
+        t.error(error);
+        t.deepEqual(paths, expected, 'returns expected paths');
+        t.end();
+    });
+});
+
+tape('the function resolves paths using `first` mode', function test(t) {
+    var expected = [path.resolve(cwd(), 'package.json')];
+    resolveParentPathsBy(['package.json'], { mode: 'first' }, function onPaths(error, paths) {
+        t.error(error);
+        t.deepEqual(paths, expected, 'returns expected paths');
+        t.end();
+    });
+});
+
+tape('the function resolves paths using `some` mode', function test(t) {
+    var expected = [path.resolve(cwd(), 'package.json')];
+    resolveParentPathsBy(['package.json', 'nonexistent'], { mode: 'some' }, function onPaths(error, paths) {
+        t.error(error);
+        t.deepEqual(paths, expected, 'returns expected paths');
+        t.end();
+    });
+});
+
+tape('the function resolves paths using `all` mode', function test(t) {
+    var expected = [path.resolve(cwd(), 'package.json'), null];
+    resolveParentPathsBy(['package.json', 'nonexistent'], { mode: 'all' }, function onPaths(error, paths) {
+        t.error(error);
+        t.deepEqual(paths, expected, 'returns expected paths');
+        t.end();
+    });
+});
+
+tape('the function resolves paths using `each` mode', function test(t) {
+    var expected = [path.resolve(cwd(), 'package.json'), null];
+    resolveParentPathsBy(['package.json', 'nonexistent'], { mode: 'each' }, function onPaths(error, paths) {
+        t.error(error);
+        t.deepEqual(paths, expected, 'returns expected paths');
+        t.end();
+    });
+});

--- a/lib/node_modules/@stdlib/fs/resolve-parent-paths-by.js/test/test.sync.js
+++ b/lib/node_modules/@stdlib/fs/resolve-parent-paths-by.js/test/test.sync.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var tape = require('tape');
+var resolveParentPaths = require('./../lib/sync').default; // Adjust path as needed
+var fs = require('@stdlib/fs/exists');
+var path = require('path');
+
+// Mock the `exists` function
+fs.sync = function () { };
+
+tape('sync: should resolve paths using different modes', function test(t) {
+    var originalCwd = process.cwd;
+    process.cwd = () => '/base/dir';
+
+    t.test('mode "first"', function (st) {
+        fs.sync = (p) => p === path.resolve('/base/dir', 'package.json');
+
+        var result = resolveParentPaths(['package.json'], { mode: 'first' });
+
+        st.deepEqual(result, [path.resolve('/base/dir', 'package.json')], 'should resolve the first path');
+        st.end();
+    });
+
+    t.test('mode "some"', function (st) {
+        fs.sync = (p) => p === path.resolve('/base/dir', 'package.json');
+
+        var result = resolveParentPaths(['package.json'], { mode: 'some' });
+
+        st.deepEqual(result, [path.resolve('/base/dir', 'package.json')], 'should resolve some paths');
+        st.end();
+    });
+
+    t.test('mode "all"', function (st) {
+        fs.sync = (p) => p === path.resolve('/base/dir', 'package.json');
+
+        var result = resolveParentPaths(['package.json'], { mode: 'all' });
+
+        st.deepEqual(result, [path.resolve('/base/dir', 'package.json')], 'should resolve all paths');
+        st.end();
+    });
+
+    t.test('mode "each"', function (st) {
+        fs.sync = (p) => p === path.resolve('/base/dir', 'package.json');
+
+        var result = resolveParentPaths(['package.json'], { mode: 'each' });
+
+        st.deepEqual(result, [path.resolve('/base/dir', 'package.json')], 'should resolve each path');
+        st.end();
+    });
+
+    process.cwd = originalCwd;
+});

--- a/lib/node_modules/@stdlib/fs/resolve-parent-paths-by.js/test/test.validate.js
+++ b/lib/node_modules/@stdlib/fs/resolve-parent-paths-by.js/test/test.validate.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var tape = require('tape');
+var validate = require('./../lib/validate');
+
+tape('validate: should validate options object', function test(t) {
+    t.test('should return an error if options is not an object', function(st) {
+        var opts = {};
+        var options = 'invalid';
+        
+        var error = validate(opts, options);
+        
+        st.equal(error instanceof TypeError, true, 'should return a TypeError');
+        st.end();
+    });
+
+    t.test('should return an error if dir is not a string', function(st) {
+        var opts = {};
+        var options = { dir: 123 };
+        
+        var error = validate(opts, options);
+        
+        st.equal(error instanceof TypeError, true, 'should return a TypeError');
+        st.end();
+    });
+
+    t.test('should return an error if mode is not valid', function(st) {
+        var opts = {};
+        var options = { mode: 'invalid' };
+        
+        var error = validate(opts, options);
+        
+        st.equal(error instanceof TypeError, true, 'should return a TypeError');
+        st.end();
+    });
+
+    t.test('should correctly populate opts with valid options', function(st) {
+        var opts = {};
+        var options = { dir: '/some/path', mode: 'some' };
+        
+        var error = validate(opts, options);
+        
+        st.equal(error, null, 'should not return an error');
+        st.deepEqual(opts, { dir: '/some/path', mode: 'some' }, 'should correctly populate opts');
+        st.end();
+    });
+});


### PR DESCRIPTION
Resolves #2567

## Description

> What is the purpose of this pull request?

This RFC proposes adding @stdlib/fs/resolve-parent-paths-by similar to [@stdlib/fs/resolve-parent-path-by](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/fs/resolve-parent-path-by), which instead of a single path, accepts an array of paths and resolves according to the predicate.

This pull request:

-   {{TODO: add description describing what this pull request does}}

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #2567  

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [X] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
