### PR TITLE
feat: add `constants/float32/max-safe-fibonacci`

### DIFF
--- a/lib/node_modules/@stdlib/constants/float32/max-safe-fibonacci/README.md
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-fibonacci/README.md
@@ -1,0 +1,172 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# FLOAT32_MAX_SAFE_FIBONACCI
+
+> Maximum safe [Fibonacci number][fibonacci-number] when stored in [single-precision floating-point][ieee754] format.
+
+<section class="usage">
+
+## Usage
+
+<!-- eslint-disable id-length -->
+
+```javascript
+var FLOAT32_MAX_SAFE_FIBONACCI = require( '@stdlib/constants/float32/max-safe-fibonacci' );
+```
+
+#### FLOAT32_MAX_SAFE_FIBONACCI
+
+The maximum [safe][safe-integers] [Fibonacci number][fibonacci-number] when stored in [single-precision floating-point][ieee754] format.
+
+<!-- eslint-disable id-length -->
+
+```javascript
+var bool = ( FLOAT32_MAX_SAFE_FIBONACCI === 14930352 );
+// returns true
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint-disable id-length -->
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var FLOAT32_MAX_SAFE_FIBONACCI = require( '@stdlib/constants/float32/max-safe-fibonacci' );
+
+var v;
+var i;
+
+function fibonacci( n ) {
+    var a;
+    var b;
+    var c;
+    var i;
+
+    a = 1;
+    b = 1;
+    for ( i = 3; i <= n; i++ ) {
+        c = a + b;
+        a = b;
+        b = c;
+    }
+    return b;
+}
+
+for ( i = 0; i < 50; i++ ) {
+    v = fibonacci( i );
+    if ( v > FLOAT32_MAX_SAFE_FIBONACCI ) {
+        console.log( 'Unsafe: %d', v );
+    } else {
+        console.log( 'Safe:   %d', v );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/constants/float32/max_safe_fibonacci.h"
+```
+
+#### STDLIB_CONSTANT_FLOAT32_MAX_SAFE_FIBONACCI
+
+Macro for the maximum [safe][safe-integers] [Fibonacci number][fibonacci-number] when stored in [single-precision floating-point][ieee754] format.
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[safe-integers]: http://www.2ality.com/2013/10/safe-integers.html
+
+[fibonacci-number]: https://en.wikipedia.org/wiki/Fibonacci_number
+
+[ieee754]: https://en.wikipedia.org/wiki/IEEE_754-1985
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-fibonacci/docs/repl.txt
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-fibonacci/docs/repl.txt
@@ -1,0 +1,13 @@
+
+{{alias}}
+    Maximum safe Fibonacci number when stored in single-precision floating-point
+    format.
+
+    Examples
+    --------
+    > {{alias}}
+    14930352
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-fibonacci/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-fibonacci/docs/types/index.d.ts
@@ -1,0 +1,33 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Maximum safe Fibonacci number when stored in single-precision floating-point format.
+*
+* @example
+* var max = FLOAT32_MAX_SAFE_FIBONACCI;
+* // returns 14930352
+*/
+declare const FLOAT32_MAX_SAFE_FIBONACCI: number;
+
+
+// EXPORTS //
+
+export = FLOAT32_MAX_SAFE_FIBONACCI;

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-fibonacci/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-fibonacci/docs/types/test.ts
@@ -1,0 +1,28 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import FLOAT32_MAX_SAFE_FIBONACCI = require( './index' );
+
+
+// TESTS //
+
+// The export is a number...
+{
+	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+	FLOAT32_MAX_SAFE_FIBONACCI; // $ExpectType number
+}

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-fibonacci/examples/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-fibonacci/examples/index.js
@@ -1,0 +1,49 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var FLOAT32_MAX_SAFE_FIBONACCI = require( './../lib' );
+
+var v;
+var i;
+
+function fibonacci( n ) {
+	var a;
+	var b;
+	var c;
+	var i;
+
+	a = 1;
+	b = 1;
+	for ( i = 3; i <= n; i++ ) {
+		c = a + b;
+		a = b;
+		b = c;
+	}
+	return b;
+}
+
+for ( i = 0; i < 50; i++ ) {
+	v = fibonacci( i );
+	if ( v > FLOAT32_MAX_SAFE_FIBONACCI ) {
+		console.log( 'Unsafe: %d', v );
+	} else {
+		console.log( 'Safe:   %d', v );
+	}
+}

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-fibonacci/examples/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-fibonacci/examples/index.js
@@ -18,7 +18,7 @@
 
 'use strict';
 
-var FLOAT32_MAX_SAFE_FIBONACCI = require( './../lib' );
+var FLOAT32_MAX_SAFE_FIBONACCI = require( './../lib' ); // eslint-disable-line id-length
 
 var v;
 var i;

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-fibonacci/include/stdlib/constants/float32/max_safe_fibonacci.h
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-fibonacci/include/stdlib/constants/float32/max_safe_fibonacci.h
@@ -1,0 +1,27 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_CONSTANTS_FLOAT32_MAX_SAFE_FIBONACCI_H
+#define STDLIB_CONSTANTS_FLOAT32_MAX_SAFE_FIBONACCI_H
+
+/**
+* Macro for the maximum safe Fibonacci number when stored in single-precision floating-point format.
+*/
+#define STDLIB_CONSTANT_FLOAT32_MAX_SAFE_FIBONACCI 14930352
+
+#endif // !STDLIB_CONSTANTS_FLOAT32_MAX_SAFE_FIBONACCI_H

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-fibonacci/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-fibonacci/lib/index.js
@@ -41,7 +41,7 @@
 * @see [Fibonacci number]{@link https://en.wikipedia.org/wiki/Fibonacci_number}
 * @see [IEEE 754]{@link https://en.wikipedia.org/wiki/IEEE_754-1985}
 */
-var FLOAT32_MAX_SAFE_FIBONACCI = 14930352;
+var FLOAT32_MAX_SAFE_FIBONACCI = 14930352; // eslint-disable-line id-length
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-fibonacci/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-fibonacci/lib/index.js
@@ -1,0 +1,49 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Maximum safe Fibonacci number when stored in single-precision floating-point format.
+*
+* @module @stdlib/constants/float32/max-safe-fibonacci
+* @type {integer}
+*
+* @example
+* var FLOAT32_MAX_SAFE_FIBONACCI = require( '@stdlib/constants/float32/max-safe-fibonacci' );
+* // returns 14930352
+*/
+
+
+// MAIN //
+
+/**
+* The maximum safe Fibonacci number when stored in single-precision floating-point format.
+*
+* @constant
+* @type {integer}
+* @default 14930352
+* @see [Fibonacci number]{@link https://en.wikipedia.org/wiki/Fibonacci_number}
+* @see [IEEE 754]{@link https://en.wikipedia.org/wiki/IEEE_754-1985}
+*/
+var FLOAT32_MAX_SAFE_FIBONACCI = 14930352;
+
+
+// EXPORTS //
+
+module.exports = FLOAT32_MAX_SAFE_FIBONACCI;

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-fibonacci/manifest.json
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-fibonacci/manifest.json
@@ -1,0 +1,36 @@
+{
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": []
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-fibonacci/package.json
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-fibonacci/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@stdlib/constants/float32/max-safe-fibonacci",
+  "version": "0.0.0",
+  "description": "Maximum safe Fibonacci number when stored in single-precision floating-point format.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "constant",
+    "const",
+    "max",
+    "maximum",
+    "fibonacci",
+    "number",
+    "fib",
+    "safe",
+    "integer",
+    "float",
+    "flt",
+    "floating",
+    "point",
+    "floating-point",
+    "float32",
+    "f32",
+    "ieee754"
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-fibonacci/test/test.js
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-fibonacci/test/test.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var FLOAT32_MAX_SAFE_FIBONACCI = require( './../lib' );
+var FLOAT32_MAX_SAFE_FIBONACCI = require( './../lib' ); // eslint-disable-line id-length
 
 
 // TESTS //

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-fibonacci/test/test.js
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-fibonacci/test/test.js
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var FLOAT32_MAX_SAFE_FIBONACCI = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a number', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof FLOAT32_MAX_SAFE_FIBONACCI, 'number', 'main export is a number' );
+	t.end();
+});
+
+tape( 'the exported value is 14930352', function test( t ) {
+	t.strictEqual( FLOAT32_MAX_SAFE_FIBONACCI, 14930352, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds `constants/float32/max-safe-fibonacci`, which would be the single-precision equivalent for [`constants/float64/max-safe-fibonacci`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/constants/float64/max-safe-fibonacci).

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

This would be useful for adding the single-precision implementation of [`math/base/special/fibonacci`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/fibonacci).

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
