### PR TITLE
feat: add `iter/cunone-by`

### DIFF
--- a/lib/node_modules/@stdlib/iter/cunone-by/README.md
+++ b/lib/node_modules/@stdlib/iter/cunone-by/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # iterCuNoneBy
 
-> Create an iterator which cumulatively tests whether no iterated value passes a test implemented by a predicate function.
+> Create an iterator which cumulatively tests whether every iterated value fails a test implemented by a predicate function.
 
 <!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
 
@@ -42,7 +42,7 @@ var iterCuNoneBy = require( '@stdlib/iter/cunone-by' );
 
 #### iterCuNoneBy( iterator, predicate\[, thisArg] )
 
-Returns an [iterator][mdn-iterator-protocol] which cumulatively tests whether no iterated value passes a test implemented by a predicate function.
+Returns an [iterator][mdn-iterator-protocol] which cumulatively tests whether every iterated value fails a test implemented by a predicate function.
 
 ```javascript
 var array2iterator = require( '@stdlib/array/to-iterator' );
@@ -79,36 +79,10 @@ The returned [iterator][mdn-iterator-protocol] protocol-compliant object has the
 -   **next**: function which returns an [iterator][mdn-iterator-protocol] protocol-compliant object containing the next iterated value (if one exists) assigned to a `value` property and a `done` property having a `boolean` value indicating whether the [iterator][mdn-iterator-protocol] is finished.
 -   **return**: function which closes an [iterator][mdn-iterator-protocol] and returns a single (optional) argument in an [iterator][mdn-iterator-protocol] protocol-compliant object.
 
-The `predicate` function is provided two arguments:
+A `predicate` function is provided two arguments:
 
--   `value`: iterated value
--   `index`: iteration index (zero-based)
-
-```javascript
-var array2iterator = require( '@stdlib/array/to-iterator' );
-
-function predicate( v, i ) {
-    return ( i >= 2 );
-}
-
-var it = iterCuNoneBy( array2iterator( [ 3, 4, 1, 2 ] ), predicate );
-// returns <Object>
-
-var v = it.next().value;
-// returns true
-
-v = it.next().value;
-// returns true
-
-v = it.next().value;
-// returns false
-
-v = it.next().value;
-// returns false
-
-var bool = it.next().done;
-// returns true
-```
+-   **value**: iterated value
+-   **index**: iteration index (zero-based)
 
 To set the `predicate` function execution context, provide a `thisArg`.
 
@@ -119,7 +93,7 @@ var array2iterator = require( '@stdlib/array/to-iterator' );
 
 function predicate( v ) {
     this.count += 1;
-    return ( v > 0 );
+    return ( v < 0 );
 }
 
 var ctx = {
@@ -130,16 +104,16 @@ var it = iterCuNoneBy( array2iterator( [ 1, 2, 3, 4 ] ), predicate, ctx );
 // returns <Object>
 
 var v = it.next().value;
-// returns false
+// returns true
 
 v = it.next().value;
-// returns false
+// returns true
 
 v = it.next().value;
-// returns false
+// returns true
 
 v = it.next().value;
-// returns false
+// returns true
 
 var count = ctx.count;
 // returns 4
@@ -152,14 +126,18 @@ var count = ctx.count;
 <!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 
 <section class="notes">
-   
+
+## Notes
+
+-   A `predicate` function is invoked for each iterated value until the first truthy `predicate` function return value. Upon encountering the first truthy return value, the returned iterator ceases to invoke the `predicate` function and returns `false` for each subsequent iterated value of the provided input `iterator`.
+
 </section>
 
 <!-- /.notes -->
 
 <!-- Package usage examples. -->
 
-<<section class="examples">
+<section class="examples">
 
 ## Examples
 
@@ -179,7 +157,7 @@ var opts = {
 };
 var riter = randu( opts );
 
-// Create an iterator which cumulatively tests whether no iterated value passes a test implemented by a predicate function
+// Create an iterator which cumulatively tests whether every iterated value fails a test:
 var it = iterCuNoneBy( riter, threshold );
 
 // Perform manual iteration...
@@ -191,7 +169,6 @@ while ( true ) {
     }
     console.log( r.value );
 }
-
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/iter/cunone-by/README.md
+++ b/lib/node_modules/@stdlib/iter/cunone-by/README.md
@@ -42,7 +42,7 @@ var iterCuNoneBy = require( '@stdlib/iter/cunone-by' );
 
 #### iterCuNoneBy( iterator, predicate\[, thisArg] )
 
-Returns an [iterator][mdn-iterator-protocol] which cumulatively tests whether every iterated value fails a test implemented by a predicate function.
+Returns an [iterator][mdn-iterator-protocol] which cumulatively tests whether every iterated value fails a test implemented by a `predicate` function.
 
 ```javascript
 var array2iterator = require( '@stdlib/array/to-iterator' );

--- a/lib/node_modules/@stdlib/iter/cunone-by/README.md
+++ b/lib/node_modules/@stdlib/iter/cunone-by/README.md
@@ -1,0 +1,225 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# iterCuNoneBy
+
+> Create an iterator which cumulatively tests whether no iterated value passes a test implemented by a predicate function.
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var iterCuNoneBy = require( '@stdlib/iter/cunone-by' );
+```
+
+#### iterCuNoneBy( iterator, predicate\[, thisArg] )
+
+Returns an [iterator][mdn-iterator-protocol] which cumulatively tests whether no iterated value passes a test implemented by a predicate function.
+
+```javascript
+var array2iterator = require( '@stdlib/array/to-iterator' );
+
+function predicate( v ) {
+    return ( v > 0 );
+}
+
+var arr = array2iterator( [ 0, 0, 0, 1, 0 ] );
+
+var it = iterCuNoneBy( arr, predicate );
+
+var v = it.next().value;
+// returns true
+
+v = it.next().value;
+// returns true
+
+v = it.next().value;
+// returns true
+
+v = it.next().value;
+// returns false
+
+v = it.next().value;
+// returns false
+
+var bool = it.next().done;
+// returns true
+```
+
+The returned [iterator][mdn-iterator-protocol] protocol-compliant object has the following properties:
+
+-   **next**: function which returns an [iterator][mdn-iterator-protocol] protocol-compliant object containing the next iterated value (if one exists) assigned to a `value` property and a `done` property having a `boolean` value indicating whether the [iterator][mdn-iterator-protocol] is finished.
+-   **return**: function which closes an [iterator][mdn-iterator-protocol] and returns a single (optional) argument in an [iterator][mdn-iterator-protocol] protocol-compliant object.
+
+The `predicate` function is provided two arguments:
+
+-   `value`: iterated value
+-   `index`: iteration index (zero-based)
+
+```javascript
+var array2iterator = require( '@stdlib/array/to-iterator' );
+
+function predicate( v, i ) {
+    return ( i >= 2 );
+}
+
+var it = iterCuNoneBy( array2iterator( [ 3, 4, 1, 2 ] ), predicate );
+// returns <Object>
+
+var v = it.next().value;
+// returns true
+
+v = it.next().value;
+// returns true
+
+v = it.next().value;
+// returns false
+
+v = it.next().value;
+// returns false
+
+var bool = it.next().done;
+// returns true
+```
+
+To set the `predicate` function execution context, provide a `thisArg`.
+
+<!-- eslint-disable no-invalid-this -->
+
+```javascript
+var array2iterator = require( '@stdlib/array/to-iterator' );
+
+function predicate( v ) {
+    this.count += 1;
+    return ( v > 0 );
+}
+
+var ctx = {
+    'count': 0
+};
+
+var it = iterCuNoneBy( array2iterator( [ 1, 2, 3, 4 ] ), predicate, ctx );
+// returns <Object>
+
+var v = it.next().value;
+// returns false
+
+v = it.next().value;
+// returns false
+
+v = it.next().value;
+// returns false
+
+v = it.next().value;
+// returns false
+
+var count = ctx.count;
+// returns 4
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+   
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
+<<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var randu = require( '@stdlib/random/iter/randu' );
+var iterCuNoneBy = require( '@stdlib/iter/cunone-by' );
+
+function threshold( r ) {
+    return ( r > 0.95 );
+}
+
+// Create an iterator which generates uniformly distributed pseudorandom numbers:
+var opts = {
+    'iter': 100
+};
+var riter = randu( opts );
+
+// Create an iterator which cumulatively tests whether no iterated value passes a test implemented by a predicate function
+var it = iterCuNoneBy( riter, threshold );
+
+// Perform manual iteration...
+var r;
+while ( true ) {
+    r = it.next();
+    if ( r.done ) {
+        break;
+    }
+    console.log( r.value );
+}
+
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+    
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[mdn-iterator-protocol]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#The_iterator_protocol
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/iter/cunone-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/cunone-by/benchmark/benchmark.js
@@ -1,0 +1,130 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var pkg = require( './../package.json' ).name;
+var iterCuNoneBy = require( './../lib' );
+
+
+// FUNCTIONS //
+
+function createIterator( arr ) {
+	var len;
+	var it;
+	var i;
+
+	len = arr.length;
+	i = -1;
+
+	it = {};
+	it.next = next;
+	it.reset = reset;
+
+	return it;
+
+	function next() {
+		i += 1;
+		if ( i < len ) {
+			return {
+				'value': arr[ i ],
+				'done': false
+			};
+		}
+		i = -1; // reset index
+		return {
+			'done': true
+		};
+	}
+
+	function reset() {
+		i = -1;
+	}
+}
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var iter;
+	var arr;
+	var i;
+
+	arr = createIterator( [ 0, 0, 0, 1, 1, 1 ] );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		iter = iterCuNoneBy( arr, predicate );
+		if ( typeof iter !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+		arr.reset();
+	}
+	b.toc();
+	if ( !isIteratorLike( iter ) ) {
+		b.fail( 'should return an iterator' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+
+	function predicate( v ) {
+		return ( v > 0 );
+	}
+});
+
+bench( pkg+'::loop', function benchmark( b ) {
+	var values;
+	var count;
+	var arr;
+	var i;
+	var j;
+
+	values = [ 0, 0, 0, 1, 1, 1 ];
+	arr = createIterator( values );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		count = 0;
+		for ( j = 0; j < values.length; j++ ) {
+			if ( predicate( arr.next().value ) ) {
+				count += 1;
+			}
+			if ( count >= 2 ) {
+				break;
+			}
+		}
+		if ( typeof count !== 'number' ) {
+			b.fail( 'should be a number' );
+		}
+		arr.reset();
+	}
+	b.toc();
+	if ( typeof count !== 'number' ) {
+		b.fail( 'should be a number' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+
+	function predicate( v ) {
+		return ( v > 0 );
+	}
+});

--- a/lib/node_modules/@stdlib/iter/cunone-by/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/iter/cunone-by/benchmark/benchmark.js
@@ -21,44 +21,24 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var iterConstant = require( '@stdlib/iter/constant' );
 var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var pkg = require( './../package.json' ).name;
 var iterCuNoneBy = require( './../lib' );
 
 
 // FUNCTIONS //
 
-function createIterator( arr ) {
-	var len;
-	var it;
-	var i;
-
-	len = arr.length;
-	i = -1;
-
-	it = {};
-	it.next = next;
-	it.reset = reset;
-
-	return it;
-
-	function next() {
-		i += 1;
-		if ( i < len ) {
-			return {
-				'value': arr[ i ],
-				'done': false
-			};
-		}
-		i = -1; // reset index
-		return {
-			'done': true
-		};
-	}
-
-	function reset() {
-		i = -1;
-	}
+/**
+* Predicate function.
+*
+* @private
+* @param {*} value - value
+* @returns {boolean} result
+*/
+function predicate( value ) {
+	return ( value < 0 );
 }
 
 
@@ -66,65 +46,44 @@ function createIterator( arr ) {
 
 bench( pkg, function benchmark( b ) {
 	var iter;
-	var arr;
+	var it;
 	var i;
 
-	arr = createIterator( [ 0, 0, 0, 1, 1, 1 ] );
+	it = iterConstant( 3.14 );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		iter = iterCuNoneBy( arr, predicate );
+		iter = iterCuNoneBy( it, predicate );
 		if ( typeof iter !== 'object' ) {
 			b.fail( 'should return an object' );
 		}
-		arr.reset();
 	}
 	b.toc();
 	if ( !isIteratorLike( iter ) ) {
-		b.fail( 'should return an iterator' );
+		b.fail( 'should return an iterator protocol-compliant object' );
 	}
 	b.pass( 'benchmark finished' );
 	b.end();
-
-	function predicate( v ) {
-		return ( v > 0 );
-	}
 });
 
-bench( pkg+'::loop', function benchmark( b ) {
-	var values;
-	var count;
-	var arr;
+bench( pkg+'::iteration', function benchmark( b ) {
+	var iter;
+	var v;
 	var i;
-	var j;
 
-	values = [ 0, 0, 0, 1, 1, 1 ];
-	arr = createIterator( values );
+	iter = iterCuNoneBy( iterConstant( 3.14 ), predicate );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		count = 0;
-		for ( j = 0; j < values.length; j++ ) {
-			if ( predicate( arr.next().value ) ) {
-				count += 1;
-			}
-			if ( count >= 2 ) {
-				break;
-			}
+		v = iter.next().value;
+		if ( !isBoolean( v ) ) {
+			b.fail( 'should return a boolean' );
 		}
-		if ( typeof count !== 'number' ) {
-			b.fail( 'should be a number' );
-		}
-		arr.reset();
 	}
 	b.toc();
-	if ( typeof count !== 'number' ) {
-		b.fail( 'should be a number' );
+	if ( !isBoolean( v ) ) {
+		b.fail( 'should return a boolean' );
 	}
 	b.pass( 'benchmark finished' );
 	b.end();
-
-	function predicate( v ) {
-		return ( v > 0 );
-	}
 });

--- a/lib/node_modules/@stdlib/iter/cunone-by/docs/repl.txt
+++ b/lib/node_modules/@stdlib/iter/cunone-by/docs/repl.txt
@@ -1,0 +1,58 @@
+
+{{alias}}( iterator, predicate[, thisArg] )
+    cumulatively tests whether no iterated value passes a test
+    implemented by a predicate function.
+
+    If an environment supports Symbol.iterator and a provided iterator is
+    iterable, the returned iterator is iterable.
+
+    The predicate function is provided two arguments:
+
+    - value: iterated value
+    - index: iteration index
+
+    If provided an iterator which does not return any iterated values,
+    the function returns an iterator which is also empty.
+
+    Parameters
+    ----------
+    iterator: Object
+        Input iterator.
+
+    predicate: Function
+        The test function.
+
+    thisArg: any (optional)
+        Execution context.
+
+    Returns
+    -------
+    iterator: Object
+        Iterator.
+
+    iterator.next(): Function
+        Returns an iterator protocol-compliant object containing the next
+        iterated value (if one exists) and a boolean flag indicating
+        whether the iterator is finished.
+
+    iterator.return( [value] ): Function
+        Finishes an iterator and returns a provided value.
+
+    Examples
+    --------
+    > var arr = {{alias:@stdlib/array/to-iterator}}( [ 0, 0, 0, 1, 0 ] );
+    > function fcn( v ) { return ( v > 0 ); };
+    > var it = {{alias}}( arr, fcn );
+    > var v = it.next().value
+    true
+    > v = it.next().value
+    true
+    > v = it.next().value
+    true
+    > v = it.next().value
+    false
+    > v = it.next().value
+    false
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/iter/cunone-by/docs/repl.txt
+++ b/lib/node_modules/@stdlib/iter/cunone-by/docs/repl.txt
@@ -1,7 +1,7 @@
 
 {{alias}}( iterator, predicate[, thisArg] )
-    cumulatively tests whether no iterated value passes a test
-    implemented by a predicate function.
+    Returns an iterator which cumulatively tests whether every iterated value
+    fails a test implemented by a predicate function.
 
     If an environment supports Symbol.iterator and a provided iterator is
     iterable, the returned iterator is iterable.
@@ -11,8 +11,14 @@
     - value: iterated value
     - index: iteration index
 
-    If provided an iterator which does not return any iterated values,
-    the function returns an iterator which is also empty.
+    A predicate function is invoked for each iterated value until the first
+    truthy predicate function return value. Upon encountering the first truthy
+    return value, the returned iterator ceases to invoke the predicate function
+    and returns `false` for each subsequent iterated value of the provided input
+    iterator.
+
+    If provided an iterator which does not return any iterated values, the
+    function returns an iterator which is also empty.
 
     Parameters
     ----------

--- a/lib/node_modules/@stdlib/iter/cunone-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/iter/cunone-by/docs/types/index.d.ts
@@ -89,7 +89,7 @@ type Predicate<T, U> = Nullary<U> | Unary<T, U> | Binary<T, U>;
 * v = it.next().value;
 * // returns false
 */
-declare function iterCuNoneBy<T, U>( iterator: Iterator<T>, predicate: Predicate<T, U>, thisArg?: ThisParameterType<Predicate<T, U>> ): Iterator<T>;
+declare function iterCuNoneBy<T, U>( iterator: Iterator<T>, predicate: Predicate<T, U>, thisArg?: ThisParameterType<Predicate<T, U>> ): Iterator<boolean>;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/iter/cunone-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/iter/cunone-by/docs/types/index.d.ts
@@ -1,0 +1,97 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { TypedIterator, TypedIterableIterator } from '@stdlib/types/iter';
+
+// Define a union type representing both iterable and non-iterable iterators:
+type Iterator<T> = TypedIterator<T> | TypedIterableIterator<T>;
+
+/**
+ * Checks whether an iterated value passes a test.
+ *
+ * @returns boolean indicating whether an iterated value passes a test
+ */
+type Nullary = () => boolean;
+
+/**
+ * Checks whether an iterated value passes a test.
+ *
+ * @param value - iterated value
+ * @returns boolean indicating whether an iterated value passes a test
+ */
+type Unary = ( value ) => boolean;
+
+/**
+ * Checks whether an iterated value passes a test.
+ *
+ * @param value - iterated value
+ * @param i - iteration index
+ * @returns boolean indicating whether an iterated value passes a test
+ */
+type Binary = ( value , i: number ) => boolean;
+
+/**
+ * Checks whether an iterated value passes a test.
+ *
+ * @param value - iterated value
+ * @param i - iteration index
+ * @returns boolean indicating whether an iterated value passes a test
+ */
+type Predicate = Nullary | Unary | Binary;
+
+/**
+ * Returns an iterator which cumulatively tests whether no iterated value passes a test implemented by a predicate function.
+ *
+ * @param iterator - source iterator
+ * @param predicate - predicate function
+ * @returns iterator
+ *
+ * @example
+ * var array2iterator = require( '@stdlib/array/to-iterator' );
+ *
+ * var it = iterCuNoneBy( array2iterator( [ 0, 0, 0, 1, 0 ] ), function( v ) { return (v > 0); } );
+ *
+ * var v = it.next().value;
+ * // returns true
+ *
+ * v = it.next().value;
+ * // returns true
+ *
+ * v = it.next().value;
+ * // returns true
+ *
+ * v = it.next().value;
+ * // returns false
+ *
+ * v = it.next().value;
+ * // returns false
+ */
+
+declare function iterCuNoneBy<T>(
+	iterator: Iterator<T>,
+	predicate: Predicate,
+	thisArg?
+): Iterator<T>;
+
+// EXPORTS //
+
+export = iterCuNoneBy ;

--- a/lib/node_modules/@stdlib/iter/cunone-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/iter/cunone-by/docs/types/index.d.ts
@@ -26,71 +26,71 @@ import { TypedIterator, TypedIterableIterator } from '@stdlib/types/iter';
 type Iterator<T> = TypedIterator<T> | TypedIterableIterator<T>;
 
 /**
- * Checks whether an iterated value passes a test.
- *
- * @returns boolean indicating whether an iterated value passes a test
- */
-type Nullary = () => boolean;
+* Checks whether an iterated value passes a test.
+*
+* @returns boolean indicating whether an iterated value passes a test
+*/
+type Nullary<U> = ( this: U ) => boolean;
 
 /**
- * Checks whether an iterated value passes a test.
- *
- * @param value - iterated value
- * @returns boolean indicating whether an iterated value passes a test
- */
-type Unary = ( value ) => boolean;
+* Checks whether an iterated value passes a test.
+*
+* @param value - iterated value
+* @returns boolean indicating whether an iterated value passes a test
+*/
+type Unary<T, U> = ( this: U, value: T ) => boolean;
 
 /**
- * Checks whether an iterated value passes a test.
- *
- * @param value - iterated value
- * @param i - iteration index
- * @returns boolean indicating whether an iterated value passes a test
- */
-type Binary = ( value , i: number ) => boolean;
+* Checks whether an iterated value passes a test.
+*
+* @param value - iterated value
+* @param index - iteration index
+* @returns boolean indicating whether an iterated value passes a test
+*/
+type Binary<T, U> = ( this: U, value: T, index: number ) => boolean;
 
 /**
- * Checks whether an iterated value passes a test.
- *
- * @param value - iterated value
- * @param i - iteration index
- * @returns boolean indicating whether an iterated value passes a test
- */
-type Predicate = Nullary | Unary | Binary;
+* Checks whether an iterated value passes a test.
+*
+* @param value - iterated value
+* @param index - iteration index
+* @returns boolean indicating whether an iterated value passes a test
+*/
+type Predicate<T, U> = Nullary<U> | Unary<T, U> | Binary<T, U>;
 
 /**
- * Returns an iterator which cumulatively tests whether no iterated value passes a test implemented by a predicate function.
- *
- * @param iterator - source iterator
- * @param predicate - predicate function
- * @returns iterator
- *
- * @example
- * var array2iterator = require( '@stdlib/array/to-iterator' );
- *
- * var it = iterCuNoneBy( array2iterator( [ 0, 0, 0, 1, 0 ] ), function( v ) { return (v > 0); } );
- *
- * var v = it.next().value;
- * // returns true
- *
- * v = it.next().value;
- * // returns true
- *
- * v = it.next().value;
- * // returns true
- *
- * v = it.next().value;
- * // returns false
- *
- * v = it.next().value;
- * // returns false
- */
+* Returns an iterator which cumulatively tests whether every iterated value fails a test implemented by a predicate function.
+*
+* @param iterator - source iterator
+* @param predicate - predicate function
+* @returns iterator
+*
+* @example
+* var array2iterator = require( '@stdlib/array/to-iterator' );
+*
+* function isPositive( v ) {
+*     return ( v > 0 );
+* }
+*
+* var it = iterCuNoneBy( array2iterator( [ 0, 0, 0, 1, 0 ] ), isPositive );
+*
+* var v = it.next().value;
+* // returns true
+*
+* v = it.next().value;
+* // returns true
+*
+* v = it.next().value;
+* // returns true
+*
+* v = it.next().value;
+* // returns false
+*
+* v = it.next().value;
+* // returns false
+*/
+declare function iterCuNoneBy<T, U>( iterator: Iterator<T>, predicate: Predicate<T, U>, thisArg?: ThisParameterType<Predicate<T, U>> ): Iterator<T>;
 
-declare function iterCuNoneBy<T>(
-	iterator: Iterator<T>,
-	predicate: Predicate,
-	thisArg?
-): Iterator<T>;
 
 // EXPORTS //
 

--- a/lib/node_modules/@stdlib/iter/cunone-by/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/iter/cunone-by/docs/types/test.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2019 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,63 +18,62 @@
 
 import { TypedIterator, TypedIteratorResult } from '@stdlib/types/iter';
 import iterCuNoneBy = require( './index' );
+
 /**
- * Returns an iterator protocol-compliant object.
- *
- * @returns iterator protocol-compliant object
- */
+* Implements the iterator protocol `next` method.
+*
+* @returns iterator protocol-compliant object
+*/
+function next(): TypedIteratorResult<number> {
+	return {
+		'value': 2.0,
+		'done': false
+	};
+}
 
-
-function iterator(): TypedIterator<boolean> {
-	/**
-	 * Implements the iterator protocol `next` method.
-	 *
-	 * @returns iterator protocol-compliant object
-	 */
-	function next(): TypedIteratorResult<boolean> {
-		return {
-			'value': true,
-			'done': false
-		};
-	}
-
+/**
+* Returns an iterator protocol-compliant object.
+*
+* @returns iterator protocol-compliant object
+*/
+function iterator(): TypedIterator<number> {
 	return {
 		'next': next
 	};
 }
 
 /**
- *
- * Predicate function.
- *
- * @param _v - iterated value
- * @param i - iteration index
- * @returns a boolean
- */
-function predicate1( _v , i: number ): boolean {
-	return i >= 10;
+* Predicate function.
+*
+* @param _v - iterated value
+* @param i - iteration index
+* @returns a boolean
+*/
+function predicate1( _v: any, i: number ): boolean {
+	return ( i > 10 );
 }
 
 /**
- * Predicate function.
- *
- * @param v - iterated value
- * @returns a boolean
- */
-function predicate2( v ): boolean {
-	return v !== v;
+* Predicate function.
+*
+* @param v - iterated value
+* @returns a boolean
+*/
+function predicate2( v: any ): boolean {
+	return ( v !== v );
 }
+
 
 // TESTS //
 
 // The function returns an iterator...
 {
-	iterCuNoneBy<boolean>( iterator(), predicate1 ); // $ExpectType Iterator<boolean>
-	iterCuNoneBy<boolean>( iterator(), predicate2 ); // $ExpectType Iterator<boolean>
-	iterCuNoneBy<boolean>( iterator(), predicate1, {} ); // $ExpectType Iterator<boolean>
-	iterCuNoneBy<boolean>( iterator(), predicate2, {} ); // $ExpectType Iterator<boolean>
-	iterCuNoneBy<boolean>( iterator(), predicate1, null ); // $ExpectType Iterator<boolean>
-	iterCuNoneBy<boolean>( iterator(), predicate2, null ); // $ExpectType Iterator<boolean>
+	iterCuNoneBy( iterator(), predicate1 ); // $ExpectType Iterator<boolean>
+	iterCuNoneBy( iterator(), predicate2 ); // $ExpectType Iterator<boolean>
+	iterCuNoneBy( iterator(), predicate1, {} ); // $ExpectType Iterator<boolean>
+	iterCuNoneBy( iterator(), predicate2, {} ); // $ExpectType Iterator<boolean>
+	iterCuNoneBy( iterator(), predicate1, null ); // $ExpectType Iterator<boolean>
+	iterCuNoneBy( iterator(), predicate2, null ); // $ExpectType Iterator<boolean>
 }
 
 // The compiler throws an error if the function is provided a first argument which is not an iterator protocol-compliant object...

--- a/lib/node_modules/@stdlib/iter/cunone-by/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/iter/cunone-by/docs/types/test.ts
@@ -1,0 +1,110 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2019 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { TypedIterator, TypedIteratorResult } from '@stdlib/types/iter';
+import iterCuNoneBy = require( './index' );
+/**
+ * Returns an iterator protocol-compliant object.
+ *
+ * @returns iterator protocol-compliant object
+ */
+
+
+function iterator(): TypedIterator<boolean> {
+	/**
+	 * Implements the iterator protocol `next` method.
+	 *
+	 * @returns iterator protocol-compliant object
+	 */
+	function next(): TypedIteratorResult<boolean> {
+		return {
+			'value': true,
+			'done': false
+		};
+	}
+
+	return {
+		'next': next
+	};
+}
+
+/**
+ *
+ * Predicate function.
+ *
+ * @param _v - iterated value
+ * @param i - iteration index
+ * @returns a boolean
+ */
+function predicate1( _v , i: number ): boolean {
+	return i >= 10;
+}
+
+/**
+ * Predicate function.
+ *
+ * @param v - iterated value
+ * @returns a boolean
+ */
+function predicate2( v ): boolean {
+	return v !== v;
+}
+
+// TESTS //
+
+// The function returns an iterator...
+{
+	iterCuNoneBy<boolean>( iterator(), predicate1 ); // $ExpectType Iterator<boolean>
+	iterCuNoneBy<boolean>( iterator(), predicate2 ); // $ExpectType Iterator<boolean>
+	iterCuNoneBy<boolean>( iterator(), predicate1, {} ); // $ExpectType Iterator<boolean>
+	iterCuNoneBy<boolean>( iterator(), predicate2, {} ); // $ExpectType Iterator<boolean>
+	iterCuNoneBy<boolean>( iterator(), predicate1, null ); // $ExpectType Iterator<boolean>
+	iterCuNoneBy<boolean>( iterator(), predicate2, null ); // $ExpectType Iterator<boolean>
+}
+
+// The compiler throws an error if the function is provided a first argument which is not an iterator protocol-compliant object...
+{
+	iterCuNoneBy( '5', predicate1 ); // $ExpectError
+	iterCuNoneBy( 5, predicate1 ); // $ExpectError
+	iterCuNoneBy( true, predicate1 ); // $ExpectError
+	iterCuNoneBy( false, predicate1 ); // $ExpectError
+	iterCuNoneBy( null, predicate1 ); // $ExpectError
+	iterCuNoneBy( undefined, predicate1 ); // $ExpectError
+	iterCuNoneBy( [], predicate1 ); // $ExpectError
+	iterCuNoneBy( {}, predicate1 ); // $ExpectError
+	iterCuNoneBy( ( x: number ): number => x, predicate1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument which is not a predicate function...
+{
+	iterCuNoneBy( iterator(), '5' ); // $ExpectError
+	iterCuNoneBy( iterator(), 5 ); // $ExpectError
+	iterCuNoneBy( iterator(), true ); // $ExpectError
+	iterCuNoneBy( iterator(), false ); // $ExpectError
+	iterCuNoneBy( iterator(), null ); // $ExpectError
+	iterCuNoneBy( iterator(), undefined ); // $ExpectError
+	iterCuNoneBy( iterator(), [] ); // $ExpectError
+	iterCuNoneBy( iterator(), {} ); // $ExpectError
+	iterCuNoneBy( iterator(), ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided insufficient arguments...
+{
+	iterCuNoneBy(); // $ExpectError
+	iterCuNoneBy( iterator() ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/iter/cunone-by/examples/index.js
+++ b/lib/node_modules/@stdlib/iter/cunone-by/examples/index.js
@@ -1,0 +1,45 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var randu = require( '@stdlib/random/iter/randu' );
+var iterCuNoneBy = require( './../lib' );
+
+function threshold( r ) {
+	return ( r > 0.95 );
+}
+
+// Create an iterator which generates uniformly distributed pseudorandom numbers:
+var opts = {
+	'iter': 100
+};
+var riter = randu( opts );
+
+// Create an iterator which cumulatively tests whether no iterated value passes a test implemented by a predicate function
+var it = iterCuNoneBy( riter, threshold );
+
+// Perform manual iteration...
+var r;
+while ( true ) {
+	r = it.next();
+	if ( r.done ) {
+		break;
+	}
+	console.log( r.value );
+}

--- a/lib/node_modules/@stdlib/iter/cunone-by/examples/index.js
+++ b/lib/node_modules/@stdlib/iter/cunone-by/examples/index.js
@@ -31,7 +31,7 @@ var opts = {
 };
 var riter = randu( opts );
 
-// Create an iterator which cumulatively tests whether no iterated value passes a test implemented by a predicate function
+// Create an iterator which cumulatively tests whether every iterated value fails a test:
 var it = iterCuNoneBy( riter, threshold );
 
 // Perform manual iteration...

--- a/lib/node_modules/@stdlib/iter/cunone-by/lib/index.js
+++ b/lib/node_modules/@stdlib/iter/cunone-by/lib/index.js
@@ -1,0 +1,65 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Create an iterator which cumulatively tests whether no iterated value passes a test implemented by a predicate function.
+
+*
+* @module @stdlib/iter/cunone-by
+*
+* @example
+* var array2iterator = require( '@stdlib/array/to-iterator' );
+* var iterCuNoneBy = require( '@stdlib/iter/cunone-by' );
+*
+* function isPositive( value ) {
+*     return (value > 0)
+*
+* var arr = array2iterator( [ 0, 0, 0, 1, 0 ] );
+*
+* var it = iterCuNoneBy( arr, isPositive );
+*
+* var v = it.next().value;
+* // returns true
+*
+* v = it.next().value;
+* // returns true
+*
+* v = it.next().value;
+* // returns true
+*
+* v = it.next().value;
+* // returns false
+*
+* v = it.next().value;
+* // returns false
+*
+* var bool = it.next().done;
+* // returns true
+*/
+
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/iter/cunone-by/lib/index.js
+++ b/lib/node_modules/@stdlib/iter/cunone-by/lib/index.js
@@ -19,8 +19,7 @@
 'use strict';
 
 /**
-* Create an iterator which cumulatively tests whether no iterated value passes a test implemented by a predicate function.
-
+* Create an iterator which cumulatively tests whether every iterated value fails a test implemented by a predicate function.
 *
 * @module @stdlib/iter/cunone-by
 *
@@ -29,7 +28,8 @@
 * var iterCuNoneBy = require( '@stdlib/iter/cunone-by' );
 *
 * function isPositive( value ) {
-*     return (value > 0)
+*     return ( value > 0 );
+* }
 *
 * var arr = array2iterator( [ 0, 0, 0, 1, 0 ] );
 *

--- a/lib/node_modules/@stdlib/iter/cunone-by/lib/main.js
+++ b/lib/node_modules/@stdlib/iter/cunone-by/lib/main.js
@@ -1,0 +1,161 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var isIteratorLike = require( '@stdlib/assert/is-iterator-like' );
+var iteratorSymbol = require( '@stdlib/symbol/iterator' );
+var format = require( '@stdlib/string/format' );
+
+
+// MAIN //
+
+/**
+* Returns an iterator which cumulatively tests whether no iterated value passes a test implemented by a predicate functionwhich cumulatively tests whether no iterated value passes a test implemented by a predicate function.
+*
+* @param {Iterator} iterator - input iterator
+* @param {Function} predicate - predicate function
+* @param {*} [thisArg] - execution context
+* @throws {TypeError} first argument must be an iterator
+* @throws {TypeError} second argument must be a predicate function
+* @returns {Iterator} iterator
+*
+* @example
+* var array2iterator = require( '@stdlib/array/to-iterator' );
+*
+* function isPositive( value ) {
+*     return (value > 0)
+* }
+*
+* var arr = array2iterator( [ 0, 0, 0, 1, 0 ] );
+*
+* var it = iterCuNoneBy( arr, isPositive );
+*
+* var v = it.next().value;
+* // returns true
+*
+* v = it.next().value;
+* // returns true
+*
+* v = it.next().value;
+* // returns true
+*
+* v = it.next().value;
+* // returns false
+*
+* v = it.next().value;
+* // returns false
+*
+* var bool = it.next().done;
+* // returns true
+*/
+function iterCuNoneBy( iterator, predicate, thisArg) {
+	var hasAnyTestPassed;
+	var iter;
+	var FLG;
+	var i;
+	if ( !isIteratorLike( iterator ) ) {
+		throw new TypeError( format( 'invalid argument. First argument must be an iterator. Value: `%s`.', iterator ) );
+	}
+	if ( !isFunction( predicate ) ) {
+		throw new TypeError( format( 'invalid argument. Second argument must be a function. Value: `%s`.', predicate ) );
+	}
+	i = -1;
+	hasAnyTestPassed=false;
+
+	// Create an iterator protocol-compliant object:
+	iter = {};
+	setReadOnly( iter, 'next', next );
+	setReadOnly( iter, 'return', end );
+
+	// If an environment supports `Symbol.iterator`, make the iterator iterable:
+	if ( iteratorSymbol && isFunction( iterator[ iteratorSymbol ] ) ) {
+		setReadOnly( iter, iteratorSymbol, factory );
+	}
+
+	return iter;
+
+	/**
+	* Returns an iterator protocol-compliant object containing the next iterated value.
+	*
+	* @private
+	* @returns {Object} iterator protocol-compliant object
+	*/
+	function next() {
+		var v;
+		if ( FLG ) {
+			return {
+				'done': true
+			};
+		}
+		while ( true ) {
+			v = iterator.next();
+			i += 1;
+			if ( v.done ) {
+				FLG = true;
+				return v;
+			}
+			if ( predicate.call( thisArg, v.value, i ) ) {
+				hasAnyTestPassed = true;
+			}
+			return {
+				'value': !hasAnyTestPassed,
+				'done': false
+			};
+		}
+	}
+
+	/**
+	* Finishes an iterator.
+	*
+	* @private
+	* @param {*} [value] - value to return
+	* @returns {Object} iterator protocol-compliant object
+	*/
+	function end( value ) {
+		FLG = true;
+		if ( arguments.length ) {
+			return {
+				'value': value,
+				'done': true
+			};
+		}
+		return {
+			'done': true
+		};
+	}
+
+	/**
+	* Returns a new iterator.
+	*
+	* @private
+	* @returns {Iterator} iterator
+	*/
+	function factory() {
+		return iterCuNoneBy( iterator[ iteratorSymbol ](), predicate, thisArg );
+	}
+}
+
+
+// EXPORTS //
+
+module.exports = iterCuNoneBy;

--- a/lib/node_modules/@stdlib/iter/cunone-by/lib/main.js
+++ b/lib/node_modules/@stdlib/iter/cunone-by/lib/main.js
@@ -30,7 +30,7 @@ var format = require( '@stdlib/string/format' );
 // MAIN //
 
 /**
-* Returns an iterator which cumulatively tests whether no iterated value passes a test implemented by a predicate functionwhich cumulatively tests whether no iterated value passes a test implemented by a predicate function.
+* Returns an iterator which cumulatively tests whether every iterated value fails a test implemented by a predicate function.
 *
 * @param {Iterator} iterator - input iterator
 * @param {Function} predicate - predicate function
@@ -43,7 +43,7 @@ var format = require( '@stdlib/string/format' );
 * var array2iterator = require( '@stdlib/array/to-iterator' );
 *
 * function isPositive( value ) {
-*     return (value > 0)
+*     return ( value > 0 );
 * }
 *
 * var arr = array2iterator( [ 0, 0, 0, 1, 0 ] );
@@ -68,8 +68,8 @@ var format = require( '@stdlib/string/format' );
 * var bool = it.next().done;
 * // returns true
 */
-function iterCuNoneBy( iterator, predicate, thisArg) {
-	var hasAnyTestPassed;
+function iterCuNoneBy( iterator, predicate, thisArg ) {
+	var value;
 	var iter;
 	var FLG;
 	var i;
@@ -79,8 +79,8 @@ function iterCuNoneBy( iterator, predicate, thisArg) {
 	if ( !isFunction( predicate ) ) {
 		throw new TypeError( format( 'invalid argument. Second argument must be a function. Value: `%s`.', predicate ) );
 	}
+	value = true;
 	i = -1;
-	hasAnyTestPassed=false;
 
 	// Create an iterator protocol-compliant object:
 	iter = {};
@@ -91,7 +91,6 @@ function iterCuNoneBy( iterator, predicate, thisArg) {
 	if ( iteratorSymbol && isFunction( iterator[ iteratorSymbol ] ) ) {
 		setReadOnly( iter, iteratorSymbol, factory );
 	}
-
 	return iter;
 
 	/**
@@ -107,21 +106,18 @@ function iterCuNoneBy( iterator, predicate, thisArg) {
 				'done': true
 			};
 		}
-		while ( true ) {
-			v = iterator.next();
-			i += 1;
-			if ( v.done ) {
-				FLG = true;
-				return v;
-			}
-			if ( predicate.call( thisArg, v.value, i ) ) {
-				hasAnyTestPassed = true;
-			}
-			return {
-				'value': !hasAnyTestPassed,
-				'done': false
-			};
+		v = iterator.next();
+		if ( v.done ) {
+			FLG = true;
+			return v;
 		}
+		if ( value && predicate.call( thisArg, v.value, i ) ) {
+			value = false;
+		}
+		return {
+			'value': value,
+			'done': false
+		};
 	}
 
 	/**

--- a/lib/node_modules/@stdlib/iter/cunone-by/package.json
+++ b/lib/node_modules/@stdlib/iter/cunone-by/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/iter/cunone-by",
   "version": "0.0.0",
-  "description": "Create an iterator which cumulatively tests whether at least n iterated values pass a test implemented by a predicate function.",
+  "description": "Create an iterator which cumulatively tests whether every iterated value fails a test implemented by a predicate function.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",
@@ -57,7 +57,9 @@
     "utils",
     "util",
     "none",
-    "cunone-by",
+    "every",
+    "all",
+    "cunone",
     "iterator",
     "iterate",
     "iteration",

--- a/lib/node_modules/@stdlib/iter/cunone-by/package.json
+++ b/lib/node_modules/@stdlib/iter/cunone-by/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@stdlib/iter/cunone-by",
+  "version": "0.0.0",
+  "description": "Create an iterator which cumulatively tests whether at least n iterated values pass a test implemented by a predicate function.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdutils",
+    "stdutil",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "none",
+    "cunone-by",
+    "iterator",
+    "iterate",
+    "iteration",
+    "iter"
+  ]
+}

--- a/lib/node_modules/@stdlib/iter/cunone-by/test/test.js
+++ b/lib/node_modules/@stdlib/iter/cunone-by/test/test.js
@@ -25,7 +25,22 @@ var proxyquire = require( 'proxyquire' );
 var array2iterator = require( '@stdlib/array/to-iterator' );
 var randu = require( '@stdlib/random/iter/randu' );
 var iteratorSymbol = require( '@stdlib/symbol/iterator' );
+var noop = require( '@stdlib/utils/noop' );
 var iterCuNoneBy = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Predicate function.
+*
+* @private
+* @param {*} value - value
+* @returns {boolean} result
+*/
+function predicate( value ) {
+	return ( value > 0 );
+}
 
 
 // TESTS //
@@ -60,7 +75,7 @@ tape( 'the function throws an error if not provided an iterator', function test(
 
 	function badValue( value ) {
 		return function badValue() {
-			iterCuNoneBy( value, function predicate() {});
+			iterCuNoneBy( value, noop );
 		};
 	}
 });
@@ -110,10 +125,6 @@ tape( 'the function returns an iterator protocol-compliant object', function tes
 	}
 	t.equal( typeof r.done, 'boolean', 'returns expected value' );
 	t.end();
-
-	function predicate(v) {
-		return ( v > 0 );
-	}
 });
 
 tape( 'if provided an "empty" iterator, the function returns an iterator which is also empty', function test( t ) {
@@ -122,19 +133,15 @@ tape( 'if provided an "empty" iterator, the function returns an iterator which i
 	var v;
 
 	arr = array2iterator( [] );
-	it = iterCuNoneBy( arr, predicate);
+	it = iterCuNoneBy( arr, predicate );
 
 	v = it.next();
 	t.strictEqual( v.done, true, 'returns expected value' );
 
 	t.end();
-
-	function predicate(v) {
-		return ( v > 0 );
-	}
 });
 
-tape( 'the function returns an iterator which cumulatively tests whether no iterated value passes a test implemented by a predicate function', function test( t ) {
+tape( 'the function returns an iterator which cumulatively tests whether every iterated value fails a test implemented by a predicate function', function test( t ) {
 	var expected;
 	var actual;
 	var values;
@@ -180,17 +187,13 @@ tape( 'the function returns an iterator which cumulatively tests whether no iter
 	}
 	t.deepEqual( actual, expected, 'returns expected values' );
 	t.end();
-
-	function predicate(v) {
-		return ( v > 0 );
-	}
 });
 
 tape( 'the returned iterator has a `return` method for closing an iterator (no argument)', function test( t ) {
 	var it;
 	var r;
 
-	it = iterCuNoneBy( randu(), function predicate() {} );
+	it = iterCuNoneBy( randu(), predicate );
 
 	r = it.next();
 	t.equal( typeof r.value, 'boolean', 'returns expected value' );
@@ -202,6 +205,31 @@ tape( 'the returned iterator has a `return` method for closing an iterator (no a
 
 	r = it.return();
 	t.equal( r.value, void 0, 'returns expected value' );
+	t.equal( r.done, true, 'returns expected value' );
+
+	r = it.next();
+	t.equal( r.value, void 0, 'returns expected value' );
+	t.equal( r.done, true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the returned iterator has a `return` method for closing an iterator (argument)', function test( t ) {
+	var it;
+	var r;
+
+	it = iterCuNoneBy( randu(), predicate );
+
+	r = it.next();
+	t.equal( typeof r.value, 'boolean', 'returns expected value' );
+	t.equal( r.done, false, 'returns expected value' );
+
+	r = it.next();
+	t.equal( typeof r.value, 'boolean', 'returns expected value' );
+	t.equal( r.done, false, 'returns expected value' );
+
+	r = it.return( 'foo' );
+	t.equal( r.value, 'foo', 'returns expected value' );
 	t.equal( r.done, true, 'returns expected value' );
 
 	r = it.next();
@@ -246,10 +274,6 @@ tape( 'if an environment supports `Symbol.iterator` and the provided iterator is
 	function factory() {
 		return randu( opts );
 	}
-
-	function predicate(v) {
-		return ( v > 0 );
-	}
 });
 
 tape( 'if an environment does not support `Symbol.iterator`, the returned iterator is not "iterable"', function test( t ) {
@@ -264,10 +288,6 @@ tape( 'if an environment does not support `Symbol.iterator`, the returned iterat
 	t.equal( it[ iteratorSymbol ], void 0, 'does not have property' );
 
 	t.end();
-
-	function predicate( v ) {
-		return ( v > 0 );
-	}
 });
 
 tape( 'if a provided iterator is not iterable, the returned iterator is not iterable', function test( t ) {
@@ -282,14 +302,10 @@ tape( 'if a provided iterator is not iterable, the returned iterator is not iter
 	rand = randu();
 	rand[ '__ITERATOR_SYMBOL__' ] = null;
 
-	it = iterCuNoneBy( rand, predicate);
+	it = iterCuNoneBy( rand, predicate );
 	t.equal( it[ iteratorSymbol ], void 0, 'does not have property' );
 
 	t.end();
-
-	function predicate( v ) {
-		return ( v > 0 );
-	}
 });
 tape( 'the function supports specifying the predicate function execution context', function test( t ) {
 	var expected;
@@ -338,7 +354,7 @@ tape( 'the function supports specifying the predicate function execution context
 		actual.push( it.next() );
 	}
 	t.deepEqual( actual, expected, 'returns expected values' );
-	t.equal( ctx.count, values.length, 'returns expected value' );
+	t.equal( ctx.count, 3, 'returns expected value' );
 	t.end();
 
 	function predicate( v ) {

--- a/lib/node_modules/@stdlib/iter/cunone-by/test/test.js
+++ b/lib/node_modules/@stdlib/iter/cunone-by/test/test.js
@@ -1,0 +1,348 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var proxyquire = require( 'proxyquire' );
+var array2iterator = require( '@stdlib/array/to-iterator' );
+var randu = require( '@stdlib/random/iter/randu' );
+var iteratorSymbol = require( '@stdlib/symbol/iterator' );
+var iterCuNoneBy = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof iterCuNoneBy, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function throws an error if not provided an iterator', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws a type error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			iterCuNoneBy( value, function predicate() {});
+		};
+	}
+});
+
+tape( 'the function throws an error if not provided a predicate function as a second argument', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		-5,
+		0,
+		3.14,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[]
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws a type error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			iterCuNoneBy( array2iterator( [ 1, 2, 3 ] ), value );
+		};
+	}
+});
+
+tape( 'the function returns an iterator protocol-compliant object', function test( t ) {
+	var arr;
+	var it;
+	var r;
+	var i;
+
+	arr = array2iterator( [ 0, 0, 1, 0, 1 ] );
+	it = iterCuNoneBy( arr, predicate );
+	for ( i = 0; i < 5; i++ ) {
+		r = it.next();
+		t.equal( typeof r.value, 'boolean', 'returns expected value' );
+		t.equal( typeof r.done, 'boolean', 'returns expected value' );
+	}
+	t.equal( typeof r.done, 'boolean', 'returns expected value' );
+	t.end();
+
+	function predicate(v) {
+		return ( v > 0 );
+	}
+});
+
+tape( 'if provided an "empty" iterator, the function returns an iterator which is also empty', function test( t ) {
+	var arr;
+	var it;
+	var v;
+
+	arr = array2iterator( [] );
+	it = iterCuNoneBy( arr, predicate);
+
+	v = it.next();
+	t.strictEqual( v.done, true, 'returns expected value' );
+
+	t.end();
+
+	function predicate(v) {
+		return ( v > 0 );
+	}
+});
+
+tape( 'the function returns an iterator which cumulatively tests whether no iterated value passes a test implemented by a predicate function', function test( t ) {
+	var expected;
+	var actual;
+	var values;
+	var it;
+	var i;
+
+	values = [ 0, 0, 1, 1, 0, 0 ];
+	expected = [
+		{
+			'value': true,
+			'done': false
+		},
+		{
+			'value': true,
+			'done': false
+		},
+		{
+			'value': false,
+			'done': false
+		},
+		{
+			'value': false,
+			'done': false
+		},
+		{
+			'value': false,
+			'done': false
+		},
+		{
+			'value': false,
+			'done': false
+		},
+		{
+			'done': true
+		}
+	];
+
+	it = iterCuNoneBy( array2iterator( values ), predicate );
+
+	actual = [];
+	for ( i = 0; i < expected.length; i++ ) {
+		actual.push( it.next() );
+	}
+	t.deepEqual( actual, expected, 'returns expected values' );
+	t.end();
+
+	function predicate(v) {
+		return ( v > 0 );
+	}
+});
+
+tape( 'the returned iterator has a `return` method for closing an iterator (no argument)', function test( t ) {
+	var it;
+	var r;
+
+	it = iterCuNoneBy( randu(), function predicate() {} );
+
+	r = it.next();
+	t.equal( typeof r.value, 'boolean', 'returns expected value' );
+	t.equal( r.done, false, 'returns expected value' );
+
+	r = it.next();
+	t.equal( typeof r.value, 'boolean', 'returns expected value' );
+	t.equal( r.done, false, 'returns expected value' );
+
+	r = it.return();
+	t.equal( r.value, void 0, 'returns expected value' );
+	t.equal( r.done, true, 'returns expected value' );
+
+	r = it.next();
+	t.equal( r.value, void 0, 'returns expected value' );
+	t.equal( r.done, true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if an environment supports `Symbol.iterator` and the provided iterator is iterable, the returned iterator is iterable', function test( t ) {
+	var iterCuNoneBy;
+	var opts;
+	var rand;
+	var it1;
+	var it2;
+	var i;
+
+	iterCuNoneBy = proxyquire( './../lib/main.js', {
+		'@stdlib/symbol/iterator': '__ITERATOR_SYMBOL__'
+	});
+
+	opts = {
+		'seed': 12345
+	};
+	rand = randu( opts );
+	rand[ '__ITERATOR_SYMBOL__' ] = factory;
+
+	it1 = iterCuNoneBy( rand, predicate );
+	t.equal( typeof it1[ '__ITERATOR_SYMBOL__' ], 'function', 'has method' );
+	t.equal( it1[ '__ITERATOR_SYMBOL__' ].length, 0, 'has zero arity' );
+
+	it2 = it1[ '__ITERATOR_SYMBOL__' ]();
+	t.equal( typeof it2, 'object', 'returns an object' );
+	t.equal( typeof it2.next, 'function', 'has method' );
+	t.equal( typeof it2.return, 'function', 'has method' );
+
+	for ( i = 0; i < 100; i++ ) {
+		t.equal( it2.next().value, it1.next().value, 'returns expected value' );
+	}
+	t.end();
+
+	function factory() {
+		return randu( opts );
+	}
+
+	function predicate(v) {
+		return ( v > 0 );
+	}
+});
+
+tape( 'if an environment does not support `Symbol.iterator`, the returned iterator is not "iterable"', function test( t ) {
+	var iterCuNoneBy;
+	var it;
+
+	iterCuNoneBy = proxyquire( './../lib/main.js', {
+		'@stdlib/symbol/iterator': false
+	});
+
+	it = iterCuNoneBy( randu(), predicate);
+	t.equal( it[ iteratorSymbol ], void 0, 'does not have property' );
+
+	t.end();
+
+	function predicate( v ) {
+		return ( v > 0 );
+	}
+});
+
+tape( 'if a provided iterator is not iterable, the returned iterator is not iterable', function test( t ) {
+	var iterCuNoneBy;
+	var rand;
+	var it;
+
+	iterCuNoneBy = proxyquire( './../lib/main.js', {
+		'@stdlib/symbol/iterator': '__ITERATOR_SYMBOL__'
+	});
+
+	rand = randu();
+	rand[ '__ITERATOR_SYMBOL__' ] = null;
+
+	it = iterCuNoneBy( rand, predicate);
+	t.equal( it[ iteratorSymbol ], void 0, 'does not have property' );
+
+	t.end();
+
+	function predicate( v ) {
+		return ( v > 0 );
+	}
+});
+tape( 'the function supports specifying the predicate function execution context', function test( t ) {
+	var expected;
+	var actual;
+	var values;
+	var ctx;
+	var it;
+	var i;
+
+	ctx = {
+		'count': 0
+	};
+
+	values = [ -1, -3, 2, 0, 1 ];
+	expected = [
+		{
+			'value': true,
+			'done': false
+		},
+		{
+			'value': true,
+			'done': false
+		},
+		{
+			'value': false,
+			'done': false
+		},
+		{
+			'value': false,
+			'done': false
+		},
+		{
+			'value': false,
+			'done': false
+		},
+		{
+			'done': true
+		}
+	];
+
+	it = iterCuNoneBy( array2iterator( values ), predicate, ctx );
+	t.equal( it.next.length, 0, 'has zero arity' );
+
+	actual = [];
+	for ( i = 0; i < expected.length; i++ ) {
+		actual.push( it.next() );
+	}
+	t.deepEqual( actual, expected, 'returns expected values' );
+	t.equal( ctx.count, values.length, 'returns expected value' );
+	t.end();
+
+	function predicate( v ) {
+		this.count += 1; // eslint-disable-line no-invalid-this
+		return ( v > 0 );
+	}
+});


### PR DESCRIPTION
This commit adds cunone-by package

Resolves #2337

## Description

> What is the purpose of this pull request?
The purpose of this pull request is to add the `@stdlib/iter/cunone-by` package which cumulatively tests whether no iterated value passes a test implemented by a predicate function.  

## Related Issues

> Does this pull request have any related issues?
#2337

This pull request:

-   resolves #2337 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
