### PR TITLE
feat: add `math/base/special/minf`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/minf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/minf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # minf
 
-> Return the minimum value (single-precision).
+> Return the minimum single-precision floating-point number.
 
 <!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
 
@@ -42,7 +42,7 @@ var minf = require( '@stdlib/math/base/special/minf' );
 
 #### minf( x, y )
 
-Returns the minimum value (single-precision).
+Returns the minimum single-precision floating-point number.
 
 ```javascript
 var v = minf( 4.2, 3.14 );
@@ -131,14 +131,14 @@ for ( i = 0; i < 100; i++ ) {
 
 #### stdlib_base_minf( x, y )
 
-Returns the minimum value (single-precision).
+Returns the minimum single-precision floating-point number.
 
 ```c
-float out = stdlib_base_minf( 4.2, 3.14 );
-// returns 3.14
+float out = stdlib_base_minf( 4.2f, 3.14f );
+// returns 3.14f
 
-out = stdlib_base_minf( 0.0, -0.0 );
-// returns -0.0
+out = stdlib_base_minf( 0.0f, -0.0f );
+// returns -0.0f
 ```
 
 The function accepts the following arguments:

--- a/lib/node_modules/@stdlib/math/base/special/minf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/minf/README.md
@@ -1,0 +1,225 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# minf
+
+> Return the minimum value (single-precision).
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var minf = require( '@stdlib/math/base/special/minf' );
+```
+
+#### minf( x, y )
+
+Returns the minimum value (single-precision).
+
+```javascript
+var v = minf( 4.2, 3.14 );
+// returns 3.14
+
+v = minf( +0.0, -0.0 );
+// returns -0.0
+```
+
+If any argument is `NaN`, the function returns `NaN`.
+
+```javascript
+var v = minf( 4.2, NaN );
+// returns NaN
+
+v = minf( NaN, 3.14 );
+// returns NaN
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var minstd = require( '@stdlib/random/base/minstd-shuffle' );
+var minf = require( '@stdlib/math/base/special/minf' );
+
+var x;
+var y;
+var v;
+var i;
+
+for ( i = 0; i < 100; i++ ) {
+    x = minstd();
+    y = minstd();
+    v = minf( x, y );
+    console.log( 'minf(%d,%d) = %d', x, y, v );
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/math/base/special/minf.h"
+```
+
+#### stdlib_base_minf( x, y )
+
+Returns the minimum value (single-precision).
+
+```c
+float out = stdlib_base_minf( 4.2, 3.14 );
+// returns 3.14
+
+out = stdlib_base_minf( 0.0, -0.0 );
+// returns -0.0
+```
+
+The function accepts the following arguments:
+
+-   **x**: `[in] float` input value.
+-   **y**: `[in] float` input value.
+
+```c
+float stdlib_base_minf( const float x, const float y );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/math/base/special/minf.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+int main( void ) {
+    float x;
+    float y;
+    float v;
+    int i;
+    
+    for ( i = 0; i < 100; i++ ) {
+        x = ( ( (float)rand() / (float)RAND_MAX ) * 200.0f ) - 100.0f;
+        y = ( ( (float)rand() / (float)RAND_MAX ) * 200.0f ) - 100.0f;
+        v = stdlib_base_minf( x, y );
+        printf( "x: %f, y: %f, minf(x, y): %f\n", x, y, v );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/math/base/special/minf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/minf/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var randu = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pkg = require( './../package.json' ).name;
 var minf = require( './../lib' );
@@ -35,11 +35,12 @@ bench( pkg, function benchmark( b ) {
 	var z;
 	var i;
 
+	x = randu( 100, -100.0, 100.0 );
+	y = randu( 100, -100.0, 100.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu() * 1000.0 ) - 500.0;
-		y = ( randu() * 1000.0 ) - 500.0;
-		z = minf( x, y );
+		z = minf( x[ i%x.length ], y[ i%y.length ] );
 		if ( isnanf( z ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/minf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/minf/benchmark/benchmark.js
@@ -1,0 +1,53 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var pkg = require( './../package.json' ).name;
+var minf = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var x;
+	var y;
+	var z;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		x = ( randu() * 1000.0 ) - 500.0;
+		y = ( randu() * 1000.0 ) - 500.0;
+		z = minf( x, y );
+		if ( isnanf( z ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnanf( z ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/minf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/minf/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var randu = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -44,11 +44,12 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var z;
 	var i;
 
+	x = randu( 100, -100.0, 100.0 );
+	y = randu( 100, -100.0, 100.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu() * 200.0 ) - 100.0;
-		y = ( randu() * 200.0 ) - 100.0;
-		z = minf( x, y );
+		z = minf( x[ i%x.length ], y[ i%y.length ] );
 		if ( isnanf( z ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/minf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/minf/benchmark/benchmark.native.js
@@ -1,0 +1,62 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var minf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( minf instanceof Error )
+};
+
+
+// MAIN //
+
+bench( pkg+'::native', opts, function benchmark( b ) {
+	var x;
+	var y;
+	var z;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		x = ( randu() * 200.0 ) - 100.0;
+		y = ( randu() * 200.0 ) - 100.0;
+		z = minf( x, y );
+		if ( isnanf( z ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnanf( z ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/minf/benchmark/c/native/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/minf/benchmark/c/native/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/minf/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/minf/benchmark/c/native/benchmark.c
@@ -1,0 +1,135 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/minf.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "minf"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+static void print_version( void ) {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+static void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+static void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+static double tic( void ) {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1).
+*
+* @return random number
+*/
+static float rand_float( void ) {
+	int r = rand();
+	return (float)r / ( (float)RAND_MAX + 1.0f );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+static double benchmark( void ) {
+	double elapsed;
+	double t;
+	float x;
+	float y;
+	float z;
+	int i;
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		x = ( 200.0f * rand_float() ) - 100.0f;
+		y = ( 200.0f * rand_float() ) - 100.0f;
+		z = stdlib_base_minf( x, y );
+		if ( z != z ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( z != z ) {
+		printf( "should not return NaN\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::native::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/math/base/special/minf/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/minf/benchmark/c/native/benchmark.c
@@ -92,16 +92,19 @@ static float rand_float( void ) {
 static double benchmark( void ) {
 	double elapsed;
 	double t;
-	float x;
-	float y;
+	float x[ 100 ];
+	float y[ 100 ];
 	float z;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 200.0f * rand_float() ) - 100.0f;
+		y[ i ] = ( 200.0f * rand_float() ) - 100.0f;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 200.0f * rand_float() ) - 100.0f;
-		y = ( 200.0f * rand_float() ) - 100.0f;
-		z = stdlib_base_minf( x, y );
+		z = stdlib_base_minf( x[ i%100 ], y[ i%100 ] );
 		if ( z != z ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/minf/binding.gyp
+++ b/lib/node_modules/@stdlib/math/base/special/minf/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/math/base/special/minf/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/minf/docs/repl.txt
@@ -1,0 +1,31 @@
+
+{{alias}}( x, y )
+    Returns the minimum value (single-precision).
+
+    If any argument is `NaN`, the function returns `NaN`.
+
+    Parameters
+    ----------
+    x: number
+        First number.
+
+    y: number
+        Second number.
+
+    Returns
+    -------
+    out: number
+        Minimum value.
+
+    Examples
+    --------
+    > var v = {{alias}}( 3.14, 4.2 )
+    3.14
+    > v = {{alias}}( 3.14, NaN )
+    NaN
+    > v = {{alias}}( +0.0, -0.0 )
+    -0.0
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/math/base/special/minf/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/minf/docs/repl.txt
@@ -1,6 +1,6 @@
 
 {{alias}}( x, y )
-    Returns the minimum value (single-precision).
+    Returns the minimum single-precision floating-point number.
 
     If any argument is `NaN`, the function returns `NaN`.
 

--- a/lib/node_modules/@stdlib/math/base/special/minf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/minf/docs/types/index.d.ts
@@ -1,0 +1,45 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Returns the minimum value (single-precision).
+*
+* @param x - first number
+* @param y - second number
+* @returns minimum value
+*
+* @example
+* var v = minf( 3.14, 4.2 );
+* // returns 3.14
+*
+* @example
+* var v = minf( 3.14, NaN );
+* // returns NaN
+*
+* @example
+* var v = minf( +0.0, -0.0 );
+* // returns -0.0
+*/
+declare function minf( x: number, y: number ): number;
+
+
+// EXPORTS //
+
+export = minf;

--- a/lib/node_modules/@stdlib/math/base/special/minf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/minf/docs/types/index.d.ts
@@ -19,7 +19,7 @@
 // TypeScript Version: 4.1
 
 /**
-* Returns the minimum value (single-precision).
+* Returns the minimum single-precision floating-point number.
 *
 * @param x - first number
 * @param y - second number

--- a/lib/node_modules/@stdlib/math/base/special/minf/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/math/base/special/minf/docs/types/test.ts
@@ -1,0 +1,51 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import minf = require( './index' );
+
+
+// TESTS //
+
+// The function returns a number...
+{
+	minf( 3.0, -0.2 ); // $ExpectType number
+}
+
+// The compiler throws an error if the function is provided non-number arguments...
+{
+	minf( true, 3.0 ); // $ExpectError
+	minf( false, 3.0 ); // $ExpectError
+	minf( [], 3.0 ); // $ExpectError
+	minf( {}, 3.0 ); // $ExpectError
+	minf( 'abc', 3.0 ); // $ExpectError
+	minf( ( x: number ): number => x, 3.0 ); // $ExpectError
+
+	minf( 1.2, true ); // $ExpectError
+	minf( 1.2, false ); // $ExpectError
+	minf( 1.2, [] ); // $ExpectError
+	minf( 1.2, {} ); // $ExpectError
+	minf( 1.2, 'abc' ); // $ExpectError
+	minf( 1.2, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	minf(); // $ExpectError
+	minf( 3.0 ); // $ExpectError
+	minf( 3.0, 2.0, 1.0 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/math/base/special/minf/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/minf/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/minf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/minf/examples/c/example.c
@@ -1,0 +1,35 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/minf.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+int main( void ) {
+    float x;
+    float y;
+    float v;
+    int i;
+
+    for ( i = 0; i < 100; i++ ) {
+        x = ( ( (float)rand() / (float)RAND_MAX ) * 200.0f ) - 100.0f;
+        y = ( ( (float)rand() / (float)RAND_MAX ) * 200.0f ) - 100.0f;
+        v = stdlib_base_minf( x, y );
+        printf( "x: %f, y: %f, minf(x, y): %f\n", x, y, v );
+    }
+}

--- a/lib/node_modules/@stdlib/math/base/special/minf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/minf/examples/index.js
@@ -1,0 +1,34 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var minstd = require( '@stdlib/random/base/minstd-shuffle' );
+var minf = require( './../lib' );
+
+var x;
+var y;
+var v;
+var i;
+
+for ( i = 0; i < 100; i++ ) {
+	x = minstd();
+	y = minstd();
+	v = minf( x, y );
+	console.log( 'minf(%d,%d) = %d', x, y, v );
+}

--- a/lib/node_modules/@stdlib/math/base/special/minf/include.gypi
+++ b/lib/node_modules/@stdlib/math/base/special/minf/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/math/base/special/minf/include/stdlib/math/base/special/minf.h
+++ b/lib/node_modules/@stdlib/math/base/special/minf/include/stdlib/math/base/special/minf.h
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_MATH_BASE_SPECIAL_MINF_H
+#define STDLIB_MATH_BASE_SPECIAL_MINF_H
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Returns the minimum value (single-precision).
+*/
+float stdlib_base_minf( const float x, const float y );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_MATH_BASE_SPECIAL_MINF_H

--- a/lib/node_modules/@stdlib/math/base/special/minf/include/stdlib/math/base/special/minf.h
+++ b/lib/node_modules/@stdlib/math/base/special/minf/include/stdlib/math/base/special/minf.h
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 /**
-* Returns the minimum value (single-precision).
+* Returns the minimum single-precision floating-point number.
 */
 float stdlib_base_minf( const float x, const float y );
 

--- a/lib/node_modules/@stdlib/math/base/special/minf/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/minf/lib/index.js
@@ -1,0 +1,46 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Return the minimum value (single-precision).
+*
+* @module @stdlib/math/base/special/minf
+*
+* @example
+* var minf = require( '@stdlib/math/base/special/minf' );
+*
+* var v = minf( 3.14, 4.2 );
+* // returns 3.14
+*
+* v = minf( 3.14, NaN );
+* // returns NaN
+*
+* v = minf( +0.0, -0.0 );
+* // returns -0.0
+*/
+
+// MODULES //
+
+var minf = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = minf;

--- a/lib/node_modules/@stdlib/math/base/special/minf/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/minf/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Return the minimum value (single-precision).
+* Return the minimum single-precision floating-point number.
 *
 * @module @stdlib/math/base/special/minf
 *

--- a/lib/node_modules/@stdlib/math/base/special/minf/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/minf/lib/main.js
@@ -1,0 +1,71 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var NINF = require( '@stdlib/constants/float32/ninf' );
+
+
+// MAIN //
+
+/**
+* Returns the minimum value (single-precision).
+*
+* @param {number} x - first number
+* @param {number} y - second number
+* @returns {number} minimum value
+*
+* @example
+* var v = minf( 3.14, 4.2 );
+* // returns 3.14
+*
+* @example
+* var v = minf( 3.14, NaN );
+* // returns NaN
+*
+* @example
+* var v = minf( +0.0, -0.0 );
+* // returns -0.0
+*/
+function minf( x, y ) {
+	if ( isnanf( x ) || isnanf( y ) ) {
+		return NaN;
+	}
+	if ( x === NINF || y === NINF ) {
+		return NINF;
+	}
+	if ( x === y && x === 0.0 ) {
+		if ( isNegativeZerof( x ) ) {
+			return x;
+		}
+		return y;
+	}
+	if ( x < y ) {
+		return x;
+	}
+	return y;
+}
+
+
+// EXPORTS //
+
+module.exports = minf;

--- a/lib/node_modules/@stdlib/math/base/special/minf/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/minf/lib/main.js
@@ -28,7 +28,7 @@ var NINF = require( '@stdlib/constants/float32/ninf' );
 // MAIN //
 
 /**
-* Returns the minimum value (single-precision).
+* Returns the minimum single-precision floating-point number.
 *
 * @param {number} x - first number
 * @param {number} y - second number

--- a/lib/node_modules/@stdlib/math/base/special/minf/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/minf/lib/native.js
@@ -26,7 +26,7 @@ var addon = require( './../src/addon.node' );
 // MAIN //
 
 /**
-* Return the minimum value (single-precision).
+* Returns the minimum single-precision floating-point number.
 *
 * @private
 * @param {number} x - first number

--- a/lib/node_modules/@stdlib/math/base/special/minf/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/minf/lib/native.js
@@ -1,0 +1,59 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Return the minimum value (single-precision).
+*
+* @private
+* @param {number} x - first number
+* @param {number} y - second number
+* @returns {number} minimum value
+*
+* @example
+* var v = minf( 4.2, 3.14 );
+* // returns ~3.14
+*
+* @example
+* var v = minf( 0.0, -0.0 );
+* // returns -0.0
+*
+* @example
+* var v = minf( 3.14, NaN );
+* // returns NaN
+*
+* @example
+* var v = minf( NaN, 5.0 );
+* // returns NaN
+*/
+function minf( x, y ) {
+	return addon( x, y );
+}
+
+
+// EXPORTS //
+
+module.exports = minf;

--- a/lib/node_modules/@stdlib/math/base/special/minf/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/minf/manifest.json
@@ -1,0 +1,78 @@
+{
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/napi/binary",
+        "@stdlib/math/base/assert/is-nanf",
+        "@stdlib/math/base/assert/is-negative-zerof",
+        "@stdlib/constants/float32/ninf"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nanf",
+        "@stdlib/math/base/assert/is-negative-zerof",
+        "@stdlib/constants/float32/ninf"
+      ]
+    },
+    {
+      "task": "examples",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nanf",
+        "@stdlib/math/base/assert/is-negative-zerof",
+        "@stdlib/constants/float32/ninf"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/special/minf/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/minf/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@stdlib/math/base/special/minf",
+  "version": "0.0.0",
+  "description": "Return the minimum value (single-precision).",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "gypfile": true,
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "src": "./src",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
+    "math.min",
+    "minimum",
+    "min",
+    "smallest"
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/special/minf/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/minf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/math/base/special/minf",
   "version": "0.0.0",
-  "description": "Return the minimum value (single-precision).",
+  "description": "Return the minimum single-precision floating-point number.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",
@@ -59,6 +59,8 @@
     "math.min",
     "minimum",
     "min",
-    "smallest"
+    "smallest",
+    "float32",
+    "float"
   ]
 }

--- a/lib/node_modules/@stdlib/math/base/special/minf/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/minf/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/minf/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/minf/src/addon.c
@@ -1,0 +1,23 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/minf.h"
+#include "stdlib/math/base/napi/binary.h"
+
+// cppcheck-suppress shadowFunction
+STDLIB_MATH_BASE_NAPI_MODULE_FF_F( stdlib_base_minf )

--- a/lib/node_modules/@stdlib/math/base/special/minf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/minf/src/main.c
@@ -1,0 +1,56 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/minf.h"
+#include "stdlib/math/base/assert/is_nanf.h"
+#include "stdlib/math/base/assert/is_negative_zerof.h"
+#include "stdlib/constants/float32/ninf.h"
+
+/**
+* Return the minimum value (single-precision).
+*
+* @param x       first number
+* @param y       second number
+* @return        minimum value
+*
+* @example
+* float v = stdlib_base_minf( 3.14, 4.2 );
+* // returns 3.14
+*
+* @example
+* float v = stdlib_base_minf( 0.0, -0.0 );
+* // returns -0.0
+*/
+float stdlib_base_minf( const float x, const float y ) {
+    if ( stdlib_base_is_nanf( x ) || stdlib_base_is_nanf( y ) ) {
+        return 0.0f / 0.0f; // NaN
+    }
+    if ( x == STDLIB_CONSTANT_FLOAT32_NINF || y == STDLIB_CONSTANT_FLOAT32_NINF ) {
+        return STDLIB_CONSTANT_FLOAT32_NINF;
+    }
+    if( x == y && x == 0.0f ) {
+        if ( stdlib_base_is_negative_zerof( x ) ) {
+            return x;
+        }
+        return y;
+    }
+    if ( x < y ) {
+        return x;
+    }
+    return y;
+}

--- a/lib/node_modules/@stdlib/math/base/special/minf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/minf/src/main.c
@@ -22,19 +22,19 @@
 #include "stdlib/constants/float32/ninf.h"
 
 /**
-* Return the minimum value (single-precision).
+* Returns the minimum single-precision floating-point number.
 *
 * @param x       first number
 * @param y       second number
 * @return        minimum value
 *
 * @example
-* float v = stdlib_base_minf( 3.14, 4.2 );
-* // returns 3.14
+* float v = stdlib_base_minf( 3.14f, 4.2f );
+* // returns 3.14f
 *
 * @example
-* float v = stdlib_base_minf( 0.0, -0.0 );
-* // returns -0.0
+* float v = stdlib_base_minf( 0.0f, -0.0f );
+* // returns -0.0f
 */
 float stdlib_base_minf( const float x, const float y ) {
     if ( stdlib_base_is_nanf( x ) || stdlib_base_is_nanf( y ) ) {

--- a/lib/node_modules/@stdlib/math/base/special/minf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/minf/test/test.js
@@ -53,10 +53,10 @@ tape( 'the function returns `-Infinity` if provided `-Infinity`', function test(
 	var v;
 
 	v = minf( NINF, 3.14 );
-	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.strictEqual( v, NINF, 'returns expected value' );
 
 	v = minf( 3.14, NINF );
-	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.strictEqual( v, NINF, 'returns expected value' );
 
 	t.end();
 });
@@ -65,16 +65,16 @@ tape( 'the function returns a correctly signed zero', function test( t ) {
 	var v;
 
 	v = minf( +0.0, -0.0 );
-	t.strictEqual( isNegativeZerof( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZerof( v ), true, 'returns expected value' );
 
 	v = minf( -0.0, +0.0 );
-	t.strictEqual( isNegativeZerof( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZerof( v ), true, 'returns expected value' );
 
 	v = minf( -0.0, -0.0 );
-	t.strictEqual( isNegativeZerof( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZerof( v ), true, 'returns expected value' );
 
 	v = minf( +0.0, +0.0 );
-	t.strictEqual( isPositiveZerof( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -83,10 +83,10 @@ tape( 'the function returns the minimum value', function test( t ) {
 	var v;
 
 	v = minf( float64ToFloat32( 4.2 ), float64ToFloat32( 3.14 ) );
-	t.strictEqual( v, float64ToFloat32( 3.14 ), 'returns min value' );
+	t.strictEqual( v, float64ToFloat32( 3.14 ), 'returns expected value' );
 
 	v = minf( float64ToFloat32( -4.2 ), float64ToFloat32( 3.14 ) );
-	t.strictEqual( v, float64ToFloat32( -4.2 ), 'returns min value' );
+	t.strictEqual( v, float64ToFloat32( -4.2 ), 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/minf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/minf/test/test.js
@@ -1,0 +1,92 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
+var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var NINF = require( '@stdlib/constants/float32/ninf' );
+var minf = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof minf, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `NaN` if provided a `NaN`', function test( t ) {
+	var v;
+
+	v = minf( NaN, 3.14 );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
+
+	v = minf( 3.14, NaN );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `-Infinity` if provided `-Infinity`', function test( t ) {
+	var v;
+
+	v = minf( NINF, 3.14 );
+	t.strictEqual( v, NINF, 'returns -infinity' );
+
+	v = minf( 3.14, NINF );
+	t.strictEqual( v, NINF, 'returns -infinity' );
+
+	t.end();
+});
+
+tape( 'the function returns a correctly signed zero', function test( t ) {
+	var v;
+
+	v = minf( +0.0, -0.0 );
+	t.strictEqual( isNegativeZerof( v ), true, 'returns -0' );
+
+	v = minf( -0.0, +0.0 );
+	t.strictEqual( isNegativeZerof( v ), true, 'returns -0' );
+
+	v = minf( -0.0, -0.0 );
+	t.strictEqual( isNegativeZerof( v ), true, 'returns -0' );
+
+	v = minf( +0.0, +0.0 );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns +0' );
+
+	t.end();
+});
+
+tape( 'the function returns the minimum value', function test( t ) {
+	var v;
+
+	v = minf( float64ToFloat32( 4.2 ), float64ToFloat32( 3.14 ) );
+	t.strictEqual( v, float64ToFloat32( 3.14 ), 'returns min value' );
+
+	v = minf( float64ToFloat32( -4.2 ), float64ToFloat32( 3.14 ) );
+	t.strictEqual( v, float64ToFloat32( -4.2 ), 'returns min value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/minf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/minf/test/test.native.js
@@ -62,10 +62,10 @@ tape( 'the function returns `-Infinity` if provided `-Infinity`', opts, function
 	var v;
 
 	v = minf( NINF, 3.14 );
-	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.strictEqual( v, NINF, 'returns expected value' );
 
 	v = minf( 3.14, NINF );
-	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.strictEqual( v, NINF, 'returns expected value' );
 
 	t.end();
 });
@@ -74,16 +74,16 @@ tape( 'the function returns a correctly signed zero', opts, function test( t ) {
 	var v;
 
 	v = minf( +0.0, -0.0 );
-	t.strictEqual( isNegativeZerof( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZerof( v ), true, 'returns expected value' );
 
 	v = minf( -0.0, +0.0 );
-	t.strictEqual( isNegativeZerof( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZerof( v ), true, 'returns expected value' );
 
 	v = minf( -0.0, -0.0 );
-	t.strictEqual( isNegativeZerof( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZerof( v ), true, 'returns expected value' );
 
 	v = minf( +0.0, +0.0 );
-	t.strictEqual( isPositiveZerof( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -92,10 +92,10 @@ tape( 'the function returns the minimum value', opts, function test( t ) {
 	var v;
 
 	v = minf( float64ToFloat32( 4.2 ), float64ToFloat32( 3.14 ) );
-	t.strictEqual( v, float64ToFloat32( 3.14 ), 'returns min value' );
+	t.strictEqual( v, float64ToFloat32( 3.14 ), 'returns expected value' );
 
 	v = minf( float64ToFloat32( -4.2 ), float64ToFloat32( 3.14 ) );
-	t.strictEqual( v, float64ToFloat32( -4.2 ), 'returns min value' );
+	t.strictEqual( v, float64ToFloat32( -4.2 ), 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/minf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/minf/test/test.native.js
@@ -1,0 +1,101 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
+var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var NINF = require( '@stdlib/constants/float32/ninf' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var minf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( minf instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof minf, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `NaN` if provided a `NaN`', opts, function test( t ) {
+	var v;
+
+	v = minf( NaN, 3.14 );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
+
+	v = minf( 3.14, NaN );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `-Infinity` if provided `-Infinity`', opts, function test( t ) {
+	var v;
+
+	v = minf( NINF, 3.14 );
+	t.strictEqual( v, NINF, 'returns -infinity' );
+
+	v = minf( 3.14, NINF );
+	t.strictEqual( v, NINF, 'returns -infinity' );
+
+	t.end();
+});
+
+tape( 'the function returns a correctly signed zero', opts, function test( t ) {
+	var v;
+
+	v = minf( +0.0, -0.0 );
+	t.strictEqual( isNegativeZerof( v ), true, 'returns -0' );
+
+	v = minf( -0.0, +0.0 );
+	t.strictEqual( isNegativeZerof( v ), true, 'returns -0' );
+
+	v = minf( -0.0, -0.0 );
+	t.strictEqual( isNegativeZerof( v ), true, 'returns -0' );
+
+	v = minf( +0.0, +0.0 );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns +0' );
+
+	t.end();
+});
+
+tape( 'the function returns the minimum value', opts, function test( t ) {
+	var v;
+
+	v = minf( float64ToFloat32( 4.2 ), float64ToFloat32( 3.14 ) );
+	t.strictEqual( v, float64ToFloat32( 3.14 ), 'returns min value' );
+
+	v = minf( float64ToFloat32( -4.2 ), float64ToFloat32( 3.14 ) );
+	t.strictEqual( v, float64ToFloat32( -4.2 ), 'returns min value' );
+
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds `math/base/special/minf`, which would be the single-precision variant for [`math/base/special/min`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/min).

```c
float stdlib_base_minf( const float x, const float y );
```

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves a part of #649.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
