### PR TITLE
bench: remove `f` suffix in C benchmark in `math/base/special/erfcx`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/erfcx/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/erfcx/benchmark/c/native/benchmark.c
@@ -97,7 +97,7 @@ static double benchmark( void ) {
 	int i;
 
 	for ( i = 0; i < 100; i++ ) {
-		x[ i ] = ( 1000.0f * rand_double() ) - 500.0f;
+		x[ i ] = ( 1000.0 * rand_double() ) - 500.0;
 	}
 
 	t = tic();


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   addresses https://github.com/stdlib-js/stdlib/commit/67d206479d7216260d585173d253b1cb48b118f6#r146798318
-   removes the `f` suffix in C benchmark in [`math/base/special/erfcx`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/erfcx).

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
