### PR TITLE
feat: add `blas/base/stpsv`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/stpsv/README.md
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/README.md
@@ -1,0 +1,257 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# stpsv
+
+> Solve one of the systems of equations `A*x = b` or `A^T*x = b`.
+
+<section class = "usage">
+
+## Usage
+
+```javascript
+var stpsv = require( '@stdlib/blas/base/stpsv' );
+```
+
+#### stpsv( order, uplo, trans, diag, N, AP, x, sx )
+
+Solves one of the systems of equations `A*x = b` or `A^T*x = b` where `b` and `x` are `N` element vectors and `A` is an `N` by `N` unit, or non-unit, upper or lower triangular matrix, supplied in packed form.
+
+```javascript
+var Float32Array = require( '@stdlib/array/float32' );
+
+var AP = new Float32Array( [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ] );
+var x = new Float32Array( [ 1.0, 2.0, 3.0 ] );
+
+stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 3, AP, x, 1 );
+// x => <Float32Array>[ 0.0, -4.0, 3.0 ]
+```
+
+The function has the following parameters:
+
+-   **order**: storage layout.
+-   **uplo**: specifies whether `A` is an upper or lower triangular matrix.
+-   **trans**: specifies whether `A` should be transposed, conjugate-transposed, or not transposed.
+-   **diag**: specifies whether `A` has a unit diagonal.
+-   **N**: number of elements along each dimension of `A`.
+-   **AP**: packed form of a symmetric matrix `A` stored in linear memory as a [`Float32Array`][mdn-float32array].
+-   **x**: input vector [`Float32Array`][mdn-float32array].
+-   **sx**: `x` stride length.
+
+The stride parameters determine how elements in the input arrays are accessed at runtime. For example, to iterate over the elements of `x` in reverse order,
+
+```javascript
+var Float32Array = require( '@stdlib/array/float32' );
+
+var AP = new Float32Array( [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ] );
+var x = new Float32Array( [ 3.0, 2.0, 1.0 ] );
+
+stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 3, AP, x, -1 );
+// x => <Float32Array>[ 3.0, -4.0, 0.0 ]
+```
+
+Note that indexing is relative to the first index. To introduce an offset, use [`typed array`][mdn-typed-array] views.
+
+<!-- eslint-disable stdlib/capitalized-comments -->
+
+```javascript
+var Float32Array = require( '@stdlib/array/float32' );
+
+// Initial arrays...
+var x0 = new Float32Array( [ 1.0, 1.0, 1.0, 1.0 ] );
+var AP = new Float32Array( [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ] );
+
+// Create offset views...
+var x1 = new Float32Array( x0.buffer, x0.BYTES_PER_ELEMENT*1 ); // start at 2nd element
+
+stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 3, AP, x1, 1 );
+// x0 => <Float32Array>[ 1.0, 0.0, -1.0, 1.0 ]
+```
+
+#### stpsv.ndarray( uplo, trans, diag, N, AP, sap, oap, x, sx, ox )
+
+Solves one of the systems of equations `A*x = b` or `A^T*x = b`, using alternative indexing semantics and where `b` and `x` are `N` element vectors and `A` is an `N` by `N` unit, or non-unit, upper or lower triangular matrix, supplied in packed form.
+
+```javascript
+var Float32Array = require( '@stdlib/array/float32' );
+
+var AP = new Float32Array( [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ] );
+var x = new Float32Array( [ 1.0, 2.0, 3.0 ] );
+
+stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 3, AP, 1, 0, x, 1, 0 );
+// x => <Float32Array>[ 0.0, -4.0, 3.0 ]
+```
+
+The function has the following additional parameters:
+
+-   **sap**: `AP` stride length.
+-   **oap**: starting index for `AP`.
+-   **ox**: starting index for `x`.
+
+While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying buffer, the offset parameters support indexing semantics based on starting indices. For example,
+
+```javascript
+var Float32Array = require( '@stdlib/array/float32' );
+
+var AP = new Float32Array( [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ] );
+var x = new Float32Array( [ 3.0, 2.0, 1.0 ] );
+
+stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 3, AP, 1, 0, x, -1, 2 );
+// x => <Float32Array>[ 3.0, -4.0, 0.0 ]
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   `stpsv()` corresponds to the [BLAS][blas] level 2 function [`stpsv`][blas-stpsv].
+-   Neither routine tests for singularity or near-singularity. Such tests must be performed before calling the routines.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var stpsv = require( '@stdlib/blas/base/stpsv' );
+
+var opts = {
+    'dtype': 'float32'
+};
+
+var N = 5;
+
+var AP = discreteUniform( N*(N+1)/2, -10.0, 10.0, opts );
+var x = discreteUniform( N, -10.0, 10.0, opts );
+
+stpsv( 'column-major', 'upper', 'no-transpose', 'unit', N, AP, x, 1 );
+console.log( x );
+
+stpsv.ndarray( 'column-major', 'upper', 'no-transpose', 'unit', N, AP, 1, 0, x, 1, 0 );
+console.log( x );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+TODO
+```
+
+#### TODO
+
+TODO.
+
+```c
+TODO
+```
+
+TODO
+
+```c
+TODO
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+TODO
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[blas]: http://www.netlib.org/blas
+
+[blas-stpsv]: https://www.netlib.org/lapack/explore-html/d7/d3b/group__tpsv_gadb3b41066652c8fab89290d2a375e053.html#gadb3b41066652c8fab89290d2a375e053
+
+[mdn-float32array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array
+
+[mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/blas/base/stpsv/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/benchmark/benchmark.js
@@ -1,0 +1,105 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var zeros = require( '@stdlib/array/zeros' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var floor = require( '@stdlib/math/base/special/floor' );
+var pkg = require( './../package.json' ).name;
+var stpsv = require( './../lib/stpsv.js' );
+
+
+// VARIABLES //
+
+var options = {
+	'dtype': 'float32'
+};
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} N - number of elements along each dimension
+* @returns {Function} benchmark function
+*/
+function createBenchmark( N ) {
+	var AP = discreteUniform( N*(N+1)/2, -10.0, 10.0, options );
+	var x = zeros( N, options.dtype );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var z;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			z = stpsv( 'row-major', 'upper', 'transpose', 'non-unit', N, AP, x, 1 );
+			if ( isnanf( z[ i%z.length ] ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnanf( z[ i%z.length ] ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var min;
+	var max;
+	var N;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		N = floor( pow( pow( 10, i ), 1.0/2.0 ) );
+		f = createBenchmark( N );
+		bench( pkg+':size='+(N*N), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/blas/base/stpsv/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/benchmark/benchmark.ndarray.js
@@ -1,0 +1,105 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var zeros = require( '@stdlib/array/zeros' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var floor = require( '@stdlib/math/base/special/floor' );
+var pkg = require( './../package.json' ).name;
+var stpsv = require( './../lib/ndarray.js' );
+
+
+// VARIABLES //
+
+var options = {
+	'dtype': 'float32'
+};
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} N - number of elements along each dimension
+* @returns {Function} benchmark function
+*/
+function createBenchmark( N ) {
+	var AP = discreteUniform( N*(N+1)/2, -10.0, 10.0, options );
+	var x = zeros( N, options.dtype );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var z;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			z = stpsv( 'row-major', 'upper', 'transpose', 'non-unit', N, AP, 1, 0, x, 1, 0 );
+			if ( isnanf( z[ i%z.length ] ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnanf( z[ i%z.length ] ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var min;
+	var max;
+	var N;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		N = floor( pow( pow( 10, i ), 1.0/2.0 ) );
+		f = createBenchmark( N );
+		bench( pkg+':ndarray:size='+(N*N), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/blas/base/stpsv/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/docs/repl.txt
@@ -1,0 +1,116 @@
+
+{{alias}}( ord, uplo, trans, diag, N, AP, x, sx )
+    Solves one of the systems of equations `A*x = b` or `A^T*x = b` where `b`
+    and `x` are `N` element vectors and `A` is an `N` by `N` unit, or non-unit,
+    upper or lower triangular matrix, supplied in packed form.
+
+    Indexing is relative to the first index. To introduce an offset, use typed
+    array views.
+
+    If `N` is equal to `0`, the function returns `x` unchanged.
+
+    Parameters
+    ----------
+    ord: string
+        Row-major (C-style) or column-major (Fortran-style) order. Must be
+        either 'row-major' or 'column-major'.
+
+    uplo: string
+        Specifies whether `A` is an upper or lower triangular matrix.
+
+    trans: string
+        Specifies whether `A` should be transposed, conjugate-transposed, or not
+        transposed.
+
+    diag: string
+        Specifies whether `A` has a unit diagonal.
+
+    N: integer
+        Number of elements along each dimension of `A`.
+
+    AP: Float32Array
+        Matrix in packed form.
+
+    x: Float32Array
+        Input vector.
+
+    sx: integer
+        Index increment for `x`.
+
+    Returns
+    -------
+    x: Float32Array
+        Input vector.
+
+    Examples
+    --------
+    > var x = new {{alias:@stdlib/array/float32}}( [ 1.0, 1.0 ] );
+    > var AP = new {{alias:@stdlib/array/float32}}( [ 1.0, 2.0, 1.0 ] );
+    > {{alias}}( 'row-major', 'upper', 'no-transpose', 'unit', 2, AP, x, 1 )
+    <Float32Array>[ -1.0, 1.0 ]
+
+
+{{alias}}.ndarray( ord, uplo, trans, diag, N, AP, sap, oap, x, sx, ox )
+    Solves one of the systems of equations `A*x = b` or `A^T*x = b`, using
+    alternative indexing semantics and where `b` and `x` are `N` element vectors
+    and `A` is an `N` by `N` unit, or non-unit, upper or lower triangular
+    matrix, supplied in packed form.
+
+    While typed array views mandate a view offset based on the underlying
+    buffer, the offset parameters support indexing semantics based on starting
+    indices.
+
+    Parameters
+    ----------
+    ord: string
+        Row-major (C-style) or column-major (Fortran-style) order. Must be
+        either 'row-major' or 'column-major'.
+
+    uplo: string
+        Specifies whether `A` is an upper or lower triangular matrix.
+
+    trans: string
+        Specifies whether `A` should be transposed, conjugate-transposed, or not
+        transposed.
+
+    diag: string
+        Specifies whether `A` has a unit diagonal.
+
+    N: integer
+        Number of elements along each dimension of `A`.
+
+    AP: Float32Array
+        Matrix in packed form.
+
+    sap: integer
+        Index increment for `AP`.
+
+    oap: integer
+        Starting index for `AP`.
+
+    x: Float32Array
+        Input vector.
+
+    sx: integer
+        Index increment for `x`.
+
+    ox: integer
+        Starting index for `x`.
+
+    Returns
+    -------
+    x: Float32Array
+        Input vector.
+
+    Examples
+    --------
+    > var x = new {{alias:@stdlib/array/float32}}( [ 1.0, 1.0 ] );
+    > var AP = new {{alias:@stdlib/array/float32}}( [ 1.0, 2.0, 1.0 ] );
+    > var ord = 'row-major';
+    > var uplo = 'upper';
+    > var trans = 'no-transpose';
+    > {{alias}}.ndarray( ord, uplo, trans, 'unit', 2, AP, 1, 0, x, 1, 0 )
+    <Float32Array>[ -1.0, 1.0 ]
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/blas/base/stpsv/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/docs/types/index.d.ts
@@ -1,0 +1,116 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { Layout, MatrixTriangle, TransposeOperation, DiagonalType } from '@stdlib/types/blas';
+
+/**
+* Interface describing `stpsv`.
+*/
+interface Routine {
+	/**
+	* Solves one of the systems of equations `A*x = b` or `A^T*x = b` where `b` and `x` are `N` element vectors and `A` is an `N` by `N` unit, or non-unit, upper or lower triangular matrix, supplied in packed form.
+	*
+	* @param order - storage layout
+	* @param uplo - specifies whether `A` is an upper or lower triangular matrix
+	* @param trans - specifies whether `A` should be transposed, conjugate-transposed, or not transposed
+	* @param diag - specifies whether `A` has a unit diagonal
+	* @param N - number of elements along each dimension in the matrix `A`
+	* @param AP - packed form of a symmetric matrix `A`
+	* @param x - input vector
+	* @param strideX - `x` stride length
+	* @returns `x`
+	*
+	* @example
+	* var Float32Array = require( '@stdlib/array/float32' );
+	*
+	* var AP = new Float32Array( [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ] ); // => [ [ 1.0, 2.0, 3.0 ], [ 0.0, 1.0, 2.0 ], [ 0.0, 0.0, 1.0 ] ]
+	* var x = new Float32Array( [ 1.0, 2.0, 3.0 ] );
+	*
+	* stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 3, AP, x, 1 );
+	* // x => <Float32Array>[ 0.0, -4.0, 3.0 ]
+	*/
+	( order: Layout, uplo: MatrixTriangle, trans: TransposeOperation, diag: DiagonalType, N: number, AP: Float32Array, x: Float32Array, strideX: number ): Float32Array;
+
+	/**
+	* Solves one of the systems of equations `A*x = b` or `A^T*x = b`, using alternative indexing semantics and where `b` and `x` are `N` element vectors and `A` is an `N` by `N` unit, or non-unit, upper or lower triangular matrix, supplied in packed form.
+	*
+	* @param uplo - specifies whether `A` is an upper or lower triangular matrix
+	* @param trans - specifies whether `A` should be transposed, conjugate-transposed, or not transposed
+	* @param diag - specifies whether `A` has a unit diagonal
+	* @param N - number of elements along each dimension in the matrix `A`
+	* @param AP - packed form of a symmetric matrix `A`
+	* @param strideAP - `AP` stride length
+	* @param offsetAP - starting index for `AP`
+	* @param x - input vector
+	* @param strideX - `x` stride length
+	* @param offsetX - starting index for `x`
+	* @returns `x`
+	*
+	* @example
+	* var Float32Array = require( '@stdlib/array/float32' );
+	*
+	* var AP = new Float32Array( [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ] ); // => [ [ 1.0, 2.0, 3.0 ], [ 0.0, 1.0, 2.0 ], [ 0.0, 0.0, 1.0 ] ]
+	* var x = new Float32Array( [ 1.0, 2.0, 3.0 ] );
+	*
+	* stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 3, AP, 1, 0, x, 1, 0 );
+	* // x => <Float32Array>[ 0.0, -4.0, 3.0 ]
+	*/
+	ndarray( uplo: MatrixTriangle, trans: TransposeOperation, diag: DiagonalType, N: number, AP: Float32Array, strideAP: number, offsetAP: number, x: Float32Array, strideX: number, offsetX: number ): Float32Array;
+}
+
+/**
+* Solves one of the systems of equations `A*x = b` or `A^T*x = b` where `b` and `x` are `N` element vectors and `A` is an `N` by `N` unit, or non-unit, upper or lower triangular matrix, supplied in packed form.
+*
+* @param order - storage layout
+* @param uplo - specifies whether `A` is an upper or lower triangular matrix
+* @param trans - specifies whether `A` should be transposed, conjugate-transposed, or not transposed
+* @param diag - specifies whether `A` has a unit diagonal
+* @param N - number of elements along each dimension in the matrix `A`
+* @param AP - packed form of a symmetric matrix `A`
+* @param x - input vector
+* @param strideX - `x` stride length
+* @returns `x`
+*
+* @example
+* var Float32Array = require( '@stdlib/array/float32' );
+*
+* var AP = new Float32Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+* var x = new Float32Array( [ 1.0, 1.0, 1.0 ] );
+*
+* stpsv( 'row-major', 'lower', 'no-transpose', 'non-unit', 3, AP, x, 1 );
+* // x => <Float32Array>[ 1.0, ~-0.33, ~-0.22 ]
+*
+* @example
+* var Float32Array = require( '@stdlib/array/float32' );
+*
+* var AP = new Float32Array( [ 1.0, 0.0, 0.0, 2.0, 3.0, 0.0, 4.0, 5.0, 6.0 ] );
+* var x = new Float32Array( [ 1.0, 1.0, 1.0 ] );
+*
+* stpsv.ndarray( 'row-major', 'lower', 'no-transpose', 'non-unit', 3, AP, 1, 0, x, 1, 0 );
+* // x => <Float32Array>[ 1.0, ~-0.33, ~-0.22 ]
+*/
+declare var stpsv: Routine;
+
+
+// EXPORTS //
+
+export = stpsv;

--- a/lib/node_modules/@stdlib/blas/base/stpsv/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/docs/types/test.ts
@@ -1,0 +1,372 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import stpsv = require( './index' );
+
+
+// TESTS //
+
+// The function returns a Float32Array...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectType Float32Array
+}
+
+// The compiler throws an error if the function is provided a first argument which is not a string...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpsv( 10, 'upper', 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpsv( true, 'upper', 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpsv( false, 'upper', 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpsv( null, 'upper', 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpsv( undefined, 'upper', 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpsv( [], 'upper', 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpsv( {}, 'upper', 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpsv( ( x: number ): number => x, 'upper', 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument which is not a string...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpsv( 'row-major', 10, 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpsv( 'row-major', true, 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpsv( 'row-major', false, 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpsv( 'row-major', null, 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpsv( 'row-major', undefined, 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpsv( 'row-major', [], 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpsv( 'row-major', {}, 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpsv( 'row-major', ( x: number ): number => x, 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a third argument which is not a string...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpsv( 'row-major', 'upper', 10, 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', true, 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', false, 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', null, 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', undefined, 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', [], 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', {}, 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', ( x: number ): number => x, 'unit', 10, AP, x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a fourth argument which is not a string...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpsv( 'row-major', 'upper', 'no-transpose', 10, 10, AP, x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', true, 10, AP, x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', false, 10, AP, x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', null, 10, AP, x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', undefined, 10, AP, x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', [], 10, AP, x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', {}, 10, AP, x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', ( x: number ): number => x, 10, AP, x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a fifth argument which is not a number...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', '10', AP, x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', true, AP, x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', false, AP, x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', null, AP, x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', undefined, AP, x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', [], AP, x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', {}, AP, x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', ( x: number ): number => x, AP, x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a sixth argument which is not a Float32Array...
+{
+	const x = new Float32Array( 10 );
+
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, 10, x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, '10', x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, true, x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, false, x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, null, x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, undefined, x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, [ '1' ], x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, {}, x, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, ( x: number ): number => x, x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a seventh argument which is not a Float32Array...
+{
+	const AP = new Float32Array( 55 );
+
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 10, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, '10', 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, true, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, false, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, null, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, undefined, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, [ '1' ], 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, {}, 1 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, ( x: number ): number => x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an eighth argument which is not a number...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, x, '10' ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, x, true ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, x, false ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, x, null ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, x, undefined ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, x, [] ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, x, {} ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, x, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpsv(); // $ExpectError
+	stpsv( 'row-major' ); // $ExpectError
+	stpsv( 'row-major', 'upper' ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose' ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit' ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10 ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, x ); // $ExpectError
+	stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, x, 1, 1 ); // $ExpectError
+}
+
+// Attached to main export is an `ndarray` method which returns a Float32Array...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectType Float32Array
+}
+
+// The compiler throws an error if the function is provided a first argument which is not a string...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpsv.ndarray( 10, 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( true, 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( false, 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( null, 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( undefined, 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( [], 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( {}, 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( ( x: number ): number => x, 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument which is not a string...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpsv.ndarray( 'row-major', 10, 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', true, 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', false, 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', null, 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', undefined, 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', [], 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', {}, 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', ( x: number ): number => x, 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a third argument which is not a string...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpsv.ndarray( 'row-major', 'upper', 10, 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', true, 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', false, 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', null, 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', undefined, 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', [], 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', {}, 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', ( x: number ): number => x, 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a fourth argument which is not a string...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 10, 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', true, 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', false, 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', null, 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', undefined, 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', [], 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', {}, 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', ( x: number ): number => x, 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a fifth argument which is not a number...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', '10', AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', true, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', false, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', null, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', undefined, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', [], AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', {}, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', ( x: number ): number => x, AP, 1, 0, x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a sixth argument which is not a Float32Array...
+{
+	const x = new Float32Array( 10 );
+
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, 10, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, '10', 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, true, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, false, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, null, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, undefined, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, [ '1' ], 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, {}, 1, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, ( x: number ): number => x, 1, 0, x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a seventh argument which is not a number...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, '10', 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, true, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, false, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, null, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, undefined, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, [], 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, {}, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, ( x: number ): number => x, 0, x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an eighth argument which is not a number...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, '10', 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, true, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, false, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, null, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, undefined, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, [], 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, {}, 0, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, ( x: number ): number => x, 0, x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a ninth argument which is not a number...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, '10', x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, true, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, false, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, null, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, undefined, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, [], x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, {}, x, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, ( x: number ): number => x, x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a tenth argument which is not a Float32Array...
+{
+	const AP = new Float32Array( 55 );
+
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, 10, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, '10', 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, true, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, false, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, null, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, undefined, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, [ '1' ], 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, {}, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, ( x: number ): number => x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an eleventh argument which is not a number...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, '10', 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, true, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, false, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, null, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, undefined, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, [], 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, {}, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, ( x: number ): number => x, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a twelfth argument which is not a number...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, '10' ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, true ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, false ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, null ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, undefined ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, [] ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, {} ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpsv.ndarray(); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper' ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose' ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit' ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1 ); // $ExpectError
+	stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0, 10 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/examples/index.js
@@ -1,0 +1,37 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var stpsv = require( './../lib' );
+
+var opts = {
+	'dtype': 'float32'
+};
+
+var N = 5;
+
+var AP = discreteUniform( N*(N+1)/2, -10.0, 10.0, opts );
+var x = discreteUniform( N, -10.0, 10.0, opts );
+
+stpsv( 'column-major', 'upper', 'no-transpose', 'unit', N, AP, N, x, 1 );
+console.log( x );
+
+stpsv.ndarray( 'upper', 'no-transpose', 'unit', N, AP, 1, 0, x, 1, 0 );
+console.log( x );

--- a/lib/node_modules/@stdlib/blas/base/stpsv/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/examples/index.js
@@ -30,8 +30,8 @@ var N = 5;
 var AP = discreteUniform( N*(N+1)/2, -10.0, 10.0, opts );
 var x = discreteUniform( N, -10.0, 10.0, opts );
 
-stpsv( 'column-major', 'upper', 'no-transpose', 'unit', N, AP, N, x, 1 );
+stpsv( 'column-major', 'upper', 'no-transpose', 'non-unit', N, AP, x, 1 );
 console.log( x );
 
-stpsv.ndarray( 'column-major', 'upper', 'no-transpose', 'unit', N, AP, 1, 0, x, 1, 0 );
+stpsv.ndarray( 'column-major', 'upper', 'no-transpose', 'non-unit', N, AP, 1, 0, x, 1, 0 );
 console.log( x );

--- a/lib/node_modules/@stdlib/blas/base/stpsv/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/examples/index.js
@@ -33,5 +33,5 @@ var x = discreteUniform( N, -10.0, 10.0, opts );
 stpsv( 'column-major', 'upper', 'no-transpose', 'unit', N, AP, N, x, 1 );
 console.log( x );
 
-stpsv.ndarray( 'upper', 'no-transpose', 'unit', N, AP, 1, 0, x, 1, 0 );
+stpsv.ndarray( 'column-major', 'upper', 'no-transpose', 'unit', N, AP, 1, 0, x, 1, 0 );
 console.log( x );

--- a/lib/node_modules/@stdlib/blas/base/stpsv/lib/base.js
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/lib/base.js
@@ -131,7 +131,7 @@ function stpsv( order, uplo, trans, diag, N, AP, strideAP, offsetAP, x, strideX,
 				iap += strideAP;
 			}
 			if ( nonunit ) {
-				tmp = f32( tmp / AP[ kk ] );
+				tmp = f32( tmp / AP[ iap ] );
 			}
 			x[ ix1 ] = tmp;
 			ix1 += strideX;

--- a/lib/node_modules/@stdlib/blas/base/stpsv/lib/base.js
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/lib/base.js
@@ -1,0 +1,168 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var f32 = require( '@stdlib/number/float64/base/to-float32' );
+
+
+// MAIN //
+
+/**
+* Solves one of the systems of equations `A*x = b` or `A^T*x = b` where `b` and `x` are `N` element vectors and `A` is an `N` by `N` unit, or non-unit, upper or lower triangular matrix, supplied in packed form.
+*
+* @private
+* @param {string} order - storage layout
+* @param {string} uplo - specifies whether `A` is an upper or lower triangular matrix
+* @param {string} trans - specifies whether `A` should be transposed, conjugate-transposed, or not transposed
+* @param {string} diag - specifies whether `A` has a unit diagonal
+* @param {NonNegativeInteger} N - number of elements along each dimension of `A`
+* @param {Float32Array} AP - input matrix
+* @param {integer} strideAP - `AP` stride length
+* @param {NonNegativeInteger} offsetAP - starting index for `AP`
+* @param {Float32Array} x - input vector
+* @param {integer} strideX - `x` stride length
+* @param {NonNegativeInteger} offsetX - starting index for `x`
+* @returns {Float32Array} `x`
+*
+* @example
+* var Float32Array = require( '@stdlib/array/float32' );
+*
+* var AP = new Float32Array( [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ] ); // => [ [ 1.0, 2.0, 3.0 ], [ 0.0, 1.0, 2.0 ], [ 0.0, 0.0, 1.0 ] ]
+* var x = new Float32Array( [ 1.0, 2.0, 3.0 ] );
+*
+* stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 3, AP, 1, 0, x, 1, 0 );
+* // x => <Float32Array>[ 0.0, -4.0, 3.0 ]
+*/
+function stpsv( order, uplo, trans, diag, N, AP, strideAP, offsetAP, x, strideX, offsetX ) { // eslint-disable-line max-params, max-len
+	var nonunit;
+	var isrm;
+	var tmp;
+	var iap;
+	var ix1;
+	var ix0;
+	var i0;
+	var i1;
+	var kk;
+	var ox;
+
+	isrm = ( order === 'row-major' );
+	nonunit = ( diag === 'non-unit' );
+	kk = offsetAP;
+	ox = offsetX;
+	if (
+		( !isrm && uplo === 'upper' && trans === 'no-transpose' ) ||
+		( isrm && uplo === 'lower' && trans !== 'no-transpose' )
+	) {
+		kk += ( ( N * ( N + 1 ) / 2 ) - 1 ) * strideAP;
+		ix1 = ox + ( ( N - 1 ) * strideX );
+		for ( i1 = N - 1; i1 >= 0; i1-- ) {
+			if ( x[ ix1 ] !== 0.0 ) {
+				if ( nonunit ) {
+					x[ ix1 ] = f32( x[ ix1 ] / AP[ kk ] );
+				}
+				tmp = x[ ix1 ];
+				ix0 = ix1;
+				iap = kk;
+				for ( i0 = i1 - 1; i0 >= 0; i0-- ) {
+					ix0 -= strideX;
+					iap -= strideAP;
+					x[ ix0 ] -= f32( tmp * AP[ iap ] );
+				}
+			}
+			ix1 -= strideX;
+			kk -= ( i1 + 1 ) * strideAP;
+		}
+		return x;
+	}
+	if (
+		( !isrm && uplo === 'lower' && trans === 'no-transpose' ) ||
+		( isrm && uplo === 'upper' && trans !== 'no-transpose' )
+	) {
+		ix1 = ox;
+		for ( i1 = 0; i1 < N; i1++ ) {
+			if ( x[ ix1 ] !== 0.0 ) {
+				if ( nonunit ) {
+					x[ ix1 ] = f32( x[ ix1 ] / AP[ kk ] );
+				}
+				tmp = x[ ix1 ];
+				ix0 = ix1;
+				iap = kk;
+				for ( i0 = i1 + 1; i0 < N; i0++ ) {
+					ix0 += strideX;
+					iap += strideAP;
+					x[ ix0 ] -= f32( tmp * AP[ iap ] );
+				}
+			}
+			ix1 += strideX;
+			kk += ( N - i1 ) * strideAP;
+		}
+		return x;
+	}
+	if (
+		( !isrm && uplo === 'upper' && 'trans' !== 'no-transpose' ) ||
+		( isrm && uplo === 'lower' && trans === 'no-transpose' )
+	) {
+		ix1 = ox;
+		for ( i1 = 0; i1 < N; i1++ ) {
+			tmp = x[ ix1 ];
+			ix0 = ox;
+			iap = kk;
+			for ( i0 = 0; i0 < i1; i0++ ) {
+				tmp -= f32( x[ ix0 ] * AP[ iap ] );
+				ix0 += strideX;
+				iap += strideAP;
+			}
+			if ( nonunit ) {
+				tmp = f32( tmp / AP[ kk ] );
+			}
+			x[ ix1 ] = tmp;
+			ix1 += strideX;
+			kk += ( i1 + 1 ) * strideAP;
+		}
+		return x;
+	}
+	// ( !isrm && uplo === 'lower' && trans !== 'no-transpose' ) || ( isrm && uplo === 'upper' && trans === 'no-transpose' )
+	kk += ( ( N * ( N + 1 ) / 2 ) - 1 ) * strideAP;
+	ox += ( N - 1 ) * strideX;
+	ix1 = ox;
+	for ( i1 = N - 1; i1 >= 0; i1-- ) {
+		tmp = x[ ix1 ];
+		ix0 = ox;
+		iap = kk;
+		for ( i0 = N - 1; i0 > i1; i0-- ) {
+			tmp -= f32( x[ ix0 ] * AP[ iap ] );
+			ix0 -= strideX;
+			iap -= strideAP;
+		}
+		if ( nonunit ) {
+			tmp = f32( tmp / AP[ iap ] );
+		}
+		x[ ix1 ] = tmp;
+		ix1 -= strideX;
+		kk -= ( N - i1 ) * strideAP;
+	}
+	return x;
+}
+
+
+// EXPORTS //
+
+module.exports = stpsv;

--- a/lib/node_modules/@stdlib/blas/base/stpsv/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/lib/index.js
@@ -1,0 +1,70 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* BLAS level 2 routine to solve one of the systems of equations `A*x = b`, or `A^T*x = b` where `b` and `x` are `N` element vectors and `A` is an `N` by `N` unit, or non-unit, upper or lower triangular matrix, supplied in packed form.
+*
+* @module @stdlib/blas/base/stpsv
+*
+* @example
+* var Float32Array = require( '@stdlib/array/float32' );
+* var stpsv = require( '@stdlib/blas/base/stpsv' );
+*
+* var AP = new Float32Array( [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ] ); // => [ [ 1.0, 2.0, 3.0 ], [ 0.0, 1.0, 2.0 ], [ 0.0, 0.0, 1.0 ] ]
+* var x = new Float32Array( [ 1.0, 2.0, 3.0 ] );
+*
+* stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 3, AP, x, 1 );
+* // x => <Float32Array>[ 0.0, -4.0, 3.0 ]
+*
+* @example
+* var Float32Array = require( '@stdlib/array/float32' );
+* var stpsv = require( '@stdlib/blas/base/stpsv' );
+*
+* var AP = new Float32Array( [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ] ); // => [ [ 1.0, 2.0, 3.0 ], [ 0.0, 1.0, 2.0 ], [ 0.0, 0.0, 1.0 ] ]
+* var x = new Float32Array( [ 1.0, 2.0, 3.0 ] );
+*
+* stpsv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 3, AP, 1, 0, x, 1, 0 );
+* // x => <Float32Array>[ 0.0, -4.0, 3.0 ]
+*/
+
+// MODULES //
+
+var join = require( 'path' ).join;
+var tryRequire = require( '@stdlib/utils/try-require' );
+var isError = require( '@stdlib/assert/is-error' );
+var main = require( './main.js' );
+
+
+// MAIN //
+
+var stpsv;
+var tmp = tryRequire( join( __dirname, './native.js' ) );
+if ( isError( tmp ) ) {
+	stpsv = main;
+} else {
+	stpsv = tmp;
+}
+
+
+// EXPORTS //
+
+module.exports = stpsv;
+
+// exports: { "ndarray": "stpsv.ndarray" }

--- a/lib/node_modules/@stdlib/blas/base/stpsv/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/lib/main.js
@@ -1,0 +1,35 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
+var stpsv = require( './stpsv.js' );
+var ndarray = require( './ndarray.js' );
+
+
+// MAIN //
+
+setReadOnly( stpsv, 'ndarray', ndarray );
+
+
+// EXPORTS //
+
+module.exports = stpsv;

--- a/lib/node_modules/@stdlib/blas/base/stpsv/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/lib/ndarray.js
@@ -1,0 +1,96 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isLayout = require( '@stdlib/blas/base/assert/is-layout' );
+var isMatrixTriangle = require( '@stdlib/blas/base/assert/is-matrix-triangle' );
+var isTransposeOperation = require( '@stdlib/blas/base/assert/is-transpose-operation' );
+var isDiagonal = require( '@stdlib/blas/base/assert/is-diagonal-type' );
+var format = require( '@stdlib/string/format' );
+var base = require( './base.js' );
+
+
+// MAIN //
+
+/**
+* Solves one of the systems of equations `A*x = b` or `A^T*x = b` where `b` and `x` are `N` element vectors and `A` is an `N` by `N` unit, or non-unit, upper or lower triangular matrix, supplied in packed form.
+*
+* @param {string} order - storage layout
+* @param {string} uplo - specifies whether `A` is an upper or lower triangular matrix
+* @param {string} trans - specifies whether `A` should be transposed, conjugate-transposed, or not transposed
+* @param {string} diag - specifies whether `A` has a unit diagonal
+* @param {NonNegativeInteger} N - number of elements along each dimension of `A`
+* @param {Float32Array} AP - matrix in packed form
+* @param {integer} strideAP - `AP` stride length
+* @param {NonNegativeInteger} offsetAP - starting index for `AP`
+* @param {Float32Array} x - input vector
+* @param {integer} strideX - `x` stride length
+* @param {NonNegativeInteger} offsetX - starting index for `x`
+* @throws {TypeError} first argument must be a valid order
+* @throws {TypeError} second argument must specify whether a lower or upper triangular matrix is supplied
+* @throws {TypeError} third argument must be a valid transpose operation
+* @throws {TypeError} fourth argument must be a valid diagonal type
+* @throws {RangeError} fifth argument must be a nonnegative integer
+* @throws {RangeError} seventh argument must be non-zero
+* @throws {RangeError} tenth argument must be non-zero
+* @returns {Float32Array} `x`
+*
+* @example
+* var Float32Array = require( '@stdlib/array/float32' );
+*
+* var AP = new Float32Array( [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ] ); // => [ [ 1.0, 2.0, 3.0 ], [ 0.0, 1.0, 2.0 ], [ 0.0, 0.0, 1.0 ] ]
+* var x = new Float32Array( [ 1.0, 2.0, 3.0 ] );
+*
+* stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 3, AP, 1, 0, x, 1, 0 );
+* // x => <Float32Array>[ 0.0, -4.0, 3.0 ]
+*/
+function stpsv( order, uplo, trans, diag, N, AP, strideAP, offsetAP, x, strideX, offsetX ) { // eslint-disable-line max-params, max-len
+	if ( !isLayout( order ) ) {
+		throw new TypeError( format( 'invalid argument. First argument must be a valid order. Value: `%s`.', order ) );
+	}
+	if ( !isMatrixTriangle( uplo ) ) {
+		throw new TypeError( format( 'invalid argument. Second argument must specify whether the lower or upper triangular matrix is supplied. Value: `%s`.', uplo ) );
+	}
+	if ( !isTransposeOperation( trans ) ) {
+		throw new TypeError( format( 'invalid argument. Third argument must be a valid transpose operation. Value: `%s`.', trans ) );
+	}
+	if ( !isDiagonal( diag ) ) {
+		throw new TypeError( format( 'invalid argument. Fourth argument must be a valid diagonal type. Value: `%s`.', diag ) );
+	}
+	if ( N < 0 ) {
+		throw new RangeError( format( 'invalid argument. Fifth argument must be a nonnegative integer. Value: `%d`.', N ) );
+	}
+	if ( strideAP === 0 ) {
+		throw new RangeError( format( 'invalid argument. Seventh argument must be non-zero. Value: `%d`.', strideAP ) );
+	}
+	if ( strideX === 0 ) {
+		throw new RangeError( format( 'invalid argument. Tenth argument must be non-zero. Value: `%d`.', strideX ) );
+	}
+	if ( N === 0 ) {
+		return x;
+	}
+	return base( order, uplo, trans, diag, N, AP, strideAP, offsetAP, x, strideX, offsetX ); // eslint-disable-line max-len
+}
+
+
+// EXPORTS //
+
+module.exports = stpsv;

--- a/lib/node_modules/@stdlib/blas/base/stpsv/lib/stpsv.js
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/lib/stpsv.js
@@ -1,0 +1,93 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isLayout = require( '@stdlib/blas/base/assert/is-layout' );
+var isMatrixTriangle = require( '@stdlib/blas/base/assert/is-matrix-triangle' );
+var isTransposeOperation = require( '@stdlib/blas/base/assert/is-transpose-operation' );
+var isDiagonal = require( '@stdlib/blas/base/assert/is-diagonal-type' );
+var stride2offset = require( '@stdlib/strided/base/stride2offset' );
+var format = require( '@stdlib/string/format' );
+var base = require( './base.js' );
+
+
+// MAIN //
+
+/**
+* Solves one of the systems of equations `A*x = b` or `A^T*x = b` where `b` and `x` are `N` element vectors and `A` is an `N` by `N` unit, or non-unit, upper or lower triangular matrix, supplied in packed form.
+*
+* @param {string} order - storage layout
+* @param {string} uplo - specifies whether the upper or lower triangular part of the symmetric matrix `A` is supplied
+* @param {string} trans - specifies whether `A` should be transposed, conjugate-transposed, or not transposed
+* @param {string} diag - specifies whether `A` has a unit diagonal
+* @param {NonNegativeInteger} N - number of elements along each dimension of `A`
+* @param {Float32Array} AP - packed form of a symmetric matrix `A`
+* @param {Float32Array} x - input vector
+* @param {integer} strideX - `x` stride length
+* @throws {TypeError} first argument must be a valid order
+* @throws {TypeError} second argument must specify whether a lower or upper triangular matrix is supplied
+* @throws {TypeError} third argument must be a valid transpose operation
+* @throws {TypeError} fourth argument must be a valid diagonal type
+* @throws {RangeError} fifth argument must be a nonnegative integer
+* @throws {RangeError} eighth argument must be non-zero
+* @returns {Float32Array} `x`
+*
+* @example
+* var Float32Array = require( '@stdlib/array/float32' );
+*
+* var AP = new Float32Array( [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ] ); // => [ [ 1.0, 2.0, 3.0 ], [ 0.0, 1.0, 2.0 ], [ 0.0, 0.0, 1.0 ] ]
+* var x = new Float32Array( [ 1.0, 2.0, 3.0 ] );
+*
+* stpsv( 'row-major', 'upper', 'no-transpose', 'unit', 3, AP, x, 1 );
+* // x => <Float32Array>[ 0.0, -4.0, 3.0 ]
+*/
+function stpsv( order, uplo, trans, diag, N, AP, x, strideX ) {
+	var ox;
+
+	if ( !isLayout( order ) ) {
+		throw new TypeError( format( 'invalid argument. First argument must be a valid order. Value: `%s`.', order ) );
+	}
+	if ( !isMatrixTriangle( uplo ) ) {
+		throw new TypeError( format( 'invalid argument. Second argument must specify whether the lower or upper triangular matrix is supplied. Value: `%s`.', uplo ) );
+	}
+	if ( !isTransposeOperation( trans ) ) {
+		throw new TypeError( format( 'invalid argument. Third argument must be a valid transpose operation. Value: `%s`.', trans ) );
+	}
+	if ( !isDiagonal( diag ) ) {
+		throw new TypeError( format( 'invalid argument. Fourth argument must be a valid diagonal type. Value: `%s`.', diag ) );
+	}
+	if ( N < 0 ) {
+		throw new RangeError( format( 'invalid argument. Fifth argument must be a nonnegative integer. Value: `%d`.', N ) );
+	}
+	if ( strideX === 0 ) {
+		throw new RangeError( format( 'invalid argument. Eighth argument must be non-zero. Value: `%d`.', strideX ) );
+	}
+	if ( N === 0 ) {
+		return x;
+	}
+	ox = stride2offset( N, strideX );
+	return base( order, uplo, trans, diag, N, AP, 1, 0, x, strideX, ox );
+}
+
+
+// EXPORTS //
+
+module.exports = stpsv;

--- a/lib/node_modules/@stdlib/blas/base/stpsv/package.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@stdlib/blas/base/stpsv",
+  "version": "0.0.0",
+  "description": "Solve one of the systems of equations `A*x = b`, or `A^T*x = b`.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
+    "blas",
+    "level 2",
+    "stpsv",
+    "linear",
+    "algebra",
+    "subroutines",
+    "array",
+    "ndarray",
+    "float32",
+    "float",
+    "float32array"
+  ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_complex_access_pattern.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_complex_access_pattern.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "no-transpose",
+  "diag": "non-unit",
+  "uplo": "lower",
+  "strideX": -1,
+  "offsetX": 2,
+  "N": 3,
+  "strideAP": -2,
+  "offsetAP": 10,
+  "AP": [ 6, 999, 5, 999, 4, 999, 3, 999, 2, 999, 1 ],
+  "x": [ 3.0, 2.0, 1.0 ],
+  "x_out": [ 0.0, 0.0, 1.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_l_nt_nu.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_l_nt_nu.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "no-transpose",
+  "diag": "non-unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 0,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 1.0, 0.0, 0.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_l_nt_u.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_l_nt_u.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "no-transpose",
+  "diag": "unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 0,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 2.0, 1.0, 1.0, 1.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 1.0, 0.0, 1.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_l_t_nu.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_l_t_nu.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "transpose",
+  "diag": "non-unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 0,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ -0.25, -0.125, 0.5 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_l_t_u.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_l_t_u.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "transpose",
+  "diag": "unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 0,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 0.0, -4.0, 3.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_oap.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_oap.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "no-transpose",
+  "diag": "non-unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 0,
+  "N": 3,
+  "strideAP": 2,
+  "offsetAP": 7,
+  "AP": [ 999, 999, 999, 999, 999, 999, 999, 1, 999, 2, 999, 3, 999, 4, 999, 5, 999, 6 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 1.0, 0.0, 0.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_ox.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_ox.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "transpose",
+  "diag": "unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 1,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ],
+  "x": [ 999.0, 1.0, 2.0, 3.0 ],
+  "x_out": [ 999.0, 0.0, -4.0, 3.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_sap.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_sap.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "transpose",
+  "diag": "unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 0,
+  "N": 3,
+  "strideAP": 2,
+  "offsetAP": 0,
+  "AP": [ 1.0, 999.0, 2.0, 999.0, 3.0, 999.0, 1.0, 999.0, 2.0, 999.0, 1.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 0.0, -4.0, 3.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_sapn.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_sapn.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "no-transpose",
+  "diag": "non-unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 0,
+  "N": 3,
+  "strideAP": -2,
+  "offsetAP": 10,
+  "AP": [ 6, 999, 5, 999, 4, 999, 3, 999, 2, 999, 1 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 1.0, 0.0, 0.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_u_nt_nu.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_u_nt_nu.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "no-transpose",
+  "diag": "non-unit",
+  "uplo": "upper",
+  "strideX": 1,
+  "offsetX": 0,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 4.0, 3.0, 5.0, 6.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ -0.25, -0.125, 0.5 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_u_nt_u.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_u_nt_u.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "no-transpose",
+  "diag": "unit",
+  "uplo": "upper",
+  "strideX": 1,
+  "offsetX": 0,
+  "N": 3,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "AP": [ 1.0, 2.0, 1.0, 3.0, 2.0, 1.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 0.0, -4.0, 3.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_u_t_nu.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_u_t_nu.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "transpose",
+  "diag": "non-unit",
+  "uplo": "upper",
+  "strideX": 1,
+  "offsetX": 0,
+  "N": 3,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "AP": [ 1.0, 2.0, 4.0, 3.0, 5.0, 6.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 1.0, 0.0, 0.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_u_t_u.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_u_t_u.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "transpose",
+  "diag": "unit",
+  "uplo": "upper",
+  "strideX": 1,
+  "offsetX": 0,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 1.0, 3.0, 2.0, 1.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 1.0, 0.0, 0.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_xn.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_xn.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "transpose",
+  "diag": "unit",
+  "uplo": "upper",
+  "strideX": -1,
+  "offsetX": 2,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 1.0, 3.0, 2.0, 1.0 ],
+  "x": [ 3.0, 2.0, 1.0 ],
+  "x_out": [ 0.0, 0.0, 1.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_xp.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/column_major_xp.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "transpose",
+  "diag": "unit",
+  "uplo": "upper",
+  "strideX": 2,
+  "offsetX": 0,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 1.0, 3.0, 2.0, 1.0 ],
+  "x": [ 1.0, 0.0, 2.0, 0.0, 3.0, 0.0 ],
+  "x_out": [ 1.0, 0.0, 0.0, 0.0, 0.0, 0.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_complex_access_pattern.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_complex_access_pattern.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "no-transpose",
+  "diag": "non-unit",
+  "uplo": "lower",
+  "strideX": -1,
+  "offsetX": 2,
+  "N": 3,
+  "strideAP": -2,
+  "offsetAP": 10,
+  "AP": [ 6, 999, 5, 999, 3, 999, 4, 999, 2, 999, 1 ],
+  "x": [ 3.0, 2.0, 1.0 ],
+  "x_out": [ 0.0, 0.0, 1.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_l_nt_nu.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_l_nt_nu.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "no-transpose",
+  "diag": "non-unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 0,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ],
+  "x": [ 0.0, 0.0, 0.0 ],
+  "x_out": [ 0.0, 0.0, 0.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_l_nt_u.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_l_nt_u.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "no-transpose",
+  "diag": "unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 0,
+  "N": 3,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "AP": [ 1.0, 2.0, 1.0, 2.0, 1.0, 1.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 1.0, 0.0, 1.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_l_t_nu.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_l_t_nu.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "transpose",
+  "diag": "non-unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 0,
+  "N": 3,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "AP": [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ],
+  "x": [ 10.0, 10.0, 3.0 ],
+  "x_out": [ 3.0, 2.5, 0.5 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_l_t_u.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_l_t_u.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "transpose",
+  "diag": "unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 0,
+  "N": 3,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "AP": [ 1.0, 2.0, 1.0, 3.0, 4.0, 1.0 ],
+  "x": [ 5.0, 5.0, 5.0 ],
+  "x_out": [ 20.0, -15.0, 5.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_oap.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_oap.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "no-transpose",
+  "diag": "non-unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 0,
+  "N": 3,
+  "strideAP": 2,
+  "offsetAP": 6,
+  "AP": [ 999, 999, 999, 999, 999, 999, 1, 999, 2, 999, 4, 999, 3, 999, 5, 999, 6 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 1.0, 0.0, 0.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_ox.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_ox.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "transpose",
+  "diag": "unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 1,
+  "N": 3,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "AP": [ 1.0, 2.0, 1.0, 3.0, 4.0, 1.0 ],
+  "x": [ 999.0, 5.0, 5.0, 5.0 ],
+  "x_out": [ 999.0, 20.0, -15.0, 5.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_sap.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_sap.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "no-transpose",
+  "diag": "non-unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 0,
+  "N": 3,
+  "strideAP": 2,
+  "offsetAP": 6,
+  "AP": [ 999, 999, 999, 999, 999, 999, 1, 999, 2, 999, 4, 999, 3, 999, 5, 999, 6, 999 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 1.0, 0.0, 0.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_sapn.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_sapn.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "no-transpose",
+  "diag": "non-unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 0,
+  "N": 3,
+  "strideAP": -2,
+  "offsetAP": 10,
+  "AP": [ 6, 999, 5, 999, 3, 999, 4, 999, 2, 999, 1 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 1.0, 0.0, 0.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_u_nt_nu.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_u_nt_nu.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "no-transpose",
+  "diag": "non-unit",
+  "uplo": "upper",
+  "strideX": 1,
+  "offsetX": 0,
+  "N": 3,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "AP": [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ -0.25, -0.125, 0.5 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_u_nt_u.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_u_nt_u.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "no-transpose",
+  "diag": "unit",
+  "uplo": "upper",
+  "strideX": 1,
+  "offsetX": 0,
+  "N": 3,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "AP": [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 0.0, -4.0, 3.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_u_t_nu.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_u_t_nu.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "transpose",
+  "diag": "non-unit",
+  "uplo": "upper",
+  "strideX": 1,
+  "offsetX": 0,
+  "N": 3,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "AP": [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ],
+  "x": [ 10.0, 10.0, 10.0 ],
+  "x_out": [ 10.0, -2.5, -1.25 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_u_t_u.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_u_t_u.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "transpose",
+  "diag": "unit",
+  "uplo": "upper",
+  "strideX": 1,
+  "offsetX": 0,
+  "N": 3,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "AP": [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ],
+  "x": [ 1.0, 1.0, 1.0 ],
+  "x_out": [ 1.0, -1.0, 0.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_xn.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_xn.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "transpose",
+  "diag": "unit",
+  "uplo": "upper",
+  "strideX": -1,
+  "offsetX": 2,
+  "N": 3,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "AP": [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 0.0, -4.0, 3.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_xp.json
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/fixtures/row_major_xp.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "transpose",
+  "diag": "unit",
+  "uplo": "upper",
+  "strideX": 2,
+  "offsetX": 0,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ],
+  "x": [ 1.0, 0.0, 2.0, 0.0, 3.0, 0.0 ],
+  "x_out": [ 1.0, 0.0, 0.0, 0.0, 0.0, 0.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/test.js
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/test.js
@@ -1,0 +1,82 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var proxyquire = require( 'proxyquire' );
+var IS_BROWSER = require( '@stdlib/assert/is-browser' );
+var stpsv = require( './../lib' );
+
+
+// VARIABLES //
+
+var opts = {
+	'skip': IS_BROWSER
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof stpsv, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the main export is a method providing an ndarray interface', function test( t ) {
+	t.strictEqual( typeof stpsv.ndarray, 'function', 'method is a function' );
+	t.end();
+});
+
+tape( 'if a native implementation is available, the main export is the native implementation', opts, function test( t ) {
+	var stpsv = proxyquire( './../lib', {
+		'@stdlib/utils/try-require': tryRequire
+	});
+
+	t.strictEqual( stpsv, mock, 'returns expected value' );
+	t.end();
+
+	function tryRequire() {
+		return mock;
+	}
+
+	function mock() {
+		// Mock...
+	}
+});
+
+tape( 'if a native implementation is not available, the main export is a JavaScript implementation', opts, function test( t ) {
+	var stpsv;
+	var main;
+
+	main = require( './../lib/stpsv.js' );
+
+	stpsv = proxyquire( './../lib', {
+		'@stdlib/utils/try-require': tryRequire
+	});
+
+	t.strictEqual( stpsv, main, 'returns expected value' );
+	t.end();
+
+	function tryRequire() {
+		return new Error( 'Cannot find module' );
+	}
+});

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/test.ndarray.js
@@ -1,0 +1,971 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* eslint-disable max-len */
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var Float32Array = require( '@stdlib/array/float32' );
+var EPS = require( '@stdlib/constants/float32/eps' );
+var abs = require( '@stdlib/math/base/special/abs' );
+var stpsv = require( './../lib/ndarray.js' );
+
+
+// FIXTURES //
+
+var rlntnu = require( './fixtures/row_major_l_nt_nu.json' );
+var rltnu = require( './fixtures/row_major_l_t_nu.json' );
+var rlntu = require( './fixtures/row_major_l_nt_u.json' );
+var rltu = require( './fixtures/row_major_l_t_u.json' );
+var runtnu = require( './fixtures/row_major_u_nt_nu.json' );
+var runtu = require( './fixtures/row_major_u_nt_u.json' );
+var rutnu = require( './fixtures/row_major_u_t_nu.json' );
+var rutu = require( './fixtures/row_major_u_t_u.json' );
+var rsap = require( './fixtures/row_major_sap.json' );
+var rsapn = require( './fixtures/row_major_sapn.json' );
+var roap = require( './fixtures/row_major_oap.json' );
+var rxp = require( './fixtures/row_major_xp.json' );
+var rxn = require( './fixtures/row_major_xn.json' );
+var rox = require( './fixtures/row_major_ox.json' );
+var rcap = require( './fixtures/row_major_complex_access_pattern.json' );
+
+var clntnu = require( './fixtures/column_major_l_nt_nu.json' );
+var cltnu = require( './fixtures/column_major_l_t_nu.json' );
+var clntu = require( './fixtures/column_major_l_nt_u.json' );
+var cltu = require( './fixtures/column_major_l_t_u.json' );
+var cuntnu = require( './fixtures/column_major_u_nt_nu.json' );
+var cuntu = require( './fixtures/column_major_u_nt_u.json' );
+var cutnu = require( './fixtures/column_major_u_t_nu.json' );
+var cutu = require( './fixtures/column_major_u_t_u.json' );
+var csap = require( './fixtures/column_major_sap.json' );
+var csapn = require( './fixtures/column_major_sapn.json' );
+var coap = require( './fixtures/column_major_oap.json' );
+var cxp = require( './fixtures/column_major_xp.json' );
+var cxn = require( './fixtures/column_major_xn.json' );
+var cox = require( './fixtures/column_major_ox.json' );
+var ccap = require( './fixtures/column_major_complex_access_pattern.json' );
+
+
+// FUNCTIONS //
+
+/**
+* Tests for element-wise approximate equality.
+*
+* @private
+* @param {Object} t - test object
+* @param {Collection} actual - actual values
+* @param {Collection} expected - expected values
+* @param {number} rtol - relative tolerance
+*/
+function isApprox( t, actual, expected, rtol ) {
+	var delta;
+	var tol;
+	var i;
+
+	t.strictEqual( actual.length, expected.length, 'returns expected value' );
+	for ( i = 0; i < expected.length; i++ ) {
+		if ( actual[ i ] === expected[ i ] ) {
+			t.strictEqual( actual[ i ], expected[ i ], 'returns expected value' );
+		} else {
+			delta = abs( actual[ i ] - expected[ i ] );
+			tol = rtol * EPS * abs( expected[ i ] );
+			t.ok( delta <= tol, 'within tolerance. actual: '+actual[ i ]+'. expected: '+expected[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
+		}
+	}
+}
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof stpsv, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 11', function test( t ) {
+	t.strictEqual( stpsv.length, 11, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function throws an error if provided an invalid first argument', function test( t ) {
+	var values;
+	var data;
+	var i;
+
+	data = rutu;
+
+	values = [
+		'foo',
+		'bar',
+		'beep',
+		'boop'
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			stpsv( value, data.uplo, data.trans, data.diag, data.N, new Float32Array( data.AP ), data.strideAP, data.offsetAP, new Float32Array( data.x ), data.strideX, data.offsetX );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an invalid second argument', function test( t ) {
+	var values;
+	var data;
+	var i;
+
+	data = rutu;
+
+	values = [
+		'foo',
+		'bar',
+		'beep',
+		'boop'
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			stpsv( data.order, value, data.trans, data.diag, data.N, new Float32Array( data.AP ), data.strideAP, data.offsetAP, new Float32Array( data.x ), data.strideX, data.offsetX );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an invalid third argument', function test( t ) {
+	var values;
+	var data;
+	var i;
+
+	data = rutu;
+
+	values = [
+		'foo',
+		'bar',
+		'beep',
+		'boop'
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			stpsv( data.order, data.uplo, value, data.diag, data.N, new Float32Array( data.AP ), data.strideAP, data.offsetAP, new Float32Array( data.x ), data.strideX, data.offsetX );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an invalid fourth argument', function test( t ) {
+	var values;
+	var data;
+	var i;
+
+	data = rutu;
+
+	values = [
+		'foo',
+		'bar',
+		'beep',
+		'boop'
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			stpsv( data.order, data.uplo, data.trans, value, data.N, new Float32Array( data.AP ), data.strideAP, data.offsetAP, new Float32Array( data.x ), data.strideX, data.offsetX );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an invalid fifth argument', function test( t ) {
+	var values;
+	var data;
+	var i;
+
+	data = rutu;
+
+	values = [
+		-1,
+		-2,
+		-3
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), RangeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			stpsv( data.order, data.uplo, data.trans, data.diag, value, new Float32Array( data.AP ), data.strideAP, data.offsetAP, new Float32Array( data.x ), data.strideX, data.offsetX );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an invalid seventh argument', function test( t ) {
+	var values;
+	var data;
+	var i;
+
+	data = rutu;
+
+	values = [
+		0
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), RangeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			stpsv( data.order, data.uplo, data.trans, data.diag, data.N, new Float32Array( data.AP ), value, data.offsetAP, new Float32Array( data.x ), data.strideX, data.offsetX );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an invalid tenth argument', function test( t ) {
+	var values;
+	var data;
+	var i;
+
+	data = rutu;
+
+	values = [
+		0
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), RangeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			stpsv( data.order, data.uplo, data.trans, data.diag, data.N, new Float32Array( data.AP ), data.strideAP, data.offsetAP, new Float32Array( data.x ), value, data.offsetX );
+		};
+	}
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (row-major, lower, no transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rlntnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 50.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (column-major, lower, no transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = clntnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (row-major, lower, transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rltnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (column-major, lower, transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cltnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (row-major, lower, no transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rlntu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (column-major, lower, no transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = clntu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (row-major, lower, transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rltu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (column-major, lower, transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cltu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (row-major, upper, no transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = runtnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (column-major, upper, no transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cuntnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (row-major, upper, no transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = runtu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (column-major, upper, no transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cuntu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (row-major, upper, transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rutnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (column-major, upper, transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cutnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (row-major, upper, transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rutu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (column-major, upper, transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cutu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function returns a reference to the input vector', function test( t ) {
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rutu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if `N` is zero, the function returns the input vector unchanged (row-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rutu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, 0, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( x, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if `N` is zero, the function returns the input vector unchanged (column-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cutu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, 0, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( x, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying an `x` stride (row-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rxp;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function supports specifying an `x` stride (column-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cxp;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function supports a negative `x` stride (row-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rxn;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function supports a negative `x` stride (column-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cxn;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function supports specifying an `x` offset (row-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rox;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function supports specifying an `x` offset (column-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cox;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function supports specifying a stride for `AP` (row-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rsap;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying a stride for `AP` (column-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = csap;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying a negative stride for `AP` (row-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rsapn;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying a negative stride for `AP` (column-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = csapn;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying an offset for `AP` (row-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = roap;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying an offset for `AP` (column-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = coap;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports complex access patterns (row-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rcap;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports complex access patterns (column-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = ccap;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/test.ndarray.js
@@ -24,8 +24,6 @@
 
 var tape = require( 'tape' );
 var Float32Array = require( '@stdlib/array/float32' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var stpsv = require( './../lib/ndarray.js' );
 
 
@@ -62,35 +60,6 @@ var cxp = require( './fixtures/column_major_xp.json' );
 var cxn = require( './fixtures/column_major_xn.json' );
 var cox = require( './fixtures/column_major_ox.json' );
 var ccap = require( './fixtures/column_major_complex_access_pattern.json' );
-
-
-// FUNCTIONS //
-
-/**
-* Tests for element-wise approximate equality.
-*
-* @private
-* @param {Object} t - test object
-* @param {Collection} actual - actual values
-* @param {Collection} expected - expected values
-* @param {number} rtol - relative tolerance
-*/
-function isApprox( t, actual, expected, rtol ) {
-	var delta;
-	var tol;
-	var i;
-
-	t.strictEqual( actual.length, expected.length, 'returns expected value' );
-	for ( i = 0; i < expected.length; i++ ) {
-		if ( actual[ i ] === expected[ i ] ) {
-			t.strictEqual( actual[ i ], expected[ i ], 'returns expected value' );
-		} else {
-			delta = abs( actual[ i ] - expected[ i ] );
-			tol = rtol * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. actual: '+actual[ i ]+'. expected: '+expected[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-	}
-}
 
 
 // TESTS //
@@ -297,7 +266,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 50.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -318,7 +287,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -339,7 +308,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -360,7 +329,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -381,7 +350,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -402,7 +371,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -423,7 +392,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -444,7 +413,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -465,7 +434,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -486,7 +455,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -507,7 +476,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -528,7 +497,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -549,7 +518,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -570,7 +539,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -591,7 +560,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -612,7 +581,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -692,7 +661,7 @@ tape( 'the function supports specifying an `x` stride (row-major)', function tes
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -713,7 +682,7 @@ tape( 'the function supports specifying an `x` stride (column-major)', function 
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -734,7 +703,7 @@ tape( 'the function supports a negative `x` stride (row-major)', function test( 
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -755,7 +724,7 @@ tape( 'the function supports a negative `x` stride (column-major)', function tes
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -776,7 +745,7 @@ tape( 'the function supports specifying an `x` offset (row-major)', function tes
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -797,7 +766,7 @@ tape( 'the function supports specifying an `x` offset (column-major)', function 
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/test.stpsv.js
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/test.stpsv.js
@@ -24,8 +24,6 @@
 
 var tape = require( 'tape' );
 var Float32Array = require( '@stdlib/array/float32' );
-var EPS = require( '@stdlib/constants/float32/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var stpsv = require( './../lib/stpsv.js' );
 
 
@@ -52,35 +50,6 @@ var cutnu = require( './fixtures/column_major_u_t_nu.json' );
 var cutu = require( './fixtures/column_major_u_t_u.json' );
 var cxp = require( './fixtures/column_major_xp.json' );
 var cxn = require( './fixtures/column_major_xn.json' );
-
-
-// FUNCTIONS //
-
-/**
-* Tests for element-wise approximate equality.
-*
-* @private
-* @param {Object} t - test object
-* @param {Collection} actual - actual values
-* @param {Collection} expected - expected values
-* @param {number} rtol - relative tolerance
-*/
-function isApprox( t, actual, expected, rtol ) {
-	var delta;
-	var tol;
-	var i;
-
-	t.strictEqual( actual.length, expected.length, 'returns expected value' );
-	for ( i = 0; i < expected.length; i++ ) {
-		if ( actual[ i ] === expected[ i ] ) {
-			t.strictEqual( actual[ i ], expected[ i ], 'returns expected value' );
-		} else {
-			delta = abs( actual[ i ] - expected[ i ] );
-			tol = rtol * EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. actual: '+actual[ i ]+'. expected: '+expected[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
-		}
-	}
-}
 
 
 // TESTS //
@@ -264,7 +233,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 50.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -285,7 +254,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -306,7 +275,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -327,7 +296,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -348,7 +317,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -369,7 +338,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -390,7 +359,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -411,7 +380,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -432,7 +401,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -453,7 +422,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -474,7 +443,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -495,7 +464,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -516,7 +485,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -537,7 +506,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -558,7 +527,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -579,7 +548,7 @@ tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x =
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -659,7 +628,7 @@ tape( 'the function supports specifying an `x` stride (row-major)', function tes
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -680,7 +649,7 @@ tape( 'the function supports specifying an `x` stride (column-major)', function 
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -701,7 +670,7 @@ tape( 'the function supports a negative `x` stride (row-major)', function test( 
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });
@@ -722,7 +691,7 @@ tape( 'the function supports a negative `x` stride (column-major)', function tes
 
 	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
 	t.strictEqual( out, x, 'returns expected value' );
-	isApprox( t, x, expected, 2.0 );
+	t.deepEqual( out, expected, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/blas/base/stpsv/test/test.stpsv.js
+++ b/lib/node_modules/@stdlib/blas/base/stpsv/test/test.stpsv.js
@@ -1,0 +1,728 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* eslint-disable max-len */
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var Float32Array = require( '@stdlib/array/float32' );
+var EPS = require( '@stdlib/constants/float32/eps' );
+var abs = require( '@stdlib/math/base/special/abs' );
+var stpsv = require( './../lib/stpsv.js' );
+
+
+// FIXTURES //
+
+var rlntnu = require( './fixtures/row_major_l_nt_nu.json' );
+var rltnu = require( './fixtures/row_major_l_t_nu.json' );
+var rlntu = require( './fixtures/row_major_l_nt_u.json' );
+var rltu = require( './fixtures/row_major_l_t_u.json' );
+var runtnu = require( './fixtures/row_major_u_nt_nu.json' );
+var runtu = require( './fixtures/row_major_u_nt_u.json' );
+var rutnu = require( './fixtures/row_major_u_t_nu.json' );
+var rutu = require( './fixtures/row_major_u_t_u.json' );
+var rxp = require( './fixtures/row_major_xp.json' );
+var rxn = require( './fixtures/row_major_xn.json' );
+
+var clntnu = require( './fixtures/column_major_l_nt_nu.json' );
+var cltnu = require( './fixtures/column_major_l_t_nu.json' );
+var clntu = require( './fixtures/column_major_l_nt_u.json' );
+var cltu = require( './fixtures/column_major_l_t_u.json' );
+var cuntnu = require( './fixtures/column_major_u_nt_nu.json' );
+var cuntu = require( './fixtures/column_major_u_nt_u.json' );
+var cutnu = require( './fixtures/column_major_u_t_nu.json' );
+var cutu = require( './fixtures/column_major_u_t_u.json' );
+var cxp = require( './fixtures/column_major_xp.json' );
+var cxn = require( './fixtures/column_major_xn.json' );
+
+
+// FUNCTIONS //
+
+/**
+* Tests for element-wise approximate equality.
+*
+* @private
+* @param {Object} t - test object
+* @param {Collection} actual - actual values
+* @param {Collection} expected - expected values
+* @param {number} rtol - relative tolerance
+*/
+function isApprox( t, actual, expected, rtol ) {
+	var delta;
+	var tol;
+	var i;
+
+	t.strictEqual( actual.length, expected.length, 'returns expected value' );
+	for ( i = 0; i < expected.length; i++ ) {
+		if ( actual[ i ] === expected[ i ] ) {
+			t.strictEqual( actual[ i ], expected[ i ], 'returns expected value' );
+		} else {
+			delta = abs( actual[ i ] - expected[ i ] );
+			tol = rtol * EPS * abs( expected[ i ] );
+			t.ok( delta <= tol, 'within tolerance. actual: '+actual[ i ]+'. expected: '+expected[ i ]+'. delta: '+delta+'. tol: '+tol+'.' );
+		}
+	}
+}
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof stpsv, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 8', function test( t ) {
+	t.strictEqual( stpsv.length, 8, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function throws an error if provided an invalid first argument', function test( t ) {
+	var values;
+	var data;
+	var i;
+
+	data = rutu;
+
+	values = [
+		'foo',
+		'bar',
+		'beep',
+		'boop'
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			stpsv( value, data.uplo, data.trans, data.diag, data.N, new Float32Array( data.AP ), new Float32Array( data.x ), data.strideX );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an invalid second argument', function test( t ) {
+	var values;
+	var data;
+	var i;
+
+	data = rutu;
+
+	values = [
+		'foo',
+		'bar',
+		'beep',
+		'boop'
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			stpsv( data.order, value, data.trans, data.diag, data.N, new Float32Array( data.AP ), new Float32Array( data.x ), data.strideX );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an invalid third argument', function test( t ) {
+	var values;
+	var data;
+	var i;
+
+	data = rutu;
+
+	values = [
+		'foo',
+		'bar',
+		'beep',
+		'boop'
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			stpsv( data.order, data.uplo, value, data.diag, data.N, new Float32Array( data.AP ), new Float32Array( data.x ), data.strideX );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an invalid fourth argument', function test( t ) {
+	var values;
+	var data;
+	var i;
+
+	data = rutu;
+
+	values = [
+		'foo',
+		'bar',
+		'beep',
+		'boop'
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			stpsv( data.order, data.uplo, data.trans, value, data.N, new Float32Array( data.AP ), new Float32Array( data.x ), data.strideX );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an invalid fifth argument', function test( t ) {
+	var values;
+	var data;
+	var i;
+
+	data = rutu;
+
+	values = [
+		-1,
+		-2,
+		-3
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), RangeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			stpsv( data.order, data.uplo, data.trans, data.diag, value, new Float32Array( data.AP ), new Float32Array( data.x ), data.strideX );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an invalid eighth argument', function test( t ) {
+	var values;
+	var data;
+	var i;
+
+	data = rutu;
+
+	values = [
+		0
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), RangeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			stpsv( data.order, data.uplo, data.trans, data.diag, data.N, new Float32Array( data.AP ), new Float32Array( data.x ), value );
+		};
+	}
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (row-major, lower, no transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rlntnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 50.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (column-major, lower, no transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = clntnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (row-major, lower, transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rltnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (column-major, lower, transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cltnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (row-major, lower, no transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rlntu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (column-major, lower, no transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = clntu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (row-major, lower, transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rltu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (column-major, lower, transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cltu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (row-major, upper, no transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = runtnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (column-major, upper, no transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cuntnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (row-major, upper, no transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = runtu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (column-major, upper, no transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cuntu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (row-major, upper, transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rutnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (column-major, upper, transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cutnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (row-major, upper, transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rutu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function solves one of the systems of equations `A*x = b` or `A^T*x = b` (column-major, upper, transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cutu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function returns a reference to the input vector', function test( t ) {
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rutu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if `N` is zero, the function returns the input vector unchanged (row-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rutu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, 0, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( x, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if `N` is zero, the function returns the input vector unchanged (column-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cutu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, 0, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( x, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying an `x` stride (row-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rxp;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function supports specifying an `x` stride (column-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cxp;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function supports a negative `x` stride (row-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rxn;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});
+
+tape( 'the function supports a negative `x` stride (column-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cxn;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpsv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	isApprox( t, x, expected, 2.0 );
+
+	t.end();
+});


### PR DESCRIPTION
Progresses #2039.

## Description

> What is the purpose of this pull request?

This RFC proposes to add a routine to solve one of the systems of equations `A*x = b` or `A^T*x = b` where `b` and `x` are `N` element vectors and `A` is an `N` by `N` unit, or non-unit, upper or lower triangular matrix, supplied in packed form as defined in [BLAS Level 2](http://www.netlib.org/blas/#_level_2) routines. Specifically adding `@stdlib/blas/base/stpsv` is proposed.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   progresses #2039 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
