### PR TITLE
fix: handle edge cases in the tokenizer for syntax highlighting in the REPL

### DIFF
--- a/lib/node_modules/@stdlib/repl/lib/tokenizer.js
+++ b/lib/node_modules/@stdlib/repl/lib/tokenizer.js
@@ -103,7 +103,7 @@ function tokenizer( line, context ) {
 	*/
 	function onToken( token ) {
 		// Ignore placeholders & EOF tokens:
-		if ( token.start === token.end ) {
+		if ( token.start >= token.end ) {
 			return;
 		}
 		if ( token.type.isLoop || isControlKeyword( token.type.keyword ) || ( token.type.label === 'name' && isUnrecognizedControlKeyword( token.value ) ) ) {
@@ -196,7 +196,7 @@ function tokenizer( line, context ) {
 		var i;
 
 		// Ignore placeholder nodes:
-		if ( node.start === node.end ) {
+		if ( node.start >= node.end ) {
 			return true;
 		}
 		// Ignore node if it is an unrecognized `keyword`:
@@ -275,7 +275,7 @@ function tokenizer( line, context ) {
 		var obj;
 
 		// Ignore placeholder nodes:
-		if ( node.start === node.end ) {
+		if ( node.start >= node.end ) {
 			return;
 		}
 
@@ -308,7 +308,7 @@ function tokenizer( line, context ) {
 		property = properties.next();
 		while ( !property.done ) {
 			// Ignore placeholder nodes:
-			if ( property.value.start === property.value.end ) {
+			if ( property.value.start >= property.value.end ) {
 				return;
 			}
 			// Case: 'bar' in `foo['bar']` - property already pushed as a string token. Ignore...


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   fixes a weird edge case that I encountered where acorn was producing tokens with the start index greater than the end index, causing unwanted behavior.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
