### PR TITLE
feat: add `F_I` in `math/base/napi/unary`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/napi/unary/README.md
+++ b/lib/node_modules/@stdlib/math/base/napi/unary/README.md
@@ -422,6 +422,46 @@ The function accepts the following arguments:
 void stdlib_math_base_napi_i_i( napi_env env, napi_callback_info info, double (*fcn)( int32_t ) );
 ```
 
+#### stdlib_math_base_napi_f_i( env, info, fcn )
+
+Invokes a unary function accepting a single-precision floating-point number and returning a signed 32-bit integer.
+
+```c
+#include <node_api.h>
+#include <stdint.h>
+
+// ...
+
+static int32_t fcn( const float x ) {
+    // ...
+}
+
+// ...
+
+/**
+* Receives JavaScript callback invocation data.
+*
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @return       Node-API value
+*/
+napi_value addon( napi_env env, napi_callback_info info ) {
+    return stdlib_math_base_napi_f_i( env, info, fcn );
+}
+
+// ...
+```
+
+The function accepts the following arguments:
+
+-   **env**: `[in] napi_env` environment under which the function is invoked.
+-   **info**: `[in] napi_callback_info` callback data.
+-   **fcn**: `[in] int32_t (*fcn)( float )` unary function.
+
+```c
+void stdlib_math_base_napi_f_i( napi_env env, napi_callback_info info, int32_t (*fcn)( float ) );
+```
+
 #### STDLIB_MATH_BASE_NAPI_MODULE_D_D( fcn )
 
 Macro for registering a Node-API module exporting an interface for invoking a unary function accepting and returning double-precision floating-point numbers.
@@ -617,6 +657,29 @@ STDLIB_MATH_BASE_NAPI_MODULE_I_D( scale );
 The macro expects the following arguments:
 
 -   **fcn**: `double (*fcn)( int32_t )` unary function.
+
+When used, this macro should be used **instead of** `NAPI_MODULE`. The macro includes `NAPI_MODULE`, thus ensuring Node-API module registration.
+
+#### STDLIB_MATH_BASE_NAPI_MODULE_F_I( fcn )
+
+Macro for registering a Node-API module exporting an interface for invoking a unary function accepting a single-precision floating-point number and returning a signed 32-bit integer.
+
+```c
+#include <stdint.h>
+
+static int32_t fcn( const float x ) {
+    // ...
+}
+
+// ...
+
+// Register a Node-API module:
+STDLIB_MATH_BASE_NAPI_MODULE_F_I( fcn );
+```
+
+The macro expects the following arguments:
+
+-   **fcn**: `int32_t (*fcn)( float )` unary function.
 
 When used, this macro should be used **instead of** `NAPI_MODULE`. The macro includes `NAPI_MODULE`, thus ensuring Node-API module registration.
 

--- a/lib/node_modules/@stdlib/math/base/napi/unary/include/stdlib/math/base/napi/unary.h
+++ b/lib/node_modules/@stdlib/math/base/napi/unary/include/stdlib/math/base/napi/unary.h
@@ -375,6 +375,48 @@
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_i_d_init )
 
+/**
+* Macro for registering a Node-API module exporting an interface invoking a unary function accepting a single-precision floating-point number and returning a signed 32-bit integer.
+*
+* @param fcn   unary function
+*
+* @example
+* #include <stdint.h>
+*
+* static int32_t fcn( const float x ) {
+*     // ...
+* }
+*
+* // ...
+*
+* // Register a Node-API module:
+* STDLIB_MATH_BASE_NAPI_MODULE_F_I( fcn );
+*/
+#define STDLIB_MATH_BASE_NAPI_MODULE_F_I( fcn )                                \
+	static napi_value stdlib_math_base_napi_f_i_wrapper(                       \
+		napi_env env,                                                          \
+		napi_callback_info info                                                \
+	) {                                                                        \
+		return stdlib_math_base_napi_f_i( env, info, fcn );                    \
+	};                                                                         \
+	static napi_value stdlib_math_base_napi_f_i_init(                          \
+		napi_env env,                                                          \
+		napi_value exports                                                     \
+	) {                                                                        \
+		napi_value fcn;                                                        \
+		napi_status status = napi_create_function(                             \
+			env,                                                               \
+			"exports",                                                         \
+			NAPI_AUTO_LENGTH,                                                  \
+			stdlib_math_base_napi_f_i_wrapper,                                 \
+			NULL,                                                              \
+			&fcn                                                               \
+		);                                                                     \
+		assert( status == napi_ok );                                           \
+		return fcn;                                                            \
+	};                                                                         \
+	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_f_i_init )
+
 /*
 * If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
 */
@@ -421,6 +463,11 @@ napi_value stdlib_math_base_napi_i_i( napi_env env, napi_callback_info info, int
 * Invokes a unary function accepting a signed 32-bit integer and returning a single-precision floating-point number.
 */
 napi_value stdlib_math_base_napi_i_d( napi_env env, napi_callback_info info, double (*fcn)( int32_t ) );
+
+/**
+* Invokes a unary function accepting a single-precision floating-point number and returning a signed 32-bit integer.
+*/
+napi_value stdlib_math_base_napi_f_i( napi_env env, napi_callback_info info, int32_t (*fcn)( float ) );
 
 #ifdef __cplusplus
 }

--- a/lib/node_modules/@stdlib/math/base/napi/unary/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/napi/unary/src/main.c
@@ -599,3 +599,51 @@ napi_value stdlib_math_base_napi_i_d( napi_env env, napi_callback_info info, dou
 
 	return v;
 }
+
+/**
+* Invokes a unary function accepting a single-precision floating-point number and returning a signed 32-bit integer.
+*
+* ## Notes
+*
+* -   This function expects that the callback `info` argument provides access to the following JavaScript arguments:
+*
+*     -   `x`: input value.
+*
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @param fcn    unary function
+* @return       function return value as a Node-API signed 32-bit integer
+*/
+napi_value stdlib_math_base_napi_f_i( napi_env env, napi_callback_info info, int32_t (*fcn)( float ) ) {
+	napi_status status;
+
+	size_t argc = 1;
+	napi_value argv[ 1 ];
+	status = napi_get_cb_info( env, info, &argc, argv, NULL, NULL );
+	assert( status == napi_ok );
+
+	if ( argc < 1 ) {
+		status = napi_throw_error( env, NULL, "invalid invocation. Must provide a number." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	napi_valuetype vtype0;
+	status = napi_typeof( env, argv[ 0 ], &vtype0 );
+	assert( status == napi_ok );
+	if ( vtype0 != napi_number ) {
+		status = napi_throw_type_error( env, NULL, "invalid argument. Must provide a number." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	double x;
+	status = napi_get_value_double( env, argv[ 0 ], &x );
+	assert( status == napi_ok );
+
+	napi_value v;
+	status = napi_create_int32( env, (int32_t)fcn( (float)x ), &v );
+	assert( status == napi_ok );
+
+	return v;
+}


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds the function `napi_value stdlib_math_base_napi_f_i( napi_env env, napi_callback_info info, int32_t (*fcn)( float ) )` in [`math/base/napi/unary`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/@stdlib/math/base/napi/unary).

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
