### PR TITLE
bench: update sample value in `math/base/assert/is-integer`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/assert/is-integer/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-integer/benchmark/benchmark.js
@@ -57,7 +57,7 @@ bench( pkg+'::true', function benchmark( b ) {
 		-8,
 		-9,
 		-10,
-		1.0e308
+		-1.0e308
 	];
 
 	b.tic();

--- a/lib/node_modules/@stdlib/math/base/assert/is-integer/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-integer/benchmark/benchmark.native.js
@@ -66,7 +66,7 @@ bench( pkg+'::native,true', opts, function benchmark( b ) {
 		-8,
 		-9,
 		-10,
-		1.0e308
+		-1.0e308
 	];
 
 	b.tic();


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   updates a value in `JS` benchmarks from `1.0e308` to `-1.0e308`, as we already have `1.0e308` above that, in [`math/base/assert/is-integer`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/assert/is-integer).
-   Ref: https://github.com/stdlib-js/stdlib/blob/develop/lib/node_modules/%40stdlib/math/base/assert/is-integer/benchmark/benchmark.js#L60

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
