### PR TITLE
feat: add `constants/float32/e`

### DIFF
--- a/lib/node_modules/@stdlib/constants/float32/e/README.md
+++ b/lib/node_modules/@stdlib/constants/float32/e/README.md
@@ -1,0 +1,135 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# E
+
+> The mathematical constant [_e_][e].
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var E = require( '@stdlib/constants/float32/e' );
+```
+
+#### E
+
+The mathematical constant [_e_][e], also known as Euler's number or Napier's constant. [_e_][e] is the base of the natural logarithm.
+
+```javascript
+var bool = ( E === 2.7182817459106445 );
+// returns true
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- TODO: better example -->
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var E = require( '@stdlib/constants/float32/e' );
+
+console.log( E );
+// => 2.7182817459106445
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/constants/float32/e.h"
+```
+
+#### STDLIB_CONSTANT_FLOAT32_E
+
+Macro for Euler's number.
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[e]: https://en.wikipedia.org/wiki/E_%28mathematical_constant%29
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/constants/float32/e/docs/repl.txt
+++ b/lib/node_modules/@stdlib/constants/float32/e/docs/repl.txt
@@ -1,0 +1,12 @@
+
+{{alias}}
+    Euler's number.
+
+    Examples
+    --------
+    > {{alias}}
+    2.7182817459106445
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/constants/float32/e/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/constants/float32/e/docs/types/index.d.ts
@@ -1,0 +1,33 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Euler's number.
+*
+* @example
+* var e = E;
+* // returns 2.7182817459106445
+*/
+declare const E: number;
+
+
+// EXPORTS //
+
+export = E;

--- a/lib/node_modules/@stdlib/constants/float32/e/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/constants/float32/e/docs/types/test.ts
@@ -1,0 +1,28 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import E = require( './index' );
+
+
+// TESTS //
+
+// The export is a number...
+{
+	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+	E; // $ExpectType number
+}

--- a/lib/node_modules/@stdlib/constants/float32/e/examples/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/e/examples/index.js
@@ -1,0 +1,24 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var E = require( './../lib' );
+
+console.log( E );
+// => 2.7182817459106445

--- a/lib/node_modules/@stdlib/constants/float32/e/include/stdlib/constants/float32/e.h
+++ b/lib/node_modules/@stdlib/constants/float32/e/include/stdlib/constants/float32/e.h
@@ -1,0 +1,27 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_CONSTANTS_FLOAT32_E_H
+#define STDLIB_CONSTANTS_FLOAT32_E_H
+
+/**
+* Macro for Euler's number.
+*/
+#define STDLIB_CONSTANT_FLOAT32_E 2.718281828459045f
+
+#endif // !STDLIB_CONSTANTS_FLOAT32_E_H

--- a/lib/node_modules/@stdlib/constants/float32/e/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/e/lib/index.js
@@ -1,0 +1,53 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Euler's number.
+*
+* @module @stdlib/constants/float32/e
+* @type {number}
+*
+* @example
+* var E = require( '@stdlib/constants/float32/e' );
+* // returns 2.7182817459106445
+*/
+
+// MODULES //
+
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+
+
+// MAIN //
+
+/**
+* Euler's number.
+*
+* @constant
+* @type {number}
+* @default 2.7182817459106445
+* @see [OEIS]{@link https://oeis.org/A001113}
+* @see [Wikipedia]{@link https://en.wikipedia.org/wiki/E_(mathematical_constant)}
+*/
+var E = float64ToFloat32( 2.718281828459045 );
+
+
+// EXPORTS //
+
+module.exports = E;

--- a/lib/node_modules/@stdlib/constants/float32/e/manifest.json
+++ b/lib/node_modules/@stdlib/constants/float32/e/manifest.json
@@ -1,0 +1,36 @@
+{
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": []
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float32/e/package.json
+++ b/lib/node_modules/@stdlib/constants/float32/e/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@stdlib/constants/float32/e",
+  "version": "0.0.0",
+  "description": "Euler's number.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "constant",
+    "const",
+    "mathematics",
+    "math",
+    "e",
+    "euler",
+    "napier",
+    "ieee754",
+    "double",
+    "dbl",
+    "single",
+    "precision",
+    "floating-point",
+    "float32"
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float32/e/package.json
+++ b/lib/node_modules/@stdlib/constants/float32/e/package.json
@@ -59,8 +59,6 @@
     "euler",
     "napier",
     "ieee754",
-    "double",
-    "dbl",
     "single",
     "precision",
     "floating-point",

--- a/lib/node_modules/@stdlib/constants/float32/e/test/test.js
+++ b/lib/node_modules/@stdlib/constants/float32/e/test/test.js
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var E = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a number', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof E, 'number', 'main export is a number' );
+	t.end();
+});
+
+tape( 'export is a single-precision floating-point number equal to 2.7182817459106445', function test( t ) {
+	t.equal( E, 2.7182817459106445, 'equals 2.7182817459106445' );
+	t.end();
+});


### PR DESCRIPTION
Resolves None.

## Description

> What is the purpose of this pull request?

- Add feature `constants/float32/e`

This pull request:

- Implements following: 
```javascript
var E = require( '@stdlib/constants/float32/e' );

console.log( E );
// => 2.7182817459106445
```

## Related Issues

> Does this pull request have any related issues?

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
