### PR TITLE
docs: compare `n` with `integer`, not a `double` in `math/base/special/binomcoefln`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/binomcoefln/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoefln/src/main.c
@@ -35,7 +35,7 @@
 * // returns ~3.332
 */
 double stdlib_base_binomcoefln( const int64_t n, const int64_t k ) {
-	if ( n < 0.0 ) {
+	if ( n < 0 ) {
 		return stdlib_base_binomcoefln( -n + k - 1, k );
 	}
 	if ( k < 0 ) {


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   addresses https://github.com/stdlib-js/stdlib/commit/5b184b681a3d1d5c3fea30b9d8f4630c86eb44af#r145257914
-   as `n` is an integer, it should be compared with `0` instead of `0.0`.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
