### PR TITLE
refactor: use `max-safe-nth-factorial` package in `math/base/special/falling-factorial`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/falling-factorial/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/falling-factorial/lib/main.js
@@ -41,7 +41,7 @@ var floor = require( '@stdlib/math/base/special/floor' );
 var abs = require( '@stdlib/math/base/special/abs' );
 var FLOAT64_MAX = require( '@stdlib/constants/float64/max' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
-var FLOAT64_MAX_SAFE_NTH_FACTORIAL = require( '@stdlib/constants/float64/max-safe-nth-factorial' );
+var FLOAT64_MAX_SAFE_NTH_FACTORIAL = require( '@stdlib/constants/float64/max-safe-nth-factorial' ); // eslint-disable-line id-length
 
 
 // FUNCTIONS //

--- a/lib/node_modules/@stdlib/math/base/special/falling-factorial/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/falling-factorial/lib/main.js
@@ -179,8 +179,8 @@ function fallingFactorial( x, n ) {
 		// Computing `1 + x` will throw away digits, so split up calculation...
 		if ( n > FLOAT64_MAX_SAFE_NTH_FACTORIAL-2 ) {
 			// Given a ratio of two very large numbers, we need to split the calculation up into two blocks:
-			t1 = x * fallingFactorial( x-1.0, FLOAT64_MAX_SAFE_NTH_FACTORIAL-2 );
-			t2 = fallingFactorial( x-FLOAT64_MAX_SAFE_NTH_FACTORIAL+1.0, n-FLOAT64_MAX_SAFE_NTH_FACTORIAL+1 );
+			t1 = x * fallingFactorial( x-1.0, FLOAT64_MAX_SAFE_NTH_FACTORIAL-2 ); // eslint-disable-line max-len
+			t2 = fallingFactorial( x-FLOAT64_MAX_SAFE_NTH_FACTORIAL+1.0, n-FLOAT64_MAX_SAFE_NTH_FACTORIAL+1 ); // eslint-disable-line max-len
 			if ( FLOAT64_MAX/abs(t1) < abs(t2) ) {
 				return PINF;
 			}

--- a/lib/node_modules/@stdlib/math/base/special/falling-factorial/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/falling-factorial/lib/main.js
@@ -41,11 +41,7 @@ var floor = require( '@stdlib/math/base/special/floor' );
 var abs = require( '@stdlib/math/base/special/abs' );
 var FLOAT64_MAX = require( '@stdlib/constants/float64/max' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
-
-
-// VARIABLES //
-
-var MAX_FACTORIAL = 170; // TODO: consider packaging as constant
+var FLOAT64_MAX_SAFE_NTH_FACTORIAL = require( '@stdlib/constants/float64/max-safe-nth-factorial' );
 
 
 // FUNCTIONS //
@@ -181,10 +177,10 @@ function fallingFactorial( x, n ) {
 	}
 	if ( x < 0.5 ) {
 		// Computing `1 + x` will throw away digits, so split up calculation...
-		if ( n > MAX_FACTORIAL-2 ) {
+		if ( n > FLOAT64_MAX_SAFE_NTH_FACTORIAL-2 ) {
 			// Given a ratio of two very large numbers, we need to split the calculation up into two blocks:
-			t1 = x * fallingFactorial( x-1.0, MAX_FACTORIAL-2 );
-			t2 = fallingFactorial( x-MAX_FACTORIAL+1.0, n-MAX_FACTORIAL+1 );
+			t1 = x * fallingFactorial( x-1.0, FLOAT64_MAX_SAFE_NTH_FACTORIAL-2 );
+			t2 = fallingFactorial( x-FLOAT64_MAX_SAFE_NTH_FACTORIAL+1.0, n-FLOAT64_MAX_SAFE_NTH_FACTORIAL+1 );
 			if ( FLOAT64_MAX/abs(t1) < abs(t2) ) {
 				return PINF;
 			}


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   replaces the hardcoded constant value of maximum possible nth factorial by the [`constants/float64/max-safe-nth-factorial`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/constants/float64/max-safe-nth-factorial) package, in [`math/base/special/falling-factorial`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/falling-factorial).

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
