### PR TITLE
fix: syntax-highlighter not updating if the input has no tokens in the REPL

### DIFF
--- a/lib/node_modules/@stdlib/repl/lib/syntax_highlighter.js
+++ b/lib/node_modules/@stdlib/repl/lib/syntax_highlighter.js
@@ -328,20 +328,20 @@ setNonEnumerableReadOnly( SyntaxHighlighter.prototype, 'onKeypress', function on
 	if ( this._line !== this._rli.line ) {
 		// Tokenize:
 		debug( 'Line change detected. Tokenizing line: %s', this._rli.line );
-		tokens = tokenizer( this._rli.line, this._repl._context );
+		this._line = this._rli.line; // update line buffer
+		tokens = tokenizer( this._line, this._repl._context );
 		if ( isEmptyArray( tokens ) ) {
 			debug( 'No tokens found. Skipping highlighting...' );
-			this._multilineHandler.updateLine( this._rli.line ); // save displayed line
-			return;
-		}
-		// Process tokens:
-		tokens.sort( tokenComparator );
-		tokens = removeDuplicateTokens( tokens );
+			this._highlightedLine = this._line;
+		} else {
+			// Process tokens:
+			tokens.sort( tokenComparator );
+			tokens = removeDuplicateTokens( tokens );
 
-		// Highlight:
-		debug( '%d tokens found. Highlighting...', tokens.length );
-		this._line = this._rli.line; // updated line buffer
-		this._highlightedLine = this._highlightLine( this._line, tokens );
+			// Highlight:
+			debug( '%d tokens found. Highlighting...', tokens.length );
+			this._highlightedLine = this._highlightLine( this._line, tokens );
+		}
 	}
 	// Replace:
 	debug( 'Replacing current line with the highlighted line...' );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   fixes a bug where the highlighted line stays partially highlighted even after the input line is no longer valid javascript.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
