### PR TITLE
fix: update completer to correctly generate completions for member expressions in the REPL

### DIFF
--- a/lib/node_modules/@stdlib/repl/lib/regexp_reserved_syntax_characters.js
+++ b/lib/node_modules/@stdlib/repl/lib/regexp_reserved_syntax_characters.js
@@ -33,7 +33,7 @@
 * // returns true
 */
 function createRegExp() {
-	return /[`~!@#%^&*()-=+[\]{}\\/|;:'",<>?. ]/;
+	return /[`~!@#%^&*()\-=+[\]{}\\/|;:'",<>? ]/;
 }
 
 


### PR DESCRIPTION
Resolves #2882.

## Description

> What is the purpose of this pull request?

This pull request:

-   removes `.` from the reserved syntax chars regexp to allow correctly completing member expressions.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #2882

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
