### PR TITLE
docs: update Twitter links

### DIFF
--- a/docs/links/database.json
+++ b/docs/links/database.json
@@ -10370,7 +10370,7 @@
       "nodejs"
     ]
   },
-  "https://twitter.com/stdlibjs": {
+  "https://x.com/stdlibjs": {
     "id": "stdlib-twitter",
     "description": "Twitter account for the stdlib standard library for JavaScript and Node.js.",
     "short_url": "",

--- a/docs/references/csl/ieee.csl
+++ b/docs/references/csl/ieee.csl
@@ -16,7 +16,7 @@
     </contributor>
     <contributor>
       <name>Rintze Zelle</name>
-      <uri>http://twitter.com/rintzezelle</uri>
+      <uri>http://x.com/rintzezelle</uri>
     </contributor>
     <contributor>
       <name>Stephen Frank</name>

--- a/etc/typedoc/index.md
+++ b/etc/typedoc/index.md
@@ -491,7 +491,7 @@ Copyright © 2016-2021. The Stdlib [Authors][stdlib-authors].
 
 [stdlib-code-coverage]: https://codecov.io/github/stdlib-js/stdlib/branch/develop
 
-[stdlib-twitter]: https://twitter.com/stdlibjs
+[stdlib-twitter]: https://x.com/stdlibjs
 
 [stdlib-gitter]: https://gitter.im/stdlib-js/stdlib
 

--- a/etc/typedoc/theme/layouts/default.hbs
+++ b/etc/typedoc/theme/layouts/default.hbs
@@ -29,7 +29,7 @@
     <meta property="og:locale" content="en_US">
     <meta property="og:image" content="">
 
-    <!-- Twitter -->
+    <!-- X -->
     <meta name="twitter:card" content="A standard library for JavaScript and Node.js.">
     <meta name="twitter:site" content="@stdlibjs">
     <meta name="twitter:url" content="https://stdlib.io/">

--- a/etc/typedoc/theme/partials/footer.hbs
+++ b/etc/typedoc/theme/partials/footer.hbs
@@ -67,7 +67,7 @@
         /
         <a href="https://gitter.im/stdlib-js/stdlib">Chat</a>
         /
-        <a href="https://twitter.com/stdlibjs">Twitter</a>
+        <a href="https://x.com/stdlibjs">X</a>
         /
         <a href="https://github.com/stdlib-js/stdlib">Contribute</a>
     </div>


### PR DESCRIPTION
This pull request:

 Updates all instances of twitter.com URLs to x.com throughout the codebase and documentation to reflect the rebranding of Twitter to X. This ensures consistency with the new brand identity and maintains accurate links.
Fix #2744.
-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
@stdlib-js/reviewers