### PR TITLE
fix: add missing `f` suffix in `constants/float32/ln-two`

### DIFF
--- a/lib/node_modules/@stdlib/constants/float32/ln-two/include/stdlib/constants/float32/ln_two.h
+++ b/lib/node_modules/@stdlib/constants/float32/ln-two/include/stdlib/constants/float32/ln_two.h
@@ -22,6 +22,6 @@
 /**
 * Macro for the natural logarithm of `2` as a single-precision floating-point number.
 */
-#define STDLIB_CONSTANT_FLOAT32_LN2 0.6931471824645996
+#define STDLIB_CONSTANT_FLOAT32_LN2 0.6931471824645996f
 
 #endif // !STDLIB_CONSTANTS_FLOAT32_LN2_H


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   addresses https://github.com/stdlib-js/stdlib/commit/893cb1b86ececb01085118705c19a842f70da511#r149027862
-   adds an `f` suffix after the number, in [`constants/float32/ln-two`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/constants/float32/ln-two).

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
