### PR TITLE
feat: add `blas/base/stpmv`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/stpmv/README.md
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/README.md
@@ -1,0 +1,256 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# stpmv
+
+> Perform one of the matrix-vector operations `x = A*x` or `x = A^T*x`.
+
+<section class = "usage">
+
+## Usage
+
+```javascript
+var stpmv = require( '@stdlib/blas/base/stpmv' );
+```
+
+#### stpmv( order, uplo, trans, diag, N, AP, x, sx )
+
+Performs one of the matrix-vector operations `x = A*x` or `x = A^T*x`, where `x` is an `N` element vector and `A` is an `N` by `N` unit, or non-unit, upper or lower triangular matrix, supplied in packed form.
+
+```javascript
+var Float32Array = require( '@stdlib/array/float32' );
+
+var AP = new Float32Array( [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ] );
+var x = new Float32Array( [ 1.0, 2.0, 3.0 ] );
+
+stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 3, AP, x, 1 );
+// x => <Float32Array>[ 14.0, 8.0, 3.0 ]
+```
+
+The function has the following parameters:
+
+-   **order**: storage layout.
+-   **uplo**: specifies whether `A` is an upper or lower triangular matrix.
+-   **trans**: specifies whether `A` should be transposed, conjugate-transposed, or not transposed.
+-   **diag**: specifies whether `A` has a unit diagonal.
+-   **N**: number of elements along each dimension of `A`.
+-   **AP**: packed form of matrix `A` stored in linear memory as a [`Float32Array`][mdn-float32array].
+-   **x**: input vector [`Float32Array`][mdn-float32array].
+-   **sx**: `x` stride length.
+
+The stride parameters determine how elements in the input arrays are accessed at runtime. For example, to iterate over the elements of `x` in reverse order,
+
+```javascript
+var Float32Array = require( '@stdlib/array/float32' );
+
+var AP = new Float32Array( [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ] );
+var x = new Float32Array( [ 1.0, 2.0, 3.0 ] );
+
+stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 3, AP, x, -1 );
+// x => <Float32Array>[ 1.0, 4.0, 10.0 ]
+```
+
+Note that indexing is relative to the first index. To introduce an offset, use [`typed array`][mdn-typed-array] views.
+
+<!-- eslint-disable stdlib/capitalized-comments -->
+
+```javascript
+var Float32Array = require( '@stdlib/array/float32' );
+
+// Initial arrays...
+var x0 = new Float32Array( [ 1.0, 1.0, 1.0, 1.0 ] );
+var AP = new Float32Array( [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ] );
+
+// Create offset views...
+var x1 = new Float32Array( x0.buffer, x0.BYTES_PER_ELEMENT*1 ); // start at 2nd element
+
+stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 3, AP, x1, 1 );
+// x0 => <Float32Array>[ 1.0, 6.0, 3.0, 1.0 ]
+```
+
+#### stpmv.ndarray( order, uplo, trans, diag, N, AP, sap, oap, x, sx, ox )
+
+Performs one of the matrix-vector operations `x = A*x` or `x = A^T*x`, using alternative indexing semantics and where `x` is an `N` element vector and `A` is an `N` by `N` unit, or non-unit, upper or lower triangular matrix, supplied in packed form.
+
+```javascript
+var Float32Array = require( '@stdlib/array/float32' );
+
+var AP = new Float32Array( [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ] );
+var x = new Float32Array( [ 1.0, 2.0, 3.0 ] );
+
+stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 3, AP, 1, 0, x, 1, 0 );
+// x => <Float32Array>[ 14.0, 8.0, 3.0 ]
+```
+
+The function has the following additional parameters:
+
+-   **sap**: `AP` stride length
+-   **oap**: starting index for `AP`.
+-   **ox**: starting index for `x`.
+
+While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying buffer, the offset parameters support indexing semantics based on starting indices. For example,
+
+```javascript
+var Float32Array = require( '@stdlib/array/float32' );
+
+var AP = new Float32Array( [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ] );
+var x = new Float32Array( [ 1.0, 2.0, 3.0 ] );
+
+stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 3, AP, 1, 0, x, -1, 2 );
+// x => <Float32Array>[ 1.0, 4.0, 10.0 ]
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   `stpmv()` corresponds to the [BLAS][blas] level 2 function [`stpmv`][blas-stpmv].
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var stpmv = require( '@stdlib/blas/base/stpmv' );
+
+var opts = {
+    'dtype': 'float32'
+};
+
+var N = 5;
+
+var AP = discreteUniform( N*(N+1)/2, -10.0, 10.0, opts );
+var x = discreteUniform( N, -10.0, 10.0, opts );
+
+stpmv( 'column-major', 'upper', 'no-transpose', 'non-unit', N, AP, x, 1 );
+console.log( x );
+
+stpmv.ndarray( 'column-major', 'upper', 'no-transpose', 'non-unit', N, AP, 1, 0, x, 1, 0 );
+console.log( x );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+TODO
+```
+
+#### TODO
+
+TODO.
+
+```c
+TODO
+```
+
+TODO
+
+```c
+TODO
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+TODO
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[blas]: http://www.netlib.org/blas
+
+[blas-stpmv]: https://www.netlib.org/lapack/explore-html/db/d62/group__tpmv_ga6258755ec99e51d23b78bd721af38e8f.html#ga6258755ec99e51d23b78bd721af38e8f
+
+[mdn-float32array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array
+
+[mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/blas/base/stpmv/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/benchmark/benchmark.js
@@ -1,0 +1,104 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var ones = require( '@stdlib/array/ones' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var floor = require( '@stdlib/math/base/special/floor' );
+var pkg = require( './../package.json' ).name;
+var stpmv = require( './../lib/stpmv.js' );
+
+
+// VARIABLES //
+
+var options = {
+	'dtype': 'float32'
+};
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} N - number of elements along each dimension
+* @returns {Function} benchmark function
+*/
+function createBenchmark( N ) {
+	var AP = ones( N*(N+1)/2, options.dtype );
+	var x = ones( N, options.dtype );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var z;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			z = stpmv( 'row-major', 'upper', 'transpose', 'non-unit', N, AP, x, 1 );
+			if ( isnanf( z[ i%z.length ] ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnanf( z[ i%z.length ] ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var min;
+	var max;
+	var N;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		N = floor( pow( pow( 10, i ), 1.0/2.0 ) );
+		f = createBenchmark( N );
+		bench( pkg+':size='+(N*N), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/blas/base/stpmv/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/benchmark/benchmark.ndarray.js
@@ -1,0 +1,104 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var ones = require( '@stdlib/array/ones' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var floor = require( '@stdlib/math/base/special/floor' );
+var pkg = require( './../package.json' ).name;
+var stpmv = require( './../lib/ndarray.js' );
+
+
+// VARIABLES //
+
+var options = {
+	'dtype': 'float32'
+};
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} N - number of elements along each dimension
+* @returns {Function} benchmark function
+*/
+function createBenchmark( N ) {
+	var AP = ones( N*(N+1)/2, options.dtype );
+	var x = ones( N, options.dtype );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var z;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			z = stpmv( 'row-major', 'upper', 'transpose', 'non-unit', N, AP, 1, 0, x, 1, 0 );
+			if ( isnanf( z[ i%z.length ] ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnanf( z[ i%z.length ] ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var min;
+	var max;
+	var N;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		N = floor( pow( pow( 10, i ), 1.0/2.0 ) );
+		f = createBenchmark( N );
+		bench( pkg+':ndarray:size='+(N*N), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/blas/base/stpmv/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/docs/repl.txt
@@ -1,0 +1,116 @@
+
+{{alias}}( order, uplo, trans, diag, N, AP, x, sx )
+    Performs one of the matrix-vector operations `x = A*x` or `x = A**T*x`,
+    where `x` is an `N` element vector and `A` is an `N` by `N` unit, or
+    non-unit, upper or lower triangular matrix, supplied in packed form.
+
+    Indexing is relative to the first index. To introduce an offset, use typed
+    array views.
+
+    If `N` is equal to `0`, the function returns `x` unchanged.
+
+    Parameters
+    ----------
+    order: string
+        Row-major (C-style) or column-major (Fortran-style) order. Must be
+        either 'row-major' or 'column-major'.
+
+    uplo: string
+        Specifies whether `A` is an upper or lower triangular matrix.
+
+    trans: string
+        Specifies whether `A` should be transposed, conjugate-transposed, or
+        not transposed.
+
+    diag: string
+        Specifies whether `A` has a unit diagonal.
+
+    N: integer
+        Number of elements along each dimension of `A`.
+
+    AP: Float32Array
+        Matrix in packed form.
+
+    x: Float32Array
+        Input vector.
+
+    sx: integer
+        Index increment for `x`.
+
+    Returns
+    -------
+    x: Float32Array
+        Input vector.
+
+    Examples
+    --------
+    > var x = new {{alias:@stdlib/array/float32}}( [ 1.0, 1.0 ] );
+    > var AP = new {{alias:@stdlib/array/float32}}( [ 1.0, 2.0, 1.0 ] );
+    > {{alias}}( 'row-major', 'upper', 'no-transpose', 'unit', 2, AP, x, 1 )
+    <Float32Array>[ 3.0, 1.0 ]
+
+
+{{alias}}.ndarray( order, uplo, trans, diag, N, AP, sap, oap, x, sx, ox )
+    Performs one of the matrix-vector operations `x = A*x` or `x = A**T*x`,
+    using alternative indexing semantics and where `x` is an `N` element vector
+    and `A` is an `N` by `N` unit, or non-unit, upper or lower triangular
+    matrix, supplied in packed form.
+
+    While typed array views mandate a view offset based on the underlying
+    buffer, the offset parameters support indexing semantics based on starting
+    indices.
+
+    Parameters
+    ----------
+    order: string
+        Row-major (C-style) or column-major (Fortran-style) order. Must be
+        either 'row-major' or 'column-major'.
+
+    uplo: string
+        Specifies whether `A` is an upper or lower triangular matrix.
+
+    trans: string
+        Specifies whether `A` should be transposed, conjugate-transposed, or
+        not transposed.
+
+    diag: string
+        Specifies whether `A` has a unit diagonal.
+
+    N: integer
+        Number of elements along each dimension of `A`.
+
+    AP: Float32Array
+        Matrix in packed form.
+
+    sap: integer
+        Index increment for `AP`.
+
+    oap: integer
+        Starting index for `AP`.
+
+    x: Float32Array
+        Input vector.
+
+    sx: integer
+        Index increment for `x`.
+
+    ox: integer
+        Starting index for `x`.
+
+    Returns
+    -------
+    x: Float32Array
+        Input vector.
+
+    Examples
+    --------
+    > var x = new {{alias:@stdlib/array/float32}}( [ 1.0, 1.0 ] );
+    > var AP = new {{alias:@stdlib/array/float32}}( [ 1.0, 2.0, 1.0 ] );
+    > var order = 'row-major';
+    > var uplo = 'upper';
+    > var trans = 'no-transpose';
+    > {{alias}}.ndarray( order, uplo, trans, 'unit', 2, AP, 1, 0, x, 1, 0 )
+    <Float32Array>[ 3.0, 1.0 ]
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/blas/base/stpmv/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/docs/types/index.d.ts
@@ -1,0 +1,116 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { Layout, MatrixTriangle, TransposeOperation, DiagonalType } from '@stdlib/types/blas';
+
+/**
+* Interface describing `stpmv`.
+*/
+interface Routine {
+	/**
+	* Performs one of the matrix-vector operations `x = A*x` or `x = A^T*x`, where `x` is an `N` element vector and `A` is an `N` by `N` unit, or non-unit, upper or lower triangular matrix, supplied in packed form.
+	*
+	* @param order - storage layout
+	* @param uplo - specifies whether `A` is an upper or lower triangular matrix
+	* @param trans - specifies whether `A` should be transposed, conjugate-transposed, or not transposed
+	* @param diag - specifies whether `A` has a unit diagonal
+	* @param N - number of elements along each dimension in the matrix `A`
+	* @param AP - packed form of a symmetric matrix `A`
+	* @param x - input vector
+	* @param strideX - `x` stride length
+	* @returns `x`
+	*
+	* @example
+	* var Float32Array = require( '@stdlib/array/float32' );
+	*
+	* var AP = new Float32Array( [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ] );
+	* var x = new Float32Array( [ 1.0, 2.0, 3.0 ] );
+	*
+	* stpmv( 'row-major', 'upper', 'no-transpose', 'non-unit', 3, AP, x, 1 );
+	* // x => <Float32Array>[ 14.0, 8.0, 3.0 ]
+	*/
+	( order: Layout, uplo: MatrixTriangle, trans: TransposeOperation, diag: DiagonalType, N: number, AP: Float32Array, x: Float32Array, strideX: number ): Float32Array;
+
+	/**
+	* Performs one of the matrix-vector operations `x = A*x` or `x = A^T*x`, using alternative indexing semantics and where `x` is an `N` element vector and `A` is an `N` by `N` unit, or non-unit, upper or lower triangular matrix, supplied in packed form.
+	*
+	* @param uplo - specifies whether `A` is an upper or lower triangular matrix
+	* @param trans - specifies whether `A` should be transposed, conjugate-transposed, or not transposed
+	* @param diag - specifies whether `A` has a unit diagonal
+	* @param N - number of elements along each dimension in the matrix `A`
+	* @param AP - packed form of a symmetric matrix `A`
+	* @param strideAP - `AP` stride length
+	* @param offsetAP - starting index for `AP`
+	* @param x - input vector
+	* @param strideX - `x` stride length
+	* @param offsetX - starting index for `x`
+	* @returns `x`
+	*
+	* @example
+	* var Float32Array = require( '@stdlib/array/float32' );
+	*
+	* var AP = new Float32Array( [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ] );
+	* var x = new Float32Array( [ 1.0, 2.0, 3.0 ] );
+	*
+	* stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'non-unit', 3, AP, 1, 0, x, 1, 0 );
+	* // x => <Float32Array>[ 14.0, 8.0, 3.0 ]
+	*/
+	ndarray( uplo: MatrixTriangle, trans: TransposeOperation, diag: DiagonalType, N: number, AP: Float32Array, strideAP: number, offsetAP: number, x: Float32Array, strideX: number, offsetX: number ): Float32Array;
+}
+
+/**
+* Performs one of the matrix-vector operations `x = A*x` or `x = A^T*x`, where `x` is an `N` element vector and `A` is an `N` by `N` unit, or non-unit, upper or lower triangular matrix, supplied in packed form.
+*
+* @param order - storage layout
+* @param uplo - specifies whether `A` is an upper or lower triangular matrix
+* @param trans - specifies whether `A` should be transposed, conjugate-transposed, or not transposed
+* @param diag - specifies whether `A` has a unit diagonal
+* @param N - number of elements along each dimension in the matrix `A`
+* @param AP - packed form of a symmetric matrix `A`
+* @param x - input vector
+* @param strideX - `x` stride length
+* @returns `x`
+*
+* @example
+* var Float32Array = require( '@stdlib/array/float32' );
+*
+* var AP = new Float32Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+* var x = new Float32Array( [ 1.0, 1.0, 1.0 ] );
+*
+* stpmv( 'row-major', 'lower', 'no-transpose', 'non-unit', 3, AP, x, 1 );
+* // x => <Float32Array>[ 1.0, 5.0, 15.0 ]
+*
+* @example
+* var Float32Array = require( '@stdlib/array/float32' );
+*
+* var AP = new Float32Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+* var x = new Float32Array( [ 1.0, 1.0, 1.0 ] );
+*
+* stpmv.ndarray( 'row-major', 'lower', 'no-transpose', 'non-unit', 3, AP, 1, 0, x, 1, 0 );
+* // x => <Float32Array>[ 1.0, 5.0, 15.0 ]
+*/
+declare var stpmv: Routine;
+
+
+// EXPORTS //
+
+export = stpmv;

--- a/lib/node_modules/@stdlib/blas/base/stpmv/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/docs/types/test.ts
@@ -23,16 +23,16 @@ import stpmv = require( './index' );
 
 // The function returns a Float32Array...
 {
-	const x = new Float32Array( 10 );
 	const AP = new Float32Array( 55 );
+	const x = new Float32Array( 10 );
 
 	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectType Float32Array
 }
 
 // The compiler throws an error if the function is provided a first argument which is not a string...
 {
-	const x = new Float32Array( 10 );
 	const AP = new Float32Array( 55 );
+	const x = new Float32Array( 10 );
 
 	stpmv( 10, 'upper', 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
 	stpmv( true, 'upper', 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
@@ -46,8 +46,8 @@ import stpmv = require( './index' );
 
 // The compiler throws an error if the function is provided a second argument which is not a string...
 {
-	const x = new Float32Array( 10 );
 	const AP = new Float32Array( 55 );
+	const x = new Float32Array( 10 );
 
 	stpmv( 'row-major', 10, 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
 	stpmv( 'row-major', true, 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
@@ -61,8 +61,8 @@ import stpmv = require( './index' );
 
 // The compiler throws an error if the function is provided a third argument which is not a string...
 {
-	const x = new Float32Array( 10 );
 	const AP = new Float32Array( 55 );
+	const x = new Float32Array( 10 );
 
 	stpmv( 'row-major', 'upper', 10, 'unit', 10, AP, x, 1 ); // $ExpectError
 	stpmv( 'row-major', 'upper', true, 'unit', 10, AP, x, 1 ); // $ExpectError
@@ -76,8 +76,8 @@ import stpmv = require( './index' );
 
 // The compiler throws an error if the function is provided a fourth argument which is not a string...
 {
-	const x = new Float32Array( 10 );
 	const AP = new Float32Array( 55 );
+	const x = new Float32Array( 10 );
 
 	stpmv( 'row-major', 'upper', 'no-transpose', 10, 10, AP, x, 1 ); // $ExpectError
 	stpmv( 'row-major', 'upper', 'no-transpose', true, 10, AP, x, 1 ); // $ExpectError
@@ -91,8 +91,8 @@ import stpmv = require( './index' );
 
 // The compiler throws an error if the function is provided a fifth argument which is not a number...
 {
-	const x = new Float32Array( 10 );
 	const AP = new Float32Array( 55 );
+	const x = new Float32Array( 10 );
 
 	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', '10', AP, x, 1 ); // $ExpectError
 	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', true, AP, x, 1 ); // $ExpectError
@@ -119,7 +119,7 @@ import stpmv = require( './index' );
 	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, ( x: number ): number => x, x, 1 ); // $ExpectError
 }
 
-// The compiler throws an error if the function is provided an seventh argument which is not a Float32Array...
+// The compiler throws an error if the function is provided a seventh argument which is not a Float32Array...
 {
 	const AP = new Float32Array( 55 );
 
@@ -134,10 +134,10 @@ import stpmv = require( './index' );
 	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, ( x: number ): number => x, 1 ); // $ExpectError
 }
 
-// The compiler throws an error if the function is provided a eighth argument which is not a number...
+// The compiler throws an error if the function is provided an eighth argument which is not a number...
 {
-	const x = new Float32Array( 10 );
 	const AP = new Float32Array( 55 );
+	const x = new Float32Array( 10 );
 
 	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, x, '10' ); // $ExpectError
 	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, x, true ); // $ExpectError
@@ -151,8 +151,8 @@ import stpmv = require( './index' );
 
 // The compiler throws an error if the function is provided an unsupported number of arguments...
 {
-	const x = new Float32Array( 10 );
 	const AP = new Float32Array( 55 );
+	const x = new Float32Array( 10 );
 
 	stpmv(); // $ExpectError
 	stpmv( 'row-major' ); // $ExpectError
@@ -167,16 +167,16 @@ import stpmv = require( './index' );
 
 // Attached to main export is an `ndarray` method which returns a Float32Array...
 {
-	const x = new Float32Array( 10 );
 	const AP = new Float32Array( 55 );
+	const x = new Float32Array( 10 );
 
 	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectType Float32Array
 }
 
 // The compiler throws an error if the function is provided a first argument which is not a string...
 {
-	const x = new Float32Array( 10 );
 	const AP = new Float32Array( 55 );
+	const x = new Float32Array( 10 );
 
 	stpmv.ndarray( 10, 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
 	stpmv.ndarray( true, 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
@@ -190,8 +190,8 @@ import stpmv = require( './index' );
 
 // The compiler throws an error if the function is provided a second argument which is not a string...
 {
-	const x = new Float32Array( 10 );
 	const AP = new Float32Array( 55 );
+	const x = new Float32Array( 10 );
 
 	stpmv.ndarray( 'row-major', 10, 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
 	stpmv.ndarray( 'row-major', true, 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
@@ -205,8 +205,8 @@ import stpmv = require( './index' );
 
 // The compiler throws an error if the function is provided a third argument which is not a string...
 {
-	const x = new Float32Array( 10 );
 	const AP = new Float32Array( 55 );
+	const x = new Float32Array( 10 );
 
 	stpmv.ndarray( 'row-major', 'upper', 10, 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
 	stpmv.ndarray( 'row-major', 'upper', true, 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
@@ -220,8 +220,8 @@ import stpmv = require( './index' );
 
 // The compiler throws an error if the function is provided a fourth argument which is not a string...
 {
-	const x = new Float32Array( 10 );
 	const AP = new Float32Array( 55 );
+	const x = new Float32Array( 10 );
 
 	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 10, 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
 	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', true, 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
@@ -235,8 +235,8 @@ import stpmv = require( './index' );
 
 // The compiler throws an error if the function is provided a fifth argument which is not a number...
 {
-	const x = new Float32Array( 10 );
 	const AP = new Float32Array( 55 );
+	const x = new Float32Array( 10 );
 
 	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', '10', AP, 1, 0, x, 1, 0 ); // $ExpectError
 	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', true, AP, 1, 0, x, 1, 0 ); // $ExpectError
@@ -265,8 +265,8 @@ import stpmv = require( './index' );
 
 // The compiler throws an error if the function is provided a seventh argument which is not a number...
 {
-	const x = new Float32Array( 10 );
 	const AP = new Float32Array( 55 );
+	const x = new Float32Array( 10 );
 
 	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, '10', 0, x, 1, 0 ); // $ExpectError
 	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, true, 0, x, 1, 0 ); // $ExpectError
@@ -280,8 +280,8 @@ import stpmv = require( './index' );
 
 // The compiler throws an error if the function is provided an eighth argument which is not a number...
 {
-	const x = new Float32Array( 10 );
 	const AP = new Float32Array( 55 );
+	const x = new Float32Array( 10 );
 
 	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, '10', x, 1, 0 ); // $ExpectError
 	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, true, x, 1, 0 ); // $ExpectError
@@ -310,8 +310,8 @@ import stpmv = require( './index' );
 
 // The compiler throws an error if the function is provided a tenth argument which is not a number...
 {
-	const x = new Float32Array( 10 );
 	const AP = new Float32Array( 55 );
+	const x = new Float32Array( 10 );
 
 	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, '10', 0 ); // $ExpectError
 	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, true, 0 ); // $ExpectError
@@ -325,8 +325,8 @@ import stpmv = require( './index' );
 
 // The compiler throws an error if the function is provided an eleventh argument which is not a number...
 {
-	const x = new Float32Array( 10 );
 	const AP = new Float32Array( 55 );
+	const x = new Float32Array( 10 );
 
 	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, '10' ); // $ExpectError
 	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, true ); // $ExpectError
@@ -340,8 +340,8 @@ import stpmv = require( './index' );
 
 // The compiler throws an error if the function is provided an unsupported number of arguments...
 {
-	const x = new Float32Array( 10 );
 	const AP = new Float32Array( 55 );
+	const x = new Float32Array( 10 );
 
 	stpmv.ndarray(); // $ExpectError
 	stpmv.ndarray( 'row-major', 'upper' ); // $ExpectError

--- a/lib/node_modules/@stdlib/blas/base/stpmv/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/docs/types/test.ts
@@ -1,0 +1,357 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import stpmv = require( './index' );
+
+
+// TESTS //
+
+// The function returns a Float32Array...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectType Float32Array
+}
+
+// The compiler throws an error if the function is provided a first argument which is not a string...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpmv( 10, 'upper', 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpmv( true, 'upper', 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpmv( false, 'upper', 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpmv( null, 'upper', 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpmv( undefined, 'upper', 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpmv( [], 'upper', 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpmv( {}, 'upper', 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpmv( ( x: number ): number => x, 'upper', 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument which is not a string...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpmv( 'row-major', 10, 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpmv( 'row-major', true, 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpmv( 'row-major', false, 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpmv( 'row-major', null, 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpmv( 'row-major', undefined, 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpmv( 'row-major', [], 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpmv( 'row-major', {}, 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpmv( 'row-major', ( x: number ): number => x, 'no-transpose', 'unit', 10, AP, x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a third argument which is not a string...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpmv( 'row-major', 'upper', 10, 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', true, 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', false, 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', null, 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', undefined, 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', [], 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', {}, 'unit', 10, AP, x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', ( x: number ): number => x, 'unit', 10, AP, x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a fourth argument which is not a string...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpmv( 'row-major', 'upper', 'no-transpose', 10, 10, AP, x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', true, 10, AP, x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', false, 10, AP, x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', null, 10, AP, x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', undefined, 10, AP, x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', [], 10, AP, x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', {}, 10, AP, x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', ( x: number ): number => x, 10, AP, x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a fifth argument which is not a number...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', '10', AP, x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', true, AP, x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', false, AP, x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', null, AP, x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', undefined, AP, x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', [], AP, x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', {}, AP, x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', ( x: number ): number => x, AP, x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a sixth argument which is not a Float32Array...
+{
+	const x = new Float32Array( 10 );
+
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, 10, x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, '10', x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, true, x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, false, x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, null, x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, undefined, x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, [ '1' ], x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, {}, x, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, ( x: number ): number => x, x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an seventh argument which is not a Float32Array...
+{
+	const AP = new Float32Array( 55 );
+
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 10, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, '10', 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, true, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, false, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, null, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, undefined, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, [ '1' ], 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, {}, 1 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, ( x: number ): number => x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a eighth argument which is not a number...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, x, '10' ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, x, true ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, x, false ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, x, null ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, x, undefined ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, x, [] ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, x, {} ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, x, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpmv(); // $ExpectError
+	stpmv( 'row-major' ); // $ExpectError
+	stpmv( 'row-major', 'upper' ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose' ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit' ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10 ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, x ); // $ExpectError
+	stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, x, 1, 1 ); // $ExpectError
+}
+
+// Attached to main export is an `ndarray` method which returns a Float32Array...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectType Float32Array
+}
+
+// The compiler throws an error if the function is provided a first argument which is not a string...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpmv.ndarray( 10, 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( true, 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( false, 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( null, 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( undefined, 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( [], 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( {}, 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( ( x: number ): number => x, 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument which is not a string...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpmv.ndarray( 'row-major', 10, 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', true, 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', false, 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', null, 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', undefined, 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', [], 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', {}, 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', ( x: number ): number => x, 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a third argument which is not a string...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpmv.ndarray( 'row-major', 'upper', 10, 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', true, 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', false, 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', null, 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', undefined, 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', [], 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', {}, 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', ( x: number ): number => x, 'unit', 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a fourth argument which is not a string...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 10, 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', true, 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', false, 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', null, 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', undefined, 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', [], 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', {}, 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', ( x: number ): number => x, 10, AP, 1, 0, x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a fifth argument which is not a number...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', '10', AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', true, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', false, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', null, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', undefined, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', [], AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', {}, AP, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', ( x: number ): number => x, AP, 1, 0, x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a sixth argument which is not a Float32Array...
+{
+	const x = new Float32Array( 10 );
+
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, 10, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, '10', 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, true, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, false, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, null, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, undefined, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, [ '1' ], 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, {}, 1, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, ( x: number ): number => x, 1, 0, x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a seventh argument which is not a number...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, '10', 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, true, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, false, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, null, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, undefined, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, [], 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, {}, 0, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, ( x: number ): number => x, 0, x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an eighth argument which is not a number...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, '10', x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, true, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, false, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, null, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, undefined, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, [], x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, {}, x, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, ( x: number ): number => x, x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a ninth argument which is not a Float32Array...
+{
+	const AP = new Float32Array( 55 );
+
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, 10, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, '10', 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, true, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, false, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, null, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, undefined, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, [ '1' ], 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, {}, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, ( x: number ): number => x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a tenth argument which is not a number...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, '10', 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, true, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, false, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, null, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, undefined, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, [], 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, {}, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, ( x: number ): number => x, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an eleventh argument which is not a number...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, '10' ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, true ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, false ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, null ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, undefined ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, [] ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, {} ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	const x = new Float32Array( 10 );
+	const AP = new Float32Array( 55 );
+
+	stpmv.ndarray(); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper' ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose' ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit' ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1 ); // $ExpectError
+	stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 10, AP, 1, 0, x, 1, 0, 10 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/examples/index.js
@@ -1,0 +1,37 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var stpmv = require( './../lib' );
+
+var opts = {
+	'dtype': 'float32'
+};
+
+var N = 5;
+
+var AP = discreteUniform( N*(N+1)/2, -10.0, 10.0, opts );
+var x = discreteUniform( N, -10.0, 10.0, opts );
+
+stpmv( 'column-major', 'upper', 'no-transpose', 'non-unit', N, AP, x, 1 );
+console.log( x );
+
+stpmv.ndarray( 'column-major', 'upper', 'no-transpose', 'non-unit', N, AP, 1, 0, x, 1, 0 );
+console.log( x );

--- a/lib/node_modules/@stdlib/blas/base/stpmv/lib/base.js
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/lib/base.js
@@ -1,0 +1,168 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var f32 = require( '@stdlib/number/float64/base/to-float32' );
+
+
+// MAIN //
+
+/**
+* Performs one of the matrix-vector operations `x = A*x` or `x = A^T*x`, where `x` is an `N` element vector and `A` is an `N` by `N` unit, or non-unit, upper or lower triangular matrix, supplied in packed form.
+*
+* @private
+* @param {string} order - storage layout
+* @param {string} uplo - specifies whether `A` is an upper or lower triangular matrix
+* @param {string} trans - specifies whether `A` should be transposed, conjugate-transposed, or not transposed
+* @param {string} diag - specifies whether `A` has a unit diagonal
+* @param {NonNegativeInteger} N - number of elements along each dimension of `A`
+* @param {Float32Array} AP - packed form of a symmetric matrix `A`
+* @param {integer} strideAP - `AP` stride length
+* @param {NonNegativeInteger} offsetAP - starting index for `AP`
+* @param {Float32Array} x - input vector
+* @param {integer} strideX - `x` stride length
+* @param {NonNegativeInteger} offsetX - starting index for `x`
+* @returns {Float32Array} `x`
+*
+* @example
+* var Float32Array = require( '@stdlib/array/float32' );
+*
+* var AP = new Float32Array( [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ] ); // => [ [ 1.0, 2.0, 3.0 ], [ 0.0, 1.0, 2.0 ], [ 0.0, 0.0, 1.0 ] ]
+* var x = new Float32Array( [ 1.0, 2.0, 3.0 ] );
+*
+* stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 3, AP, 1, 0, x, 1, 0 );
+* // x => <Float32Array>[ 14.0, 8.0, 3.0 ]
+*/
+function stpmv( order, uplo, trans, diag, N, AP, strideAP, offsetAP, x, strideX, offsetX ) { // eslint-disable-line max-params, max-len
+	var nonunit;
+	var isrm;
+	var tmp;
+	var iap;
+	var ix0;
+	var ix1;
+	var i0;
+	var i1;
+	var kk;
+	var ox;
+
+	isrm = ( order === 'row-major' );
+	nonunit = ( diag === 'non-unit' );
+	kk = offsetAP;
+	ox = offsetX;
+	if (
+		( !isrm && uplo === 'upper' && trans === 'no-transpose' ) ||
+		( isrm && uplo === 'lower' && trans !== 'no-transpose' )
+	) {
+		ix1 = ox;
+		for ( i1 = 0; i1 < N; i1++ ) {
+			if ( x[ ix1 ] !== 0.0 ) {
+				tmp = x[ ix1 ];
+				iap = kk;
+				ix0 = ox;
+				for ( i0 = 0; i0 < i1; i0++ ) {
+					x[ ix0 ] += f32( AP[ iap ] * tmp );
+					iap += strideAP;
+					ix0 += strideX;
+				}
+				if ( nonunit ) {
+					x[ix0] = f32( x[ ix0 ] * AP[ iap ] );
+				}
+			}
+			ix1 += strideX;
+			kk += ( i1 + 1 ) * strideAP;
+		}
+		return x;
+	}
+	if (
+		( !isrm && uplo === 'lower' && trans === 'no-transpose' ) ||
+		( isrm && uplo === 'upper' && trans !== 'no-transpose' )
+	) {
+		kk += ( ( N * ( N + 1 ) / 2 ) - 1 ) * strideAP;
+		ox += ( N - 1 ) * strideX;
+		ix1 = ox;
+		for ( i1 = N-1; i1 >=0; i1-- ) {
+			if ( x[ ix1 ] !== 0.0 ) {
+				tmp = x[ ix1 ];
+				iap = kk;
+				ix0 = ox;
+				for ( i0 = N-1; i0 > i1; i0-- ) {
+					x[ ix0 ] += f32( AP[ iap ] * tmp );
+					iap -= strideAP;
+					ix0 -= strideX;
+				}
+				if ( nonunit ) {
+					x[ ix0 ] = f32( x[ ix0 ] * AP[ iap ] );
+				}
+			}
+			ix1 -= strideX;
+			kk -= ( N - i1 ) * strideAP;
+		}
+		return x;
+	}
+	if (
+		( !isrm && uplo === 'upper' && trans !== 'no-transpose' ) ||
+		( isrm && uplo === 'lower' && trans === 'no-transpose' )
+	) {
+		kk += ( ( N * ( N + 1 ) / 2 ) - 1 ) * strideAP;
+		ix1 = ox + ( ( N - 1 ) * strideX );
+		for ( i1 = N-1; i1 >= 0; i1-- ) {
+			tmp = x[ ix1 ];
+			iap = kk;
+			ix0 = ix1;
+			if ( nonunit ) {
+				tmp = f32( tmp * AP[ iap ] );
+			}
+			for ( i0 = i1-1; i0 >= 0; i0-- ) {
+				ix0 -= strideX;
+				iap -= strideAP;
+				tmp = f32( tmp + f32( AP[ iap ] * x[ ix0 ] ) );
+			}
+			x[ ix1 ] = tmp;
+			ix1 -= strideX;
+			kk -= ( i1 + 1 ) * strideAP;
+		}
+		return x;
+	}
+	// ( !isrm && uplo === 'lower' && trans !== 'no-transpose' ) || ( isrm && uplo === 'upper' && trans === 'no-transpose' )
+	ix1 = ox;
+	for ( i1 = 0; i1 < N; i1++ ) {
+		tmp = x[ ix1 ];
+		iap = kk;
+		ix0 = ix1;
+		if ( nonunit ) {
+			tmp = f32( tmp * AP[ iap ] );
+		}
+		for ( i0 = i1+1; i0 < N; i0++ ) {
+			ix0 += strideX;
+			iap += strideAP;
+			tmp = f32( tmp + f32( AP[ iap ] * x[ ix0 ] ) );
+		}
+		x[ ix1 ] = tmp;
+		ix1 += strideX;
+		kk += ( N - i1 ) * strideAP;
+	}
+	return x;
+}
+
+
+// EXPORTS //
+
+module.exports = stpmv;

--- a/lib/node_modules/@stdlib/blas/base/stpmv/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/lib/index.js
@@ -1,0 +1,70 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* BLAS level 2 routine to perform one of the matrix-vector operations `x = A*x` or `x = A^T*x`, where `x` is an `N` element vector and `A` is an `N` by `N` unit, or non-unit, upper or lower triangular matrix, supplied in packed form.
+*
+* @module @stdlib/blas/base/stpmv
+*
+* @example
+* var Float32Array = require( '@stdlib/array/float32' );
+* var stpmv = require( '@stdlib/blas/base/stpmv' );
+*
+* var AP = new Float32Array( [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ] );
+* var x = new Float32Array( [ 1.0, 2.0, 3.0 ] );
+*
+* stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 3, AP, x, 1 );
+* // x => <Float32Array>[ 14.0, 8.0, 3.0 ]
+*
+* @example
+* var Float32Array = require( '@stdlib/array/float32' );
+* var stpmv = require( '@stdlib/blas/base/stpmv' );
+*
+* var AP = new Float32Array( [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ] );
+* var x = new Float32Array( [ 1.0, 2.0, 3.0 ] );
+*
+* stpmv.ndarray( 'row-major', 'upper', 'no-transpose', 'unit', 3, AP, 1, 0, x, 1, 0 );
+* // x => <Float32Array>[ 14.0, 8.0, 3.0 ]
+*/
+
+// MODULES //
+
+var join = require( 'path' ).join;
+var tryRequire = require( '@stdlib/utils/try-require' );
+var isError = require( '@stdlib/assert/is-error' );
+var main = require( './main.js' );
+
+
+// MAIN //
+
+var stpmv;
+var tmp = tryRequire( join( __dirname, './native.js' ) );
+if ( isError( tmp ) ) {
+	stpmv = main;
+} else {
+	stpmv = tmp;
+}
+
+
+// EXPORTS //
+
+module.exports = stpmv;
+
+// exports: { "ndarray": "stpmv.ndarray" }

--- a/lib/node_modules/@stdlib/blas/base/stpmv/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/lib/main.js
@@ -1,0 +1,35 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
+var stpmv = require( './stpmv.js' );
+var ndarray = require( './ndarray.js' );
+
+
+// MAIN //
+
+setReadOnly( stpmv, 'ndarray', ndarray );
+
+
+// EXPORTS //
+
+module.exports = stpmv;

--- a/lib/node_modules/@stdlib/blas/base/stpmv/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/lib/ndarray.js
@@ -1,0 +1,96 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isLayout = require( '@stdlib/blas/base/assert/is-layout' );
+var isMatrixTriangle = require( '@stdlib/blas/base/assert/is-matrix-triangle' );
+var isTransposeOperation = require( '@stdlib/blas/base/assert/is-transpose-operation' );
+var isDiagonal = require( '@stdlib/blas/base/assert/is-diagonal-type' );
+var format = require( '@stdlib/string/format' );
+var base = require( './base.js' );
+
+
+// MAIN //
+
+/**
+* Performs one of the matrix-vector operations `x = A*x` or `x = A^T*x`, where `x` is an `N` element vector and `A` is an `N` by `N` unit, or non-unit, upper or lower triangular matrix, supplied in packed form.
+*
+* @param {string} order - storage layout
+* @param {string} uplo - specifies whether `A` is an upper or lower triangular matrix
+* @param {string} trans - specifies whether `A` should be transposed, conjugate-transposed, or not transposed
+* @param {string} diag - specifies whether `A` has a unit diagonal
+* @param {NonNegativeInteger} N - number of elements along each dimension of `A`
+* @param {Float32Array} AP - packed form of a symmetric matrix `A`
+* @param {integer} strideAP - `AP` stride length
+* @param {NonNegativeInteger} offsetAP - starting index for `AP`
+* @param {Float32Array} x - input vector
+* @param {integer} strideX - `x` stride length
+* @param {NonNegativeInteger} offsetX - starting index for `x`
+* @throws {TypeError} first argument must be a valid order
+* @throws {TypeError} second argument must specify whether a lower or upper triangular matrix is supplied
+* @throws {TypeError} third argument must be a valid transpose operation
+* @throws {TypeError} fourth argument must be a valid diagonal type
+* @throws {RangeError} fifth argument must be a nonnegative integer
+* @throws {RangeError} seventh argument must be non-zero
+* @throws {RangeError} tenth argument must be non-zero
+* @returns {Float32Array} `x`
+*
+* @example
+* var Float32Array = require( '@stdlib/array/float32' );
+*
+* var AP = new Float32Array( [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ] ); // => [ [ 1.0, 2.0, 3.0 ], [ 0.0, 1.0, 2.0 ], [ 0.0, 0.0, 1.0 ] ]
+* var x = new Float32Array( [ 1.0, 2.0, 3.0 ] );
+*
+* stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 3, AP, 1, 0, x, 1, 0 );
+* // x => <Float32Array>[ 14.0, 8.0, 3.0 ]
+*/
+function stpmv( order, uplo, trans, diag, N, AP, strideAP, offsetAP, x, strideX, offsetX ) { // eslint-disable-line max-params, max-len
+	if ( !isLayout( order ) ) {
+		throw new TypeError( format( 'invalid argument. First argument must be a valid order. Value: `%s`.', order ) );
+	}
+	if ( !isMatrixTriangle( uplo ) ) {
+		throw new TypeError( format( 'invalid argument. Second argument must specify whether the lower or upper triangular matrix is supplied. Value: `%s`.', uplo ) );
+	}
+	if ( !isTransposeOperation( trans ) ) {
+		throw new TypeError( format( 'invalid argument. Third argument must be a valid transpose operation. Value: `%s`.', trans ) );
+	}
+	if ( !isDiagonal( diag ) ) {
+		throw new TypeError( format( 'invalid argument. Fourth argument must be a valid diagonal type. Value: `%s`.', diag ) );
+	}
+	if ( N < 0 ) {
+		throw new RangeError( format( 'invalid argument. Fifth argument must be a nonnegative integer. Value: `%d`.', N ) );
+	}
+	if ( strideAP === 0 ) {
+		throw new RangeError( format( 'invalid argument. Seventh argument must be non-zero. Value: `%d`.', strideAP ) );
+	}
+	if ( strideX === 0 ) {
+		throw new RangeError( format( 'invalid argument. Tenth argument must be non-zero. Value: `%d`.', strideX ) );
+	}
+	if ( N === 0 ) {
+		return x;
+	}
+	return base( order, uplo, trans, diag, N, AP, strideAP, offsetAP, x, strideX, offsetX ); // eslint-disable-line max-len
+}
+
+
+// EXPORTS //
+
+module.exports = stpmv;

--- a/lib/node_modules/@stdlib/blas/base/stpmv/lib/stpmv.js
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/lib/stpmv.js
@@ -1,0 +1,93 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isLayout = require( '@stdlib/blas/base/assert/is-layout' );
+var isMatrixTriangle = require( '@stdlib/blas/base/assert/is-matrix-triangle' );
+var isTransposeOperation = require( '@stdlib/blas/base/assert/is-transpose-operation' );
+var isDiagonal = require( '@stdlib/blas/base/assert/is-diagonal-type' );
+var stride2offset = require( '@stdlib/strided/base/stride2offset' );
+var format = require( '@stdlib/string/format' );
+var base = require( './base.js' );
+
+
+// MAIN //
+
+/**
+* Performs one of the matrix-vector operations `x = A*x` or `x = A^T*x`, where `x` is an `N` element vector and `A` is an `N` by `N` unit, or non-unit, upper or lower triangular matrix, supplied in packed form.
+*
+* @param {string} order - storage layout
+* @param {string} uplo - specifies whether `A` is an upper or lower triangular matrix
+* @param {string} trans - specifies whether `A` should be transposed, conjugate-transposed, or not transposed
+* @param {string} diag - specifies whether `A` has a unit diagonal
+* @param {NonNegativeInteger} N - number of elements along each dimension of `A`
+* @param {Float32Array} AP - packed form of a symmetric matrix `A`
+* @param {Float32Array} x - input vector
+* @param {integer} strideX - `x` stride length
+* @throws {TypeError} first argument must be a valid order
+* @throws {TypeError} second argument must specify whether a lower or upper triangular matrix is supplied
+* @throws {TypeError} third argument must be a valid transpose operation
+* @throws {TypeError} fourth argument must be a valid diagonal type
+* @throws {RangeError} fifth argument must be a nonnegative integer
+* @throws {RangeError} eighth argument must be non-zero
+* @returns {Float32Array} `x`
+*
+* @example
+* var Float32Array = require( '@stdlib/array/float32' );
+*
+* var AP = new Float32Array( [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ] ); // => [ [ 1.0, 2.0, 3.0 ], [ 0.0, 1.0, 2.0 ], [ 0.0, 0.0, 1.0 ] ]
+* var x = new Float32Array( [ 1.0, 2.0, 3.0 ] );
+*
+* stpmv( 'row-major', 'upper', 'no-transpose', 'unit', 3, AP, x, 1 );
+* // x => <Float32Array>[ 14.0, 8.0, 3.0 ]
+*/
+function stpmv( order, uplo, trans, diag, N, AP, x, strideX ) {
+	var ox;
+
+	if ( !isLayout( order ) ) {
+		throw new TypeError( format( 'invalid argument. First argument must be a valid order. Value: `%s`.', order ) );
+	}
+	if ( !isMatrixTriangle( uplo ) ) {
+		throw new TypeError( format( 'invalid argument. Second argument must specify whether the lower or upper triangular matrix is supplied. Value: `%s`.', uplo ) );
+	}
+	if ( !isTransposeOperation( trans ) ) {
+		throw new TypeError( format( 'invalid argument. Third argument must be a valid transpose operation. Value: `%s`.', trans ) );
+	}
+	if ( !isDiagonal( diag ) ) {
+		throw new TypeError( format( 'invalid argument. Fourth argument must be a valid diagonal type. Value: `%s`.', diag ) );
+	}
+	if ( N < 0 ) {
+		throw new RangeError( format( 'invalid argument. Fifth argument must be a nonnegative integer. Value: `%d`.', N ) );
+	}
+	if ( strideX === 0 ) {
+		throw new RangeError( format( 'invalid argument. Eighth argument must be non-zero. Value: `%d`.', strideX ) );
+	}
+	if ( N === 0 ) {
+		return x;
+	}
+	ox = stride2offset( N, strideX );
+	return base( order, uplo, trans, diag, N, AP, 1, 0, x, strideX, ox );
+}
+
+
+// EXPORTS //
+
+module.exports = stpmv;

--- a/lib/node_modules/@stdlib/blas/base/stpmv/package.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@stdlib/blas/base/stpmv",
+  "version": "0.0.0",
+  "description": "Perform one of the matrix-vector operations `x = A*x` or `x = A^T*x`.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
+    "blas",
+    "level 2",
+    "stpmv",
+    "linear",
+    "algebra",
+    "subroutines",
+    "array",
+    "ndarray",
+    "float32",
+    "float",
+    "float32array"
+  ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_complex_access_pattern.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_complex_access_pattern.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "transpose",
+  "diag": "unit",
+  "uplo": "lower",
+  "strideX": -2,
+  "offsetX": 5,
+  "strideAP": -2,
+  "offsetAP": 11,
+  "N": 3,
+  "AP": [ 0.0, 1.0, 0.0, 2.0, 0.0, 1.0, 0.0, 3.0, 0.0, 2.0, 0.0, 1.0 ],
+  "x": [ 0.0, 3.0, 0.0, 2.0, 0.0, 1.0 ],
+  "x_out": [ 0.0, 3.0, 0.0, 8.0, 0.0, 14.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_l_nt_nu.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_l_nt_nu.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "no-transpose",
+  "diag": "non-unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 0,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 1.0, 10.0, 31.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_l_nt_u.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_l_nt_u.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "no-transpose",
+  "diag": "unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 0,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 2.0, 1.0, 1.0, 1.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 1.0, 4.0, 7.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_l_t_nu.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_l_t_nu.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "transpose",
+  "diag": "non-unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 0,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 14.0, 23.0, 18.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_l_t_u.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_l_t_u.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "transpose",
+  "diag": "unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 0,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 14.0, 8.0, 3.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_oap.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_oap.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "no-transpose",
+  "diag": "non-unit",
+  "uplo": "lower",
+  "strideAP": 2,
+  "offsetAP": 7,
+  "strideX": 1,
+  "offsetX": 0,
+  "N": 3,
+  "AP": [ 999, 999, 999, 999, 999, 999, 999, 1, 999, 2, 999, 3, 999, 4, 999, 5, 999, 6 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 1.0, 10.0, 31.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_ox.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_ox.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "transpose",
+  "diag": "unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 2,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ],
+  "x": [ 0.0, 0.0, 1.0, 2.0, 3.0 ],
+  "x_out": [ 0.0, 0.0, 14.0, 8.0, 3.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_sap.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_sap.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "transpose",
+  "diag": "unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 0,
+  "strideAP": 2,
+  "offsetAP": 1,
+  "N": 3,
+  "AP": [ 0.0, 1.0, 0.0, 2.0, 0.0, 3.0, 0.0, 1.0, 0.0, 2.0, 0.0, 1.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 14.0, 8.0, 3.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_sapn.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_sapn.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "transpose",
+  "diag": "unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 0,
+  "strideAP": -2,
+  "offsetAP": 11,
+  "N": 3,
+  "AP": [ 0.0, 1.0, 0.0, 2.0, 0.0, 1.0, 0.0, 3.0, 0.0, 2.0, 0.0, 1.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 14.0, 8.0, 3.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_u_nt_nu.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_u_nt_nu.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "no-transpose",
+  "diag": "non-unit",
+  "uplo": "upper",
+  "strideX": 1,
+  "offsetX": 0,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 4.0, 3.0, 5.0, 6.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 14.0, 23.0, 18.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_u_nt_u.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_u_nt_u.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "no-transpose",
+  "diag": "unit",
+  "uplo": "upper",
+  "strideX": 1,
+  "offsetX": 0,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 1.0, 3.0, 2.0, 1.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 14.0, 8.0, 3.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_u_t_nu.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_u_t_nu.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "transpose",
+  "diag": "non-unit",
+  "uplo": "upper",
+  "strideX": 1,
+  "offsetX": 0,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 4.0, 3.0, 5.0, 6.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 1.0, 10.0, 31.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_u_t_u.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_u_t_u.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "transpose",
+  "diag": "unit",
+  "uplo": "upper",
+  "strideX": 1,
+  "offsetX": 0,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 1.0, 3.0, 2.0, 1.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 1.0, 4.0, 10.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_xn.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_xn.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "transpose",
+  "diag": "unit",
+  "uplo": "upper",
+  "strideX": -1,
+  "offsetX": 2,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 1.0, 3.0, 2.0, 1.0 ],
+  "x": [ 3.0, 2.0, 1.0 ],
+  "x_out": [ 10.0, 4.0, 1.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_xp.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/column_major_xp.json
@@ -1,0 +1,14 @@
+{
+  "order": "column-major",
+  "trans": "transpose",
+  "diag": "unit",
+  "uplo": "upper",
+  "strideX": 2,
+  "offsetX": 0,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 1.0, 3.0, 2.0, 1.0 ],
+  "x": [ 1.0, 0.0, 2.0, 0.0, 3.0, 0.0 ],
+  "x_out": [ 1.0, 0.0, 4.0, 0.0, 10.0, 0.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_complex_access_pattern.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_complex_access_pattern.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "transpose",
+  "diag": "unit",
+  "uplo": "lower",
+  "strideX": 2,
+  "offsetX": 1,
+  "strideAP": -2,
+  "offsetAP": 10,
+  "N": 3,
+  "AP": [ 1.0, 0.0, 4.0, 0.0, 3.0, 0.0, 1.0, 0.0, 2.0, 0.0, 1.0 ],
+  "x": [ 0.0, 1.0, 0.0, 2.0, 0.0, 3.0 ],
+  "x_out": [ 0.0, 14.0, 0.0, 14.0, 0.0, 3.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_l_nt_nu.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_l_nt_nu.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "no-transpose",
+  "diag": "non-unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 0,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 1.0, 8.0, 32.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_l_nt_u.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_l_nt_u.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "no-transpose",
+  "diag": "unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 0,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 1.0, 2.0, 1.0, 1.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 1.0, 4.0, 7.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_l_t_nu.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_l_t_nu.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "transpose",
+  "diag": "non-unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 0,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 17.0, 21.0, 18.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_l_t_u.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_l_t_u.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "transpose",
+  "diag": "unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 0,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 1.0, 3.0, 4.0, 1.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 14.0, 14.0, 3.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_oap.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_oap.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "no-transpose",
+  "diag": "non-unit",
+  "uplo": "lower",
+  "strideAP": 2,
+  "offsetAP": 6,
+  "strideX": 1,
+  "offsetX": 0,
+  "N": 3,
+  "AP": [ 999, 999, 999, 999, 999, 999, 1, 999, 2, 999, 4, 999, 3, 999, 5, 999, 6, 999 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 1.0, 10.0, 31.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_ox.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_ox.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "transpose",
+  "diag": "unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 2,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 1.0, 3.0, 4.0, 1.0 ],
+  "x": [ 0.0, 0.0, 1.0, 2.0, 3.0 ],
+  "x_out": [ 0.0, 0.0, 14.0, 14.0, 3.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_sap.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_sap.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "transpose",
+  "diag": "unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 0,
+  "strideAP": 2,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 0.0, 2.0, 0.0, 1.0, 0.0, 3.0, 0.0, 4.0, 0.0, 1.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 14.0, 14.0, 3.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_sapn.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_sapn.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "transpose",
+  "diag": "unit",
+  "uplo": "lower",
+  "strideX": 1,
+  "offsetX": 0,
+  "strideAP": -2,
+  "offsetAP": 10,
+  "N": 3,
+  "AP": [ 1.0, 0.0, 4.0, 0.0, 3.0, 0.0, 1.0, 0.0, 2.0, 0.0, 1.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 14.0, 14.0, 3.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_u_nt_nu.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_u_nt_nu.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "no-transpose",
+  "diag": "non-unit",
+  "uplo": "upper",
+  "strideX": 1,
+  "offsetX": 0,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 14.0, 23.0, 18.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_u_nt_u.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_u_nt_u.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "no-transpose",
+  "diag": "unit",
+  "uplo": "upper",
+  "strideX": 1,
+  "offsetX": 0,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 14.0, 8.0, 3.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_u_t_nu.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_u_t_nu.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "transpose",
+  "diag": "non-unit",
+  "uplo": "upper",
+  "strideX": 1,
+  "offsetX": 0,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 1.0, 10.0, 31.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_u_t_u.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_u_t_u.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "transpose",
+  "diag": "unit",
+  "uplo": "upper",
+  "strideX": 1,
+  "offsetX": 0,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 1.0, 4.0, 10.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_xn.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_xn.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "transpose",
+  "diag": "unit",
+  "uplo": "upper",
+  "strideX": -1,
+  "offsetX": 2,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ],
+  "x": [ 1.0, 2.0, 3.0 ],
+  "x_out": [ 14.0, 8.0, 3.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_xp.json
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/fixtures/row_major_xp.json
@@ -1,0 +1,14 @@
+{
+  "order": "row-major",
+  "trans": "transpose",
+  "diag": "unit",
+  "uplo": "upper",
+  "strideX": 2,
+  "offsetX": 0,
+  "strideAP": 1,
+  "offsetAP": 0,
+  "N": 3,
+  "AP": [ 1.0, 2.0, 3.0, 1.0, 2.0, 1.0 ],
+  "x": [ 1.0, 0.0, 2.0, 0.0, 3.0, 0.0 ],
+  "x_out": [ 1.0, 0.0, 4.0, 0.0, 10.0, 0.0 ]
+}

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/test.js
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/test.js
@@ -1,0 +1,82 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var proxyquire = require( 'proxyquire' );
+var IS_BROWSER = require( '@stdlib/assert/is-browser' );
+var stpmv = require( './../lib' );
+
+
+// VARIABLES //
+
+var opts = {
+	'skip': IS_BROWSER
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof stpmv, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the main export is a method providing an ndarray interface', function test( t ) {
+	t.strictEqual( typeof stpmv.ndarray, 'function', 'method is a function' );
+	t.end();
+});
+
+tape( 'if a native implementation is available, the main export is the native implementation', opts, function test( t ) {
+	var stpmv = proxyquire( './../lib', {
+		'@stdlib/utils/try-require': tryRequire
+	});
+
+	t.strictEqual( stpmv, mock, 'returns expected value' );
+	t.end();
+
+	function tryRequire() {
+		return mock;
+	}
+
+	function mock() {
+		// Mock...
+	}
+});
+
+tape( 'if a native implementation is not available, the main export is a JavaScript implementation', opts, function test( t ) {
+	var stpmv;
+	var main;
+
+	main = require( './../lib/stpmv.js' );
+
+	stpmv = proxyquire( './../lib', {
+		'@stdlib/utils/try-require': tryRequire
+	});
+
+	t.strictEqual( stpmv, main, 'returns expected value' );
+	t.end();
+
+	function tryRequire() {
+		return new Error( 'Cannot find module' );
+	}
+});

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/test.ndarray.js
@@ -1,0 +1,940 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* eslint-disable max-len */
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var Float32Array = require( '@stdlib/array/float32' );
+var stpmv = require( './../lib/ndarray.js' );
+
+
+// FIXTURES //
+
+var rlntnu = require( './fixtures/row_major_l_nt_nu.json' );
+var rltnu = require( './fixtures/row_major_l_t_nu.json' );
+var rlntu = require( './fixtures/row_major_l_nt_u.json' );
+var rltu = require( './fixtures/row_major_l_t_u.json' );
+var runtnu = require( './fixtures/row_major_u_nt_nu.json' );
+var runtu = require( './fixtures/row_major_u_nt_u.json' );
+var rutnu = require( './fixtures/row_major_u_t_nu.json' );
+var rutu = require( './fixtures/row_major_u_t_u.json' );
+var rxp = require( './fixtures/row_major_xp.json' );
+var rxn = require( './fixtures/row_major_xn.json' );
+var rox = require( './fixtures/row_major_ox.json' );
+var rsap = require( './fixtures/row_major_sap.json' );
+var rsapn = require( './fixtures/row_major_sapn.json' );
+var roap = require( './fixtures/row_major_oap.json' );
+var rcap = require( './fixtures/row_major_complex_access_pattern.json' );
+
+var clntnu = require( './fixtures/column_major_l_nt_nu.json' );
+var cltnu = require( './fixtures/column_major_l_t_nu.json' );
+var clntu = require( './fixtures/column_major_l_nt_u.json' );
+var cltu = require( './fixtures/column_major_l_t_u.json' );
+var cuntnu = require( './fixtures/column_major_u_nt_nu.json' );
+var cuntu = require( './fixtures/column_major_u_nt_u.json' );
+var cutnu = require( './fixtures/column_major_u_t_nu.json' );
+var cutu = require( './fixtures/column_major_u_t_u.json' );
+var cxp = require( './fixtures/column_major_xp.json' );
+var cxn = require( './fixtures/column_major_xn.json' );
+var cox = require( './fixtures/column_major_ox.json' );
+var csap = require( './fixtures/column_major_sap.json' );
+var csapn = require( './fixtures/column_major_sapn.json' );
+var coap = require( './fixtures/column_major_oap.json' );
+var ccap = require( './fixtures/column_major_complex_access_pattern.json' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof stpmv, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 11', function test( t ) {
+	t.strictEqual( stpmv.length, 11, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function throws an error if provided an invalid first argument', function test( t ) {
+	var values;
+	var data;
+	var i;
+
+	data = rutu;
+
+	values = [
+		'foo',
+		'bar',
+		'beep',
+		'boop'
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			stpmv( value, data.uplo, data.trans, data.diag, data.N, new Float32Array( data.AP ), data.strideAP, data.offsetAP, new Float32Array( data.x ), data.strideX );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an invalid second argument', function test( t ) {
+	var values;
+	var data;
+	var i;
+
+	data = rutu;
+
+	values = [
+		'foo',
+		'bar',
+		'beep',
+		'boop'
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			stpmv( data.order, value, data.trans, data.diag, data.N, new Float32Array( data.AP ), data.strideAP, data.offsetAP, new Float32Array( data.x ), data.strideX );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an invalid third argument', function test( t ) {
+	var values;
+	var data;
+	var i;
+
+	data = rutu;
+
+	values = [
+		'foo',
+		'bar',
+		'beep',
+		'boop'
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			stpmv( data.order, data.uplo, value, data.diag, data.N, new Float32Array( data.AP ), data.strideAP, data.offsetAP, new Float32Array( data.x ), data.strideX );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an invalid fourth argument', function test( t ) {
+	var values;
+	var data;
+	var i;
+
+	data = rutu;
+
+	values = [
+		'foo',
+		'bar',
+		'beep',
+		'boop'
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			stpmv( data.order, data.uplo, data.trans, value, data.N, new Float32Array( data.AP ), data.strideAP, data.offsetAP, new Float32Array( data.x ), data.strideX );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an invalid fifth argument', function test( t ) {
+	var values;
+	var data;
+	var i;
+
+	data = rutu;
+
+	values = [
+		-1,
+		-2,
+		-3
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), RangeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			stpmv( data.order, data.uplo, data.trans, data.diag, value, new Float32Array( data.AP ), data.strideAP, data.offsetAP, new Float32Array( data.x ), data.strideX );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an invalid seventh argument', function test( t ) {
+	var values;
+	var data;
+	var i;
+
+	data = rutu;
+
+	values = [
+		0
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), RangeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			stpmv( data.order, data.uplo, data.trans, data.diag, data.N, new Float32Array( data.AP ), value, data.offsetAP, new Float32Array( data.x ), data.strideX, data.offsetX );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an invalid tenth argument', function test( t ) {
+	var values;
+	var data;
+	var i;
+
+	data = rutu;
+
+	values = [
+		0
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), RangeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			stpmv( data.order, data.uplo, data.trans, data.diag, data.N, new Float32Array( data.AP ), data.strideAP, data.offsetAP, new Float32Array( data.x ), value, data.offsetX );
+		};
+	}
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (row-major, lower, no transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rlntnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (column-major, lower, no transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = clntnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (row-major, lower, transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rltnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (column-major, lower, transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cltnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (row-major, lower, no transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rlntu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (column-major, lower, no transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = clntu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (row-major, lower, transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rltu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (column-major, lower, transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cltu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (row-major, upper, no transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = runtnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (column-major, upper, no transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cuntnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (row-major, upper, no transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = runtu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (column-major, upper, no transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cuntu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (row-major, upper, transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rutnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (column-major, upper, transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cutnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (row-major, upper, transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rutu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (column-major, upper, transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cutu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a reference to the input vector', function test( t ) {
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rutu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if `N` is zero, the function returns the input vector unchanged (row-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rutu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, 0, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( x, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if `N` is zero, the function returns the input vector unchanged (column-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cutu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, 0, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( x, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying an `x` stride (row-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rxp;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying an `x` stride (column-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cxp;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a negative `x` stride (row-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rxn;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a negative `x` stride (column-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cxn;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying an `x` offset (row-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rox;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying an `x` offset (column-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cox;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying a stride for `AP` (row-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rsap;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying a stride for `AP` (column-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = csap;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying a negative stride for `AP` (row-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rsapn;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying a negative stride for `AP` (column-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = csapn;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying an offset for `AP` (row-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = roap;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying an offset for `AP` (column-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = coap;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports complex access patterns (row-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rcap;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports complex access patterns (column-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = ccap;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, data.strideAP, data.offsetAP, x, data.strideX, data.offsetX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/blas/base/stpmv/test/test.stpmv.js
+++ b/lib/node_modules/@stdlib/blas/base/stpmv/test/test.stpmv.js
@@ -1,0 +1,697 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* eslint-disable max-len */
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var Float32Array = require( '@stdlib/array/float32' );
+var stpmv = require( './../lib/stpmv.js' );
+
+
+// FIXTURES //
+
+var rlntnu = require( './fixtures/row_major_l_nt_nu.json' );
+var rltnu = require( './fixtures/row_major_l_t_nu.json' );
+var rlntu = require( './fixtures/row_major_l_nt_u.json' );
+var rltu = require( './fixtures/row_major_l_t_u.json' );
+var runtnu = require( './fixtures/row_major_u_nt_nu.json' );
+var runtu = require( './fixtures/row_major_u_nt_u.json' );
+var rutnu = require( './fixtures/row_major_u_t_nu.json' );
+var rutu = require( './fixtures/row_major_u_t_u.json' );
+var rxp = require( './fixtures/row_major_xp.json' );
+var rxn = require( './fixtures/row_major_xn.json' );
+
+var clntnu = require( './fixtures/column_major_l_nt_nu.json' );
+var cltnu = require( './fixtures/column_major_l_t_nu.json' );
+var clntu = require( './fixtures/column_major_l_nt_u.json' );
+var cltu = require( './fixtures/column_major_l_t_u.json' );
+var cuntnu = require( './fixtures/column_major_u_nt_nu.json' );
+var cuntu = require( './fixtures/column_major_u_nt_u.json' );
+var cutnu = require( './fixtures/column_major_u_t_nu.json' );
+var cutu = require( './fixtures/column_major_u_t_u.json' );
+var cxp = require( './fixtures/column_major_xp.json' );
+var cxn = require( './fixtures/column_major_xn.json' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof stpmv, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 8', function test( t ) {
+	t.strictEqual( stpmv.length, 8, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function throws an error if provided an invalid first argument', function test( t ) {
+	var values;
+	var data;
+	var i;
+
+	data = rutu;
+
+	values = [
+		'foo',
+		'bar',
+		'beep',
+		'boop'
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			stpmv( value, data.uplo, data.trans, data.diag, data.N, new Float32Array( data.AP ), new Float32Array( data.x ), data.strideX );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an invalid second argument', function test( t ) {
+	var values;
+	var data;
+	var i;
+
+	data = rutu;
+
+	values = [
+		'foo',
+		'bar',
+		'beep',
+		'boop'
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			stpmv( data.order, value, data.trans, data.diag, data.N, new Float32Array( data.AP ), new Float32Array( data.x ), data.strideX );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an invalid third argument', function test( t ) {
+	var values;
+	var data;
+	var i;
+
+	data = rutu;
+
+	values = [
+		'foo',
+		'bar',
+		'beep',
+		'boop'
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			stpmv( data.order, data.uplo, value, data.diag, data.N, new Float32Array( data.AP ), new Float32Array( data.x ), data.strideX );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an invalid fourth argument', function test( t ) {
+	var values;
+	var data;
+	var i;
+
+	data = rutu;
+
+	values = [
+		'foo',
+		'bar',
+		'beep',
+		'boop'
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			stpmv( data.order, data.uplo, data.trans, value, data.N, new Float32Array( data.AP ), new Float32Array( data.x ), data.strideX );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an invalid fifth argument', function test( t ) {
+	var values;
+	var data;
+	var i;
+
+	data = rutu;
+
+	values = [
+		-1,
+		-2,
+		-3
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), RangeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			stpmv( data.order, data.uplo, data.trans, data.diag, value, new Float32Array( data.AP ), new Float32Array( data.x ), data.strideX );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an invalid eighth argument', function test( t ) {
+	var values;
+	var data;
+	var i;
+
+	data = rutu;
+
+	values = [
+		0
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), RangeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			stpmv( data.order, data.uplo, data.trans, data.diag, data.N, new Float32Array( data.AP ), new Float32Array( data.x ), value );
+		};
+	}
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (row-major, lower, no transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rlntnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (column-major, lower, no transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = clntnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (row-major, lower, transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rltnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (column-major, lower, transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cltnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (row-major, lower, no transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rlntu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (column-major, lower, no transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = clntu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (row-major, lower, transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rltu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (column-major, lower, transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cltu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (row-major, upper, no transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = runtnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (column-major, upper, no transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cuntnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (row-major, upper, no transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = runtu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (column-major, upper, no transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cuntu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (row-major, upper, transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rutnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (column-major, upper, transpose, non-unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cutnu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (row-major, upper, transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rutu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function performs one of the matrix-vector operations `x = A*x` or `x = A**T*x` (column-major, upper, transpose, unit)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cutu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a reference to the input vector', function test( t ) {
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rutu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if `N` is zero, the function returns the input vector unchanged (row-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rutu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, 0, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( x, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if `N` is zero, the function returns the input vector unchanged (column-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cutu;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, 0, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( x, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying an `x` stride (row-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rxp;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports specifying an `x` stride (column-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cxp;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a negative `x` stride (row-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = rxn;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a negative `x` stride (column-major)', function test( t ) {
+	var expected;
+	var data;
+	var out;
+	var ap;
+	var x;
+
+	data = cxn;
+
+	ap = new Float32Array( data.AP );
+	x = new Float32Array( data.x );
+
+	expected = new Float32Array( data.x_out );
+
+	out = stpmv( data.order, data.uplo, data.trans, data.diag, data.N, ap, x, data.strideX );
+	t.strictEqual( out, x, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});


### PR DESCRIPTION
Progresses: #2039. 

## Description

> What is the purpose of this pull request?

This RFC proposes to add a routine to perform one of the matrix-vector operations `x = A*x`, or `x = A**T*x`, where `x` is an `N` element vector, and `A` is an `N` by `N` unit, or non-unit, upper or lower triangular matrix, supplied in packed form as defined in [BLAS Level 2](http://www.netlib.org/blas/#_level_2) routines. Specifically adding `@stdlib/blas/base/stpmv` is proposed.

## Related Issues

> Does this pull request have any related issues?

This pull request:

- progresses: #2039.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
