### PR TITLE
fix: add the missing `.ndarray` to `blas/base/cscal` tests for argument validation

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/cscal/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/base/cscal/docs/types/test.ts
@@ -147,15 +147,15 @@ import cscal = require( './index' );
 	const cx = new Complex64Array( 10 );
 	const ca = new Complex64( 2.0, 2.0 );
 
-	cscal( cx.length, ca, 10, 1, 0 ); // $ExpectError
-	cscal( cx.length, ca, '10', 1, 0 ); // $ExpectError
-	cscal( cx.length, ca, true, 1, 0 ); // $ExpectError
-	cscal( cx.length, ca, false, 1, 0 ); // $ExpectError
-	cscal( cx.length, ca, null, 1, 0 ); // $ExpectError
-	cscal( cx.length, ca, undefined, 1, 0 ); // $ExpectError
-	cscal( cx.length, ca, [ '1' ], 1, 0 ); // $ExpectError
-	cscal( cx.length, ca, {}, 1, 0 ); // $ExpectError
-	cscal( cx.length, ca, ( cx: number ): number => cx, 1, 0 ); // $ExpectError
+	cscal.ndarray( cx.length, ca, 10, 1, 0 ); // $ExpectError
+	cscal.ndarray( cx.length, ca, '10', 1, 0 ); // $ExpectError
+	cscal.ndarray( cx.length, ca, true, 1, 0 ); // $ExpectError
+	cscal.ndarray( cx.length, ca, false, 1, 0 ); // $ExpectError
+	cscal.ndarray( cx.length, ca, null, 1, 0 ); // $ExpectError
+	cscal.ndarray( cx.length, ca, undefined, 1, 0 ); // $ExpectError
+	cscal.ndarray( cx.length, ca, [ '1' ], 1, 0 ); // $ExpectError
+	cscal.ndarray( cx.length, ca, {}, 1, 0 ); // $ExpectError
+	cscal.ndarray( cx.length, ca, ( cx: number ): number => cx, 1, 0 ); // $ExpectError
 }
 
 // The compiler throws an error if the `ndarray` method is provided a fourth argument which is not a number...


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

-   add the missing `.ndarray` to cscal typescript test cases for argument validation

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
