### PR TITLE
feat: support negative strides for `idamax` and `isamax`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/idamax/README.md
+++ b/lib/node_modules/@stdlib/blas/base/idamax/README.md
@@ -157,7 +157,7 @@ console.log( idx );
 
 [blas]: http://www.netlib.org/blas
 
-[idamax]: http://www.netlib.org/lapack/explore-html/de/da4/group__double__blas__level1.html
+[idamax]: https://netlib.org/lapack/explore-html/dd/de0/idamax_8f_source.html
 
 [@stdlib/array/float64]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/float64
 

--- a/lib/node_modules/@stdlib/blas/base/idamax/README.md
+++ b/lib/node_modules/@stdlib/blas/base/idamax/README.md
@@ -112,7 +112,7 @@ var idx = idamax.ndarray( 5, x, 1, 1 );
 
 ## Notes
 
--   If `N < 1` or `strideX <= 0`, both functions return `-1`.
+-   If `N < 1`, both functions return `-1`.
 -   `idamax()` corresponds to the [BLAS][blas] level 1 function [`idamax`][idamax].
 
 </section>

--- a/lib/node_modules/@stdlib/blas/base/idamax/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/base/idamax/docs/repl.txt
@@ -8,7 +8,7 @@
     Indexing is relative to the first index. To introduce an offset, use typed
     array views.
 
-    If `N < 1` or `strideX <= 0`, the function returns `-1`.
+    If `N < 1`, both functions return `-1`.
 
     Parameters
     ----------

--- a/lib/node_modules/@stdlib/blas/base/idamax/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/idamax/lib/ndarray.js
@@ -49,7 +49,7 @@ function idamax( N, x, strideX, offsetX ) {
 	var v;
 	var i;
 
-	if ( N < 1 || strideX <= 0 ) {
+	if ( N < 1 ) {
 		return -1;
 	}
 	idx = 0;

--- a/lib/node_modules/@stdlib/blas/base/idamax/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/idamax/lib/ndarray.native.js
@@ -48,6 +48,9 @@ function idamax( N, x, strideX, offsetX ) {
 	var viewX;
 	offsetX = minViewBufferIndex( N, strideX, offsetX );
 	viewX = offsetView( x, offsetX );
+	if ( strideX < 0 ) {
+		return N - 1 - addon( N, viewX, -strideX );
+	}
 	return addon( N, viewX, strideX );
 }
 

--- a/lib/node_modules/@stdlib/blas/base/idamax/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/idamax/test/test.ndarray.js
@@ -108,19 +108,21 @@ tape( 'if provided an `N` parameter equal to `1`, the function returns `0`', fun
 	t.end();
 });
 
-tape( 'if provided a `strideX` parameter less than or equal to `0`, the function returns `-1`', function test( t ) {
-	var expected;
+tape( 'the function supports accessing elements in reverse order', function test( t ) {
 	var idx;
 	var x;
 
 	x = new Float64Array( [ 3.0, -4.0, 1.0, 15.0, 4.0, 3.0 ] );
-	expected = -1;
 
-	idx = idamax( x.length, x, 0, 0 );
-	t.strictEqual( idx, expected, 'returns expected value' );
+	idx = idamax( x.length, x, -1, x.length-1 );
+	t.strictEqual( idx, 2, 'returns expected value' );
 
-	idx = idamax( x.length, x, -1, 0 );
-	t.strictEqual( idx, expected, 'returns expected value' );
+	idx = idamax( x.length, x, -1, x.length-4 );
+	t.strictEqual( idx, 1, 'returns expected value' );
+
+	x = new Float64Array( [ 3.0, 999.9, 999.9, -4.0, 999.9, 999.9, 1.0, 999.9, 999.9, 15.0, 999.9, 999.9, 4.0, 999.9, 999.9, 3.0 ] );
+	idx = idamax( x.length, x, -3, x.length-1 );
+	t.strictEqual( idx, 2, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/blas/base/idamax/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/idamax/test/test.ndarray.js
@@ -117,11 +117,11 @@ tape( 'the function supports accessing elements in reverse order', function test
 	idx = idamax( x.length, x, -1, x.length-1 );
 	t.strictEqual( idx, 2, 'returns expected value' );
 
-	idx = idamax( x.length, x, -1, x.length-4 );
+	idx = idamax( 3, x, -1, x.length-4 );
 	t.strictEqual( idx, 1, 'returns expected value' );
 
 	x = new Float64Array( [ 3.0, 999.9, 999.9, -4.0, 999.9, 999.9, 1.0, 999.9, 999.9, 15.0, 999.9, 999.9, 4.0, 999.9, 999.9, 3.0 ] );
-	idx = idamax( x.length, x, -3, x.length-1 );
+	idx = idamax( 6, x, -3, x.length-1 );
 	t.strictEqual( idx, 2, 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/blas/base/idamax/test/test.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/idamax/test/test.ndarray.native.js
@@ -117,19 +117,21 @@ tape( 'if provided an `N` parameter equal to `1`, the function returns `0`', opt
 	t.end();
 });
 
-tape( 'if provided a `strideX` parameter less than or equal to `0`, the function returns `-1`', opts, function test( t ) {
-	var expected;
+tape( 'the function supports accessing elements in reverse order', function test( t ) {
 	var idx;
 	var x;
 
 	x = new Float64Array( [ 3.0, -4.0, 1.0, 15.0, 4.0, 3.0 ] );
-	expected = -1;
 
-	idx = idamax( x.length, x, 0, 0 );
-	t.strictEqual( idx, expected, 'returns expected value' );
+	idx = idamax( x.length, x, -1, x.length-1 );
+	t.strictEqual( idx, 2, 'returns expected value' );
 
-	idx = idamax( x.length, x, -1, 5 );
-	t.strictEqual( idx, expected, 'returns expected value' );
+	idx = idamax( 3, x, -1, x.length-4 );
+	t.strictEqual( idx, 1, 'returns expected value' );
+
+	x = new Float64Array( [ 3.0, 999.9, 999.9, -4.0, 999.9, 999.9, 1.0, 999.9, 999.9, 15.0, 999.9, 999.9, 4.0, 999.9, 999.9, 3.0 ] );
+	idx = idamax( 6, x, -3, x.length-1 );
+	t.strictEqual( idx, 2, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/blas/base/isamax/README.md
+++ b/lib/node_modules/@stdlib/blas/base/isamax/README.md
@@ -112,7 +112,7 @@ var idx = isamax.ndarray( 5, x, 1, 1 );
 
 ## Notes
 
--   If `N < 1` or `strideX <= 0`, both functions return `-1`.
+-   If `N < 1`, both functions return `-1`.
 -   `isamax()` corresponds to the [BLAS][blas] level 1 function [`isamax`][isamax].
 
 </section>

--- a/lib/node_modules/@stdlib/blas/base/isamax/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/base/isamax/docs/repl.txt
@@ -8,7 +8,7 @@
     Indexing is relative to the first index. To introduce an offset, use typed
     array views.
 
-    If `N < 1` or `strideX <= 0`, the function returns `-1`.
+    If `N < 1`, both functions return `-1`.
 
     Parameters
     ----------

--- a/lib/node_modules/@stdlib/blas/base/isamax/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/isamax/lib/ndarray.js
@@ -49,7 +49,7 @@ function isamax( N, x, strideX, offsetX ) {
 	var v;
 	var i;
 
-	if ( N < 1 || strideX <= 0 ) {
+	if ( N < 1 ) {
 		return -1;
 	}
 	idx = 0;

--- a/lib/node_modules/@stdlib/blas/base/isamax/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/isamax/lib/ndarray.native.js
@@ -48,6 +48,9 @@ function isamax( N, x, strideX, offsetX ) {
 	var viewX;
 	offsetX = minViewBufferIndex( N, strideX, offsetX );
 	viewX = offsetView( x, offsetX );
+	if ( strideX < 0 ) {
+		return N - 1 - addon( N, viewX, -strideX );
+	}
 	return addon( N, viewX, strideX );
 }
 

--- a/lib/node_modules/@stdlib/blas/base/isamax/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/isamax/test/test.ndarray.js
@@ -117,11 +117,11 @@ tape( 'the function supports accessing elements in reverse order', function test
 	idx = isamax( x.length, x, -1, x.length-1 );
 	t.strictEqual( idx, 2, 'returns expected value' );
 
-	idx = isamax( x.length, x, -1, x.length-4 );
+	idx = isamax( 3, x, -1, x.length-4 );
 	t.strictEqual( idx, 1, 'returns expected value' );
 
 	x = new Float32Array( [ 3.0, 999.9, 999.9, -4.0, 999.9, 999.9, 1.0, 999.9, 999.9, 15.0, 999.9, 999.9, 4.0, 999.9, 999.9, 3.0 ] );
-	idx = isamax( x.length, x, -3, x.length-1 );
+	idx = isamax( 6, x, -3, x.length-1 );
 	t.strictEqual( idx, 2, 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/blas/base/isamax/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/isamax/test/test.ndarray.js
@@ -108,19 +108,21 @@ tape( 'if provided an `N` parameter equal to `1`, the function returns `0`', fun
 	t.end();
 });
 
-tape( 'if provided a `strideX` parameter less than or equal to `0`, the function returns `-1`', function test( t ) {
-	var expected;
+tape( 'the function supports accessing elements in reverse order', function test( t ) {
 	var idx;
 	var x;
 
 	x = new Float32Array( [ 3.0, -4.0, 1.0, 15.0, 4.0, 3.0 ] );
-	expected = -1;
 
-	idx = isamax( x.length, x, 0, 0 );
-	t.strictEqual( idx, expected, 'returns expected value' );
+	idx = isamax( x.length, x, -1, x.length-1 );
+	t.strictEqual( idx, 2, 'returns expected value' );
 
-	idx = isamax( x.length, x, -1, 0 );
-	t.strictEqual( idx, expected, 'returns expected value' );
+	idx = isamax( x.length, x, -1, x.length-4 );
+	t.strictEqual( idx, 1, 'returns expected value' );
+
+	x = new Float32Array( [ 3.0, 999.9, 999.9, -4.0, 999.9, 999.9, 1.0, 999.9, 999.9, 15.0, 999.9, 999.9, 4.0, 999.9, 999.9, 3.0 ] );
+	idx = isamax( x.length, x, -3, x.length-1 );
+	t.strictEqual( idx, 2, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/blas/base/isamax/test/test.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/isamax/test/test.ndarray.native.js
@@ -117,19 +117,21 @@ tape( 'if provided an `N` parameter equal to `1`, the function returns `0`', opt
 	t.end();
 });
 
-tape( 'if provided a `strideX` parameter less than or equal to `0`, the function returns `-1`', opts, function test( t ) {
-	var expected;
+tape( 'the function supports accessing elements in reverse order', function test( t ) {
 	var idx;
 	var x;
 
 	x = new Float32Array( [ 3.0, -4.0, 1.0, 15.0, 4.0, 3.0 ] );
-	expected = -1;
 
-	idx = isamax( x.length, x, 0, 0 );
-	t.strictEqual( idx, expected, 'returns expected value' );
+	idx = isamax( x.length, x, -1, x.length-1 );
+	t.strictEqual( idx, 2, 'returns expected value' );
 
-	idx = isamax( x.length, x, -1, 5 );
-	t.strictEqual( idx, expected, 'returns expected value' );
+	idx = isamax( 3, x, -1, x.length-4 );
+	t.strictEqual( idx, 1, 'returns expected value' );
+
+	x = new Float32Array( [ 3.0, 999.9, 999.9, -4.0, 999.9, 999.9, 1.0, 999.9, 999.9, 15.0, 999.9, 999.9, 4.0, 999.9, 999.9, 3.0 ] );
+	idx = isamax( 6, x, -3, x.length-1 );
+	t.strictEqual( idx, 2, 'returns expected value' );
 
 	t.end();
 });


### PR DESCRIPTION
Resolves #2792. Towards #2464.

## Description

> What is the purpose of this pull request?

This pull request enhances existing JS ndarray implementation of `blas/base/idamax` and `blas/base/isamax` to support negative strides.

## Related Issues

> Does this pull request have any related issues?

NA

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
