### PR TITLE
feat: add `constants/float32/max-base2-exponent`

### DIFF
--- a/lib/node_modules/@stdlib/constants/float32/max-base2-exponent/README.md
+++ b/lib/node_modules/@stdlib/constants/float32/max-base2-exponent/README.md
@@ -1,0 +1,143 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# FLOAT32_MAX_BASE2_EXPONENT
+
+> The maximum biased base 2 exponent for a [single-precision floating-point number][ieee754].
+
+<section class="usage">
+
+## Usage
+
+<!-- eslint-disable id-length -->
+
+```javascript
+var FLOAT32_MAX_BASE2_EXPONENT = require( '@stdlib/constants/float32/max-base2-exponent' );
+```
+
+#### FLOAT32_MAX_BASE2_EXPONENT
+
+The maximum biased base 2 exponent for a [single-precision floating-point number][ieee754].
+
+<!-- eslint-disable id-length -->
+
+```javascript
+var bool = ( FLOAT32_MAX_BASE2_EXPONENT === 127 );
+// returns true
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+<!-- eslint-disable id-length -->
+
+```javascript
+var FLOAT32_MAX_BASE2_EXPONENT = require( '@stdlib/constants/float32/max-base2-exponent' );
+
+console.log( FLOAT32_MAX_BASE2_EXPONENT );
+// => 127
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/constants/float32/max_base2_exponent.h"
+```
+
+#### STDLIB_CONSTANT_FLOAT32_MAX_BASE2_EXPONENT
+
+Macro for the maximum biased base 2 exponent for a [single-precision floating-point number][ieee754].
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[ieee754]: https://en.wikipedia.org/wiki/IEEE_754-1985
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/constants/float32/max-base2-exponent/docs/repl.txt
+++ b/lib/node_modules/@stdlib/constants/float32/max-base2-exponent/docs/repl.txt
@@ -1,0 +1,13 @@
+
+{{alias}}
+    The maximum biased base 2 exponent for a single-precision floating-point
+    number.
+
+    Examples
+    --------
+    > {{alias}}
+    127
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/constants/float32/max-base2-exponent/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/constants/float32/max-base2-exponent/docs/types/index.d.ts
@@ -1,0 +1,33 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* The maximum biased base 2 exponent for a single-precision floating-point number.
+*
+* @example
+* var exp = FLOAT32_MAX_BASE2_EXPONENT;
+* // returns 127
+*/
+declare const FLOAT32_MAX_BASE2_EXPONENT: number;
+
+
+// EXPORTS //
+
+export = FLOAT32_MAX_BASE2_EXPONENT;

--- a/lib/node_modules/@stdlib/constants/float32/max-base2-exponent/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/constants/float32/max-base2-exponent/docs/types/test.ts
@@ -1,0 +1,28 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import FLOAT32_MAX_BASE2_EXPONENT = require( './index' );
+
+
+// TESTS //
+
+// The export is a number...
+{
+	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+	FLOAT32_MAX_BASE2_EXPONENT; // $ExpectType number
+}

--- a/lib/node_modules/@stdlib/constants/float32/max-base2-exponent/examples/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/max-base2-exponent/examples/index.js
@@ -1,0 +1,24 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var FLOAT32_MAX_BASE2_EXPONENT = require( './../lib' );
+
+console.log( FLOAT32_MAX_BASE2_EXPONENT );
+// => 127

--- a/lib/node_modules/@stdlib/constants/float32/max-base2-exponent/include/stdlib/constants/float64/max_base2_exponent.h
+++ b/lib/node_modules/@stdlib/constants/float32/max-base2-exponent/include/stdlib/constants/float64/max_base2_exponent.h
@@ -1,0 +1,27 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_CONSTANTS_FLOAT32_MAX_BASE2_EXPONENT_H
+#define STDLIB_CONSTANTS_FLOAT32_MAX_BASE2_EXPONENT_H
+
+/**
+* Macro for the maximum biased base 2 exponent for a single-precision floating-point number.
+*/
+#define STDLIB_CONSTANT_FLOAT32_MAX_BASE2_EXPONENT 127
+
+#endif // !STDLIB_CONSTANTS_FLOAT32_MAX_BASE2_EXPONENT_H

--- a/lib/node_modules/@stdlib/constants/float32/max-base2-exponent/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/max-base2-exponent/lib/index.js
@@ -1,0 +1,54 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* The maximum biased base 2 exponent for a single-precision floating-point number.
+*
+* @module @stdlib/constants/float32/max-base2-exponent
+* @type {integer32}
+*
+* @example
+* var FLOAT32_MAX_BASE2_EXPONENT = require( '@stdlib/constants/float32/max-base2-exponent' );
+* // returns 127
+*/
+
+
+// MAIN //
+
+/**
+* The maximum biased base 2 exponent for a single-precision floating-point number.
+*
+* ```text
+* 11111110 => 254 - BIAS = 127
+* ```
+*
+* where `BIAS = 127`.
+*
+* @constant
+* @type {integer32}
+* @default 127
+* @see [IEEE 754]{@link https://en.wikipedia.org/wiki/IEEE_754-1985}
+*/
+var FLOAT32_MAX_BASE2_EXPONENT = 127|0; // asm type annotation
+
+
+// EXPORTS //
+
+module.exports = FLOAT32_MAX_BASE2_EXPONENT;

--- a/lib/node_modules/@stdlib/constants/float32/max-base2-exponent/manifest.json
+++ b/lib/node_modules/@stdlib/constants/float32/max-base2-exponent/manifest.json
@@ -1,0 +1,36 @@
+{
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": []
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float32/max-base2-exponent/package.json
+++ b/lib/node_modules/@stdlib/constants/float32/max-base2-exponent/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@stdlib/constants/float32/max-base2-exponent",
+  "version": "0.0.0",
+  "description": "The maximum biased base 2 exponent for a single-precision floating-point number.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "constant",
+    "const",
+    "mathematics",
+    "math",
+    "single",
+    "flt",
+    "floating-point",
+    "float",
+    "ieee754",
+    "bias",
+    "exponent",
+    "max",
+    "maximum",
+    "binary",
+    "base 2"
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float32/max-base2-exponent/test/test.js
+++ b/lib/node_modules/@stdlib/constants/float32/max-base2-exponent/test/test.js
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var FLOAT32_MAX_BASE2_EXPONENT = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a number', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof FLOAT32_MAX_BASE2_EXPONENT, 'number', 'main export is a number' );
+	t.end();
+});
+
+tape( 'the exported value is 127', function test( t ) {
+	t.equal( FLOAT32_MAX_BASE2_EXPONENT, 127, 'equals 127' );
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds `constants/float32/max-base2-exponent`, which would be the single precision variant for [`constants/float64/max-base2-exponent`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/constants/float64/max-base2-exponent).
-   is a pre-requisite for the single-precision implementation of [`math/base/special/ldexp`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/ldexp).

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves a part of #649.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
