### PR TITLE
fix: update C function names in `blas/ext/base/cfill` to prevent name collisions

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/cfill/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/cfill/README.md
@@ -285,7 +285,7 @@ console.log( x.get( 0 ).toString() );
 #include "stdlib/blas/ext/base/cfill.h"
 ```
 
-#### c_cfill( N, alpha, \*X, strideX )
+#### stdlib_strided_cfill( N, alpha, \*X, strideX )
 
 Fills a single-precision floating-point strided array `X` with a specified scalar constant `alpha`.
 
@@ -293,7 +293,7 @@ Fills a single-precision floating-point strided array `X` with a specified scala
 float x[] = { 1.0f, 2.0f, 3.0f, 4.0f };
 const stdlib_complex64_t alpha = stdlib_complex64( 2.0f, 2.0f );
 
-c_cfill( 2, alpha, (stdlib_complex64_t *)x, 1 );
+stdlib_strided_cfill( 2, alpha, (stdlib_complex64_t *)x, 1 );
 ```
 
 The function accepts the following arguments:
@@ -304,10 +304,10 @@ The function accepts the following arguments:
 -   **strideX**: `[in] CBLAS_INT` index increment for `X`.
 
 ```c
-void c_cfill( const CBLAS_INT N, const stdlib_complex64_t alpha, stdlib_complex64_t *X, const CBLAS_INT strideX );
+void stdlib_strided_cfill( const CBLAS_INT N, const stdlib_complex64_t alpha, stdlib_complex64_t *X, const CBLAS_INT strideX );
 ```
 
-#### c_cfill_ndarray( N, alpha, \*X, strideX, offsetX )
+#### stdlib_strided_cfill_ndarray( N, alpha, \*X, strideX, offsetX )
 
 Fills a single-precision complex floating-point strided array `X` with a specified scalar constant `alpha` using alternative indexing semantics.
 
@@ -315,7 +315,7 @@ Fills a single-precision complex floating-point strided array `X` with a specifi
 float x[] = { 1.0f, 2.0f, 3.0f, 4.0f };
 const stdlib_complex64_t alpha = stdlib_complex64( 2.0f, 2.0f );
 
-c_cfill_ndarray( 4, alpha, (stdlib_complex64_t *x), 1, 0 );
+stdlib_strided_cfill_ndarray( 4, alpha, (stdlib_complex64_t *x), 1, 0 );
 ```
 
 The function accepts the following arguments:
@@ -327,7 +327,7 @@ The function accepts the following arguments:
 -   **offsetX**: `[in] CBLAS_INT` starting index for `X`.
 
 ```c
-void c_cfill_ndarray( const CBLAS_INT N, const stdlib_complex64_t alpha, stdlib_complex_64_t *X, const CBLAS_INT strideX, const CBLAS_INT offsetX );
+void stdlib_strided_cfill_ndarray( const CBLAS_INT N, const stdlib_complex64_t alpha, stdlib_complex_64_t *X, const CBLAS_INT strideX, const CBLAS_INT offsetX );
 ```
 
 </section>
@@ -367,7 +367,7 @@ int main( void ) {
     const int strideX = 1;
 
     // Fill the array:
-    c_cfill( N, alpha, (stdlib_complex_64_t *)x, strideX );
+    stdlib_strided_cfill( N, alpha, (stdlib_complex_64_t *)x, strideX );
 
     // Print the result:
     for ( int i = 0; i < N; i++ ) {

--- a/lib/node_modules/@stdlib/blas/ext/base/cfill/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/cfill/benchmark/c/benchmark.length.c
@@ -109,7 +109,7 @@ static double benchmark1( int iterations, int len ) {
 	}
 	t = tic();
 	for ( i = 0; i < iterations; i++ ) {
-		c_cfill( len, alpha, (stdlib_complex64_t *)x, 1 );
+		stdlib_strided_cfill( len, alpha, (stdlib_complex64_t *)x, 1 );
 		if ( x[ 0 ] != x[ 0 ] ) {
 			printf( "should not return NaN\n" );
 			break;
@@ -143,7 +143,7 @@ static double benchmark2( int iterations, int len ) {
 	}
 	t = tic();
 	for ( i = 0; i < iterations; i++ ) {
-		c_cfill_ndarray( len, alpha, (stdlib_complex64_t *)x, 1, 0 );
+		stdlib_strided_cfill_ndarray( len, alpha, (stdlib_complex64_t *)x, 1, 0 );
 		if ( x[ 0 ] != x[ 0 ] ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/blas/ext/base/cfill/examples/c/example.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/cfill/examples/c/example.c
@@ -34,7 +34,7 @@ int main() {
 	const int strideX = 1;
 
 	// Fill the array:
-	c_cfill( N, alpha, (stdlib_complex64_t *)x, strideX );
+	stdlib_strided_cfill( N, alpha, (stdlib_complex64_t *)x, strideX );
 
 	// Print the result:
 	for ( int i = 0; i < 8; i++ ) {

--- a/lib/node_modules/@stdlib/blas/ext/base/cfill/include/stdlib/blas/ext/base/cfill.h
+++ b/lib/node_modules/@stdlib/blas/ext/base/cfill/include/stdlib/blas/ext/base/cfill.h
@@ -32,12 +32,12 @@ extern "C" {
 /**
 * Fills a single-precision complex floating-point strided array with a specified scalar constant.
 */
-void API_SUFFIX(c_cfill)( const CBLAS_INT N, const stdlib_complex64_t alpha, stdlib_complex64_t *X, const CBLAS_INT strideX );
+void API_SUFFIX(stdlib_strided_cfill)( const CBLAS_INT N, const stdlib_complex64_t alpha, stdlib_complex64_t *X, const CBLAS_INT strideX );
 
 /**
 * Fills a single-precision complex floating-point strided array with a specified scalar constant using alternative indexing semantics.
 */
-void API_SUFFIX(c_cfill_ndarray)( const CBLAS_INT N, const stdlib_complex64_t alpha, stdlib_complex64_t *X, const CBLAS_INT strideX, const CBLAS_INT offsetX );
+void API_SUFFIX(stdlib_strided_cfill_ndarray)( const CBLAS_INT N, const stdlib_complex64_t alpha, stdlib_complex64_t *X, const CBLAS_INT strideX, const CBLAS_INT offsetX );
 
 #ifdef __cplusplus
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/cfill/src/addon.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/cfill/src/addon.c
@@ -39,7 +39,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 3 );
 	STDLIB_NAPI_ARGV_COMPLEX64( env, alpha, argv, 1 );
 	STDLIB_NAPI_ARGV_STRIDED_COMPLEX64ARRAY( env, X, N, strideX, argv, 2 );
-	API_SUFFIX(c_cfill)( N, alpha, (stdlib_complex64_t *)X, strideX );
+	API_SUFFIX(stdlib_strided_cfill)( N, alpha, (stdlib_complex64_t *)X, strideX );
 	return NULL;
 }
 
@@ -57,7 +57,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 3 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 4 );
 	STDLIB_NAPI_ARGV_STRIDED_COMPLEX64ARRAY( env, X, N, strideX, argv, 2 );
-	API_SUFFIX(c_cfill_ndarray)( N, alpha, (stdlib_complex64_t *)X, strideX, offsetX );
+	API_SUFFIX(stdlib_strided_cfill_ndarray)( N, alpha, (stdlib_complex64_t *)X, strideX, offsetX );
 	return NULL;
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/cfill/src/main.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/cfill/src/main.c
@@ -30,9 +30,9 @@
 * @param strideX  index increment
 */
 
-void API_SUFFIX(c_cfill)( const CBLAS_INT N, const stdlib_complex64_t alpha, stdlib_complex64_t *X, const CBLAS_INT strideX ) {
+void API_SUFFIX(stdlib_strided_cfill)( const CBLAS_INT N, const stdlib_complex64_t alpha, stdlib_complex64_t *X, const CBLAS_INT strideX ) {
 	CBLAS_INT ox = stdlib_strided_stride2offset( N, strideX );
-	API_SUFFIX(c_cfill_ndarray)( N, alpha, X, strideX, ox );
+	API_SUFFIX(stdlib_strided_cfill_ndarray)( N, alpha, X, strideX, ox );
 }
 
 /**
@@ -45,7 +45,7 @@ void API_SUFFIX(c_cfill)( const CBLAS_INT N, const stdlib_complex64_t alpha, std
 * @param offsetX  starting index
 */
 
-void API_SUFFIX(c_cfill_ndarray)( const CBLAS_INT N, const stdlib_complex64_t alpha, stdlib_complex64_t *X, const CBLAS_INT strideX, const CBLAS_INT offsetX ) {
+void API_SUFFIX(stdlib_strided_cfill_ndarray)( const CBLAS_INT N, const stdlib_complex64_t alpha, stdlib_complex64_t *X, const CBLAS_INT strideX, const CBLAS_INT offsetX ) {
 	CBLAS_INT ix;
 	CBLAS_INT m;
 	CBLAS_INT i;


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors `blas/ext/base/cfill` to prevent C function name collisions.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
