### PR TITLE
docs: include `stdbool`, remove backticks in `math/base/assert/is-nonnegative-integer`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/assert/is-nonnegative-integer/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/is-nonnegative-integer/README.md
@@ -32,7 +32,7 @@ var isNonNegativeInteger = require( '@stdlib/math/base/assert/is-nonnegative-int
 
 #### isNonNegativeInteger( x )
 
-Tests if a finite [double-precision floating-point number][ieee754] is a nonnegative `integer`.
+Tests if a finite [double-precision floating-point number][ieee754] is a nonnegative integer.
 
 ```javascript
 var bool = isNonNegativeInteger( 1.0 );
@@ -53,7 +53,7 @@ bool = isNonNegativeInteger( -10.0 );
 
 ## Notes
 
--   The function assumes a **finite** `number`. If provided positive `infinity`, the function will return `true`, when, in fact, the result is undefined. If `x` can be `infinite`, wrap the implementation as follows:
+-   The function assumes a **finite** number. If provided positive `infinity`, the function will return `true`, when, in fact, the result is undefined. If `x` can be `infinite`, wrap the implementation as follows:
 
     ```javascript
     function check( x ) {
@@ -141,6 +141,8 @@ bool = isNonNegativeInteger( NaN );
 Tests if a finite [double-precision floating-point number][ieee754] is a nonnegative integer.
 
 ```c
+#include <stdbool.h>
+
 bool out = stdlib_base_is_nonnegative_integer( 1.0 );
 // returns true
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   removes backticks and adds `stdbool.h` include in examples in `README.md`, in [`math/base/assert/is-nonnegative-integer`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/assert/is-nonnegative-integer).

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
