### PR TITLE
test: add and modify tests in `math/base/special/maxabs`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/maxabs/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/maxabs/test/test.js
@@ -39,13 +39,13 @@ tape( 'the function returns `NaN` if provided a `NaN`', function test( t ) {
 	var v;
 
 	v = maxabs( NaN, 3.14 );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = maxabs( 3.14, NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
-	v = maxabs( NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	v = maxabs( NaN, NaN );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -54,10 +54,10 @@ tape( 'the function returns `+Infinity` if provided `+Infinity`', function test(
 	var v;
 
 	v = maxabs( PINF, 3.14 );
-	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.strictEqual( v, PINF, 'returns expected value' );
 
 	v = maxabs( 3.14, PINF );
-	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.strictEqual( v, PINF, 'returns expected value' );
 
 	t.end();
 });
@@ -66,16 +66,16 @@ tape( 'the function returns a correctly signed zero', function test( t ) {
 	var v;
 
 	v = maxabs( +0.0, -0.0 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = maxabs( -0.0, +0.0 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = maxabs( -0.0, -0.0 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = maxabs( +0.0, +0.0 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/maxabs/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/maxabs/test/test.native.js
@@ -48,10 +48,25 @@ tape( 'the function returns `NaN` if provided a `NaN`', opts, function test( t )
 	var v;
 
 	v = maxabs( NaN, 3.14 );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = maxabs( 3.14, NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	v = maxabs( NaN, NaN );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `+Infinity` if provided `+Infinity`', opts, function test( t ) {
+	var v;
+
+	v = maxabs( PINF, 3.14 );
+	t.strictEqual( v, PINF, 'returns expected value' );
+
+	v = maxabs( 3.14, PINF );
+	t.strictEqual( v, PINF, 'returns expected value' );
 
 	t.end();
 });
@@ -60,16 +75,16 @@ tape( 'the function returns a correctly signed zero', opts, function test( t ) {
 	var v;
 
 	v = maxabs( +0.0, -0.0 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = maxabs( -0.0, +0.0 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = maxabs( -0.0, -0.0 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = maxabs( +0.0, +0.0 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -82,12 +97,6 @@ tape( 'the function returns the maximum absolute value', opts, function test( t 
 
 	v = maxabs( -4.2, 3.14 );
 	t.strictEqual( v, 4.2, 'returns expected value' );
-
-	v = maxabs( PINF, 3.14 );
-	t.strictEqual( v, PINF, 'returns expected value' );
-
-	v = maxabs( 3.14, PINF );
-	t.strictEqual( v, PINF, 'returns expected value' );
 
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   addresses https://github.com/stdlib-js/stdlib/pull/2829#discussion_r1729907763
-   adds the missing second `NaN` argument in a test in [`test.js`](https://github.com/stdlib-js/stdlib/pull/2830/files#diff-3cf24ec2642945cf045ee0956f9c4b99f41ccdd4d3292b56f203b6fe95f8fa86R47).
-   adds the missing test where both inputs are `NaN` in [`test.native.js`](https://github.com/stdlib-js/stdlib/pull/2830/files#diff-a359f7cb7b803edd1b36f29819917f6cbd8bba07c026f41f9fa58db09078c8fbR56-R57).
-   moves the tests which have inputs as `PINF` to another section in `test.native.js`, similar to what we have in `test.js`.
-   updates the test descriptions to use `expected value`.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
