### PR TITLE
docs: update comment to use 8 bits in `constants/float32/max-base2-exponent-subnormal`

### DIFF
--- a/lib/node_modules/@stdlib/constants/float32/max-base2-exponent-subnormal/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/max-base2-exponent-subnormal/lib/index.js
@@ -36,7 +36,7 @@
 * The maximum biased base 2 exponent for a subnormal single-precision floating-point number.
 *
 * ```text
-* 00000000000 => 0 - BIAS = -127
+* 00000000 => 0 - BIAS = -127
 * ```
 *
 * where `BIAS = 127`.


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   addresses https://github.com/stdlib-js/stdlib/commit/130c7a5c01c584fd0b1f68d70f929a69de50456f#r145111707
-   updates the comment to use `8` bits instead of `11`.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
