### PR TITLE
feat: add `math/base/special/nanmaxf`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/nanmaxf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/nanmaxf/README.md
@@ -1,0 +1,224 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# nanmaxf
+
+> Return the maximum value of two single-precision floating-point numbers, ignoring NaN.
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var nanmaxf = require( '@stdlib/math/base/special/nanmaxf' );
+```
+
+#### nanmaxf( x, y )
+
+Returns the maximum value of two single-precision floating-point numbers, ignoring NaN.
+
+```javascript
+var v = nanmaxf( 4.2, 3.14 );
+// returns 4.2
+
+v = nanmaxf( +0.0, -0.0 );
+// returns +0.0
+```
+
+If any argument is `NaN`, the function returns the other operand.
+
+```javascript
+var v = nanmaxf( 4.2, NaN );
+// returns 4.2
+
+v = nanmaxf( NaN, 3.14 );
+// returns 3.14
+```
+
+If both arguments are `NaN`, the function returns `NaN`.
+
+```javascript
+var v = nanmaxf( NaN, NaN );
+// returns NaN
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var nanmaxf = require( '@stdlib/math/base/special/nanmaxf' );
+
+var m = nanmaxf( 3.0, 4.0 );
+console.log( m );
+// => 4.0
+
+m = nanmaxf( NaN, 4.0 );
+console.log( m );
+// => 4.0
+
+m = nanmaxf( 4.0, NaN );
+console.log( m );
+// => 4.0
+
+m = nanmaxf( NaN, NaN );
+console.log( m );
+// => NaN
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/math/base/special/nanmaxf.h"
+```
+
+#### stdlib_base_nanmaxf( x, y )
+
+Returns the maximum value of two single-precision floating-point numbers, ignoring NaN.
+
+```c
+float out = stdlib_base_nanmaxf( 4.2f, 3.14f );
+// returns 4.2f
+
+out = stdlib_base_nanmaxf( 4.14f, 0.0f / 0.0f );
+// returns 4.14f
+```
+
+The function accepts the following arguments:
+
+-   **x**: `[in] float` input value.
+-   **y**: `[in] float` input value.
+
+```c
+float stdlib_base_nanmaxf( const float x, const float y );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/math/base/special/nanmaxf.h"
+#include <stdio.h>
+
+int main( void ) {
+    const float x[] = { 1.0f, 0.45f, -0.89f, 0.0f / 0.0f, -0.78f, -0.22f, 0.66f, 0.11f, -0.55f, 0.0f };
+    const float y[] = { -0.22f, 0.66f, 0.0f, -0.55f, 0.33f, 1.0f, 0.0f / 0.0f, 0.11f, 0.45f, -0.78f };
+
+    float v;
+    int i;
+    for ( i = 0; i < 10; i++ ) {
+        v = stdlib_base_nanmaxf( x[ i ], y[ i ] );
+        printf( "x[ %d ]: %f, y[ %d ]: %f, nanmaxf( x[ %d ], y[ %d ] ): %f\n", i, x[ i ], i, y[ i ], i, i, v );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+    
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/math/base/special/nanmaxf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/nanmaxf/benchmark/benchmark.js
@@ -1,0 +1,55 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var pkg = require( './../package.json' ).name;
+var nanmaxf = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var values;
+	var x;
+	var y;
+	var z;
+	var i;
+
+	values = [ 3.0, 2.0, 2.0, 1.5, NaN ];
+	x = 0.4;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		y = values[ i % values.length ];
+		z = nanmaxf( x, y );
+		if ( isnanf( z ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnanf( z ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/nanmaxf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/nanmaxf/benchmark/benchmark.native.js
@@ -1,0 +1,64 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var nanmaxf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( nanmaxf instanceof Error )
+};
+
+
+// MAIN //
+
+bench( pkg+'::native', opts, function benchmark( b ) {
+	var values;
+	var x;
+	var y;
+	var z;
+	var i;
+
+	values = [ 3.0, 2.0, 2.0, 1.5, NaN ];
+	x = 0.4;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		y = values[ i % values.length ];
+		z = nanmaxf( x, y );
+		if ( isnanf( z ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnanf( z ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/nanmaxf/benchmark/c/native/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/nanmaxf/benchmark/c/native/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/nanmaxf/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/nanmaxf/benchmark/c/native/benchmark.c
@@ -1,0 +1,138 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/nanmaxf.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "nanmaxf"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+static void print_version( void ) {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+static void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+static void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+static double tic( void ) {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1).
+*
+* @return random number
+*/
+static float rand_float( void ) {
+	int r = rand();
+	return (float)r / ( (float)RAND_MAX + 1.0f );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+static double benchmark( void ) {
+	double elapsed;
+	float x[ 100 ];
+	float y[ 100 ];
+	double t;
+	float z;
+	int i;
+
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = 2.0f * rand_float();
+		y[ i ] = 2.0f * rand_float();
+	}
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		z = stdlib_base_nanmaxf( x[ i % 100 ], y[ i % 100 ] );
+		if ( z != z ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( z != z ) {
+		printf( "should not return NaN\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::native::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/math/base/special/nanmaxf/binding.gyp
+++ b/lib/node_modules/@stdlib/math/base/special/nanmaxf/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/math/base/special/nanmaxf/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/nanmaxf/docs/repl.txt
@@ -1,0 +1,33 @@
+
+{{alias}}( x, y )
+    Returns the maximum value of two single-precision floating-point numbers,
+    ignoring NaN.
+
+    If one operand is NaN, the other operand is always returned.
+
+    Parameters
+    ----------
+    x: number
+        First number.
+
+    y: number
+        Second number.
+
+    Returns
+    -------
+    out: number
+        Maximum value.
+
+    Examples
+    --------
+    > var v = {{alias}}( 3.14, 4.2 )
+    4.2
+    > v = {{alias}}( 3.14, NaN )
+    3.14
+    > v = {{alias}}( NaN, 4.2 )
+    4.2
+    > v = {{alias}}( NaN, NaN )
+    NaN
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/math/base/special/nanmaxf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/nanmaxf/docs/types/index.d.ts
@@ -1,0 +1,45 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Returns the maximum value of two single-precision floating-point numbers, ignoring NaN.
+*
+* @param x - first number
+* @param y - second number
+* @returns maximum value
+*
+* @example
+* var v = nanmaxf( 3.14, 4.2 );
+* // returns 4.2
+*
+* @example
+* var v = nanmaxf( 4.14, NaN );
+* // returns 4.14
+*
+* @example
+* var v = nanmaxf( NaN, NaN );
+* // returns NaN
+*/
+declare function nanmaxf( x: number, y: number ): number;
+
+
+// EXPORTS //
+
+export = nanmaxf;

--- a/lib/node_modules/@stdlib/math/base/special/nanmaxf/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/math/base/special/nanmaxf/docs/types/test.ts
@@ -1,0 +1,51 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import nanmaxf = require( './index' );
+
+
+// TESTS //
+
+// The function returns a number...
+{
+	nanmaxf( 3.0, -0.4 ); // $ExpectType number
+}
+
+// The compiler throws an error if the function is provided non-number arguments...
+{
+	nanmaxf( true, 3.0 ); // $ExpectError
+	nanmaxf( false, 3.0 ); // $ExpectError
+	nanmaxf( [], 3.0 ); // $ExpectError
+	nanmaxf( {}, 3.0 ); // $ExpectError
+	nanmaxf( 'abc', 3.0 ); // $ExpectError
+	nanmaxf( ( x: number ): number => x, 3.0 ); // $ExpectError
+
+	nanmaxf( 1.2, true ); // $ExpectError
+	nanmaxf( 1.2, false ); // $ExpectError
+	nanmaxf( 1.2, [] ); // $ExpectError
+	nanmaxf( 1.2, {} ); // $ExpectError
+	nanmaxf( 1.2, 'abc' ); // $ExpectError
+	nanmaxf( 1.2, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	nanmaxf(); // $ExpectError
+	nanmaxf( 3.0 ); // $ExpectError
+	nanmaxf( 3.0, 2.0, 1.0 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/math/base/special/nanmaxf/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/nanmaxf/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/nanmaxf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/nanmaxf/examples/c/example.c
@@ -1,0 +1,32 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/nanmaxf.h"
+#include <stdio.h>
+
+int main( void ) {
+	const float x[] = { 1.0f, 0.45f, -0.89f, 0.0f / 0.0f, -0.78f, -0.22f, 0.66f, 0.11f, -0.55f, 0.0f };
+	const float y[] = { -0.22f, 0.66f, 0.0f, -0.55f, 0.33f, 1.0f, 0.0f / 0.0f, 0.11f, 0.45f, -0.78f };
+
+	float v;
+	int i;
+	for ( i = 0; i < 10; i++ ) {
+		v = stdlib_base_nanmaxf( x[ i ], y[ i ] );
+		printf( "x[ %d ]: %f, y[ %d ]: %f, nanmaxf( x[ %d ], y[ %d ] ): %f\n", i, x[ i ], i, y[ i ], i, i, v );
+	}
+}

--- a/lib/node_modules/@stdlib/math/base/special/nanmaxf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/nanmaxf/examples/index.js
@@ -1,0 +1,37 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var nanmaxf = require( './../lib' );
+
+var m = nanmaxf( 3.0, 4.0 );
+console.log( m );
+// => 4.0
+
+m = nanmaxf( NaN, 4.0 );
+console.log( m );
+// => 4.0
+
+m = nanmaxf( 4.0, NaN );
+console.log( m );
+// => 4.0
+
+m = nanmaxf( NaN, NaN );
+console.log( m );
+// => NaN

--- a/lib/node_modules/@stdlib/math/base/special/nanmaxf/include.gypi
+++ b/lib/node_modules/@stdlib/math/base/special/nanmaxf/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/math/base/special/nanmaxf/include/stdlib/math/base/special/nanmaxf.h
+++ b/lib/node_modules/@stdlib/math/base/special/nanmaxf/include/stdlib/math/base/special/nanmaxf.h
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_MATH_BASE_SPECIAL_NANMAXF_H
+#define STDLIB_MATH_BASE_SPECIAL_NANMAXF_H
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Returns the maximum value of two single-precision floating-point numbers, ignoring NaN.
+*/
+float stdlib_base_nanmaxf( const float x, const float y );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_MATH_BASE_SPECIAL_NANMAXF_H

--- a/lib/node_modules/@stdlib/math/base/special/nanmaxf/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/nanmaxf/lib/index.js
@@ -1,0 +1,46 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Return the maximum value of two single-precision floating-point numbers, ignoring NaN.
+*
+* @module @stdlib/math/base/special/nanmaxf
+*
+* @example
+* var nanmaxf = require( '@stdlib/math/base/special/nanmaxf' );
+*
+* var v = nanmaxf( 3.14, 4.2 );
+* // returns 4.2
+*
+* v = nanmaxf( 4.14, NaN );
+* // returns 4.14
+*
+* v = nanmaxf( NaN, NaN );
+* // returns NaN
+*/
+
+// MODULES //
+
+var nanmaxf = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = nanmaxf;

--- a/lib/node_modules/@stdlib/math/base/special/nanmaxf/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/nanmaxf/lib/main.js
@@ -1,0 +1,58 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var maxf = require( '@stdlib/math/base/special/maxf' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+
+
+// MAIN //
+
+/**
+* Returns the maximum value of two single-precision floating-point numbers, ignoring NaN.
+*
+* @param {number} x - first number
+* @param {number} y - second number
+* @returns {number} maximum value
+*
+* @example
+* var v = nanmaxf( 3.14, 4.2 );
+* // returns 4.2
+*
+* @example
+* var v = nanmaxf( 4.14, NaN );
+* // returns 4.14
+*
+* @example
+* var v = nanmaxf( NaN, NaN );
+* // returns NaN
+*/
+function nanmaxf( x, y ) {
+	if ( isnanf( x ) ) {
+		return ( isnanf( y ) ) ? NaN : y;
+	}
+	return ( isnanf( y ) ) ? x : maxf( x, y );
+}
+
+
+// EXPORTS //
+
+module.exports = nanmaxf;

--- a/lib/node_modules/@stdlib/math/base/special/nanmaxf/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/nanmaxf/lib/native.js
@@ -1,0 +1,55 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Returns the maximum value of two single-precision floating-point numbers, ignoring NaN.
+*
+* @private
+* @param {number} x - first number
+* @param {number} y - second number
+* @returns {number} maximum value
+*
+* @example
+* var v = nanmaxf( 3.14, 4.2 );
+* // returns ~4.2
+*
+* @example
+* var v = nanmaxf( 4.14, NaN );
+* // returns ~4.14
+*
+* @example
+* var v = nanmaxf( NaN, NaN );
+* // returns NaN
+*/
+function nanmaxf( x, y ) {
+	return addon( x, y );
+}
+
+
+// EXPORTS //
+
+module.exports = nanmaxf;

--- a/lib/node_modules/@stdlib/math/base/special/nanmaxf/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/nanmaxf/manifest.json
@@ -1,0 +1,75 @@
+{
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/napi/binary",
+        "@stdlib/math/base/assert/is-nanf",
+        "@stdlib/math/base/special/maxf"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nanf",
+        "@stdlib/math/base/special/maxf"
+      ]
+    },
+    {
+      "task": "examples",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nanf",
+        "@stdlib/math/base/special/maxf"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/special/nanmaxf/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/nanmaxf/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@stdlib/math/base/special/nanmaxf",
+  "version": "0.0.0",
+  "description": "Return the maximum value of two single-precision floating-point numbers, ignoring NaN.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "gypfile": true,
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "src": "./src",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
+    "math.max",
+    "maximum",
+    "max",
+    "smallest"
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/special/nanmaxf/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/nanmaxf/package.json
@@ -59,6 +59,6 @@
     "math.max",
     "maximum",
     "max",
-    "smallest"
+    "largest"
   ]
 }

--- a/lib/node_modules/@stdlib/math/base/special/nanmaxf/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/nanmaxf/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/nanmaxf/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/nanmaxf/src/addon.c
@@ -1,0 +1,23 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/nanmaxf.h"
+#include "stdlib/math/base/napi/binary.h"
+
+// cppcheck-suppress shadowFunction
+STDLIB_MATH_BASE_NAPI_MODULE_FF_F( stdlib_base_nanmaxf )

--- a/lib/node_modules/@stdlib/math/base/special/nanmaxf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/nanmaxf/src/main.c
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/nanmaxf.h"
+#include "stdlib/math/base/assert/is_nanf.h"
+#include "stdlib/math/base/special/maxf.h"
+
+/**
+* Returns the maximum value of two single-precision floating-point numbers, ignoring NaN.
+*
+* @param x       first number
+* @param y       second number
+* @return        maximum value
+*
+* @example
+* float v = stdlib_base_nanmaxf( 3.14f, 4.2f );
+* // returns 4.2f
+*
+* @example
+* float v = stdlib_base_nanmaxf( 4.14f, 0.0f / 0.0f );
+* // returns 4.14f
+*/
+float stdlib_base_nanmaxf( const float x, const float y ) {
+	if ( stdlib_base_is_nanf( x ) ) {
+		return stdlib_base_is_nanf( y ) ? 0.0f / 0.0f : y;
+	}
+	return stdlib_base_is_nanf( y ) ? x : stdlib_base_maxf( x, y );
+}

--- a/lib/node_modules/@stdlib/math/base/special/nanmaxf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/nanmaxf/test/test.js
@@ -1,0 +1,67 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var nanmaxf = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof nanmaxf, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `NaN` if both operands are `NaN`', function test( t ) {
+	var v;
+
+	v = nanmaxf( NaN, NaN );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns the non-NaN value if one of the operands is `NaN`', function test( t ) {
+	var v;
+
+	v = nanmaxf( NaN, float64ToFloat32( 3.14 ) );
+	t.strictEqual( v, float64ToFloat32( 3.14 ), 'returns expected value' );
+
+	v = nanmaxf( float64ToFloat32( 4.2 ), NaN );
+	t.strictEqual( v, float64ToFloat32( 4.2 ), 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns the maximum value', function test( t ) {
+	var v;
+
+	v = nanmaxf( float64ToFloat32( 5.2 ), float64ToFloat32( 3.14 ) );
+	t.strictEqual( v, float64ToFloat32( 5.2 ), 'returns expected value' );
+
+	v = nanmaxf( float64ToFloat32( -4.2 ), float64ToFloat32( 3.14 ) );
+	t.strictEqual( v, float64ToFloat32( 3.14 ), 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/nanmaxf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/nanmaxf/test/test.native.js
@@ -1,0 +1,76 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var nanmaxf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( nanmaxf instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof nanmaxf, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `NaN` if both operands are `NaN`', opts, function test( t ) {
+	var v;
+
+	v = nanmaxf( NaN, NaN );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns the non-NaN value if one of the operands is `NaN`', opts, function test( t ) {
+	var v;
+
+	v = nanmaxf( NaN, float64ToFloat32( 3.14 ) );
+	t.strictEqual( v, float64ToFloat32( 3.14 ), 'returns expected value' );
+
+	v = nanmaxf( float64ToFloat32( 4.2 ), NaN );
+	t.strictEqual( v, float64ToFloat32( 4.2 ), 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns the maximum value', opts, function test( t ) {
+	var v;
+
+	v = nanmaxf( float64ToFloat32( 5.2 ), float64ToFloat32( 3.14 ) );
+	t.strictEqual( v, float64ToFloat32( 5.2 ), 'returns expected value' );
+
+	v = nanmaxf( float64ToFloat32( -4.2 ), float64ToFloat32( 3.14 ) );
+	t.strictEqual( v, float64ToFloat32( 3.14 ), 'returns expected value' );
+
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds `math/base/special/nanmaxf`, which would be the single-precision equivalent for [`math/base/special/nanmax`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/nanmax).

```c
float stdlib_base_nanmaxf( const float x, const float y )
```

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves a part of #649.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
