### PR TITLE
feat: add `math/base/special/maxabsf`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/README.md
@@ -1,0 +1,225 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# maxabsf
+
+> Return the maximum absolute single-precision floating-point number.
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var maxabsf = require( '@stdlib/math/base/special/maxabsf' );
+```
+
+#### maxabsf( x, y )
+
+Returns the maximum absolute single-precision floating-point number.
+
+```javascript
+var v = maxabsf( -4.2, 3.14 );
+// returns ~4.2
+
+v = maxabsf( +0.0, -0.0 );
+// returns +0.0
+```
+
+If any argument is `NaN`, the function returns `NaN`.
+
+```javascript
+var v = maxabsf( 4.2, NaN );
+// returns NaN
+
+v = maxabsf( NaN, 3.14 );
+// returns NaN
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var randu = require( '@stdlib/random/base/randu' );
+var maxabsf = require( '@stdlib/math/base/special/maxabsf' );
+
+var x;
+var y;
+var v;
+var i;
+
+for ( i = 0; i < 100; i++ ) {
+    x = ( randu() * 1000.0 ) - 500.0;
+    y = ( randu() * 1000.0 ) - 500.0;
+    v = maxabsf( x, y );
+    console.log( 'maxabsf(%d,%d) = %d', x, y, v );
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/math/base/special/maxabsf.h"
+```
+
+#### stdlib_base_maxabsf( x, y )
+
+Returns the maximum absolute single-precision floating-point number.
+
+```c
+float out = stdlib_base_maxabsf( -4.2f, 3.14f );
+// returns ~4.2f
+
+out = stdlib_base_maxabsf( 0.0f, -0.0f );
+// returns +0.0f
+```
+
+The function accepts the following arguments:
+
+-   **x**: `[in] float` input value.
+-   **y**: `[in] float` input value.
+
+```c
+float stdlib_base_maxabsf( const float x, const float y );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/math/base/special/maxabsf.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+int main( void ) {
+    float x;
+    float y;
+    float v;
+    int i;
+    
+    for ( i = 0; i < 100; i++ ) {
+        x = ( ( (float)rand() / (float)RAND_MAX ) * 1000.0f ) - 500.0f;
+        y = ( ( (float)rand() / (float)RAND_MAX ) * 1000.0f ) - 500.0f;
+        v = stdlib_base_maxabsf( x, y );
+        printf( "x: %f, y: %f, maxabsf(x, y): %f\n", x, y, v );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/benchmark/benchmark.js
@@ -1,0 +1,54 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/array/uniform' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var pkg = require( './../package.json' ).name;
+var maxabsf = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var x;
+	var y;
+	var z;
+	var i;
+
+	x = randu( 100, -500.0, 500.0 );
+	y = randu( 100, -500.0, 500.0 );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		z = maxabsf( x[ i % x.length ], y[ i % y.length ] );
+		if ( isnanf( z ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnanf( z ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/benchmark/benchmark.native.js
@@ -1,0 +1,63 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/array/uniform' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var maxabsf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( maxabsf instanceof Error )
+};
+
+
+// MAIN //
+
+bench( pkg+'::native', opts, function benchmark( b ) {
+	var x;
+	var y;
+	var z;
+	var i;
+
+	x = randu( 100, -500.0, 500.0 );
+	y = randu( 100, -500.0, 500.0 );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		z = maxabsf( x[ i % x.length ], y[ i % y.length ] );
+		if ( isnanf( z ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnanf( z ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/benchmark/c/native/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/benchmark/c/native/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/benchmark/c/native/benchmark.c
@@ -1,0 +1,138 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/maxabsf.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "maxabsf"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+static void print_version( void ) {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+static void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+static void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+static double tic( void ) {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1).
+*
+* @return random number
+*/
+static float rand_float( void ) {
+	int r = rand();
+	return (float)r / ( (float)RAND_MAX + 1.0f );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+static double benchmark( void ) {
+	double elapsed;
+	double t;
+	float x[ 100 ];
+	float y[ 100 ];
+	float z;
+	int i;
+
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0f * rand_float() ) - 500.0f;
+		y[ i ] = ( 1000.0f * rand_float() ) - 500.0f;
+	}
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		z = stdlib_base_maxabs( x[ i % 100 ], y[ i % 100 ] );
+		if ( z != z ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( z != z ) {
+		printf( "should not return NaN\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::native::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/benchmark/c/native/benchmark.c
@@ -104,7 +104,7 @@ static double benchmark( void ) {
 
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		z = stdlib_base_maxabs( x[ i % 100 ], y[ i % 100 ] );
+		z = stdlib_base_maxabsf( x[ i % 100 ], y[ i % 100 ] );
 		if ( z != z ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/binding.gyp
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/docs/repl.txt
@@ -1,0 +1,31 @@
+
+{{alias}}( x, y )
+    Returns the maximum absolute single-precision floating-point number.
+
+    If any argument is `NaN`, the function returns `NaN`.
+
+    Parameters
+    ----------
+    x: number
+        First number.
+
+    y: number
+        Second number.
+
+    Returns
+    -------
+    out: number
+        Maximum absolute value.
+
+    Examples
+    --------
+    > var v = {{alias}}( 3.14, -4.2 )
+    ~4.2
+    > v = {{alias}}( 3.14, NaN )
+    NaN
+    > v = {{alias}}( +0.0, -0.0 )
+    +0.0
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/docs/types/index.d.ts
@@ -21,10 +21,6 @@
 /**
 * Returns the maximum absolute single-precision floating-point number.
 *
-* ## Notes
-*
-* -   When an empty set is considered a subset of the extended reals (all real numbers, including positive and negative infinity), negative infinity is the least upper bound. Similar to zero being the identity element for the sum of an empty set and to one being the identity element for the product of an empty set, negative infinity is the identity element for the maximum, and thus, if not provided any arguments, the function returns `+infinity` (i.e., the absolute value of `-infinity`).
-*
 * @param x - first number
 * @param y - second number
 * @returns maximum absolute value

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/docs/types/index.d.ts
@@ -1,0 +1,49 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Returns the maximum absolute single-precision floating-point number.
+*
+* ## Notes
+*
+* -   When an empty set is considered a subset of the extended reals (all real numbers, including positive and negative infinity), negative infinity is the least upper bound. Similar to zero being the identity element for the sum of an empty set and to one being the identity element for the product of an empty set, negative infinity is the identity element for the maximum, and thus, if not provided any arguments, the function returns `+infinity` (i.e., the absolute value of `-infinity`).
+*
+* @param x - first number
+* @param y - second number
+* @returns maximum absolute value
+*
+* @example
+* var v = maxabsf( 3.14, -4.2 );
+* // returns 4.2
+*
+* @example
+* var v = maxabsf( 3.14, NaN );
+* // returns NaN
+*
+* @example
+* var v = maxabsf( +0.0, -0.0 );
+* // returns +0.0
+*/
+declare function maxabsf( x: number, y: number ): number;
+
+
+// EXPORTS //
+
+export = maxabsf;

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/docs/types/test.ts
@@ -1,0 +1,51 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import maxabsf = require( './index' );
+
+
+// TESTS //
+
+// The function returns a number...
+{
+	maxabsf( 3, -0.2 ); // $ExpectType number
+}
+
+// The compiler throws an error if the function is provided non-number arguments...
+{
+	maxabsf( true, 3 ); // $ExpectError
+	maxabsf( false, 3 ); // $ExpectError
+	maxabsf( [], 3 ); // $ExpectError
+	maxabsf( {}, 3 ); // $ExpectError
+	maxabsf( 'abc', 3 ); // $ExpectError
+	maxabsf( ( x: number ): number => x, 3 ); // $ExpectError
+
+	maxabsf( 1.2, true ); // $ExpectError
+	maxabsf( 1.2, false ); // $ExpectError
+	maxabsf( 1.2, [] ); // $ExpectError
+	maxabsf( 1.2, {} ); // $ExpectError
+	maxabsf( 1.2, 'abc' ); // $ExpectError
+	maxabsf( 1.2, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if provided an unsupported number of arguments...
+{
+	maxabsf(); // $ExpectError
+	maxabsf( -0.2 ); // $ExpectError
+	maxabsf( 3, -0.2, -1.2, -4.0 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/examples/c/example.c
@@ -1,0 +1,35 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/maxabsf.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+int main( void ) {
+	float x;
+	float y;
+	float v;
+	int i;
+
+	for ( i = 0; i < 100; i++ ) {
+		x = ( ( (float)rand() / (float)RAND_MAX ) * 1000.0f ) - 500.0f;
+		y = ( ( (float)rand() / (float)RAND_MAX ) * 1000.0f ) - 500.0f;
+		v = stdlib_base_maxabsf( x, y );
+		printf( "x: %f, y: %f, maxabsf(x, y): %f\n", x, y, v );
+	}
+}

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/examples/index.js
@@ -1,0 +1,34 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var randu = require( '@stdlib/random/base/randu' );
+var maxabsf = require( './../lib' );
+
+var x;
+var y;
+var v;
+var i;
+
+for ( i = 0; i < 100; i++ ) {
+	x = ( randu() * 1000.0 ) - 500.0;
+	y = ( randu() * 1000.0 ) - 500.0;
+	v = maxabsf( x, y );
+	console.log( 'maxabsf(%d,%d) = %d', x, y, v );
+}

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/include.gypi
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/include/stdlib/math/base/special/maxabsf.h
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/include/stdlib/math/base/special/maxabsf.h
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_MATH_BASE_SPECIAL_MAXABSF_H
+#define STDLIB_MATH_BASE_SPECIAL_MAXABSF_H
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Returns the maximum absolute single-precision floating-point number.
+*/
+float stdlib_base_maxabsf( const float x, const float y );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_MATH_BASE_SPECIAL_MAXABSF_H

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/lib/index.js
@@ -1,0 +1,46 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Return the maximum absolute single-precision floating-point number.
+*
+* @module @stdlib/math/base/special/maxabsf
+*
+* @example
+* var maxabsf = require( '@stdlib/math/base/special/maxabsf' );
+*
+* var v = maxabsf( 3.14, -4.2 );
+* // returns ~4.2
+*
+* v = maxabsf( 3.14, NaN );
+* // returns NaN
+*
+* v = maxabsf( +0.0, -0.0 );
+* // returns +0.0
+*/
+
+// MODULES //
+
+var maxabsf = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = maxabsf;

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/lib/main.js
@@ -1,0 +1,56 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var absf = require( '@stdlib/math/base/special/absf' );
+var maxf = require( '@stdlib/math/base/special/maxf' );
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+
+
+// MAIN //
+
+/**
+* Returns the maximum absolute single-precision floating-point number.
+*
+* @param {number} x - first number
+* @param {number} y - second number
+* @returns {number} maximum absolute value
+*
+* @example
+* var v = maxabsf( 3.14, -4.2 );
+* // returns ~4.2
+*
+* @example
+* var v = maxabsf( 3.14, NaN );
+* // returns NaN
+*
+* @example
+* var v = maxabsf( +0.0, -0.0 );
+* // returns +0.0
+*/
+function maxabsf( x, y ) {
+	return maxf( absf( float64ToFloat32( x ) ), absf( float64ToFloat32( y ) ) );
+}
+
+
+// EXPORTS //
+
+module.exports = maxabsf;

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/lib/native.js
@@ -1,0 +1,59 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Returns the maximum absolute single-precision floating-point number.
+*
+* @private
+* @param {number} x - first number
+* @param {number} y - second number
+* @returns {number} maximum absolute value
+*
+* @example
+* var v = maxabsf( -4.2, 3.14 );
+* // returns ~4.2
+*
+* @example
+* var v = maxabsf( 0.0, -0.0 );
+* // returns +0.0
+*
+* @example
+* var v = maxabsf( 3.14, NaN );
+* // returns NaN
+*
+* @example
+* var v = maxabsf( NaN, 5.0 );
+* // returns NaN
+*/
+function maxabsf( x, y ) {
+	return addon( x, y );
+}
+
+
+// EXPORTS //
+
+module.exports = maxabsf;

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/manifest.json
@@ -1,0 +1,75 @@
+{
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/napi/binary",
+        "@stdlib/math/base/special/absf",
+        "@stdlib/math/base/special/maxf"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/absf",
+        "@stdlib/math/base/special/maxf"
+      ]
+    },
+    {
+      "task": "examples",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/absf",
+        "@stdlib/math/base/special/maxf"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@stdlib/math/base/special/maxabsf",
+  "version": "0.0.0",
+  "description": "Return the maximum absolute single-precision floating-point number.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "gypfile": true,
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "src": "./src",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
+    "math.max",
+    "math.abs",
+    "maximum",
+    "max",
+    "largest",
+    "greatest",
+    "absolute",
+    "value",
+    "abs",
+    "magnitude"
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/src/addon.c
@@ -1,0 +1,23 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/maxabsf.h"
+#include "stdlib/math/base/napi/binary.h"
+
+// cppcheck-suppress shadowFunction
+STDLIB_MATH_BASE_NAPI_MODULE_FF_F( stdlib_base_maxabsf )

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/src/main.c
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/maxabsf.h"
+#include "stdlib/math/base/special/maxf.h"
+#include "stdlib/math/base/special/absf.h"
+
+/**
+* Returns the maximum absolute single-precision floating-point number.
+*
+* @param x       first number
+* @param y       second number
+* @return        maximum absolute value
+*
+* @example
+* float v = stdlib_base_maxabsf( 3.14f, -4.2f );
+* // returns ~4.2f
+*
+* @example
+* float v = stdlib_base_maxabsf( 0.0f, -0.0f );
+* // returns +0.0f
+*/
+float stdlib_base_maxabsf( const float x, const float y ) {
+	return stdlib_base_maxf( stdlib_base_absf( x ), stdlib_base_absf( y ) );
+}

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/test/test.js
@@ -1,0 +1,94 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var PINF = require( '@stdlib/constants/float32/pinf' );
+var maxabsf = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof maxabsf, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `NaN` if provided a `NaN`', function test( t ) {
+	var v;
+
+	v = maxabsf( NaN, 3.14 );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
+
+	v = maxabsf( 3.14, NaN );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
+
+	v = maxabsf( NaN );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `+Infinity` if provided `+Infinity`', function test( t ) {
+	var v;
+
+	v = maxabsf( PINF, 3.14 );
+	t.strictEqual( v, PINF, 'returns expected value' );
+
+	v = maxabsf( 3.14, PINF );
+	t.strictEqual( v, PINF, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a correctly signed zero', function test( t ) {
+	var v;
+
+	v = maxabsf( +0.0, -0.0 );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns expected value' );
+
+	v = maxabsf( -0.0, +0.0 );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns expected value' );
+
+	v = maxabsf( -0.0, -0.0 );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns expected value' );
+
+	v = maxabsf( +0.0, +0.0 );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns the maximum absolute value', function test( t ) {
+	var v;
+
+	v = maxabsf( float64ToFloat32( 4.2 ), float64ToFloat32( 3.14 ) );
+	t.strictEqual( v, float64ToFloat32( 4.2 ), 'returns expected value' );
+
+	v = maxabsf( float64ToFloat32( -4.2 ), float64ToFloat32( 3.14 ) );
+	t.strictEqual( v, float64ToFloat32( 4.2 ), 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/test/test.js
@@ -45,7 +45,7 @@ tape( 'the function returns `NaN` if provided a `NaN`', function test( t ) {
 	v = maxabsf( 3.14, NaN );
 	t.strictEqual( isnanf( v ), true, 'returns expected value' );
 
-	v = maxabsf( NaN );
+	v = maxabsf( NaN, NaN );
 	t.strictEqual( isnanf( v ), true, 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/test/test.native.js
@@ -54,6 +54,9 @@ tape( 'the function returns `NaN` if provided a `NaN`', opts, function test( t )
 	v = maxabsf( 3.14, NaN );
 	t.strictEqual( isnanf( v ), true, 'returns expected value' );
 
+	v = maxabsf( NaN, NaN );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
+
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/test/test.native.js
@@ -1,0 +1,100 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var PINF = require( '@stdlib/constants/float32/pinf' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var maxabsf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( maxabsf instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof maxabsf, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `NaN` if provided a `NaN`', opts, function test( t ) {
+	var v;
+
+	v = maxabsf( NaN, 3.14 );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
+
+	v = maxabsf( 3.14, NaN );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `+Infinity` if provided `+Infinity`', opts, function test( t ) {
+	var v;
+
+	v = maxabsf( PINF, 3.14 );
+	t.strictEqual( v, PINF, 'returns expected value' );
+
+	v = maxabsf( 3.14, PINF );
+	t.strictEqual( v, PINF, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a correctly signed zero', opts, function test( t ) {
+	var v;
+
+	v = maxabsf( +0.0, -0.0 );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns expected value' );
+
+	v = maxabsf( -0.0, +0.0 );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns expected value' );
+
+	v = maxabsf( -0.0, -0.0 );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns expected value' );
+
+	v = maxabsf( +0.0, +0.0 );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns the maximum absolute value', opts, function test( t ) {
+	var v;
+
+	v = maxabsf( float64ToFloat32( 4.2 ), float64ToFloat32( 3.14 ) );
+	t.strictEqual( v, float64ToFloat32( 4.2 ), 'returns expected value' );
+
+	v = maxabsf( float64ToFloat32( -4.2 ), float64ToFloat32( 3.14 ) );
+	t.strictEqual( v, float64ToFloat32( 4.2 ), 'returns expected value' );
+
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds `math/base/special/maxabsf`, which would be the single-precision variant for [`math/base/special/maxabs`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/maxabs).

```c
float stdlib_base_maxabsf( const float x, const float y );
```

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves a part of #649.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
