### PR TITLE
fix: handle seed initialization correctly

### DIFF
--- a/lib/node_modules/@stdlib/random/shuffle/lib/factory.js
+++ b/lib/node_modules/@stdlib/random/shuffle/lib/factory.js
@@ -63,7 +63,7 @@ function factory( config ) {
 			throw err;
 		}
 	}
-	if ( config && config.seed ) {
+	if ( config && Object.prototype.hasOwnProperty.call( config, 'seed' ) ) {
 		rand = randu({
 			'seed': config.seed
 		});


### PR DESCRIPTION
The previous implementation used a direct property check (`config.seed`), which could inadvertently treat falsy values like "0" as missing. This caused incorrect random seed initialization in some cases.

Changed the condition to explicitly check for the presence of the `seed` property using `Object.prototype.hasOwnProperty.call()`. Now, seed initialization handles falsy but valid seed values correctly.

Resolves #2952.

## Description

> What is the purpose of this pull request?

This pull request:

-   Bug fix : This pull request addresses the bug fix where setting seed=0 leads to 
non-deterministic behavior.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
