### PR TITLE
feat: add `constants/float32/max-safe-nth-factorial`

### DIFF
--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-factorial/README.md
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-factorial/README.md
@@ -69,6 +69,8 @@ function factorial( n ) {
     return a;
 }
 
+var v;
+var i;
 for ( i = 0; i < 100; i++ ) {
     v = factorial( i );
     if ( i > FLOAT32_MAX_SAFE_NTH_FACTORIAL ) {

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-factorial/README.md
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-factorial/README.md
@@ -1,0 +1,164 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# FLOAT32_MAX_SAFE_NTH_FACTORIAL
+
+> Maximum safe nth [factorial][factorial] when stored in [single-precision floating-point][ieee754] format.
+
+<section class="usage">
+
+## Usage
+
+<!-- eslint-disable id-length -->
+
+```javascript
+var FLOAT32_MAX_SAFE_NTH_FACTORIAL = require( '@stdlib/constants/float32/max-safe-nth-factorial' );
+```
+
+#### FLOAT32_MAX_SAFE_NTH_FACTORIAL
+
+The maximum [safe][safe-integers] nth [factorial][factorial] when stored in [single-precision floating-point][ieee754] format.
+
+<!-- eslint-disable id-length -->
+
+```javascript
+var bool = ( FLOAT32_MAX_SAFE_NTH_FACTORIAL === 34 );
+// returns true
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint-disable id-length -->
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var FLOAT32_MAX_SAFE_NTH_FACTORIAL = require( '@stdlib/constants/float32/max-safe-nth-factorial' );
+
+function factorial( n ) {
+    var a;
+    var i;
+
+    a = 1;
+    for ( i = 2; i <= n; i++ ) {
+        a *= i;
+    }
+    return a;
+}
+
+for ( i = 0; i < 100; i++ ) {
+    v = factorial( i );
+    if ( i > FLOAT32_MAX_SAFE_NTH_FACTORIAL ) {
+        console.log( 'Unsafe: %d', v );
+    } else {
+        console.log( 'Safe:   %d', v );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/constants/float32/max_safe_nth_factorial.h"
+```
+
+#### STDLIB_CONSTANT_FLOAT32_MAX_SAFE_NTH_FACTORIAL
+
+Macro for the maximum [safe][safe-integers] nth [factorial][factorial] when stored in [single-precision floating-point][ieee754] format.
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[safe-integers]: http://www.2ality.com/2013/10/safe-integers.html
+
+[factorial]: https://en.wikipedia.org/wiki/Factorial
+
+[ieee754]: https://en.wikipedia.org/wiki/IEEE_754-1985
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-factorial/docs/repl.txt
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-factorial/docs/repl.txt
@@ -1,0 +1,13 @@
+
+{{alias}}
+    Maximum safe nth factorial when stored in single-precision floating-
+    point format.
+
+    Examples
+    --------
+    > {{alias}}
+    34
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-factorial/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-factorial/docs/types/index.d.ts
@@ -1,0 +1,33 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Maximum safe nth factorial when stored in single-precision floating-point format.
+*
+* @example
+* var max = FLOAT32_MAX_SAFE_NTH_FACTORIAL;
+* // returns 34
+*/
+declare const FLOAT32_MAX_SAFE_NTH_FACTORIAL: number;
+
+
+// EXPORTS //
+
+export = FLOAT32_MAX_SAFE_NTH_FACTORIAL;

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-factorial/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-factorial/docs/types/test.ts
@@ -1,0 +1,28 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import FLOAT32_MAX_SAFE_NTH_FACTORIAL = require( './index' );
+
+
+// TESTS //
+
+// The export is a number...
+{
+	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+	FLOAT32_MAX_SAFE_NTH_FACTORIAL; // $ExpectType number
+}

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-factorial/examples/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-factorial/examples/index.js
@@ -1,0 +1,44 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var FLOAT32_MAX_SAFE_NTH_FACTORIAL = require( './../lib' );
+
+var v;
+var i;
+
+function factorial( n ) {
+	var a;
+	var i;
+
+	a = 1;
+	for ( i = 2; i <= n; i++ ) {
+		a *= i;
+	}
+	return a;
+}
+
+for ( i = 0; i < 100; i++ ) {
+	v = factorial( i );
+	if ( i > FLOAT32_MAX_SAFE_NTH_FACTORIAL ) {
+		console.log( 'Unsafe: %d', v );
+	} else {
+		console.log( 'Safe:   %d', v );
+	}
+}

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-factorial/examples/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-factorial/examples/index.js
@@ -18,10 +18,7 @@
 
 'use strict';
 
-var FLOAT32_MAX_SAFE_NTH_FACTORIAL = require( './../lib' );
-
-var v;
-var i;
+var FLOAT32_MAX_SAFE_NTH_FACTORIAL = require( './../lib' ); // eslint-disable-line id-length
 
 function factorial( n ) {
 	var a;
@@ -34,6 +31,8 @@ function factorial( n ) {
 	return a;
 }
 
+var v;
+var i;
 for ( i = 0; i < 100; i++ ) {
 	v = factorial( i );
 	if ( i > FLOAT32_MAX_SAFE_NTH_FACTORIAL ) {

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-factorial/include/stdlib/constants/float32/max_safe_nth_factorial.h
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-factorial/include/stdlib/constants/float32/max_safe_nth_factorial.h
@@ -1,0 +1,27 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_CONSTANTS_FLOAT32_MAX_SAFE_NTH_FACTORIAL_H
+#define STDLIB_CONSTANTS_FLOAT32_MAX_SAFE_NTH_FACTORIAL_H
+
+/**
+* Macro for the maximum safe nth factorial when stored in single-precision floating-point format.
+*/
+#define STDLIB_CONSTANT_FLOAT32_MAX_SAFE_NTH_FACTORIAL 34
+
+#endif // !STDLIB_CONSTANTS_FLOAT32_MAX_SAFE_NTH_FACTORIAL_H

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-factorial/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-factorial/lib/index.js
@@ -16,6 +16,8 @@
 * limitations under the License.
 */
 
+/* eslint-disable id-length */
+
 'use strict';
 
 /**

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-factorial/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-factorial/lib/index.js
@@ -1,0 +1,49 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Maximum safe nth factorial when stored in single-precision floating-point format.
+*
+* @module @stdlib/constants/float32/max-safe-nth-factorial
+* @type {integer}
+*
+* @example
+* var FLOAT32_MAX_SAFE_NTH_FACTORIAL = require( '@stdlib/constants/float32/max-safe-nth-factorial' );
+* // returns 34
+*/
+
+
+// MAIN //
+
+/**
+* The maximum safe nth factorial when stored in single-precision floating-point format.
+*
+* @constant
+* @type {integer}
+* @default 34
+* @see [factorial]{@link https://en.wikipedia.org/wiki/Factorial}
+* @see [IEEE 754]{@link https://en.wikipedia.org/wiki/IEEE_754-1985}
+*/
+var FLOAT32_MAX_SAFE_NTH_FACTORIAL = 34|0; // asm type annotation
+
+
+// EXPORTS //
+
+module.exports = FLOAT32_MAX_SAFE_NTH_FACTORIAL;

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-factorial/manifest.json
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-factorial/manifest.json
@@ -1,0 +1,36 @@
+{
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": []
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-factorial/package.json
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-factorial/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@stdlib/constants/float32/max-safe-nth-factorial",
+  "version": "0.0.0",
+  "description": "Maximum safe nth factorial when stored in single-precision floating-point format.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "constant",
+    "const",
+    "max",
+    "maximum",
+    "factorial",
+    "number",
+    "safe",
+    "integer",
+    "float",
+    "flt",
+    "floating",
+    "point",
+    "floating-point",
+    "float32",
+    "f32",
+    "ieee754"
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-factorial/test/test.js
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-factorial/test/test.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var FLOAT32_MAX_SAFE_NTH_FACTORIAL = require( './../lib' );
+var FLOAT32_MAX_SAFE_NTH_FACTORIAL = require( './../lib' ); // eslint-disable-line id-length
 
 
 // TESTS //

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-factorial/test/test.js
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-factorial/test/test.js
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var FLOAT32_MAX_SAFE_NTH_FACTORIAL = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a number', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof FLOAT32_MAX_SAFE_NTH_FACTORIAL, 'number', 'main export is a number' );
+	t.end();
+});
+
+tape( 'the exported value is 34', function test( t ) {
+	t.strictEqual( FLOAT32_MAX_SAFE_NTH_FACTORIAL, 34, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds `constants/float32/max-safe-nth-factorial`, which would be the single-precision variant for [`constants/float64/max-safe-nth-factorial`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/constants/float64/max-safe-nth-factorial).
-   is one of the pre-requisites for adding `math/base/special/factorialf`, which would be the single-precision variant for [`math/base/special/factorial`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/factorial).

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves a part of #649.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

I have used the maximum possible nth value as `34`.
```bash
34! = ~2.952327990396041e38
```

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
