### PR TITLE
test: fix typos in test descriptions in `math/base/special/rempio2`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/rempio2/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/rempio2/test/test.js
@@ -69,7 +69,7 @@ tape( 'the function returns `0` and sets the elements of `y` to `NaN` if provide
 	t.end();
 });
 
-tape( 'the function returns `n` and stores `r` as two double-precision floating points numbers in `y` such that `x - nπ/2 = r` (positive)', function test( t ) {
+tape( 'the function returns `n` and stores `r` as two double-precision floating point numbers in `y` such that `x - nπ/2 = r` (positive)', function test( t ) {
 	var delta;
 	var tol;
 	var x;
@@ -95,7 +95,7 @@ tape( 'the function returns `n` and stores `r` as two double-precision floating 
 	t.end();
 });
 
-tape( 'the function returns `n` and stores `r` as two double-precision floating points numbers in `y` such that `x - nπ/2 = r` (tiny positive)', function test( t ) {
+tape( 'the function returns `n` and stores `r` as two double-precision floating point numbers in `y` such that `x - nπ/2 = r` (tiny positive)', function test( t ) {
 	var delta;
 	var tol;
 	var x;
@@ -121,7 +121,7 @@ tape( 'the function returns `n` and stores `r` as two double-precision floating 
 	t.end();
 });
 
-tape( 'the function returns `n` and stores `r` as two double-precision floating points numbers in `y` such that `x - nπ/2 = r` (negative)', function test( t ) {
+tape( 'the function returns `n` and stores `r` as two double-precision floating point numbers in `y` such that `x - nπ/2 = r` (negative)', function test( t ) {
 	var delta;
 	var tol;
 	var x;
@@ -147,7 +147,7 @@ tape( 'the function returns `n` and stores `r` as two double-precision floating 
 	t.end();
 });
 
-tape( 'the function returns `n` and stores `r` as two double-precision floating points numbers in `y` such that `x - nπ/2 = r` (tiny negative)', function test( t ) {
+tape( 'the function returns `n` and stores `r` as two double-precision floating point numbers in `y` such that `x - nπ/2 = r` (tiny negative)', function test( t ) {
 	var delta;
 	var tol;
 	var x;
@@ -173,7 +173,7 @@ tape( 'the function returns `n` and stores `r` as two double-precision floating 
 	t.end();
 });
 
-tape( 'the function returns `n` and stores `r` as two double-precision floating points numbers in `y` such that `x - nπ/2 = r` (multiples of π/4)', function test( t ) {
+tape( 'the function returns `n` and stores `r` as two double-precision floating point numbers in `y` such that `x - nπ/2 = r` (multiples of π/4)', function test( t ) {
 	var delta;
 	var tol;
 	var x;
@@ -199,7 +199,7 @@ tape( 'the function returns `n` and stores `r` as two double-precision floating 
 	t.end();
 });
 
-tape( 'for large positive input values, the function returns the last three binary digits of `n` and stores `r` as two double-precision floating points numbers in `y`', function test( t ) {
+tape( 'for large positive input values, the function returns the last three binary digits of `n` and stores `r` as two double-precision floating point numbers in `y`', function test( t ) {
 	var x;
 	var y;
 	var n;
@@ -217,7 +217,7 @@ tape( 'for large positive input values, the function returns the last three bina
 	t.end();
 });
 
-tape( 'for large negative input values, the function returns the last three binary digits of `n` and stores `r` as two double-precision floating points numbers in `y`', function test( t ) {
+tape( 'for large negative input values, the function returns the last three binary digits of `n` and stores `r` as two double-precision floating point numbers in `y`', function test( t ) {
 	var x;
 	var y;
 	var n;
@@ -235,7 +235,7 @@ tape( 'for large negative input values, the function returns the last three bina
 	t.end();
 });
 
-tape( 'for huge positive input values, the function returns the last three binary digits of `n` and stores `r` as two double-precision floating points numbers in `y`', function test( t ) {
+tape( 'for huge positive input values, the function returns the last three binary digits of `n` and stores `r` as two double-precision floating point numbers in `y`', function test( t ) {
 	var x;
 	var y;
 	var n;
@@ -253,7 +253,7 @@ tape( 'for huge positive input values, the function returns the last three binar
 	t.end();
 });
 
-tape( 'for huge negative input values, the function returns the last three binary digits of `n` and stores `r` as two double-precision floating points numbers in `y`', function test( t ) {
+tape( 'for huge negative input values, the function returns the last three binary digits of `n` and stores `r` as two double-precision floating point numbers in `y`', function test( t ) {
 	var x;
 	var y;
 	var n;

--- a/lib/node_modules/@stdlib/math/base/special/rempio2/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/rempio2/test/test.native.js
@@ -79,7 +79,7 @@ tape( 'the function returns `0` and sets the elements of `y` to `NaN` if provide
 	t.end();
 });
 
-tape( 'the function returns `n` and stores `r` as two double-precision floating points numbers in `y` such that `x - nπ/2 = r` (positive)', opts, function test( t ) {
+tape( 'the function returns `n` and stores `r` as two double-precision floating point numbers in `y` such that `x - nπ/2 = r` (positive)', opts, function test( t ) {
 	var delta;
 	var tol;
 	var x;
@@ -105,7 +105,7 @@ tape( 'the function returns `n` and stores `r` as two double-precision floating 
 	t.end();
 });
 
-tape( 'the function returns `n` and stores `r` as two double-precision floating points numbers in `y` such that `x - nπ/2 = r` (tiny positive)', opts, function test( t ) {
+tape( 'the function returns `n` and stores `r` as two double-precision floating point numbers in `y` such that `x - nπ/2 = r` (tiny positive)', opts, function test( t ) {
 	var delta;
 	var tol;
 	var x;
@@ -131,7 +131,7 @@ tape( 'the function returns `n` and stores `r` as two double-precision floating 
 	t.end();
 });
 
-tape( 'the function returns `n` and stores `r` as two double-precision floating points numbers in `y` such that `x - nπ/2 = r` (negative)', opts, function test( t ) {
+tape( 'the function returns `n` and stores `r` as two double-precision floating point numbers in `y` such that `x - nπ/2 = r` (negative)', opts, function test( t ) {
 	var delta;
 	var tol;
 	var x;
@@ -157,7 +157,7 @@ tape( 'the function returns `n` and stores `r` as two double-precision floating 
 	t.end();
 });
 
-tape( 'the function returns `n` and stores `r` as two double-precision floating points numbers in `y` such that `x - nπ/2 = r` (tiny negative)', opts, function test( t ) {
+tape( 'the function returns `n` and stores `r` as two double-precision floating point numbers in `y` such that `x - nπ/2 = r` (tiny negative)', opts, function test( t ) {
 	var delta;
 	var tol;
 	var x;
@@ -183,7 +183,7 @@ tape( 'the function returns `n` and stores `r` as two double-precision floating 
 	t.end();
 });
 
-tape( 'the function returns `n` and stores `r` as two double-precision floating points numbers in `y` such that `x - nπ/2 = r` (multiples of π/4)', opts, function test( t ) {
+tape( 'the function returns `n` and stores `r` as two double-precision floating point numbers in `y` such that `x - nπ/2 = r` (multiples of π/4)', opts, function test( t ) {
 	var delta;
 	var tol;
 	var x;
@@ -209,7 +209,7 @@ tape( 'the function returns `n` and stores `r` as two double-precision floating 
 	t.end();
 });
 
-tape( 'for large positive input values, the function returns the last three binary digits of `n` and stores `r` as two double-precision floating points numbers in `y`', opts, function test( t ) {
+tape( 'for large positive input values, the function returns the last three binary digits of `n` and stores `r` as two double-precision floating point numbers in `y`', opts, function test( t ) {
 	var x;
 	var y;
 	var n;
@@ -227,7 +227,7 @@ tape( 'for large positive input values, the function returns the last three bina
 	t.end();
 });
 
-tape( 'for large negative input values, the function returns the last three binary digits of `n` and stores `r` as two double-precision floating points numbers in `y`', opts, function test( t ) {
+tape( 'for large negative input values, the function returns the last three binary digits of `n` and stores `r` as two double-precision floating point numbers in `y`', opts, function test( t ) {
 	var x;
 	var y;
 	var n;
@@ -245,7 +245,7 @@ tape( 'for large negative input values, the function returns the last three bina
 	t.end();
 });
 
-tape( 'for huge positive input values, the function returns the last three binary digits of `n` and stores `r` as two double-precision floating points numbers in `y`', opts, function test( t ) {
+tape( 'for huge positive input values, the function returns the last three binary digits of `n` and stores `r` as two double-precision floating point numbers in `y`', opts, function test( t ) {
 	var x;
 	var y;
 	var n;
@@ -263,7 +263,7 @@ tape( 'for huge positive input values, the function returns the last three binar
 	t.end();
 });
 
-tape( 'for huge negative input values, the function returns the last three binary digits of `n` and stores `r` as two double-precision floating points numbers in `y`', opts, function test( t ) {
+tape( 'for huge negative input values, the function returns the last three binary digits of `n` and stores `r` as two double-precision floating point numbers in `y`', opts, function test( t ) {
 	var x;
 	var y;
 	var n;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   corrects typos in test descriptions in `test.js` and `test.native.js` in [`math/base/special/rempio2`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/rempio2).
-   changes them from `floating-points numbers` to `floating-point numbers`.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
