### PR TITLE
fix: update C function names in `blas/ext/base/dfill` to prevent name collisions

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dfill/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/dfill/README.md
@@ -168,14 +168,14 @@ console.log( x );
 #include "stdlib/blas/ext/base/dfill.h"
 ```
 
-#### c_dfill( N, alpha, \*X, strideX )
+#### stdlib_strided_dfill( N, alpha, \*X, strideX )
 
 Fills a double-precision floating-point strided array `X` with a specified scalar constant `alpha`.
 
 ```c
 double x[] = { 1.0, 2.0, 3.0, 4.0 };
 
-c_dfill( 4, 5.0, x, 1 );
+stdlib_strided_dfill( 4, 5.0, x, 1 );
 ```
 
 The function accepts the following arguments:
@@ -186,17 +186,17 @@ The function accepts the following arguments:
 -   **strideX**: `[in] CBLAS_INT` index increment for `X`.
 
 ```c
-void c_dfill( const CBLAS_INT N, const double alpha, double *X, const CBLAS_INT strideX );
+void stdlib_strided_dfill( const CBLAS_INT N, const double alpha, double *X, const CBLAS_INT strideX );
 ```
 
-#### c_dfill_ndarray( N, alpha, \*X, strideX, offsetX )
+#### stdlib_strided_dfill_ndarray( N, alpha, \*X, strideX, offsetX )
 
 Fills a double-precision floating-point strided array `X` with a specified scalar constant `alpha` using alternative indexing semantics.
 
 ```c
 double x[] = { 1.0, 2.0, 3.0, 4.0 };
 
-c_dfill_ndarray( 4, 5.0, x, 1, 0 );
+stdlib_strided_dfill_ndarray( 4, 5.0, x, 1, 0 );
 ```
 
 The function accepts the following arguments:
@@ -208,7 +208,7 @@ The function accepts the following arguments:
 -   **offsetX**: `[in] CBLAS_INT` starting index for `X`.
 
 ```c
-void c_dfill_ndarray( const CBLAS_INT N, const double alpha, double *X, const CBLAS_INT strideX, const CBLAS_INT offsetX );
+void stdlib_strided_dfill_ndarray( const CBLAS_INT N, const double alpha, double *X, const CBLAS_INT strideX, const CBLAS_INT offsetX );
 ```
 
 </section>
@@ -244,7 +244,7 @@ int main( void ) {
     const int strideX = 1;
 
     // Fill the array:
-    c_dfill( N, 5.0, x, strideX );
+    stdlib_strided_dfill( N, 5.0, x, strideX );
 
     // Print the result:
     for ( int i = 0; i < 8; i++ ) {

--- a/lib/node_modules/@stdlib/blas/ext/base/dfill/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/dfill/benchmark/c/benchmark.length.c
@@ -105,7 +105,7 @@ static double benchmark1( int iterations, int len ) {
 	}
 	t = tic();
 	for ( i = 0; i < iterations; i++ ) {
-		c_dfill( len, i, x, 1 );
+		stdlib_strided_dfill( len, i, x, 1 );
 		if ( x[ 0 ] != x[ 0 ] ) {
 			printf( "should not return NaN\n" );
 			break;
@@ -136,7 +136,7 @@ static double benchmark2( int iterations, int len ) {
 	}
 	t = tic();
 	for ( i = 0; i < iterations; i++ ) {
-		c_dfill_ndarray( len, i, x, 1, 0 );
+		stdlib_strided_dfill_ndarray( len, i, x, 1, 0 );
 		if ( x[ 0 ] != x[ 0 ] ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/blas/ext/base/dfill/examples/c/example.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/dfill/examples/c/example.c
@@ -30,7 +30,7 @@ int main( void ) {
 	const int strideX = 1;
 
 	// Fill the array:
-	c_dfill( N, 5.0, x, strideX );
+	stdlib_strided_dfill( N, 5.0, x, strideX );
 
 	// Print the result:
 	for ( int i = 0; i < 8; i++ ) {

--- a/lib/node_modules/@stdlib/blas/ext/base/dfill/include/stdlib/blas/ext/base/dfill.h
+++ b/lib/node_modules/@stdlib/blas/ext/base/dfill/include/stdlib/blas/ext/base/dfill.h
@@ -31,12 +31,12 @@ extern "C" {
 /**
 * Fills a double-precision floating-point strided array with a specified scalar constant.
 */
-void API_SUFFIX(c_dfill)( const CBLAS_INT N, const double alpha, double *X, const CBLAS_INT strideX );
+void API_SUFFIX(stdlib_strided_dfill)( const CBLAS_INT N, const double alpha, double *X, const CBLAS_INT strideX );
 
 /**
 * Fills a double-precision floating-point strided array with a specified scalar constant using alternative indexing semantics.
 */
-void API_SUFFIX(c_dfill_ndarray)( const CBLAS_INT N, const double alpha, double *X, const CBLAS_INT strideX, const CBLAS_INT offsetX );
+void API_SUFFIX(stdlib_strided_dfill_ndarray)( const CBLAS_INT N, const double alpha, double *X, const CBLAS_INT strideX, const CBLAS_INT offsetX );
 
 #ifdef __cplusplus
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/dfill/src/addon.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/dfill/src/addon.c
@@ -38,7 +38,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_DOUBLE( env, alpha, argv, 1 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 2 );
-	API_SUFFIX(c_dfill)( N, alpha, X, strideX );
+	API_SUFFIX(stdlib_strided_dfill)( N, alpha, X, strideX );
 	return NULL;
 }
 
@@ -56,7 +56,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 3 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 4 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 2 );
-	API_SUFFIX(c_dfill_ndarray)( N, alpha, X, strideX, offsetX );
+	API_SUFFIX(stdlib_strided_dfill_ndarray)( N, alpha, X, strideX, offsetX );
 	return NULL;
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/dfill/src/main.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/dfill/src/main.c
@@ -28,9 +28,9 @@
 * @param X        input array
 * @param strideX  index increment
 */
-void API_SUFFIX(c_dfill)( const CBLAS_INT N, const double alpha, double *X, const CBLAS_INT strideX ) {
+void API_SUFFIX(stdlib_strided_dfill)( const CBLAS_INT N, const double alpha, double *X, const CBLAS_INT strideX ) {
 	CBLAS_INT ox = stdlib_strided_stride2offset( N, strideX );
-	API_SUFFIX(c_dfill_ndarray)( N, alpha, X, strideX, ox );
+	API_SUFFIX(stdlib_strided_dfill_ndarray)( N, alpha, X, strideX, ox );
 }
 
 /**
@@ -42,7 +42,7 @@ void API_SUFFIX(c_dfill)( const CBLAS_INT N, const double alpha, double *X, cons
 * @param strideX  index increment
 * @param offsetX  starting index
 */
-void API_SUFFIX(c_dfill_ndarray)( const CBLAS_INT N, const double alpha, double *X, const CBLAS_INT strideX, const CBLAS_INT offsetX ) {
+void API_SUFFIX(stdlib_strided_dfill_ndarray)( const CBLAS_INT N, const double alpha, double *X, const CBLAS_INT strideX, const CBLAS_INT offsetX ) {
 	CBLAS_INT ix;
 	CBLAS_INT m;
 	CBLAS_INT i;


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

-   Updates C function names in `blas/ext/base/fill` to prevent name collisions.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
