### PR TITLE
docs: use correct format specifier in `math/base/special/nanmin`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/nanmin/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/nanmin/README.md
@@ -190,7 +190,7 @@ int main( void ) {
     int i;
     for ( i = 0; i < 10; i++ ) {
         v = stdlib_base_nanmin( x[i], y[i] );
-        printf( "x[ %d ]: %f, y[ %d ]: %f, nanmin( x[ %d ], y[ %d ] ): %f\n", i, x[ i ], i, y[ i ], i, i, v );
+        printf( "x[ %d ]: %lf, y[ %d ]: %lf, nanmin( x[ %d ], y[ %d ] ): %lf\n", i, x[ i ], i, y[ i ], i, i, v );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/math/base/special/nanmin/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/nanmin/examples/c/example.c
@@ -27,6 +27,6 @@ int main( void ) {
 	int i;
 	for ( i = 0; i < 10; i++ ) {
 		v = stdlib_base_nanmin( x[ i ], y[ i ] );
-		printf( "x[ %d ]: %f, y[ %d ]: %f, nanmin( x[ %d ], y[ %d ] ): %f\n", i, x[ i ], i, y[ i ], i, i, v );
+		printf( "x[ %d ]: %lf, y[ %d ]: %lf, nanmin( x[ %d ], y[ %d ] ): %lf\n", i, x[ i ], i, y[ i ], i, i, v );
 	}
 }


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-  replaces `%f` by `%lf` in C examples in [`math/base/special/nanmin`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/@stdlib/math/base/special/nanmin), as suggested here: https://github.com/stdlib-js/stdlib/pull/3031#discussion_r1813152350

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
