### PR TITLE
feat: add `constants/float64/max-safe-nth-double-factorial`

### DIFF
--- a/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/README.md
+++ b/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/README.md
@@ -1,0 +1,164 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL
+
+> Maximum safe nth [double factorial][double-factorial] when stored in [double-precision floating-point][ieee754] format.
+
+<section class="usage">
+
+## Usage
+
+<!-- eslint-disable id-length -->
+
+```javascript
+var FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL = require( '@stdlib/constants/float64/max-safe-nth-double-factorial' );
+```
+
+#### FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL
+
+The maximum [safe][safe-integers] nth [double factorial][double-factorial] when stored in [double-precision floating-point][ieee754] format.
+
+<!-- eslint-disable id-length -->
+
+```javascript
+var bool = ( FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL === 301 );
+// returns true
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint-disable id-length -->
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL = require( '@stdlib/constants/float64/max-safe-nth-double-factorial' );
+
+function factorial( n ) {
+    var a;
+    var i;
+
+    a = 1;
+    for ( i = n; i >= 2; i -= 2 ) {
+        a *= i;
+    }
+    return a;
+}
+
+for ( i = 0; i < 400; i++ ) {
+    v = factorial( i );
+    if ( i > FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL ) {
+        console.log( 'Unsafe: %d', v );
+    } else {
+        console.log( 'Safe:   %d', v );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/constants/float64/max_safe_nth_double_factorial.h"
+```
+
+#### STDLIB_CONSTANT_FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL
+
+Macro for the maximum [safe][safe-integers] nth [double factorial][double-factorial] when stored in [double-precision floating-point][ieee754] format.
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[safe-integers]: http://www.2ality.com/2013/10/safe-integers.html
+
+[double-factorial]: https://en.wikipedia.org/wiki/Double_factorial
+
+[ieee754]: https://en.wikipedia.org/wiki/IEEE_754-1985
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/README.md
+++ b/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/README.md
@@ -69,6 +69,8 @@ function factorial( n ) {
     return a;
 }
 
+var v;
+var i;
 for ( i = 0; i < 400; i++ ) {
     v = factorial( i );
     if ( i > FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL ) {

--- a/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/docs/repl.txt
+++ b/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/docs/repl.txt
@@ -1,0 +1,13 @@
+
+{{alias}}
+    Maximum safe nth double factorial when stored in double-precision floating-
+    point format.
+
+    Examples
+    --------
+    > {{alias}}
+    301
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/docs/types/index.d.ts
@@ -1,0 +1,33 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Maximum safe nth double factorial when stored in double-precision floating-point format.
+*
+* @example
+* var max = FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL;
+* // returns 301
+*/
+declare const FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL: number;
+
+
+// EXPORTS //
+
+export = FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL;

--- a/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/docs/types/test.ts
@@ -1,0 +1,28 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL = require( './index' );
+
+
+// TESTS //
+
+// The export is a number...
+{
+	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+	FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL; // $ExpectType number
+}

--- a/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/examples/index.js
+++ b/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/examples/index.js
@@ -1,0 +1,44 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL = require( './../lib' );
+
+var v;
+var i;
+
+function factorial( n ) {
+	var a;
+	var i;
+
+	a = 1;
+	for ( i = n; i >= 2; i -= 2 ) {
+		a *= i;
+	}
+	return a;
+}
+
+for ( i = 0; i < 400; i++ ) {
+	v = factorial( i );
+	if ( i > FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL ) {
+		console.log( 'Unsafe: %d', v );
+	} else {
+		console.log( 'Safe:   %d', v );
+	}
+}

--- a/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/examples/index.js
+++ b/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/examples/index.js
@@ -18,7 +18,7 @@
 
 'use strict';
 
-var FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL = require( './../lib' );
+var FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL = require( './../lib' ); // eslint-disable-line id-length
 
 var v;
 var i;

--- a/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/examples/index.js
+++ b/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/examples/index.js
@@ -20,9 +20,6 @@
 
 var FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL = require( './../lib' ); // eslint-disable-line id-length
 
-var v;
-var i;
-
 function factorial( n ) {
 	var a;
 	var i;
@@ -34,6 +31,8 @@ function factorial( n ) {
 	return a;
 }
 
+var v;
+var i;
 for ( i = 0; i < 400; i++ ) {
 	v = factorial( i );
 	if ( i > FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL ) {

--- a/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/include/stdlib/constants/float64/max_safe_nth_double_factorial.h
+++ b/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/include/stdlib/constants/float64/max_safe_nth_double_factorial.h
@@ -1,0 +1,27 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_CONSTANTS_FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL
+#define STDLIB_CONSTANTS_FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL
+
+/**
+* Macro for the maximum safe nth double factorial when stored in double-precision floating-point format.
+*/
+#define STDLIB_CONSTANT_FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL 301
+
+#endif // !STDLIB_CONSTANTS_FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL_H

--- a/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/lib/index.js
@@ -1,0 +1,49 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Maximum safe nth double factorial when stored in double-precision floating-point format.
+*
+* @module @stdlib/constants/float64/max-safe-nth-double-factorial
+* @type {integer}
+*
+* @example
+* var FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL = require( '@stdlib/constants/float64/max-safe-nth-double-factorial' );
+* // returns 301
+*/
+
+
+// MAIN //
+
+/**
+* The maximum safe nth double factorial when stored in double-precision floating-point format.
+*
+* @constant
+* @type {integer}
+* @default 301
+* @see [double factorial]{@link https://en.wikipedia.org/wiki/Double_factorial}
+* @see [IEEE 754]{@link https://en.wikipedia.org/wiki/IEEE_754-1985}
+*/
+var FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL = 301|0; // asm type annotation
+
+
+// EXPORTS //
+
+module.exports = FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL;

--- a/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/lib/index.js
@@ -41,7 +41,7 @@
 * @see [double factorial]{@link https://en.wikipedia.org/wiki/Double_factorial}
 * @see [IEEE 754]{@link https://en.wikipedia.org/wiki/IEEE_754-1985}
 */
-var FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL = 301|0; // asm type annotation
+var FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL = 301|0; // eslint-disable-line id-length
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/manifest.json
+++ b/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/manifest.json
@@ -1,0 +1,36 @@
+{
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": []
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/package.json
+++ b/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@stdlib/constants/float64/max-safe-nth-double-factorial",
+  "version": "0.0.0",
+  "description": "Maximum safe nth double factorial when stored in double-precision floating-point format.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "constant",
+    "const",
+    "max",
+    "maximum",
+    "factorial",
+    "number",
+    "safe",
+    "integer",
+    "double",
+    "dbl",
+    "floating",
+    "point",
+    "floating-point",
+    "float",
+    "float64",
+    "f64",
+    "ieee754"
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/test/test.js
+++ b/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/test/test.js
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a number', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL, 'number', 'main export is a number' );
+	t.end();
+});
+
+tape( 'the exported value is 301', function test( t ) {
+	t.strictEqual( FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL, 301, 'returns expected value' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/test/test.js
+++ b/lib/node_modules/@stdlib/constants/float64/max-safe-nth-double-factorial/test/test.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL = require( './../lib' );
+var FLOAT64_MAX_SAFE_NTH_DOUBLE_FACTORIAL = require( './../lib' ); // eslint-disable-line id-length
 
 
 // TESTS //


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds `constants/float64/max-safe-nth-double-factorial`, which would be a pre-requisite for the TODO at: https://github.com/stdlib-js/stdlib/blob/develop/lib/node_modules/%40stdlib/math/base/special/factorial2/lib/main.js#L31

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
