### PR TITLE
feat: add `constants/float32/ln-two`

### DIFF
--- a/lib/node_modules/@stdlib/constants/float32/ln-two/README.md
+++ b/lib/node_modules/@stdlib/constants/float32/ln-two/README.md
@@ -1,0 +1,137 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# FLOAT32_LN2
+
+> [Natural logarithm][@stdlib/math/base/special/lnf] of `2` as a single-precision floating-point number.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var FLOAT32_LN2 = require( '@stdlib/constants/float32/ln-two' );
+```
+
+#### FLOAT32_LN2
+
+[Natural logarithm][@stdlib/math/base/special/lnf] of `2` as a single-precision floating-point number.
+
+```javascript
+var bool = ( FLOAT32_LN2 === 0.6931471824645996 );
+// returns true
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var FLOAT32_LN2 = require( '@stdlib/constants/float32/ln-two' );
+
+console.log( FLOAT32_LN2 );
+// => 0.6931471824645996
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/constants/float32/ln_two.h"
+```
+
+#### STDLIB_CONSTANT_FLOAT32_LN2
+
+Macro for the [natural logarithm][@stdlib/math/base/special/lnf] of `2` as a single-precision floating-point number.
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[@stdlib/math/base/special/lnf]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/lnf
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/constants/float32/ln-two/docs/repl.txt
+++ b/lib/node_modules/@stdlib/constants/float32/ln-two/docs/repl.txt
@@ -1,0 +1,12 @@
+
+{{alias}}
+    Natural logarithm of `2` as a single-precision floating-point number.
+
+    Examples
+    --------
+    > {{alias}}
+    0.6931471824645996
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/constants/float32/ln-two/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/constants/float32/ln-two/docs/types/index.d.ts
@@ -1,0 +1,33 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Natural logarithm of `2` as a single-precision floating-point number.
+*
+* @example
+* var val = FLOAT32_LN2;
+* // returns 0.6931471824645996
+*/
+declare const FLOAT32_LN2: number;
+
+
+// EXPORTS //
+
+export = FLOAT32_LN2;

--- a/lib/node_modules/@stdlib/constants/float32/ln-two/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/constants/float32/ln-two/docs/types/test.ts
@@ -1,0 +1,28 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import FLOAT32_LN2 = require( './index' );
+
+
+// TESTS //
+
+// The export is a number...
+{
+	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+	FLOAT32_LN2; // $ExpectType number
+}

--- a/lib/node_modules/@stdlib/constants/float32/ln-two/examples/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/ln-two/examples/index.js
@@ -1,0 +1,24 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var FLOAT32_LN2 = require( './../lib' );
+
+console.log( FLOAT32_LN2 );
+// => 0.6931471824645996

--- a/lib/node_modules/@stdlib/constants/float32/ln-two/include/stdlib/constants/float32/ln_two.h
+++ b/lib/node_modules/@stdlib/constants/float32/ln-two/include/stdlib/constants/float32/ln_two.h
@@ -1,0 +1,27 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_CONSTANTS_FLOAT32_LN2_H
+#define STDLIB_CONSTANTS_FLOAT32_LN2_H
+
+/**
+* Macro for the natural logarithm of `2` as a single-precision floating-point number.
+*/
+#define STDLIB_CONSTANT_FLOAT32_LN2 0.6931471824645996
+
+#endif // !STDLIB_CONSTANTS_FLOAT32_LN2_H

--- a/lib/node_modules/@stdlib/constants/float32/ln-two/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/ln-two/lib/index.js
@@ -1,0 +1,51 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Natural logarithm of `2` as a single-precision floating-point number.
+*
+* @module @stdlib/constants/float32/ln-two
+* @type {number}
+*
+* @example
+* var FLOAT32_LN2 = require( '@stdlib/constants/float32/ln-two' );
+* // returns 0.6931471824645996
+*/
+
+
+// MAIN //
+
+/**
+* Natural logarithm of `2` as a single-precision floating-point number.
+*
+* ```tex
+* \ln 2
+* ```
+*
+* @constant
+* @type {number}
+* @default 0.6931471824645996
+*/
+var FLOAT32_LN2 = 0.6931471824645996;
+
+
+// EXPORTS //
+
+module.exports = FLOAT32_LN2;

--- a/lib/node_modules/@stdlib/constants/float32/ln-two/manifest.json
+++ b/lib/node_modules/@stdlib/constants/float32/ln-two/manifest.json
@@ -1,0 +1,36 @@
+{
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": []
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float32/ln-two/package.json
+++ b/lib/node_modules/@stdlib/constants/float32/ln-two/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@stdlib/constants/float32/ln-two",
+  "version": "0.0.0",
+  "description": "Natural logarithm of 2 as a single-precision floating-point number.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "constant",
+    "const",
+    "mathematics",
+    "math",
+    "ln",
+    "ln2",
+    "natural",
+    "logarithm",
+    "log",
+    "ieee754",
+    "single",
+    "sgl",
+    "precision",
+    "floating-point",
+    "float32"
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float32/ln-two/test/test.js
+++ b/lib/node_modules/@stdlib/constants/float32/ln-two/test/test.js
@@ -1,0 +1,56 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var lnf = require( '@stdlib/math/base/special/lnf' );
+var absf = require( '@stdlib/math/base/special/absf' );
+var EPS = require( '@stdlib/constants/float32/eps' );
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var FLOAT32_LN2 = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a number', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof FLOAT32_LN2, 'number', 'main export is a number' );
+	t.end();
+});
+
+tape( 'export is a single-precision floating-point number equal to `0.6931471824645996`', function test( t ) {
+	t.equal( FLOAT32_LN2, float64ToFloat32( 0.6931471805599453 ), 'equals 0.6931471824645996' );
+	t.end();
+});
+
+tape( 'export equals `lnf(2)`', function test( t ) {
+	var delta;
+	var tol;
+	var v;
+
+	v = lnf( 2.0 );
+	delta = absf( float64ToFloat32( v - FLOAT32_LN2 ) );
+	tol = EPS * FLOAT32_LN2;
+
+	t.ok( delta <= tol, 'equals lnf(2) within tolerance '+tol );
+
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds `constants/float32/ln-two`, which would be the single-precision equivalent for [`constants/float64/ln-two`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/constants/float64/ln-two).
-   unblocks the implementation of `math/base/special/powf`, which would be the single-precision equivalent for [`math/base/special/pow`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/pow).

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
