### PR TITLE
bench: remove irrelevant benchmark, update `boost` link in `math/base/special/gamma-delta-ratio`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/benchmark/benchmark.native.js
@@ -22,7 +22,6 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var gamma = require( '@stdlib/math/base/special/gamma' );
 var randu = require( '@stdlib/random/base/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/benchmark/benchmark.native.js
@@ -61,26 +61,3 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	b.pass( 'benchmark finished' );
 	b.end();
 });
-
-bench( pkg+'::native,naive', function benchmark( b ) {
-	var delta;
-	var z;
-	var y;
-	var i;
-
-	b.tic();
-	for ( i = 0; i < b.iterations; i++ ) {
-		z = randu() * 100.0;
-		delta = randu() * 100.0;
-		y = gamma( z ) / gamma( z + delta );
-		if ( isnan( y ) ) {
-			b.fail( 'should not return NaN' );
-		}
-	}
-	b.toc();
-	if ( isnan( y ) ) {
-		b.fail( 'should not return NaN' );
-	}
-	b.pass( 'benchmark finished' );
-	b.end();
-});

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/lib/gamma_delta_ratio_lanczos.js
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/lib/gamma_delta_ratio_lanczos.js
@@ -18,7 +18,7 @@
 *
 * ## Notice
 *
-* The original C++ code and copyright notice are from the [Boost library]{@link http://www.boost.org/doc/libs/1_64_0/boost/math/special_functions/gamma.hpp}. The implementation has been modified for JavaScript.
+* The original C++ code and copyright notice are from the [Boost library]{@link http://www.boost.org/doc/libs/1_85_0/boost/math/special_functions/gamma.hpp}. The implementation has been modified for JavaScript.
 *
 * ```text
 * Copyright John Maddock 2006-7, 2013-14.


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   addresses https://github.com/stdlib-js/stdlib/commit/3985f47c6ec78cc644a98aa916740a1b2d37338f#r145257940 and https://github.com/stdlib-js/stdlib/commit/3985f47c6ec78cc644a98aa916740a1b2d37338f#r145257955
-   removes unrelated benchmark from `benchmark.native.js`
-   updates `boost` link in `gamma_delta_ratio_lanczos.js`.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
