### PR TITLE
build: add a script to find packages with structured meta data

### DIFF
--- a/lib/node_modules/@stdlib/_tools/scaffold/math-iter-unary/scripts/data.json
+++ b/lib/node_modules/@stdlib/_tools/scaffold/math-iter-unary/scripts/data.json
@@ -1,0 +1,149 @@
+[
+  {
+    "$schema": "math/base@v1.0",
+    "base_alias": "cbrt",
+    "alias": "cbrt",
+    "pkg_desc": "compute the cube root",
+    "desc": "computes the cube root",
+    "short_desc": "cube root",
+    "parameters": [
+      {
+        "name": "x",
+        "desc": "input value",
+        "type": {
+          "javascript": "number",
+          "jsdoc": "number",
+          "c": "double",
+          "dtype": "float64"
+        },
+        "domain": [
+          {
+            "min": "-infinity",
+            "max": "infinity"
+          }
+        ],
+        "rand": {
+          "prng": "random/base/uniform",
+          "parameters": [
+            -10,
+            10
+          ]
+        },
+        "example_values": [
+          64,
+          27,
+          0,
+          0,
+          -9,
+          8,
+          -1,
+          125,
+          -10.2,
+          11.3,
+          -12.4,
+          3.5,
+          -1.6,
+          15.7,
+          -16,
+          17.9,
+          -188,
+          19.11,
+          -200,
+          21.15
+        ]
+      }
+    ],
+    "returns": {
+      "desc": "cube root",
+      "type": {
+        "javascript": "number",
+        "jsdoc": "number",
+        "c": "double",
+        "dtype": "float64"
+      }
+    },
+    "keywords": [
+      "cube",
+      "root",
+      "cbrt",
+      "cubic",
+      "power"
+    ],
+    "extra_keywords": [
+      "math.cbrt"
+    ]
+  },
+  {
+    "$schema": "math/base@v1.0",
+    "base_alias": "exp",
+    "alias": "exp",
+    "pkg_desc": "evaluate the natural exponential function",
+    "desc": "evaluates the natural exponential function",
+    "short_desc": "natural exponential function",
+    "parameters": [
+      {
+        "name": "x",
+        "desc": "input value",
+        "type": {
+          "javascript": "number",
+          "jsdoc": "number",
+          "c": "double",
+          "dtype": "float64"
+        },
+        "domain": [
+          {
+            "min": "-infinity",
+            "max": "infinity"
+          }
+        ],
+        "rand": {
+          "prng": "random/base/uniform",
+          "parameters": [
+            -10,
+            10
+          ]
+        },
+        "example_values": [
+          -1.2,
+          2,
+          -3.1,
+          -4.7,
+          5.5,
+          6.7,
+          8.9,
+          -10.2,
+          11.3,
+          -12.4,
+          13.5,
+          14.6,
+          -15.7,
+          16.8,
+          -17.9,
+          18.1,
+          -19.11,
+          20.12,
+          -21.15,
+          23.78
+        ]
+      }
+    ],
+    "returns": {
+      "desc": "function value",
+      "type": {
+        "javascript": "number",
+        "jsdoc": "number",
+        "c": "double",
+        "dtype": "float64"
+      }
+    },
+    "keywords": [
+      "natural",
+      "exponential",
+      "exp",
+      "power"
+    ],
+    "extra_keywords": [
+      "math.exp"
+    ]
+  }
+]

--- a/lib/node_modules/@stdlib/_tools/scaffold/math-iter-unary/scripts/generate_data.js
+++ b/lib/node_modules/@stdlib/_tools/scaffold/math-iter-unary/scripts/generate_data.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var findPkgs = require( '@stdlib/_tools/pkgs/find' ).sync;
+var readJSON = require( '@stdlib/fs/read-json' ).sync;
+
+
+// VARIABLES //
+
+var ROOT_DIR = resolve( __dirname, '..', '..', '..', '..', '..' );
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var pkgPath;
+	var pkgJson;
+	var pkgs;
+	var i;
+
+	pkgs = findPkgs({
+		'dir': ROOT_DIR,
+		'pattern': '**/math/base/special/*/package.json'
+	});
+
+	for ( i = 0; i < pkgs.length; i++ ) {
+		pkgPath = resolve( ROOT_DIR, pkgs[i] );
+		pkgJson = readJSON( pkgPath + '/package.json' );
+
+		if ( pkgJson && pkgJson.__stdlib__ && pkgJson.__stdlib__.scaffold ) { // eslint-disable-line no-underscore-dangle
+			console.log( pkgs[i] ); // eslint-disable-line no-console
+		}
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/_tools/scaffold/math-iter-unary/scripts/generate_data.js
+++ b/lib/node_modules/@stdlib/_tools/scaffold/math-iter-unary/scripts/generate_data.js
@@ -25,11 +25,16 @@
 var resolve = require( 'path' ).resolve;
 var findPkgs = require( '@stdlib/_tools/pkgs/find' ).sync;
 var readJSON = require( '@stdlib/fs/read-json' ).sync;
+var writeFile = require( '@stdlib/fs/write-file' ).sync;
+var rootDir = require( '@stdlib/_tools/utils/root-dir' );
 
 
 // VARIABLES //
 
-var ROOT_DIR = resolve( __dirname, '..', '..', '..', '..', '..' );
+var ROOT_DIR = rootDir();
+var opts = {
+	'encoding': 'utf8'
+};
 
 
 // MAIN //
@@ -40,24 +45,35 @@ var ROOT_DIR = resolve( __dirname, '..', '..', '..', '..', '..' );
 * @private
 */
 function main() {
-	var pkgPath;
-	var pkgJson;
+	var path;
+	var json;
 	var pkgs;
+	var out;
+	var o;
 	var i;
 
+	// Resolve unary "special" math packages:
 	pkgs = findPkgs({
 		'dir': ROOT_DIR,
 		'pattern': '**/math/base/special/*/package.json'
 	});
 
+	// Filter for package's containing scaffold metadata and which have unary APIs...
+	out = [];
 	for ( i = 0; i < pkgs.length; i++ ) {
-		pkgPath = resolve( ROOT_DIR, pkgs[i] );
-		pkgJson = readJSON( pkgPath + '/package.json' );
-
-		if ( pkgJson && pkgJson.__stdlib__ && pkgJson.__stdlib__.scaffold ) { // eslint-disable-line no-underscore-dangle
-			console.log( pkgs[i] ); // eslint-disable-line no-console
+		path = resolve( ROOT_DIR, pkgs[i] );
+		json = readJSON( resolve( path, 'package.json' ), opts );
+		if ( json instanceof Error ) {
+			console.error( 'Encountered an error when attempting to read package: %s. Error: %s.', pkgs[ i ], json.message );
+			continue;
+		}
+		o = json.__stdlib__; // eslint-disable-line no-underscore-dangle
+		if ( o && o.scaffold && o.scaffold.parameters.length === 1 ) {
+			out.push( o.scaffold );
 		}
 	}
+	// Write the metadata to a local file for subsequent consumption by other scripts:
+	writeFile( resolve( __dirname, 'data.json' ), JSON.stringify( out, null, '  ' )+'\n', opts );
 }
 
 main();


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-  adds a `generate_data.js` in [`_tools/scaffold/math-iter-unary/scripts`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/_tools/scaffold/math-iter-unary/scripts), which finds the packages in [`math/base/special`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special) having structured meta data, as a `scaffold` field inside `__stdlib__` in `package.json`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves a part of #1147.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
