### PR TITLE
bench: use `float` instead of `double` in benchmarks for `math/base/special/truncf`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/truncf/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/truncf/benchmark/c/benchmark.c
@@ -78,7 +78,7 @@ static double tic( void ) {
 *
 * @return random number
 */
-static float rand_double( void ) {
+static float rand_float( void ) {
 	int r = rand();
 	return (float)r / ( (float)RAND_MAX + 1.0f );
 }
@@ -97,7 +97,7 @@ static double benchmark( void ) {
 
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0f * rand_double() ) - 500.0f;
+		x = ( 1000.0f * rand_float() ) - 500.0f;
 		y = truncf( x );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );

--- a/lib/node_modules/@stdlib/math/base/special/truncf/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/truncf/benchmark/c/benchmark.c
@@ -78,9 +78,9 @@ static double tic( void ) {
 *
 * @return random number
 */
-static double rand_double( void ) {
+static float rand_double( void ) {
 	int r = rand();
-	return (double)r / ( (double)RAND_MAX + 1.0 );
+	return (float)r / ( (float)RAND_MAX + 1.0f );
 }
 
 /**
@@ -90,14 +90,14 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
-	double y;
 	double t;
+	float x;
+	float y;
 	int i;
 
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) - 500.0;
+		x = ( 1000.0f * rand_double() ) - 500.0f;
 		y = truncf( x );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );

--- a/lib/node_modules/@stdlib/math/base/special/truncf/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/truncf/benchmark/c/native/benchmark.c
@@ -79,9 +79,9 @@ static double tic( void ) {
 *
 * @return random number
 */
-static double rand_double( void ) {
+static float rand_float( void ) {
 	int r = rand();
-	return (double)r / ( (double)RAND_MAX + 1.0 );
+	return (float)r / ( (float)RAND_MAX + 1.0f );
 }
 
 /**
@@ -91,14 +91,14 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
-	double y;
 	double t;
+	float x;
+	float y;
 	int i;
 
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) - 500.0;
+		x = ( 1000.0f * rand_float() ) - 500.0f;
 		y = stdlib_base_truncf( x );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   replaces the use of `double` by `float` in `C` benchmarks, in [`math/base/special/truncf`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/truncf).

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
