### PR TITLE
feat: add `assert/is-same-array-like-object`

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-same-array-like-object/README.md
+++ b/lib/node_modules/@stdlib/assert/is-same-array-like-object/README.md
@@ -1,0 +1,112 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# isSameArrayLikeObject
+
+> Test if two arguments are both [array-like objects][@stdlib/assert/is-array-like-object] and have the [same values][@stdlib/assert/is-same-value].
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var isSameArrayLikeObject = require( '@stdlib/assert/is-same-array-like-object' );
+```
+
+#### isSameArrayLikeObject( v1, v2 )
+
+Test if two arguments are both [array-like objects][@stdlib/assert/is-array-like-object] and have the [same values][@stdlib/assert/is-same-value].
+
+```javascript
+var x = [ 1.0, 2.0 ];
+var y = [ 1.0, 2.0 ];
+var bool = isSameArrayLikeObject( x, y );
+// returns true
+
+bool = isSameArrayLikeObject( x, [ -1.0, 2.0 ] );
+// returns false
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   In contrast to the strict equality operator `===`, the function distinguishes between `+0` and `-0` and treats `NaNs` as the [same value][@stdlib/assert/is-same-value].
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var isSameArrayLikeObject = require( '@stdlib/assert/is-same-array-like-object' );
+
+var x = [ 1.0, 2.0, 3.0 ];
+var y = [ 1.0, 2.0, 3.0 ];
+var out = isSameArrayLikeObject( x, y );
+// returns true
+
+x = [ -0.0, 0.0, -0.0 ];
+y = [ 0.0, -0.0, 0.0 ];
+out = isSameArrayLikeObject( x, y );
+// returns false
+
+x = [ NaN, NaN, NaN ];
+y = [ NaN, NaN, NaN ];
+out = isSameArrayLikeObject( x, y );
+// returns true
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[@stdlib/assert/is-array-like-object]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-array-like-object
+
+[@stdlib/assert/is-same-value]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-same-value
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/assert/is-same-array-like-object/benchmark/benchmark.length.js
+++ b/lib/node_modules/@stdlib/assert/is-same-array-like-object/benchmark/benchmark.length.js
@@ -1,0 +1,96 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var pow = require( '@stdlib/math/base/special/pow' );
+var zeroTo = require( '@stdlib/array/base/zero-to' );
+var pkg = require( './../package.json' ).name;
+var isSameArrayLikeObject = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = zeroTo( len );
+	var y = zeroTo( len );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var bool;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			bool = isSameArrayLikeObject( x, y );
+			if ( typeof bool !== 'boolean' ) {
+				b.fail( 'should return a boolean' );
+			}
+		}
+		b.toc();
+		if ( !isBoolean( bool ) ) {
+			b.fail( 'should return a boolean' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/assert/is-same-array-like-object/docs/repl.txt
+++ b/lib/node_modules/@stdlib/assert/is-same-array-like-object/docs/repl.txt
@@ -1,0 +1,35 @@
+
+{{alias}}( v1, v2 )
+    Tests if two arguments are both array-like objects and have the same values.
+
+    The function differs from the `===` operator in that the function treats
+    `-0` and `+0` as distinct and `NaNs` as the same.
+
+    Parameters
+    ----------
+    v1: any
+        First input value.
+
+    v2: any
+        Second input value.
+
+    Returns
+    -------
+    bool: boolean
+        Boolean indicating whether two arguments are the same.
+
+    Examples
+    --------
+    > var x = [ 1.0, 2.0, 3.0 ];
+    > var y = [ 1.0, 2.0, 3.0 ];
+    > var bool = {{alias}}( x, y )
+    true
+
+    > x = [ NaN, NaN, NaN ];
+    > y = [ NaN, NaN, NaN ];
+    > bool = {{alias}}( x, y )
+    true
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/assert/is-same-array-like-object/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/is-same-array-like-object/docs/types/index.d.ts
@@ -1,0 +1,51 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Tests if two arguments are both array-like objects and have the same values.
+*
+* ## Notes
+*
+* -   The function differs from the `===` operator in that the function treats `-0` and `+0` as distinct and `NaNs` as the same.
+*
+* @param v1 - first input value
+* @param v2 - second input value
+* @returns boolean indicating whether two arguments are the same
+*
+* @example
+* var x = [ 1.0, 2.0, 3.0 ];
+* var y = [ 1.0, 2.0, 3.0 ];
+*
+* var out = isSameArrayLikeObject( x, y );
+* // returns true
+*
+* @example
+* var x = [ 1.0, 2.0, 3.0 ];
+* var y = [ 1.0, 2.0, 4.0 ];
+*
+* var out = isSameArrayLikeObject( x, y );
+* // returns false
+*/
+declare function isSameArrayLikeObject( v1: any, v2: any ): boolean;
+
+
+// EXPORTS //
+
+export = isSameArrayLikeObject;

--- a/lib/node_modules/@stdlib/assert/is-same-array-like-object/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/assert/is-same-array-like-object/docs/types/test.ts
@@ -1,0 +1,36 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import isSameArrayLikeObject = require( './index' );
+
+
+// TESTS //
+
+// The function returns a boolean...
+{
+	isSameArrayLikeObject( 3.14, 3.14 ); // $ExpectType boolean
+	isSameArrayLikeObject( null, null ); // $ExpectType boolean
+	isSameArrayLikeObject( 'beep', 'boop' ); // $ExpectType boolean
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	isSameArrayLikeObject(); // $ExpectError
+	isSameArrayLikeObject( 3.14 ); // $ExpectError
+	isSameArrayLikeObject( 'beep', 'beep', 3.14 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/assert/is-same-array-like-object/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-same-array-like-object/examples/index.js
@@ -37,9 +37,3 @@ y = [ NaN, NaN, NaN ];
 out = isSameArrayLikeObject( x, y );
 console.log( out );
 // => true
-
-x = [ NaN, NaN, NaN ];
-y = [ NaN, NaN, NaN ];
-out = isSameArrayLikeObject( x, y );
-console.log( out );
-// => true

--- a/lib/node_modules/@stdlib/assert/is-same-array-like-object/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-same-array-like-object/examples/index.js
@@ -1,0 +1,45 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var isSameArrayLikeObject = require( './../lib' );
+
+var x = [ 1.0, 2.0, 3.0 ];
+var y = [ 1.0, 2.0, 3.0 ];
+var out = isSameArrayLikeObject( x, y );
+console.log( out );
+// => true
+
+x = [ -0.0, 0.0, -0.0 ];
+y = [ 0.0, -0.0, 0.0 ];
+out = isSameArrayLikeObject( x, y );
+console.log( out );
+// => false
+
+x = [ NaN, NaN, NaN ];
+y = [ NaN, NaN, NaN ];
+out = isSameArrayLikeObject( x, y );
+console.log( out );
+// => true
+
+x = [ NaN, NaN, NaN ];
+y = [ NaN, NaN, NaN ];
+out = isSameArrayLikeObject( x, y );
+console.log( out );
+// => true

--- a/lib/node_modules/@stdlib/assert/is-same-array-like-object/lib/index.js
+++ b/lib/node_modules/@stdlib/assert/is-same-array-like-object/lib/index.js
@@ -1,0 +1,52 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Test if two arguments are both array-like objects and have the same values.
+*
+* @module @stdlib/assert/is-same-array-like-object
+*
+* @example
+* var isSameArrayLikeObject = require( '@stdlib/assert/is-same-array-like-object' );
+*
+* var x = [ 1.0, 2.0, 3.0 ];
+* var y = [ 1.0, 2.0, 3.0 ];
+*
+* var out = isSameArrayLikeObject( x, y );
+* // returns true
+*
+* @example
+* var isSameArrayLikeObject = require( '@stdlib/assert/is-same-array-like-object' );
+*
+* var x = [ 1.0, 2.0, 3.0 ];
+* var y = [ 1.0, 2.0, 4.0 ];
+*
+* var out = isSameArrayLikeObject( x, y );
+* // returns false
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/assert/is-same-array-like-object/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/is-same-array-like-object/lib/main.js
@@ -1,0 +1,60 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isArrayLikeObject = require( '@stdlib/assert/is-array-like-object' );
+var hasSameValues = require( '@stdlib/array/base/assert/has-same-values' );
+
+
+// MAIN //
+
+/**
+* Tests if two arguments are both array-like objects and have the same values.
+*
+* @param {*} v1 - first value
+* @param {*} v2 - second value
+* @returns {boolean} boolean result
+*
+* @example
+* var x = [ 1.0, 2.0, 3.0 ];
+* var y = [ 1.0, 2.0, 3.0 ];
+*
+* var out = isSameArrayLikeObject( x, y );
+* // returns true
+*
+* @example
+* var x = [ 1.0, 2.0, 3.0 ];
+* var y = [ 1.0, 2.0, 4.0 ];
+*
+* var out = isSameArrayLikeObject( x, y );
+* // returns false
+*/
+function isSameArrayLikeObject( v1, v2 ) {
+	if ( isArrayLikeObject( v1 ) && isArrayLikeObject( v2 ) ) {
+		return hasSameValues( v1, v2 );
+	}
+	return false;
+}
+
+
+// EXPORTS //
+
+module.exports = isSameArrayLikeObject;

--- a/lib/node_modules/@stdlib/assert/is-same-array-like-object/package.json
+++ b/lib/node_modules/@stdlib/assert/is-same-array-like-object/package.json
@@ -1,0 +1,77 @@
+{
+  "name": "@stdlib/assert/is-same-array-like-object",
+  "version": "0.0.0",
+  "description": "Test if two arguments are both array-like objects and have the same values.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdassert",
+    "assertion",
+    "assert",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "equal",
+    "same",
+    "strict",
+    "is",
+    "issame",
+    "issamevalue",
+    "isequal",
+    "isstrictequal",
+    "type",
+    "check",
+    "valid",
+    "validate",
+    "test",
+    "typed",
+    "array",
+    "generic"
+  ]
+}

--- a/lib/node_modules/@stdlib/assert/is-same-array-like-object/test/test.js
+++ b/lib/node_modules/@stdlib/assert/is-same-array-like-object/test/test.js
@@ -51,6 +51,9 @@ tape( 'the function returns `true` if provided two array-like values having the 
 	y = [ NaN, NaN, NaN ];
 	t.strictEqual( isSameArrayLikeObject( x, y ), true, 'returns expected value' );
 
+	x = { 'length': 10 };
+	y = { 'length': 10 };
+	t.strictEqual( isSameArrayLikeObject( x, y ), true, 'returns expected value' );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/assert/is-same-array-like-object/test/test.js
+++ b/lib/node_modules/@stdlib/assert/is-same-array-like-object/test/test.js
@@ -1,0 +1,107 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isSameArrayLikeObject = require( '@stdlib/assert/is-same-array-like-object/lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof isSameArrayLikeObject, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `true` if provided two array-like values having the same contents', function test( t ) {
+	var x;
+	var y;
+
+	x = [ 1.0, 2.0, 3.0 ];
+	t.strictEqual( isSameArrayLikeObject( x, x ), true, 'returns expected value' );
+
+	x = [ 1.0, 2.0, 3.0 ];
+	y = [ 1.0, 2.0, 3.0 ];
+	t.strictEqual( isSameArrayLikeObject( x, y ), true, 'returns expected value' );
+
+	x = [ -0.0, 0.0, -0.0 ];
+	y = [ -0.0, 0.0, -0.0 ];
+	t.strictEqual( isSameArrayLikeObject( x, y ), true, 'returns expected value' );
+
+	x = [ NaN, NaN, NaN ];
+	y = [ NaN, NaN, NaN ];
+	t.strictEqual( isSameArrayLikeObject( x, y ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `false` if not provided two array-like values having the same contents', function test( t ) {
+	var x;
+	var y;
+	var i;
+
+	x = [
+		'',
+		'beep',
+		'beep',
+		[ 'b', 'e', 'e', 'p' ],
+		[],
+		5,
+		3.14,
+		-3.14,
+		0.0,
+		-0.0,
+		true,
+		false,
+		null,
+		void 0,
+		[ 1.0 ],
+		{},
+		function noop() {},
+		[ 1.0, 2.0, 3.0 ],
+		[ -0.0, -0.0, -0.0 ]
+	];
+	y = [
+		'abc',
+		'boop',
+		[ 'b', 'e', 'e', 'p' ],
+		'beep',
+		-5,
+		-3.14,
+		3.14,
+		-0.0,
+		0.0,
+		false,
+		true,
+		void 0,
+		null,
+		[ -1.0 ],
+		{},
+		function noop() {},
+		[ 2.0, 4.0, 6.0 ],
+		[ 0.0, 0.0, 0.0 ]
+	];
+	for ( i = 0; i < x.length; i++ ) {
+		t.strictEqual( isSameArrayLikeObject( x[ i ], y[ i ] ), false, 'returns expected value when provided '+x[ i ]+' and '+y[ i ] );
+	}
+	t.end();
+});

--- a/lib/node_modules/@stdlib/assert/is-same-array-like-object/test/test.js
+++ b/lib/node_modules/@stdlib/assert/is-same-array-like-object/test/test.js
@@ -51,11 +51,11 @@ tape( 'the function returns `true` if provided two array-like values having the 
 	y = [ NaN, NaN, NaN ];
 	t.strictEqual( isSameArrayLikeObject( x, y ), true, 'returns expected value' );
 
-	x = { 
-		'length': 10 
+	x = {
+		'length': 10
 	};
-	y = { 
-		'length': 10 
+	y = {
+		'length': 10
 	};
 	t.strictEqual( isSameArrayLikeObject( x, y ), true, 'returns expected value' );
 	t.end();

--- a/lib/node_modules/@stdlib/assert/is-same-array-like-object/test/test.js
+++ b/lib/node_modules/@stdlib/assert/is-same-array-like-object/test/test.js
@@ -51,8 +51,12 @@ tape( 'the function returns `true` if provided two array-like values having the 
 	y = [ NaN, NaN, NaN ];
 	t.strictEqual( isSameArrayLikeObject( x, y ), true, 'returns expected value' );
 
-	x = { 'length': 10 };
-	y = { 'length': 10 };
+	x = { 
+		'length': 10 
+	};
+	y = { 
+		'length': 10 
+	};
 	t.strictEqual( isSameArrayLikeObject( x, y ), true, 'returns expected value' );
 	t.end();
 });


### PR DESCRIPTION
Resolves #2886.

## Description

Add additonal package `@stdlib/assert/is-same-array-like-object` to check same array like objects.

This pull request:

-   Resolves:https://github.com/stdlib-js/stdlib/issues/2886

## Other
This Package is just same as `is-same-array-like` but it checks if objects also match or not .
ex:"bee",["b","e","e"]  doesnt match.
i only find above one difference and wrote code according to these.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].
-  [x] I have read and understood the [Code of Conduct](https://github.com/stdlib-js/stdlib/blob/develop/CODE_OF_CONDUCT.md).
- [x]  Searched for existing issues and pull requests.
- [x] The issue name begins with RFC:.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
