### PR TITLE
feat: add `I_F` in `math/base/napi/unary`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/napi/unary/README.md
+++ b/lib/node_modules/@stdlib/math/base/napi/unary/README.md
@@ -496,7 +496,7 @@ The function accepts the following arguments:
 
 -   **env**: `[in] napi_env` environment under which the function is invoked.
 -   **info**: `[in] napi_callback_info` callback data.
--   **fcn**: `[in] int32_t (*fcn)( float )` unary function.
+-   **fcn**: `[in] float (*fcn)( int32_t )` unary function.
 
 ```c
 void stdlib_math_base_napi_i_f( napi_env env, napi_callback_info info, float (*fcn)( int32_t ) );

--- a/lib/node_modules/@stdlib/math/base/napi/unary/README.md
+++ b/lib/node_modules/@stdlib/math/base/napi/unary/README.md
@@ -462,6 +462,46 @@ The function accepts the following arguments:
 void stdlib_math_base_napi_f_i( napi_env env, napi_callback_info info, int32_t (*fcn)( float ) );
 ```
 
+#### stdlib_math_base_napi_i_f( env, info, fcn )
+
+Invokes a unary function accepting a signed 32-bit integer and returning a single-precision floating-point number.
+
+```c
+#include <node_api.h>
+#include <stdint.h>
+
+// ...
+
+static float fcn( const int32_t x ) {
+    // ...
+}
+
+// ...
+
+/**
+* Receives JavaScript callback invocation data.
+*
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @return       Node-API value
+*/
+napi_value addon( napi_env env, napi_callback_info info ) {
+    return stdlib_math_base_napi_i_f( env, info, fcn );
+}
+
+// ...
+```
+
+The function accepts the following arguments:
+
+-   **env**: `[in] napi_env` environment under which the function is invoked.
+-   **info**: `[in] napi_callback_info` callback data.
+-   **fcn**: `[in] int32_t (*fcn)( float )` unary function.
+
+```c
+void stdlib_math_base_napi_i_f( napi_env env, napi_callback_info info, float (*fcn)( int32_t ) );
+```
+
 #### STDLIB_MATH_BASE_NAPI_MODULE_D_D( fcn )
 
 Macro for registering a Node-API module exporting an interface for invoking a unary function accepting and returning double-precision floating-point numbers.
@@ -680,6 +720,29 @@ STDLIB_MATH_BASE_NAPI_MODULE_F_I( fcn );
 The macro expects the following arguments:
 
 -   **fcn**: `int32_t (*fcn)( float )` unary function.
+
+When used, this macro should be used **instead of** `NAPI_MODULE`. The macro includes `NAPI_MODULE`, thus ensuring Node-API module registration.
+
+#### STDLIB_MATH_BASE_NAPI_MODULE_I_F( fcn )
+
+Macro for registering a Node-API module exporting an interface for invoking a unary function accepting a signed 32-bit integer and returning a single-precision floating-point number.
+
+```c
+#include <stdint.h>
+
+static float fcn( const int32_t x ) {
+    // ...
+}
+
+// ...
+
+// Register a Node-API module:
+STDLIB_MATH_BASE_NAPI_MODULE_I_F( fcn );
+```
+
+The macro expects the following arguments:
+
+-   **fcn**: `float (*fcn)( int32_t )` unary function.
 
 When used, this macro should be used **instead of** `NAPI_MODULE`. The macro includes `NAPI_MODULE`, thus ensuring Node-API module registration.
 

--- a/lib/node_modules/@stdlib/math/base/napi/unary/include/stdlib/math/base/napi/unary.h
+++ b/lib/node_modules/@stdlib/math/base/napi/unary/include/stdlib/math/base/napi/unary.h
@@ -417,6 +417,48 @@
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_f_i_init )
 
+/**
+* Macro for registering a Node-API module exporting an interface invoking a unary function accepting a signed 32-bit integer and returning a single-precision floating-point number.
+*
+* @param fcn   unary function
+*
+* @example
+* #include <stdint.h>
+*
+* static float fcn( const int32_t x ) {
+*     // ...
+* }
+*
+* // ...
+*
+* // Register a Node-API module:
+* STDLIB_MATH_BASE_NAPI_MODULE_I_F( fcn );
+*/
+#define STDLIB_MATH_BASE_NAPI_MODULE_I_F( fcn )                                \
+	static napi_value stdlib_math_base_napi_i_f_wrapper(                       \
+		napi_env env,                                                          \
+		napi_callback_info info                                                \
+	) {                                                                        \
+		return stdlib_math_base_napi_i_f( env, info, fcn );                    \
+	};                                                                         \
+	static napi_value stdlib_math_base_napi_i_f_init(                          \
+		napi_env env,                                                          \
+		napi_value exports                                                     \
+	) {                                                                        \
+		napi_value fcn;                                                        \
+		napi_status status = napi_create_function(                             \
+			env,                                                               \
+			"exports",                                                         \
+			NAPI_AUTO_LENGTH,                                                  \
+			stdlib_math_base_napi_i_f_wrapper,                                 \
+			NULL,                                                              \
+			&fcn                                                               \
+		);                                                                     \
+		assert( status == napi_ok );                                           \
+		return fcn;                                                            \
+	};                                                                         \
+	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_i_f_init )
+
 /*
 * If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
 */
@@ -468,6 +510,11 @@ napi_value stdlib_math_base_napi_i_d( napi_env env, napi_callback_info info, dou
 * Invokes a unary function accepting a single-precision floating-point number and returning a signed 32-bit integer.
 */
 napi_value stdlib_math_base_napi_f_i( napi_env env, napi_callback_info info, int32_t (*fcn)( float ) );
+
+/**
+* Invokes a unary function accepting a signed 32-bit integer and returning a single-precision floating-point number.
+*/
+napi_value stdlib_math_base_napi_i_f( napi_env env, napi_callback_info info, float (*fcn)( int32_t ) );
 
 #ifdef __cplusplus
 }

--- a/lib/node_modules/@stdlib/math/base/napi/unary/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/napi/unary/src/main.c
@@ -690,7 +690,7 @@ napi_value stdlib_math_base_napi_i_f( napi_env env, napi_callback_info info, flo
 	assert( status == napi_ok );
 
 	napi_value v;
-	status = napi_create_double( env, (double)fcn( (int32_t)x ), &v );
+	status = napi_create_double( env, (double)fcn( x ), &v );
 	assert( status == napi_ok );
 
 	return v;

--- a/lib/node_modules/@stdlib/math/base/napi/unary/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/napi/unary/src/main.c
@@ -647,3 +647,51 @@ napi_value stdlib_math_base_napi_f_i( napi_env env, napi_callback_info info, int
 
 	return v;
 }
+
+/**
+* Invokes a unary function accepting a signed 32-bit integer and returning a single-precision floating-point number.
+*
+* ## Notes
+*
+* -   This function expects that the callback `info` argument provides access to the following JavaScript arguments:
+*
+*     -   `x`: input value.
+*
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @param fcn    unary function
+* @return       function return value as a Node-API single-precision floating-point number
+*/
+napi_value stdlib_math_base_napi_i_f( napi_env env, napi_callback_info info, float (*fcn)( int32_t ) ) {
+	napi_status status;
+
+	size_t argc = 1;
+	napi_value argv[ 1 ];
+	status = napi_get_cb_info( env, info, &argc, argv, NULL, NULL );
+	assert( status == napi_ok );
+
+	if ( argc < 1 ) {
+		status = napi_throw_error( env, NULL, "invalid invocation. Must provide a number." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	napi_valuetype vtype0;
+	status = napi_typeof( env, argv[ 0 ], &vtype0 );
+	assert( status == napi_ok );
+	if ( vtype0 != napi_number ) {
+		status = napi_throw_type_error( env, NULL, "invalid argument. Must provide a number." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	int32_t x;
+	status = napi_get_value_int32( env, argv[ 0 ], &x );
+	assert( status == napi_ok );
+
+	napi_value v;
+	status = napi_create_double( env, (double)fcn( (int32_t)x ), &v );
+	assert( status == napi_ok );
+
+	return v;
+}

--- a/lib/node_modules/@stdlib/math/base/napi/unary/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/napi/unary/src/main.c
@@ -660,7 +660,7 @@ napi_value stdlib_math_base_napi_f_i( napi_env env, napi_callback_info info, int
 * @param env    environment under which the function is invoked
 * @param info   callback data
 * @param fcn    unary function
-* @return       function return value as a Node-API single-precision floating-point number
+* @return       function return value as a Node-API double-precision floating-point number
 */
 napi_value stdlib_math_base_napi_i_f( napi_env env, napi_callback_info info, float (*fcn)( int32_t ) ) {
 	napi_status status;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds the function `napi_value stdlib_math_base_napi_i_f( napi_env env, napi_callback_info info, float (*fcn)( int32_t ) )` in [`math/base/napi/unary`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/@stdlib/math/base/napi/unary).

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

This would be needed for adding the single-precision implementation of [`math/base/special/fibonacci`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/fibonacci).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
