### PR TITLE
docs: use correct operator for modulus in `math/base/special/fmod`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/fmod/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/fmod/README.md
@@ -94,7 +94,7 @@ var i;
 for ( i = 0; i < 100; i++ ) {
     x = round( randu() * 10.0 );
     y = round( randu() * 10.0 ) - 5.0;
-    console.log( '%d^%d = %d', x, y, fmod( x, y ) );
+    console.log( '%d%%%d = %d', x, y, fmod( x, y ) );
 }
 ```
 

--- a/lib/node_modules/@stdlib/math/base/special/fmod/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/fmod/examples/index.js
@@ -29,5 +29,5 @@ var i;
 for ( i = 0; i < 100; i++ ) {
 	x = round( randu() * 10.0 );
 	y = round( randu() * 10.0 ) - 5.0;
-	console.log( '%d^%d = %d', x, y, fmod( x, y ) );
+	console.log( '%d%%%d = %d', x, y, fmod( x, y ) );
 }

--- a/lib/node_modules/@stdlib/math/base/special/fmod/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/fmod/src/main.c
@@ -46,7 +46,7 @@
 *
 * @param x    dividend
 * @param y    divisor
-* @return    remainder
+* @return     remainder
 *
 * @example
 * double out = stdlib_base_fmod( 8.9, 3.0 );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   uses correct operator for modulus in examples in [`math/base/special/fmod`](https://github.com/stdlib-js/stdlib/blob/develop/lib/node_modules/%40stdlib/math/base/special/fmod/examples/index.js#L32).

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
