### PR TITLE
feat: add `@stdlib/assert/is-same-accessor-array`

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-same-accessor-array/README.md
+++ b/lib/node_modules/@stdlib/assert/is-same-accessor-array/README.md
@@ -1,0 +1,115 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# isSameAccessorArray
+
+> Test if two arguments are both [accessor arrays][@stdlib/assert/is-accessor-array] and have the [same values][@stdlib/assert/is-same-value].
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var isSameAccessorArray = require( '@stdlib/assert/is-same-accessor-array' );
+```
+
+#### isSameAccessorArray( v1, v2 )
+
+Tests if two arguments are both [accessor arrays][@stdlib/assert/is-accessor-array] and have the [same values][@stdlib/assert/is-same-value].
+
+```javascript
+var Complex128Array = require( '@stdlib/array/complex128' );
+
+var x = new Complex128Array( [ 1.0, 2.0 ] );
+var y = new Complex128Array( [ 1.0, 2.0 ] );
+var bool = isSameAccessorArray( x, y );
+// returns true
+
+bool = isSameAccessorArray( x, [ -1.0, 2.0 ] );
+// returns false
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   In contrast to the strict equality operator `===`, the function distinguishes between `+0` and `-0` and treats `NaNs` as the [same value][@stdlib/assert/is-same-value].
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var isSameAccessorArray = require( '@stdlib/assert/is-same-accessor-array' );
+var Complex128Array = require( '@stdlib/array/complex128' );
+
+var x = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+var y = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+var out = isSameAccessorArray( x, y );
+// returns true
+
+x = new Complex128Array( [ 1.0, 2.0, 0.0, 4.0 ] );
+y = new Complex128Array( [ 1.0, 2.0, 3.0, -1.0 ] );
+out = isSameAccessorArray( x, y );
+// returns false
+
+x = new Complex128Array( [ NaN, NaN ] );
+y = new Complex128Array( [ NaN, NaN ] );
+out = isSameAccessorArray( x, y );
+// returns true
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[@stdlib/assert/is-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-same-value
+
+[@stdlib/assert/is-accessor-array]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-accessor-array
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/assert/is-same-accessor-array/benchmark/benchmark.length.js
+++ b/lib/node_modules/@stdlib/assert/is-same-accessor-array/benchmark/benchmark.length.js
@@ -1,0 +1,97 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var complex128Array = require( '@stdlib/array/complex128' );
+var bench = require( '@stdlib/bench' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var pow = require( '@stdlib/math/base/special/pow' );
+var zeroTo = require( '@stdlib/array/base/zero-to' );
+var pkg = require( './../package.json' ).name;
+var isSameAccessorArray = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = complex128Array( zeroTo( len ) );
+	var y = complex128Array( zeroTo( len ) );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var bool;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			bool = isSameAccessorArray( x, y );
+			if ( typeof bool !== 'boolean' ) {
+				b.fail( 'should return a boolean' );
+			}
+		}
+		b.toc();
+		if ( !isBoolean( bool ) ) {
+			b.fail( 'should return a boolean' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/assert/is-same-accessor-array/docs/repl.txt
+++ b/lib/node_modules/@stdlib/assert/is-same-accessor-array/docs/repl.txt
@@ -1,0 +1,38 @@
+
+{{alias}}( v1, v2 )
+    Tests if two arguments are both accessor arrays and have the same values.
+
+    The function differs from the `===` operator in that the function treats
+    `-0` and `+0` as distinct and `NaNs` as the same.
+
+    Parameters
+    ----------
+    v1: any
+        First input value.
+
+    v2: any
+        Second input value.
+
+    Returns
+    -------
+    bool: boolean
+        Boolean indicating whether two arguments are both accessor arrays 
+        having the same values.
+
+    Examples
+    --------
+    > var Complex128Array = require( '@stdlib/array/complex128' );
+    > var x = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+    > var y = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+    > var bool = {{alias}}( x, y )
+    true
+
+    > var Complex128Array = require( '@stdlib/array/complex128' );
+    > x = new Complex128Array( [] );
+    > y = new Complex128Array( [] );
+    > bool = {{alias}}( x, y )
+    true
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/assert/is-same-accessor-array/docs/repl.txt
+++ b/lib/node_modules/@stdlib/assert/is-same-accessor-array/docs/repl.txt
@@ -21,15 +21,13 @@
 
     Examples
     --------
-    > var Complex128Array = require( '@stdlib/array/complex128' );
-    > var x = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
-    > var y = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+    > var x = new {{alias:@stdlib/array/complex128}}( [ 1.0, 2.0, 3.0, 4.0 ] );
+    > var y = new {{alias:@stdlib/array/complex128}}( [ 1.0, 2.0, 3.0, 4.0 ] );
     > var bool = {{alias}}( x, y )
     true
 
-    > var Complex128Array = require( '@stdlib/array/complex128' );
-    > x = new Complex128Array( [] );
-    > y = new Complex128Array( [] );
+    > x = new {{alias:@stdlib/array/complex128}}( [] );
+    > y = new {{alias:@stdlib/array/complex128}}( [] );
     > bool = {{alias}}( x, y )
     true
 

--- a/lib/node_modules/@stdlib/assert/is-same-accessor-array/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/is-same-accessor-array/docs/types/index.d.ts
@@ -31,31 +31,25 @@
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
-* var isSameAccessorArray = require( '@stdlib/assert/is-same-accessor-array' );
 *
 * var x = new Complex128Array( [ 1, 2, 1, 2 ] );
 * var y = new Complex128Array( [ 1, 2, 1, 2 ] );
-*
 * var out = isSameAccessorArray( x, y );
 * // returns true
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
-* var isSameAccessorArray = require( '@stdlib/assert/is-same-accessor-array' );
 *
 * var x = new Complex128Array( [ 1, 2, 1, 2 ] );
 * var y = new Complex128Array( [ 2, 1, 2, 1 ] );
-*
 * var out = isSameAccessorArray( x, y );
 * // returns false
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
-* var isSameAccessorArray = require( '@stdlib/assert/is-same-accessor-array' );
 *
 * var x = new Complex128Array( [ 1, 2, 1, 2 ] );
 * var y = [ 1, 2, 3 ];
-*
 * var out = isSameAccessorArray( x, y );
 * // returns false
 */

--- a/lib/node_modules/@stdlib/assert/is-same-accessor-array/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/is-same-accessor-array/docs/types/index.d.ts
@@ -1,0 +1,67 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Tests if two arguments are both accessor arrays and have the same values.
+*
+* ## Notes
+*
+* -   The function differs from the `===` operator in that the function treats `-0` and `+0` as distinct and `NaNs` as the same.
+*
+* @param v1 - first input value
+* @param v2 - second input value
+* @returns boolean indicating whether two arguments are accessor arrays with the same content
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+* var isSameAccessorArray = require( '@stdlib/assert/is-same-accessor-array' );
+*
+* var x = new Complex128Array( [ 1, 2, 1, 2 ] );
+* var y = new Complex128Array( [ 1, 2, 1, 2 ] );
+*
+* var out = isSameAccessorArray( x, y );
+* // returns true
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+* var isSameAccessorArray = require( '@stdlib/assert/is-same-accessor-array' );
+*
+* var x = new Complex128Array( [ 1, 2, 1, 2 ] );
+* var y = new Complex128Array( [ 2, 1, 2, 1 ] );
+*
+* var out = isSameAccessorArray( x, y );
+* // returns false
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+* var isSameAccessorArray = require( '@stdlib/assert/is-same-accessor-array' );
+*
+* var x = new Complex128Array( [ 1, 2, 1, 2 ] );
+* var y = [ 1, 2, 3 ];
+*
+* var out = isSameAccessorArray( x, y );
+* // returns false
+*/
+declare function isSameAccessorArray( v1: any, v2: any ): boolean;
+
+
+// EXPORTS //
+
+export = isSameAccessorArray;

--- a/lib/node_modules/@stdlib/assert/is-same-accessor-array/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/assert/is-same-accessor-array/docs/types/test.ts
@@ -1,0 +1,36 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import isSameAccessorArray = require( './index' );
+
+
+// TESTS //
+
+// The function returns a boolean...
+{
+	isSameAccessorArray( 3.14, 3.14 ); // $ExpectType boolean
+	isSameAccessorArray( null, null ); // $ExpectType boolean
+	isSameAccessorArray( 'beep', 'boop' ); // $ExpectType boolean
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	isSameAccessorArray(); // $ExpectError
+	isSameAccessorArray( 3.14 ); // $ExpectError
+	isSameAccessorArray( 'beep', 'beep', 3.14 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/assert/is-same-accessor-array/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-same-accessor-array/examples/index.js
@@ -1,0 +1,41 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var Complex128Array = require( '@stdlib/array/complex128' );
+var Complex64Array = require( '@stdlib/array/complex64' );
+var isSameAccessorArray = require( './../lib' );
+
+var x = new Complex128Array( [ 1, 2, 3, 4 ] );
+var y = new Complex128Array( [ 1, 2, 3, 4 ] );
+var out = isSameAccessorArray( x, y );
+console.log( out );
+// => true
+
+x = new Complex64Array( [ 1, 2 ]);
+y = [ 0.0, -0.0, 0.0 ];
+out = isSameAccessorArray( x, y );
+console.log( out );
+// => false
+
+x = new Complex128Array( [] );
+y = new Complex64Array( [] );
+out = isSameAccessorArray( x, y );
+console.log( out );
+// => true

--- a/lib/node_modules/@stdlib/assert/is-same-accessor-array/lib/index.js
+++ b/lib/node_modules/@stdlib/assert/is-same-accessor-array/lib/index.js
@@ -1,0 +1,64 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Test if two arguments are both accessor arrays and have the same values.
+*
+* @module @stdlib/assert/is-same-accessor-array
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+* var isSameAccessorArray = require( '@stdlib/assert/is-same-accessor-array' );
+*
+* var x = new Complex128Array( [ 1, 2, 1, 2 ] );
+* var y = new Complex128Array( [ 1, 2, 1, 2 ] );
+*
+* var out = isSameAccessorArray( x, y );
+* // returns true
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+* var isSameAccessorArray = require( '@stdlib/assert/is-same-accessor-array' );
+*
+* var x = new Complex128Array( [ 1, 2, 1, 2 ] );
+* var y = new Complex128Array( [ 2, 1, 2, 1 ] );
+*
+* var out = isSameAccessorArray( x, y );
+* // returns false
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+* var isSameAccessorArray = require( '@stdlib/assert/is-same-accessor-array' );
+*
+* var x = new Complex128Array( [ 1, 2, 1, 2 ] );
+* var y = [ 1, 2, 3 ];
+*
+* var out = isSameAccessorArray( x, y );
+* // returns false
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/assert/is-same-accessor-array/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/is-same-accessor-array/lib/main.js
@@ -35,31 +35,25 @@ var hasSameValues = require( '@stdlib/array/base/assert/has-same-values' );
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
-* var isSameAccessorArray = require( '@stdlib/assert/is-same-accessor-array' );
 *
 * var x = new Complex128Array( [ 1, 2, 1, 2 ] );
 * var y = new Complex128Array( [ 1, 2, 1, 2 ] );
-*
 * var out = isSameAccessorArray( x, y );
 * // returns true
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
-* var isSameAccessorArray = require( '@stdlib/assert/is-same-accessor-array' );
 *
 * var x = new Complex128Array( [ 1, 2, 1, 2 ] );
 * var y = new Complex128Array( [ 2, 1, 2, 1 ] );
-*
 * var out = isSameAccessorArray( x, y );
 * // returns false
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
-* var isSameAccessorArray = require( '@stdlib/assert/is-same-accessor-array' );
 *
 * var x = new Complex128Array( [ 1, 2, 1, 2 ] );
 * var y = [ 1, 2, 3 ];
-*
 * var out = isSameAccessorArray( x, y );
 * // returns false
 */

--- a/lib/node_modules/@stdlib/assert/is-same-accessor-array/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/is-same-accessor-array/lib/main.js
@@ -1,0 +1,76 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isAccessorArray = require( '@stdlib/assert/is-accessor-array' );
+var hasSameValues = require( '@stdlib/array/base/assert/has-same-values' );
+
+
+// MAIN //
+
+/**
+* Tests if two arguments are both accessor arrays and have the same values.
+*
+* @param {*} v1 - first value
+* @param {*} v2 - second value
+* @returns {boolean} boolean result
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+* var isSameAccessorArray = require( '@stdlib/assert/is-same-accessor-array' );
+*
+* var x = new Complex128Array( [ 1, 2, 1, 2 ] );
+* var y = new Complex128Array( [ 1, 2, 1, 2 ] );
+*
+* var out = isSameAccessorArray( x, y );
+* // returns true
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+* var isSameAccessorArray = require( '@stdlib/assert/is-same-accessor-array' );
+*
+* var x = new Complex128Array( [ 1, 2, 1, 2 ] );
+* var y = new Complex128Array( [ 2, 1, 2, 1 ] );
+*
+* var out = isSameAccessorArray( x, y );
+* // returns false
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+* var isSameAccessorArray = require( '@stdlib/assert/is-same-accessor-array' );
+*
+* var x = new Complex128Array( [ 1, 2, 1, 2 ] );
+* var y = [ 1, 2, 3 ];
+*
+* var out = isSameAccessorArray( x, y );
+* // returns false
+*/
+function isSameAccessorArray( v1, v2 ) {
+	if ( isAccessorArray( v1 ) && isAccessorArray( v2 ) ) {
+		return hasSameValues( v1, v2 );
+	}
+	return false;
+}
+
+
+// EXPORTS //
+
+module.exports = isSameAccessorArray;

--- a/lib/node_modules/@stdlib/assert/is-same-accessor-array/package.json
+++ b/lib/node_modules/@stdlib/assert/is-same-accessor-array/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/assert/is-same-accessor-array",
   "version": "0.0.0",
-  "description": "Test if two arguments are both array-like and have the same values.",
+  "description": "Test if two arguments are both accessor arrays and have the same values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/assert/is-same-accessor-array/package.json
+++ b/lib/node_modules/@stdlib/assert/is-same-accessor-array/package.json
@@ -72,6 +72,22 @@
     "test",
     "typed",
     "array",
-    "generic"
+    "generic",
+    "typed array",
+    "collection",
+    "float64array",
+    "float32array",
+    "int32array",
+    "uint32array",
+    "int16array",
+    "uint16array",
+    "int8array",
+    "uint8array",
+    "uint8clampedarray",
+    "complex128array",
+    "complex64array",
+    "accessors",
+    "isarray",
+    "isaccessorarray"
   ]
 }

--- a/lib/node_modules/@stdlib/assert/is-same-accessor-array/package.json
+++ b/lib/node_modules/@stdlib/assert/is-same-accessor-array/package.json
@@ -1,0 +1,77 @@
+{
+  "name": "@stdlib/assert/is-same-accessor-array",
+  "version": "0.0.0",
+  "description": "Test if two arguments are both array-like and have the same values.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdassert",
+    "assertion",
+    "assert",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "equal",
+    "same",
+    "strict",
+    "is",
+    "issame",
+    "issamevalue",
+    "isequal",
+    "isstrictequal",
+    "type",
+    "check",
+    "valid",
+    "validate",
+    "test",
+    "typed",
+    "array",
+    "generic"
+  ]
+}

--- a/lib/node_modules/@stdlib/assert/is-same-accessor-array/test/test.js
+++ b/lib/node_modules/@stdlib/assert/is-same-accessor-array/test/test.js
@@ -1,0 +1,138 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var Complex128Array = require( '@stdlib/array/complex128' );
+var Complex64Array = require( '@stdlib/array/complex64' );
+var isSameAccessorArray = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof isSameAccessorArray, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `true` if provided two accessor arrays with the same contents', function test( t ) {
+	var x;
+	var y;
+	var i;
+
+	x = [
+		new Complex128Array( [ 1, 2, 3, 4 ] ),
+		new Complex64Array( [ 1, 2, 3, 4 ] ),
+		new Complex128Array( [ NaN, NaN ] ),
+		new Complex64Array( [] ),
+		new Complex64Array( [ 1, 2, 3, 4 ] ),
+		new Complex128Array( [ -0.0, 0.0 ] )
+	];
+	y = [
+		new Complex128Array( [1, 2, 3, 4] ),
+		new Complex64Array( [ 1, 2, 3, 4 ] ),
+		new Complex64Array( [ NaN, NaN ] ),
+		new Complex128Array( [] ),
+		new Complex128Array( [ 1, 2, 3, 4 ] ),
+		new Complex128Array( [ -0.0, 0.0 ] )
+	];
+	for ( i = 0; i < x.length; i++ ) {
+		t.strictEqual( isSameAccessorArray( x[ i ], y[ i ] ), true, 'returns true when provided two identical accessor arrays' );
+	}
+	t.end();
+});
+
+tape( 'the function returns `false` if provided two accessor arrays with different contents', function test( t ) {
+	var x;
+	var y;
+	var i;
+
+	x = [
+		new Complex128Array( [ 1, 2, 3, 4 ] ),
+		new Complex128Array( [ 1, 2, 3, 4, 5, 6 ] ),
+		new Complex64Array( [ 1, 2, 3, 4 ] ),
+		new Complex64Array( [] ),
+		new Complex128Array( [ -0.0, 0.0 ] ),
+		new Complex128Array( [ -0.0, NaN ] ),
+		new Complex128Array( [ 1, 2 ] )
+	];
+	y = [
+		new Complex128Array( [1, 2, 3, 5] ),
+		new Complex128Array( [7, 8, 9, 10, 11, 12] ),
+		new Complex64Array( [1, 2, 3, 5] ),
+		new Complex128Array( [ 0, 0 ] ),
+		new Complex128Array( [ 0.0, -0.0 ] ),
+		new Complex128Array( [ NaN, 0.0 ] ),
+		new Complex128Array( [ -0.0, 0.0, 1, 2 ] )
+	];
+	for ( i = 0; i < x.length; i++ ) {
+		t.strictEqual( isSameAccessorArray( x[ i ], y[ i ] ), false, 'returns false when provided two different accessor arrays' );
+	}
+	t.end();
+});
+
+tape( 'the function returns `false` if provided a non-accessor array', function test( t ) {
+	var x;
+	var y;
+	var i;
+
+	x = [
+		'',
+		'beep',
+		5,
+		3.14,
+		-3.14,
+		0.0,
+		-0.0,
+		true,
+		false,
+		null,
+		void 0,
+		[ 1.0 ],
+		{},
+		function noop() {},
+		[ 1.0, 2.0, 3.0 ],
+		[ -0.0, -0.0, -0.0 ]
+	];
+	y = [
+		'abc',
+		'boop',
+		-5,
+		-3.14,
+		3.14,
+		-0.0,
+		0.0,
+		false,
+		true,
+		void 0,
+		null,
+		[ -1.0 ],
+		{},
+		function noop() {},
+		[ 2.0, 4.0, 6.0 ],
+		[ 0.0, 0.0, 0.0 ]
+	];
+	for ( i = 0; i < x.length; i++ ) {
+		t.strictEqual( isSameAccessorArray( x[ i ], y[ i ] ), false, 'returns false when provided a non-accessor array' );
+	}
+	t.end();
+});

--- a/lib/node_modules/@stdlib/assert/is-same-accessor-array/test/test.js
+++ b/lib/node_modules/@stdlib/assert/is-same-accessor-array/test/test.js
@@ -48,7 +48,7 @@ tape( 'the function returns `true` if provided two accessor arrays with the same
 		new Complex128Array( [ -0.0, 0.0 ] )
 	];
 	y = [
-		new Complex128Array( [1, 2, 3, 4] ),
+		new Complex128Array( [ 1, 2, 3, 4 ] ),
 		new Complex64Array( [ 1, 2, 3, 4 ] ),
 		new Complex64Array( [ NaN, NaN ] ),
 		new Complex128Array( [] ),
@@ -76,9 +76,9 @@ tape( 'the function returns `false` if provided two accessor arrays with differe
 		new Complex128Array( [ 1, 2 ] )
 	];
 	y = [
-		new Complex128Array( [1, 2, 3, 5] ),
-		new Complex128Array( [7, 8, 9, 10, 11, 12] ),
-		new Complex64Array( [1, 2, 3, 5] ),
+		new Complex128Array( [ 1, 2, 3, 5 ] ),
+		new Complex128Array( [ 7, 8, 9, 10, 11, 12 ] ),
+		new Complex64Array( [ 1, 2, 3, 5 ] ),
 		new Complex128Array( [ 0, 0 ] ),
 		new Complex128Array( [ 0.0, -0.0 ] ),
 		new Complex128Array( [ NaN, 0.0 ] ),
@@ -90,7 +90,7 @@ tape( 'the function returns `false` if provided two accessor arrays with differe
 	t.end();
 });
 
-tape( 'the function returns `false` if provided a non-accessor array', function test( t ) {
+tape( 'the function returns `false` if not provided two accessor arrays', function test( t ) {
 	var x;
 	var y;
 	var i;
@@ -132,7 +132,7 @@ tape( 'the function returns `false` if provided a non-accessor array', function 
 		[ 0.0, 0.0, 0.0 ]
 	];
 	for ( i = 0; i < x.length; i++ ) {
-		t.strictEqual( isSameAccessorArray( x[ i ], y[ i ] ), false, 'returns false when provided a non-accessor array' );
+		t.strictEqual( isSameAccessorArray( x[ i ], y[ i ] ), false, 'returns false when not provided an accessor array' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves #2888.

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds the feature '@stdlib/assert/is-same-accessor-array'

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #2888  

## Questions

> Any questions for reviewers of this pull request?

-   Are the keywords in package.json correct?
-   Do I need to cover any more examples or tests other than Complex128Array and Complex64Array? I couldn't find any other ways to make Accessor Arrays

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   I am a first time contributor kindly forgive any rookie errors. I've tried my best to adhere to the Code Structure of this repository. Open to reviews!!

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
