### PR TITLE
feat: add `math/base/special/croundf`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/croundf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/README.md
@@ -1,0 +1,251 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# croundf
+
+> Round each component of a single-precision complex floating-point number to the nearest integer.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var croundf = require( '@stdlib/math/base/special/croundf' );
+```
+
+#### croundf( z )
+
+Rounds each component of a single-precision complex floating-point number to the nearest integer.
+
+```javascript
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var real = require( '@stdlib/complex/float32/real' );
+var imag = require( '@stdlib/complex/float32/imag' );
+
+var v = croundf( new Complex64( -4.2, 5.5 ) );
+// returns <Complex64>
+
+var re = real( v );
+// returns -4.0
+
+var im = imag( v );
+// returns 6.0
+
+v = croundf( new Complex64( 9.99999, 0.1 ) );
+// returns <Complex64>
+
+re = real( v );
+// returns 10.0
+
+im = imag( v );
+// returns 0.0
+
+v = croundf( new Complex64( 0.0, 0.0 ) );
+// returns <Complex64>
+
+re = real( v );
+// returns 0.0
+
+im = imag( v );
+// returns 0.0
+
+v = croundf( new Complex64( NaN, NaN ) );
+// returns <Complex64>
+
+re = real( v );
+// returns NaN
+
+im = imag( v );
+// returns NaN
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var uniform = require( '@stdlib/random/base/uniform' ).factory;
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var croundf = require( '@stdlib/math/base/special/croundf' );
+
+var rand = uniform( -50.0, 50.0 );
+
+var z;
+var i;
+for ( i = 0; i < 100; i++ ) {
+    z = new Complex64( rand(), rand() );
+    console.log( 'croundf(%s) = %s', z, croundf( z ) );
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/math/base/special/croundf.h"
+```
+
+#### stdlib_base_croundf( z )
+
+Rounds each component of a single-precision complex floating-point number to the nearest integer.
+
+```c
+#include "stdlib/complex/float32/ctor.h"
+#include "stdlib/complex/float32/real.h"
+#include "stdlib/complex/float32/imag.h"
+
+stdlib_complex64_t z = stdlib_complex64( -4.2, 5.5 );
+
+stdlib_complex64_t out = stdlib_base_croundf( z );
+
+float re = stdlib_complex64_real( out );
+// returns -4.0
+
+float im = stdlib_complex64_imag( out );
+// returns 6.0
+```
+
+The function accepts the following arguments:
+
+-   **z**: `[in] stdlib_complex64_t` input value.
+
+```c
+stdlib_complex64_t stdlib_base_croundf( const stdlib_complex64_t z );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/math/base/special/croundf.h"
+#include "stdlib/complex/float32/ctor.h"
+#include "stdlib/complex/float32/reim.h"
+#include <stdio.h>
+
+int main( void ) {
+    const stdlib_complex64_t x[] = {
+        stdlib_complex64( 3.14, 1.5 ),
+        stdlib_complex64( -3.14, -1.5 ),
+        stdlib_complex64( 0.0, 0.0 ),
+        stdlib_complex64( 0.0/0.0, 0.0/0.0 )
+    };
+
+    stdlib_complex64_t v;
+    stdlib_complex64_t y;
+    float re1;
+    float im1;
+    float re2;
+    float im2;
+    int i;
+    for ( i = 0; i < 4; i++ ) {
+        v = x[ i ];
+        y = stdlib_base_croundf( v );
+        stdlib_complex64_reim( v, &re1, &im1 );
+        stdlib_complex64_reim( y, &re2, &im2 );
+        printf( "croundf(%f + %fi) = %f + %fi\n", re1, im1, re2, im2 );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/math/base/special/cceilf`][@stdlib/math/base/special/cceilf]</span><span class="delimiter">: </span><span class="description">round a single-precision complex floating-point number toward positive infinity.</span>
+-   <span class="package-name">[`@stdlib/math/base/special/cfloor`][@stdlib/math/base/special/cfloor]</span><span class="delimiter">: </span><span class="description">round a double-precision complex floating-point number toward negative infinity.</span>
+-   <span class="package-name">[`@stdlib/math/base/special/croundn`][@stdlib/math/base/special/croundn]</span><span class="delimiter">: </span><span class="description">round each component of a double-precision complex floating-point number to the nearest multiple of 10^n.</span>
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+<!-- <related-links> -->
+
+[@stdlib/math/base/special/cceilf]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/cceilf
+
+[@stdlib/math/base/special/cfloor]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/cfloor
+
+[@stdlib/math/base/special/croundn]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/croundn
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/math/base/special/croundf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/benchmark/benchmark.js
@@ -1,0 +1,58 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var real = require( '@stdlib/complex/float32/real' );
+var imag = require( '@stdlib/complex/float32/imag' );
+var pkg = require( './../package.json' ).name;
+var croundf = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var values;
+	var y;
+	var i;
+
+	values = [
+		new Complex64( uniform( -500.0, 500.0 ), uniform( -500.0, 500.0 ) ),
+		new Complex64( uniform( -500.0, 500.0 ), uniform( -500.0, 500.0 ) )
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		y = croundf( values[ i%values.length ] );
+		if ( isnanf( real( y ) ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnanf( imag( y ) ) ) {
+		b.fail( 'should not return not NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/croundf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/benchmark/benchmark.native.js
@@ -1,0 +1,66 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var real = require( '@stdlib/complex/float32/real' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var croundf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( croundf instanceof Error )
+};
+
+
+// MAIN //
+
+bench( pkg+'::native', opts, function benchmark( b ) {
+	var values;
+	var y;
+	var i;
+
+	values = [
+		new Complex64( uniform( -500.0, 500.0 ), uniform( -500.0, 500.0 ) ),
+		new Complex64( uniform( -500.0, 500.0 ), uniform( -500.0, 500.0 ) )
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		y = croundf( values[ i%values.length ] );
+		if ( isnanf( real( y ) ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnanf( real( y ) ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/croundf/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/benchmark/c/Makefile
@@ -1,0 +1,107 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+endif
+
+# Determine the OS:
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate [position independent code][1]:
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# TARGETS #
+
+# Default target.
+#
+# This target is the default target.
+
+all: $(c_targets)
+
+.PHONY: all
+
+
+# Compile C source.
+#
+# This target compiles C source files.
+
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) -o $@ $< -lm
+
+
+# Run a benchmark.
+#
+# This target runs a benchmark.
+
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+
+# Perform clean-up.
+#
+# This target removes generated files.
+
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/croundf/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/benchmark/c/benchmark.c
@@ -1,0 +1,137 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <complex.h>
+#include <sys/time.h>
+
+#define NAME "roundf"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+static void print_version( void ) {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+static void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+static void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+static double tic( void ) {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1).
+*
+* @return random number
+*/
+static float rand_float( void ) {
+	int r = rand();
+	return (float)r / ( (float)RAND_MAX + 1.0f );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+static double benchmark( void ) {
+	double elapsed;
+	double t;
+	float re;
+	float im;
+	int i;
+
+	float complex z;
+	float complex y;
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		re = ( 1000.0*rand_float() ) - 500.0;
+		im = ( 1000.0*rand_float() ) - 500.0;
+		z = re + im*I;
+		y = roundf( crealf(z) ) + roundf( cimagf(z) )*I;
+		if ( y != y ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( y != y ) {
+		printf( "should not return NaN\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/math/base/special/croundf/benchmark/c/native/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/benchmark/c/native/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/croundf/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/benchmark/c/native/benchmark.c
@@ -1,0 +1,141 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/croundf.h"
+#include "stdlib/complex/float32/ctor.h"
+#include "stdlib/complex/float32/reim.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "croundf"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+static void print_version( void ) {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+static void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+static void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+static double tic( void ) {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1).
+*
+* @return random number
+*/
+static float rand_float( void ) {
+	int r = rand();
+	return (float)r / ( (float)RAND_MAX + 1.0f );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+static double benchmark( void ) {
+	double elapsed;
+	double t;
+	float re;
+	float im;
+	float v;
+	int i;
+
+	stdlib_complex64_t x;
+	stdlib_complex64_t y;
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		v = ( 1000.0*rand_float() ) - 500.0;
+		x = stdlib_complex64( v, v );
+		y = stdlib_base_croundf( x );
+		stdlib_complex64_reim( y, &re, &im );
+		if ( re != re ) {
+			printf( "unexpected result\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( im != im ) {
+		printf( "unexpected result\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::native::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/math/base/special/croundf/binding.gyp
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/math/base/special/croundf/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/docs/repl.txt
@@ -1,0 +1,27 @@
+
+{{alias}}( z )
+    Rounds each component of a single-precision complex floating-point number
+    to the nearest integer.
+
+    Parameters
+    ----------
+    z: Complex64
+        Complex number.
+
+    Returns
+    -------
+    out: Complex64
+        Rounded complex number.
+
+    Examples
+    --------
+    > var v = {{alias}}( new {{alias:@stdlib/complex/float32/ctor}}( 5.5, 3.3 ) )
+    <Complex64>
+    > var re = {{alias:@stdlib/complex/float32/real}}( v )
+    6.0
+    > var im = {{alias:@stdlib/complex/float32/imag}}( v )
+    3.0
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/math/base/special/croundf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/docs/types/index.d.ts
@@ -1,0 +1,50 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { Complex64 } from '@stdlib/types/complex';
+
+/**
+* Rounds each component of a single-precision complex floating-point number to the nearest integer.
+*
+* @param z - input value
+* @returns result
+*
+* @example
+* var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var real = require( '@stdlib/complex/float32/real' );
+* var imag = require( '@stdlib/complex/float32/imag' );
+*
+* var v = croundf( new Complex64( -4.2, 5.5 ) );
+* // returns <Complex64>
+*
+* var re = real( v );
+* // returns -4.0
+*
+* var im = imag( v );
+* // returns 6.0
+*/
+declare function croundf( z: Complex64 ): Complex64;
+
+
+// EXPORTS //
+
+export = croundf;

--- a/lib/node_modules/@stdlib/math/base/special/croundf/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/docs/types/test.ts
@@ -1,0 +1,45 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import Complex64 = require( '@stdlib/complex/float32/ctor' );
+import croundf = require( './index' );
+
+
+// TESTS //
+
+// The function returns a double-precision complex floating-point number...
+{
+	croundf( new Complex64( 1.0, 2.0 ) ); // $ExpectType Complex64
+}
+
+// The compiler throws an error if the function is provided a real component which is not a number...
+{
+	croundf( true ); // $ExpectError
+	croundf( false ); // $ExpectError
+	croundf( null ); // $ExpectError
+	croundf( undefined ); // $ExpectError
+	croundf( '5' ); // $ExpectError
+	croundf( [] ); // $ExpectError
+	croundf( {} ); // $ExpectError
+	croundf( ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided insufficient arguments...
+{
+	croundf(); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/math/base/special/croundf/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/croundf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/examples/c/example.c
@@ -1,0 +1,46 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/croundf.h"
+#include "stdlib/complex/float32/ctor.h"
+#include "stdlib/complex/float32/reim.h"
+#include <stdio.h>
+
+int main( void ) {
+	const stdlib_complex64_t x[] = {
+		stdlib_complex64( 3.14, 1.5 ),
+		stdlib_complex64( -3.14, -1.5 ),
+		stdlib_complex64( 0.0, 0.0 ),
+		stdlib_complex64( 0.0/0.0, 0.0/0.0 )
+	};
+
+	stdlib_complex64_t v;
+	stdlib_complex64_t y;
+	float re1;
+	float im1;
+	float re2;
+	float im2;
+	int i;
+	for ( i = 0; i < 4; i++ ) {
+		v = x[ i ];
+		y = stdlib_base_croundf( v );
+		stdlib_complex64_reim( v, &re1, &im1 );
+		stdlib_complex64_reim( y, &re2, &im2 );
+		printf( "croundf(%f + %fi) = %f + %fi\n", re1, im1, re2, im2 );
+	}
+}

--- a/lib/node_modules/@stdlib/math/base/special/croundf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/examples/index.js
@@ -1,0 +1,32 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var uniform = require( '@stdlib/random/base/uniform' ).factory;
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var croundf = require( './../lib' );
+
+var rand = uniform( -50.0, 50.0 );
+
+var z;
+var i;
+for ( i = 0; i < 100; i++ ) {
+	z = new Complex64( rand(), rand() );
+	console.log( 'croundf(%s) = %s', z, croundf( z ) );
+}

--- a/lib/node_modules/@stdlib/math/base/special/croundf/include.gypi
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/math/base/special/croundf/include/stdlib/math/base/special/croundf.h
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/include/stdlib/math/base/special/croundf.h
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_MATH_BASE_SPECIAL_CROUNDF_H
+#define STDLIB_MATH_BASE_SPECIAL_CROUNDF_H
+
+#include "stdlib/complex/float32/ctor.h"
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Rounds each component of a single-precision complex floating-point number to the nearest integer.
+*/
+stdlib_complex64_t stdlib_base_croundf( const stdlib_complex64_t z );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_MATH_BASE_SPECIAL_CROUNDF_H

--- a/lib/node_modules/@stdlib/math/base/special/croundf/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/lib/index.js
@@ -1,0 +1,76 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Round each component of a single-precision complex floating-point number to the nearest integer.
+*
+* @module @stdlib/math/base/special/croundf
+*
+* @example
+* var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var real = require( '@stdlib/complex/float32/real' );
+* var imag = require( '@stdlib/complex/float32/imag' );
+* var croundf = require( '@stdlib/math/base/special/croundf' );
+*
+* var v = croundf( new Complex64( -4.2, 5.5 ) );
+* // returns <Complex64>
+*
+* var re = real( v );
+* // returns -5.0
+*
+* var im = imag( v );
+* // returns 6.0
+*
+* v = croundf( new Complex64( 9.99999, 0.1 ) );
+* // returns <Complex64>
+*
+* re = real( v );
+* // returns 10.0
+*
+* im = imag( v );
+* // returns 0.0
+*
+* v = croundf( new Complex64( 0.0, 0.0 ) );
+* // returns <Complex64>
+*
+* re = real( v );
+* // returns 0.0
+*
+* im = imag( v );
+* // returns 0.0
+*
+* v = croundf( new Complex64( NaN, NaN ) );
+* // returns <Complex64>
+*
+* re = real( v );
+* // returns NaN
+*
+* im = imag( v );
+* // returns NaN
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/math/base/special/croundf/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/lib/main.js
@@ -1,0 +1,85 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var roundf = require( '@stdlib/math/base/special/roundf' );
+var real = require( '@stdlib/complex/float32/real' );
+var imag = require( '@stdlib/complex/float32/imag' );
+
+
+// MAIN //
+
+/**
+* Rounds each component of a single-precision complex floating-point number to the nearest integer.
+*
+* @param {Complex64} z - complex number
+* @returns {Complex64} rounded complex number
+*
+* @example
+* var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var real = require( '@stdlib/complex/float32/real' );
+* var imag = require( '@stdlib/complex/float32/imag' );
+*
+* var v = croundf( new Complex64( -4.2, 5.5 ) );
+* // returns <Complex64>
+*
+* var re = real( v );
+* // returns -4
+*
+* var im = imag( v );
+* // returns 6.0
+*
+* v = croundf( new Complex64( 9.99999, 0.1 ) );
+* // returns <Complex64>
+*
+* re = real( v );
+* // returns 10.0
+*
+* im = imag( v );
+* // returns 0.0
+*
+* v = croundf( new Complex64( 0.0, 0.0 ) );
+* // returns <Complex64>
+*
+* re = real( v );
+* // returns 0.0
+*
+* im = imag( v );
+* // returns 0.0
+*
+* v = croundf( new Complex64( NaN, NaN ) );
+* // returns <Complex64>
+*
+* re = real( v );
+* // returns NaN
+*
+* im = imag( v );
+* // returns NaN
+*/
+function croundf( z ) {
+	return new Complex64( roundf( real( z ) ), roundf( imag( z ) ) );
+}
+
+
+// EXPORTS //
+
+module.exports = croundf;

--- a/lib/node_modules/@stdlib/math/base/special/croundf/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/lib/main.js
@@ -43,7 +43,7 @@ var imag = require( '@stdlib/complex/float32/imag' );
 * // returns <Complex64>
 *
 * var re = real( v );
-* // returns -4
+* // returns -4.0
 *
 * var im = imag( v );
 * // returns 6.0

--- a/lib/node_modules/@stdlib/math/base/special/croundf/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/lib/native.js
@@ -1,0 +1,58 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Rounds each component of a single-precision complex floating-point number to the nearest integer.
+*
+* @private
+* @param {Complex64} z - complex number
+* @returns {Complex64} result
+*
+* @example
+* var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var real = require( '@stdlib/complex/float32/real' );
+* var imag = require( '@stdlib/complex/float32/imag' );
+*
+* var v = croundf( new Complex64( -4.2, 5.5 ) );
+* // returns <Complex64>
+*
+* var re = real( v );
+* // returns -4
+*
+* var im = imag( v );
+* // returns 6.0
+*/
+function croundf( z ) {
+	var v = addon( z );
+	return new Complex64( v.re, v.im );
+}
+
+
+// EXPORTS //
+
+module.exports = croundf;

--- a/lib/node_modules/@stdlib/math/base/special/croundf/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/manifest.json
@@ -1,0 +1,75 @@
+{
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/napi/unary",
+        "@stdlib/complex/float32/ctor",
+        "@stdlib/complex/float32/reim"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/complex/float32/ctor",
+        "@stdlib/complex/float32/reim"
+      ]
+    },
+    {
+      "task": "examples",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/complex/float32/ctor",
+        "@stdlib/complex/float32/reim"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/special/croundf/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/manifest.json
@@ -37,6 +37,7 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/napi/unary",
+        "@stdlib/math/base/special/roundf",
         "@stdlib/complex/float32/ctor",
         "@stdlib/complex/float32/reim"
       ]
@@ -52,6 +53,7 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
+        "@stdlib/math/base/special/roundf",
         "@stdlib/complex/float32/ctor",
         "@stdlib/complex/float32/reim"
       ]
@@ -67,6 +69,7 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
+        "@stdlib/math/base/special/roundf",
         "@stdlib/complex/float32/ctor",
         "@stdlib/complex/float32/reim"
       ]

--- a/lib/node_modules/@stdlib/math/base/special/croundf/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@stdlib/math/base/special/croundf",
+  "version": "0.0.0",
+  "description": "Round each component of a single-precision complex floating-point number to the nearest integer.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "gypfile": true,
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "src": "./src",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
+    "math.round",
+    "round",
+    "cround",
+    "floor",
+    "ceil",
+    "integer",
+    "nearest",
+    "value",
+    "complex",
+    "cmplx",
+    "number"
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/special/croundf/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/croundf/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/src/addon.c
@@ -1,0 +1,23 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/croundf.h"
+#include "stdlib/math/base/napi/unary.h"
+
+// cppcheck-suppress shadowFunction
+STDLIB_MATH_BASE_NAPI_MODULE_C_C( stdlib_base_croundf )

--- a/lib/node_modules/@stdlib/math/base/special/croundf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/src/main.c
@@ -1,0 +1,54 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/croundf.h"
+#include "stdlib/complex/float32/ctor.h"
+#include "stdlib/complex/float32/reim.h"
+#include <math.h>
+
+/**
+* Rounds each component of a single-precision complex floating-point number to the nearest integer.
+*
+* @param z       input value
+* @return        result
+*
+* @example
+* #include "stdlib/complex/float32/ctor.h"
+* #include "stdlib/complex/float32/real.h"
+* #include "stdlib/complex/float32/imag.h"
+*
+* stdlib_complex64_t z = stdlib_complex64( -4.2, 5.5 );
+*
+* stdlib_complex64_t out = stdlib_base_croundf( z );
+*
+* float re = stdlib_complex64_real( out );
+* // returns -5.0
+*
+* float im = stdlib_complex64_imag( out );
+* // returns 6.0
+*/
+stdlib_complex64_t stdlib_base_croundf( const stdlib_complex64_t z ) {
+	float re;
+	float im;
+
+	stdlib_complex64_reim( z, &re, &im );
+
+	re = roundf( re ); // TODO: replace with stdlib function once available
+	im = roundf( im ); // TODO: replace with stdlib function once available
+	return stdlib_complex64( re, im );
+}

--- a/lib/node_modules/@stdlib/math/base/special/croundf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/src/main.c
@@ -37,7 +37,7 @@
 * stdlib_complex64_t out = stdlib_base_croundf( z );
 *
 * float re = stdlib_complex64_real( out );
-* // returns -5.0
+* // returns -4.0
 *
 * float im = stdlib_complex64_imag( out );
 * // returns 6.0

--- a/lib/node_modules/@stdlib/math/base/special/croundf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/src/main.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/math/base/special/croundf.h"
+#include "stdlib/math/base/special/roundf.h"
 #include "stdlib/complex/float32/ctor.h"
 #include "stdlib/complex/float32/reim.h"
 #include <math.h>
@@ -48,7 +49,7 @@ stdlib_complex64_t stdlib_base_croundf( const stdlib_complex64_t z ) {
 
 	stdlib_complex64_reim( z, &re, &im );
 
-	re = roundf( re ); // TODO: replace with stdlib function once available
-	im = roundf( im ); // TODO: replace with stdlib function once available
+	re = stdlib_base_roundf( re ); // TODO: replace with stdlib function once available
+	im = stdlib_base_roundf( im ); // TODO: replace with stdlib function once available
 	return stdlib_complex64( re, im );
 }

--- a/lib/node_modules/@stdlib/math/base/special/croundf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/src/main.c
@@ -49,7 +49,7 @@ stdlib_complex64_t stdlib_base_croundf( const stdlib_complex64_t z ) {
 
 	stdlib_complex64_reim( z, &re, &im );
 
-	re = stdlib_base_roundf( re ); // TODO: replace with stdlib function once available
-	im = stdlib_base_roundf( im ); // TODO: replace with stdlib function once available
+	re = stdlib_base_roundf( re );
+	im = stdlib_base_roundf( im );
 	return stdlib_complex64( re, im );
 }

--- a/lib/node_modules/@stdlib/math/base/special/croundf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/test/test.js
@@ -1,0 +1,104 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var PINF = require( '@stdlib/constants/float32/pinf' );
+var NINF = require( '@stdlib/constants/float32/ninf' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zerof' );
+var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zerof' );
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var real = require( '@stdlib/complex/float32/real' );
+var imag = require( '@stdlib/complex/float32/imag' );
+var croundf = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof croundf, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function rounds real and imaginary components to the nearest integer', function test( t ) {
+	var v;
+
+	v = croundf( new Complex64( -4.2, 5.5 ) );
+	t.strictEqual( real( v ), -4.0, 'returns expected value' );
+	t.strictEqual( imag( v ), 6.0, 'returns expected value' );
+
+	v = croundf( new Complex64( 9.99999, 0.1 ) );
+	t.strictEqual( real( v ), 10.0, 'returns expected value' );
+	t.strictEqual( imag( v ), 0.0, 'returns expected value' );
+
+	v = croundf( new Complex64( 0.0, 0.0 ) );
+	t.strictEqual( real( v ), 0.0, 'returns expected value' );
+	t.strictEqual( imag( v ), 0.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a `NaN` if provided a `NaN`', function test( t ) {
+	var v;
+
+	v = croundf( new Complex64( NaN, NaN ) );
+	t.strictEqual( isnanf( real( v ) ), true, 'returns expected value' );
+	t.strictEqual( isnanf( imag( v ) ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `-0` if provided `-0`', function test( t ) {
+	var v;
+
+	v = croundf( new Complex64( -0.0, -0.0 ) );
+	t.strictEqual( isNegativeZero( real( v ) ), true, 'returns expected value' );
+	t.strictEqual( isNegativeZero( imag( v ) ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `+0` if provided `+0`', function test( t ) {
+	var v;
+
+	v = croundf( new Complex64( +0.0, +0.0 ) );
+	t.strictEqual( isPositiveZero( real( v ) ), true, 'returns expected value' );
+	t.strictEqual( isPositiveZero( imag( v ) ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `+infinity` if provided `+infinity`', function test( t ) {
+	var v;
+
+	v = croundf( new Complex64( PINF, PINF ) );
+	t.strictEqual( real( v ), PINF, 'returns expected value' );
+	t.strictEqual( imag( v ), PINF, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `-infinity` if provided `-infinity`', function test( t ) {
+	var v;
+
+	v = croundf( new Complex64( NINF, NINF ) );
+	t.strictEqual( real( v ), NINF, 'returns expected value' );
+	t.strictEqual( imag( v ), NINF, 'returns expected value' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/croundf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/test/test.native.js
@@ -1,0 +1,113 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var PINF = require( '@stdlib/constants/float32/pinf' );
+var NINF = require( '@stdlib/constants/float32/ninf' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zerof' );
+var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zerof' );
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var real = require( '@stdlib/complex/float32/real' );
+var imag = require( '@stdlib/complex/float32/imag' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var croundf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( croundf instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof croundf, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function rounds real and imaginary components to the nearest integer', opts, function test( t ) {
+	var v;
+
+	v = croundf( new Complex64( -4.2, 5.5 ) );
+	t.strictEqual( real( v ), -4.0, 'returns expected value' );
+	t.strictEqual( imag( v ), 6.0, 'returns expected value' );
+
+	v = croundf( new Complex64( 9.99999, 0.1 ) );
+	t.strictEqual( real( v ), 10.0, 'returns expected value' );
+	t.strictEqual( imag( v ), 0.0, 'returns expected value' );
+
+	v = croundf( new Complex64( 0.0, 0.0 ) );
+	t.strictEqual( real( v ), 0.0, 'returns expected value' );
+	t.strictEqual( imag( v ), 0.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns a `NaN` if provided a `NaN`', opts, function test( t ) {
+	var v;
+
+	v = croundf( new Complex64( NaN, NaN ) );
+	t.strictEqual( isnanf( real( v ) ), true, 'returns expected value' );
+	t.strictEqual( isnanf( imag( v ) ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `-0` if provided `-0`', opts, function test( t ) {
+	var v;
+
+	v = croundf( new Complex64( -0.0, -0.0 ) );
+	t.strictEqual( isNegativeZero( real( v ) ), true, 'returns expected value' );
+	t.strictEqual( isNegativeZero( imag( v ) ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `+0` if provided `+0`', opts, function test( t ) {
+	var v;
+
+	v = croundf( new Complex64( +0.0, +0.0 ) );
+	t.strictEqual( isPositiveZero( real( v ) ), true, 'returns expected value' );
+	t.strictEqual( isPositiveZero( imag( v ) ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `+infinity` if provided `+infinity`', opts, function test( t ) {
+	var v;
+
+	v = croundf( new Complex64( PINF, PINF ) );
+	t.strictEqual( real( v ), PINF, 'returns expected value' );
+	t.strictEqual( imag( v ), PINF, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `-infinity` if provided `-infinity`', opts, function test( t ) {
+	var v;
+
+	v = croundf( new Complex64( NINF, NINF ) );
+	t.strictEqual( real( v ), NINF, 'returns expected value' );
+	t.strictEqual( imag( v ), NINF, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
Resolves #649 

## Description

> What is the purpose of this pull request?
- adds `math/base/special/croundf`, which would be the single-precision equivalent for [math/base/special/cround](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/cround).

```c
stdlib_complex64_t stdlib_base_croundf( const stdlib_complex64_t z );
```

## Related Issues

> Does this pull request have any related issues?

This pull request:

- Progresses: #649 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
