### PR TITLE
fix: update fix function of  `jsdoc-no-space-aligned-asterisks` rule

### DIFF
--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-no-space-aligned-asterisks/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-no-space-aligned-asterisks/lib/main.js
@@ -94,7 +94,7 @@ function main( context ) {
 			*/
 			function fix( fixer ) {
 				var fixed = replace( comment, RE_LEADING_SPACE, '*' );
-				fixed = '/*' + fixed + '/';
+				fixed = '/*' + fixed + '*/';
 				return fixer.replaceTextRange( range, fixed );
 			}
 		}


### PR DESCRIPTION
Resolves #3109.

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds the correct closing marker to the `fix` function of `jsdoc-no-space-aligned-asterisks` ESLint rule.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #3109  

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
