### PR TITLE
refactor: use `int64_t`, check last bit, cast to `double` in `math/base/special/binomcoef`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/binomcoef/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoef/benchmark/c/native/benchmark.c
@@ -91,8 +91,8 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double n;
-	double k;
+	int64_t n;
+	int64_t k;
 	double y;
 	double t;
 	int i;

--- a/lib/node_modules/@stdlib/math/base/special/binomcoef/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoef/manifest.json
@@ -41,7 +41,6 @@
         "@stdlib/math/base/napi/binary",
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/gcd",
-        "@stdlib/math/base/assert/is-odd",
         "@stdlib/constants/float64/pinf",
         "@stdlib//constants/float64/max-safe-integer"
       ]
@@ -61,7 +60,6 @@
       "dependencies": [
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/gcd",
-        "@stdlib/math/base/assert/is-odd",
         "@stdlib/constants/float64/pinf",
         "@stdlib//constants/float64/max-safe-integer"
       ]
@@ -81,7 +79,6 @@
       "dependencies": [
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/gcd",
-        "@stdlib/math/base/assert/is-odd",
         "@stdlib/constants/float64/pinf",
         "@stdlib//constants/float64/max-safe-integer"
       ]

--- a/lib/node_modules/@stdlib/math/base/special/binomcoef/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoef/src/main.c
@@ -19,7 +19,6 @@
 #include "stdlib/math/base/special/binomcoef.h"
 #include "stdlib/math/base/special/floor.h"
 #include "stdlib/math/base/special/gcd.h"
-#include "stdlib/math/base/assert/is_odd.h"
 #include "stdlib/constants/float64/pinf.h"
 #include "stdlib//constants/float64/max_safe_integer.h"
 #include <stdint.h>

--- a/lib/node_modules/@stdlib/math/base/special/binomcoef/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoef/src/main.c
@@ -53,7 +53,7 @@ double stdlib_base_binomcoef( const int64_t n, const int64_t k ) {
 	nc = n;
 	if ( nc < 0 ) {
 		nc = -nc + k - 1;
-		if ( stdlib_base_is_odd( (double)k ) ) {
+		if ( k & 1 ) {
 			sgn *= -1.0;
 		}
 	}
@@ -64,7 +64,7 @@ double stdlib_base_binomcoef( const int64_t n, const int64_t k ) {
 		return sgn;
 	}
 	if ( k == 1 || k == nc - 1 ) {
-		return sgn * nc;
+		return sgn * (double)nc;
 	}
 
 	// Minimize the number of computed terms by leveraging symmetry:


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   changes they type of `n` and `k` in `benchmark.c` to `int64_t`.
-   checks the last bit to check if `k` is odd.
-   casts `nc` to `double`.
-   addresses https://github.com/stdlib-js/stdlib/commit/06b80119890e1868578ba4904e9efaa071b27b05#r144990986, https://github.com/stdlib-js/stdlib/commit/06b80119890e1868578ba4904e9efaa071b27b05#r144991031 and https://github.com/stdlib-js/stdlib/commit/06b80119890e1868578ba4904e9efaa071b27b05#r144991056.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
