### PR TITLE
docs: add comment, revert to previous tolerance in `math/base/special/factorialln`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/factorialln/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/factorialln/test/test.js
@@ -143,7 +143,7 @@ tape( 'the function evaluates the natural logarithm of the factorial of `x` (med
 			t.equal( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
 			delta = abs( y - expected[i] );
-			tol = 1.5 * EPS * abs( expected[i] );
+			tol = EPS * abs( expected[i] );
 			t.equal( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
 		}
 	}

--- a/lib/node_modules/@stdlib/math/base/special/factorialln/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/factorialln/test/test.native.js
@@ -152,6 +152,8 @@ tape( 'the function evaluates the natural logarithm of the factorial of `x` (med
 			t.equal( y, expected[i], 'x: '+x[i]+', y: '+y+', expected: '+expected[i] );
 		} else {
 			delta = abs( y - expected[i] );
+
+			// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2774#discussion_r1712904184
 			tol = 1.5 * EPS * abs( expected[i] );
 			t.equal( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. Δ: '+delta+'. Tolerance: '+tol+'.' );
 		}


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds a comment in `test.native.js` to explain the variation in tolerance levels among `C` and `JS` implementation tests.
-   reverts back to previous tolerance level in `test.js`.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
