### PR TITLE
docs: remove comments, set `isNegative` to `uint8_t` in `math/base/special/gammaln`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/gammaln/include/stdlib/math/base/special/gammaln.h
+++ b/lib/node_modules/@stdlib/math/base/special/gammaln/include/stdlib/math/base/special/gammaln.h
@@ -16,9 +16,6 @@
 * limitations under the License.
 */
 
-/**
-* Header file containing function declarations.
-*/
 #ifndef STDLIB_MATH_BASE_SPECIAL_GAMMALN_H
 #define STDLIB_MATH_BASE_SPECIAL_GAMMALN_H
 

--- a/lib/node_modules/@stdlib/math/base/special/gammaln/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/gammaln/src/main.c
@@ -403,7 +403,7 @@ static double polyval_w( const double x ) {
 * // returns 0.0
 */
 double stdlib_base_gammaln( const double x ) {
-	bool isNegative;
+	uint8_t isNegative;
 	int32_t flg;
 	double nadj;
 	double xc;
@@ -429,10 +429,10 @@ double stdlib_base_gammaln( const double x ) {
 	}
 	xc = x;
 	if ( xc < 0.0 ) {
-		isNegative = true;
+		isNegative = 1;
 		xc = -xc;
 	} else {
-		isNegative = false;
+		isNegative = 0;
 	}
 
 	// If |x| < 2**-56, return -ln(|x|)
@@ -483,7 +483,7 @@ double stdlib_base_gammaln( const double x ) {
 				flg = 2;
 			}
 		}
-		switch ( flg ) { // eslint-disable-line default-case
+		switch ( flg ) {
 		case 0:
 			z = y * y;
 			p1 = A1C + ( z * polyval_a1( z ) );
@@ -513,7 +513,7 @@ double stdlib_base_gammaln( const double x ) {
 		q = RC + ( y * polyval_r( y ) );
 		r = ( 0.5 * y ) + ( p / q );
 		z = 1.0; // gammaln(1+s) = ln(s) + gammaln(s)
-		switch ( flg ) { // eslint-disable-line default-case
+		switch ( flg ) {
 		case 7:
 			z *= y + 6.0;
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   removes eslint comments from `main.c`.
-   removes a comment from `gammaln.h`.
-   sets the type of `isNegative` to `uint8_t`.
-   addresses https://github.com/stdlib-js/stdlib/commit/d74581415b30604ce6db2b3a2c4f242040eb3e8e#r144990834, https://github.com/stdlib-js/stdlib/commit/d74581415b30604ce6db2b3a2c4f242040eb3e8e#r144990913 and https://github.com/stdlib-js/stdlib/commit/d74581415b30604ce6db2b3a2c4f242040eb3e8e#r144990932.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
