### PR TITLE
refactor: use external constant and update license in `math/base/special/pow`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/pow/include/stdlib/math/base/special/pow.h
+++ b/lib/node_modules/@stdlib/math/base/special/pow/include/stdlib/math/base/special/pow.h
@@ -29,7 +29,7 @@ extern "C" {
 /**
 * Evaluates the exponential function.
 */
-double stdlib_base_pow( const double base, const double exponent );
+double stdlib_base_pow( const double x, const double y );
 
 #ifdef __cplusplus
 }

--- a/lib/node_modules/@stdlib/math/base/special/pow/lib/log2ax.js
+++ b/lib/node_modules/@stdlib/math/base/special/pow/lib/log2ax.js
@@ -38,6 +38,7 @@ var getHighWord = require( '@stdlib/number/float64/base/get-high-word' );
 var setLowWord = require( '@stdlib/number/float64/base/set-low-word' );
 var setHighWord = require( '@stdlib/number/float64/base/set-high-word' );
 var BIAS = require( '@stdlib/constants/float64/exponent-bias' );
+var HIGH_NUM_SIGNIFICAND_BITS = require( '@stdlib/constants/float64/num-high-word-significand-bits' );
 var polyvalL = require( './polyval_l.js' );
 
 
@@ -57,9 +58,6 @@ var HIGH_BIASED_EXP_NEG_512 = 0x20000000|0; // asm type annotation
 
 // 0x00080000 = 524288 => 0 00000000000 10000000000000000000
 var HIGH_SIGNIFICAND_HALF = 0x00080000|0; // asm type annotation
-
-// TODO: consider making an external constant
-var HIGH_NUM_SIGNIFICAND_BITS = 20|0; // asm type annotation
 
 var TWO53 = 9007199254740992.0;	// 0x43400000, 0x00000000
 

--- a/lib/node_modules/@stdlib/math/base/special/pow/lib/pow2.js
+++ b/lib/node_modules/@stdlib/math/base/special/pow/lib/pow2.js
@@ -43,6 +43,7 @@ var LN2 = require( '@stdlib/constants/float64/ln-two' );
 var BIAS = require( '@stdlib/constants/float64/exponent-bias' );
 var ABS_MASK = require( '@stdlib/constants/float64/high-word-abs-mask' );
 var HIGH_SIGNIFICAND_MASK = require( '@stdlib/constants/float64/high-word-significand-mask' );
+var HIGH_NUM_SIGNIFICAND_BITS = require( '@stdlib/constants/float64/num-high-word-significand-bits' );
 var polyvalP = require( './polyval_p.js' );
 
 
@@ -53,9 +54,6 @@ var HIGH_MIN_NORMAL_EXP = 0x00100000|0; // asm type annotation
 
 // 0x3fe00000 = 1071644672 => 0 01111111110 00000000000000000000 => biased exponent: 1022 = -1+1023 => 2^-1
 var HIGH_BIASED_EXP_NEG_1 = 0x3fe00000|0; // asm type annotation
-
-// TODO: consider making into an external constant
-var HIGH_NUM_SIGNIFICAND_BITS = 20|0; // asm type annotation
 
 // High: LN2
 var LN2_HI = 6.93147182464599609375e-01; // 0x3FE62E43, 0x00000000

--- a/lib/node_modules/@stdlib/math/base/special/pow/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/pow/manifest.json
@@ -54,7 +54,8 @@
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/assert/is-integer",
         "@stdlib/math/base/special/sqrt",
-        "@stdlib/number/float64/base/to-words"
+        "@stdlib/number/float64/base/to-words",
+        "@stdlib/constants/float64/num-high-word-significand-bits"
       ]
     },
     {
@@ -85,7 +86,8 @@
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/assert/is-integer",
         "@stdlib/math/base/special/sqrt",
-        "@stdlib/number/float64/base/to-words"
+        "@stdlib/number/float64/base/to-words",
+        "@stdlib/constants/float64/num-high-word-significand-bits"
       ]
     },
     {
@@ -116,7 +118,8 @@
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/math/base/assert/is-integer",
         "@stdlib/math/base/special/sqrt",
-        "@stdlib/number/float64/base/to-words"
+        "@stdlib/number/float64/base/to-words",
+        "@stdlib/constants/float64/num-high-word-significand-bits"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/pow/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/pow/src/main.c
@@ -35,6 +35,7 @@
 #include "stdlib/math/base/assert/is_integer.h"
 #include "stdlib/math/base/special/sqrt.h"
 #include "stdlib/number/float64/base/to_words.h"
+#include "stdlib/constants/float64/num_high_word_significand_bits.h"
 
 // 0x3fefffff = 1072693247 => 0 01111111110 11111111111111111111 => biased exponent: 1022 = -1+1023 => 2^-1
 static const int32_t HIGH_MAX_NEAR_UNITY = 0x3fefffff;
@@ -48,9 +49,6 @@ static const int32_t HIGH_MIN_NORMAL_EXP = 0x00100000;
 
 // 0x3fe00000 = 1071644672 => 0 01111111110 00000000000000000000 => biased exponent: 1022 = -1+1023 => 2^-1
 static const int32_t HIGH_BIASED_EXP_NEG_1 = 0x3fe00000;
-
-// TODO: consider making into an external constant
-static const int32_t HIGH_NUM_SIGNIFICAND_BITS = 20;
 
 // High: LN2
 static const double LN2_HI = 6.93147182464599609375e-01; // 0x3FE62E43, 0x00000000
@@ -316,18 +314,18 @@ static double pow2( uint32_t j, const double hp, const double lp ) {
 	hpc = hp;
 	jc = (int32_t)j;
 	i = ( j & STDLIB_CONSTANT_FLOAT64_HIGH_WORD_ABS_MASK );
-	k = ( ( i >> HIGH_NUM_SIGNIFICAND_BITS ) - STDLIB_CONSTANT_FLOAT64_EXPONENT_BIAS );
+	k = ( ( i >> STDLIB_CONSTANT_FLOAT64_NUM_HIGH_WORD_SIGNIFICAND_BITS ) - STDLIB_CONSTANT_FLOAT64_EXPONENT_BIAS );
 	n = 0;
 	nc = (int32_t)n;
 
 	// `|z| > 0.5`, set `n = z+0.5`
 	if ( i > HIGH_BIASED_EXP_NEG_1 ) {
 		n = ( j + ( HIGH_MIN_NORMAL_EXP >> ( k + 1 ) ) );
-		k = ( ( ( n & STDLIB_CONSTANT_FLOAT64_HIGH_WORD_ABS_MASK ) >> HIGH_NUM_SIGNIFICAND_BITS ) - STDLIB_CONSTANT_FLOAT64_EXPONENT_BIAS ); // new k for n
+		k = ( ( ( n & STDLIB_CONSTANT_FLOAT64_HIGH_WORD_ABS_MASK ) >> STDLIB_CONSTANT_FLOAT64_NUM_HIGH_WORD_SIGNIFICAND_BITS ) - STDLIB_CONSTANT_FLOAT64_EXPONENT_BIAS ); // new k for n
 		tmp = ( ( n & ~( HIGH_SIGNIFICAND_MASK >> k ) ) );
 		t = 0.0;
 		stdlib_base_float64_set_high_word( tmp, &t );
-		n = ( ( ( n & HIGH_SIGNIFICAND_MASK ) | HIGH_MIN_NORMAL_EXP ) >> ( HIGH_NUM_SIGNIFICAND_BITS - k ) );
+		n = ( ( ( n & HIGH_SIGNIFICAND_MASK ) | HIGH_MIN_NORMAL_EXP ) >> ( STDLIB_CONSTANT_FLOAT64_NUM_HIGH_WORD_SIGNIFICAND_BITS - k ) );
 		nc = (int32_t)n;
 		if ( jc < 0 ) {
 			nc = -nc;
@@ -345,11 +343,11 @@ static double pow2( uint32_t j, const double hp, const double lp ) {
 	r = ( ( z * t1 ) / ( t1 - 2.0 ) ) - ( w + ( z * w ) );
 	z = 1.0 - ( r - z );
 	stdlib_base_float64_get_high_word( z, &j );
-	j = j + ( nc << HIGH_NUM_SIGNIFICAND_BITS );
+	j = j + ( nc << STDLIB_CONSTANT_FLOAT64_NUM_HIGH_WORD_SIGNIFICAND_BITS );
 	jc = (int32_t)j;
 
 	// Check for subnormal output...
-	if ( ( jc >> HIGH_NUM_SIGNIFICAND_BITS ) <= 0 ) {
+	if ( ( jc >> STDLIB_CONSTANT_FLOAT64_NUM_HIGH_WORD_SIGNIFICAND_BITS ) <= 0 ) {
 		z = stdlib_base_ldexp( z, nc );
 	} else {
 		stdlib_base_float64_set_high_word( j, &z );
@@ -437,7 +435,7 @@ void log2ax( const double ax, const int32_t ahx, double *o1, double *o2 ) {
 		ahxc = (int32_t)ahxcc;
 	}
 	// Extract the unbiased exponent of `x`:
-	n += ( ( ahxc >> HIGH_NUM_SIGNIFICAND_BITS ) - STDLIB_CONSTANT_FLOAT64_EXPONENT_BIAS );
+	n += ( ( ahxc >> STDLIB_CONSTANT_FLOAT64_NUM_HIGH_WORD_SIGNIFICAND_BITS ) - STDLIB_CONSTANT_FLOAT64_EXPONENT_BIAS );
 
 	// Isolate the significand bits of `x`:
 	j = ( ahxc & HIGH_SIGNIFICAND_MASK );

--- a/lib/node_modules/@stdlib/math/base/special/pow/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/pow/src/main.c
@@ -14,6 +14,20 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
+*
+*
+* ## Notice
+*
+* The following copyright and license were part of the original implementation available as part of [FreeBSD]{@link https://svnweb.freebsd.org/base/release/9.3.0/lib/msun/src/s_pow.c}. The implementation follows the original, but has been modified for JavaScript.
+*
+* ```text
+* Copyright (C) 2004 by Sun Microsystems, Inc. All rights reserved.
+*
+* Developed at SunPro, a Sun Microsystems, Inc. business.
+* Permission to use, copy, modify, and distribute this
+* software is freely granted, provided that this notice
+* is preserved.
+* ```
 */
 
 #include "stdlib/math/base/special/pow.h"


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   completes the TODO to use external constant for `HIGH_NUM_SIGNIFICAND_BITS`, i.e., [`constants/float64/num-high-word-significand-bits`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/constants/float64/num-high-word-significand-bits), in [`math/base/special/pow`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/pow).
-   updates the license header in [`main.c`](https://github.com/stdlib-js/stdlib/blob/develop/lib/node_modules/%40stdlib/math/base/special/pow/src/main.c), to match with that in [`main.js`](https://github.com/gunjjoshi/stdlib/blob/pow/lib/node_modules/%40stdlib/math/base/special/pow/lib/main.js).

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
