### PR TITLE
docs: fix incorrect package description in `string/left-trim-n`

### DIFF
--- a/lib/node_modules/@stdlib/string/README.md
+++ b/lib/node_modules/@stdlib/string/README.md
@@ -61,7 +61,7 @@ The namespace exposes the following string manipulation functions:
 -   <span class="signature">[`kebabcase( str )`][@stdlib/string/kebabcase]</span><span class="delimiter">: </span><span class="description">convert a string to kebab case.</span>
 -   <span class="signature">[`last( str[, n][, options] )`][@stdlib/string/last]</span><span class="delimiter">: </span><span class="description">return the last character(s) of a string.</span>
 -   <span class="signature">[`lpad( str, len[, pad] )`][@stdlib/string/left-pad]</span><span class="delimiter">: </span><span class="description">left pad a string.</span>
--   <span class="signature">[`ltrimN( str, n[, chars] )`][@stdlib/string/left-trim-n]</span><span class="delimiter">: </span><span class="description">trim `n` characters from the end of a string.</span>
+-   <span class="signature">[`ltrimN( str, n[, chars] )`][@stdlib/string/left-trim-n]</span><span class="delimiter">: </span><span class="description">trim `n` characters from the beginning of a string.</span>
 -   <span class="signature">[`ltrim( str )`][@stdlib/string/left-trim]</span><span class="delimiter">: </span><span class="description">trim whitespace characters from the beginning of a string.</span>
 -   <span class="signature">[`lowercase( str )`][@stdlib/string/lowercase]</span><span class="delimiter">: </span><span class="description">convert a string to lowercase.</span>
 -   <span class="signature">[`nextCodePointIndex( string[, fromIndex] )`][@stdlib/string/next-code-point-index]</span><span class="delimiter">: </span><span class="description">return the position of the next Unicode code point in a string after a specified position.</span>

--- a/lib/node_modules/@stdlib/string/README.md
+++ b/lib/node_modules/@stdlib/string/README.md
@@ -61,7 +61,7 @@ The namespace exposes the following string manipulation functions:
 -   <span class="signature">[`kebabcase( str )`][@stdlib/string/kebabcase]</span><span class="delimiter">: </span><span class="description">convert a string to kebab case.</span>
 -   <span class="signature">[`last( str[, n][, options] )`][@stdlib/string/last]</span><span class="delimiter">: </span><span class="description">return the last character(s) of a string.</span>
 -   <span class="signature">[`lpad( str, len[, pad] )`][@stdlib/string/left-pad]</span><span class="delimiter">: </span><span class="description">left pad a string.</span>
--   <span class="signature">[`ltrimN( str, n[, chars] )`][@stdlib/string/left-trim-n]</span><span class="delimiter">: </span><span class="description">trim `n` characters from the beginning of a string.</span>
+-   <span class="signature">[`ltrimN( str, n[, chars] )`][@stdlib/string/left-trim-n]</span><span class="delimiter">: </span><span class="description">trim `n` characters from the end of a string.</span>
 -   <span class="signature">[`ltrim( str )`][@stdlib/string/left-trim]</span><span class="delimiter">: </span><span class="description">trim whitespace characters from the beginning of a string.</span>
 -   <span class="signature">[`lowercase( str )`][@stdlib/string/lowercase]</span><span class="delimiter">: </span><span class="description">convert a string to lowercase.</span>
 -   <span class="signature">[`nextCodePointIndex( string[, fromIndex] )`][@stdlib/string/next-code-point-index]</span><span class="delimiter">: </span><span class="description">return the position of the next Unicode code point in a string after a specified position.</span>

--- a/lib/node_modules/@stdlib/string/left-trim-n/README.md
+++ b/lib/node_modules/@stdlib/string/left-trim-n/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # ltrimN
 
-> Trim `n` characters from the end of a string.
+> Trim `n` characters from the beginning of a string.
 
 <!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   fixes incorrect package description in `string/left-trim-n`


## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
