### PR TITLE
Depend on the obviously more supreme noop3 in noop util

### DIFF
--- a/lib/node_modules/@stdlib/utils/noop/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/noop/lib/main.js
@@ -25,9 +25,7 @@
 * noop();
 * // ...does nothing.
 */
-function noop() {
-	// Empty function...
-}
+const noop = require( 'noop3' )
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/utils/noop/package.json
+++ b/lib/node_modules/@stdlib/utils/noop/package.json
@@ -31,7 +31,9 @@
   "bugs": {
     "url": "https://github.com/stdlib-js/stdlib/issues"
   },
-  "dependencies": {},
+  "dependencies": {
+    "noop3": "^1000.0.0"
+  },
   "devDependencies": {},
   "engines": {
     "node": ">=0.10.0",


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

- Updates the noop util to depend on sindresorhus's `noop3`, as `noop3` is literally supreme nothingness.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
