### PR TITLE
refactor: use macros in addon and update examples in `math/base/assert/is-evenf`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/assert/is-evenf/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/is-evenf/README.md
@@ -88,15 +88,11 @@ bool = isEvenf( NaN );
 var randu = require( '@stdlib/random/array/discrete-uniform' );
 var isEvenf = require( '@stdlib/math/base/assert/is-evenf' );
 
-var bool;
-var x;
+var x = randu( 100, 0, 100 );
+
 var i;
-
-x = randu( 100, 0, 100 );
-
 for ( i = 0; i < 100; i++ ) {
-    bool = isEvenf( x[ i ] );
-    console.log( '%d is %s', x[ i ], ( bool ) ? 'even' : 'not even' );
+    console.log( '%d is %s', x[ i ], ( isEvenf( x[ i ] ) ) ? 'even' : 'not even' );
 }
 ```
 
@@ -135,6 +131,8 @@ for ( i = 0; i < 100; i++ ) {
 Tests if a finite single-precision floating-point number is an even number.
 
 ```c
+#include <stdbool.h>
+
 bool out = stdlib_base_is_evenf( 1.0f );
 // returns false
 
@@ -169,6 +167,7 @@ bool stdlib_base_is_evenf( const float x );
 ### Examples
 
 ```c
+#include "stdlib/math/base/assert/is_evenf.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>

--- a/lib/node_modules/@stdlib/math/base/assert/is-evenf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-evenf/examples/index.js
@@ -21,13 +21,9 @@
 var randu = require( '@stdlib/random/array/discrete-uniform' );
 var isEvenf = require( './../lib' );
 
-var bool;
-var x;
+var x = randu( 100, 0, 100 );
+
 var i;
-
-x = randu( 100, 0, 100 );
-
 for ( i = 0; i < 100; i++ ) {
-	bool = isEvenf( x[ i ] );
-	console.log( '%d is %s', x[ i ], ( bool ) ? 'even' : 'not even' );
+	console.log( '%d is %s', x[ i ], ( isEvenf( x[ i ] ) ) ? 'even' : 'not even' );
 }

--- a/lib/node_modules/@stdlib/math/base/assert/is-evenf/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/assert/is-evenf/manifest.json
@@ -36,6 +36,10 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
+        "@stdlib/napi/argv",
+        "@stdlib/napi/argv-float",
+        "@stdlib/napi/create-int32",
+        "@stdlib/napi/export",
         "@stdlib/math/base/assert/is-integerf"
       ]
     },

--- a/lib/node_modules/@stdlib/math/base/assert/is-evenf/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/assert/is-evenf/src/addon.c
@@ -22,6 +22,7 @@
 #include "stdlib/napi/create_int32.h"
 #include "stdlib/napi/export.h"
 #include <node_api.h>
+#include <stdint.h>
 
 /**
 * Receives JavaScript callback invocation data.
@@ -33,7 +34,7 @@
 static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV( env, info, argv, argc, 1 );
 	STDLIB_NAPI_ARGV_FLOAT( env, x, argv, 0 );
-	STDLIB_NAPI_CREATE_INT32( env, stdlib_base_is_evenf( x ), out );
+	STDLIB_NAPI_CREATE_INT32( env, (int32_t)stdlib_base_is_evenf( x ), out );
 	return out;
 }
 

--- a/lib/node_modules/@stdlib/math/base/assert/is-evenf/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/assert/is-evenf/src/addon.c
@@ -17,9 +17,11 @@
 */
 
 #include "stdlib/math/base/assert/is_evenf.h"
+#include "stdlib/napi/argv.h"
+#include "stdlib/napi/argv_float.h"
+#include "stdlib/napi/create_int32.h"
+#include "stdlib/napi/export.h"
 #include <node_api.h>
-#include <stdint.h>
-#include <assert.h>
 
 /**
 * Receives JavaScript callback invocation data.
@@ -29,60 +31,10 @@
 * @return       Node-API value
 */
 static napi_value addon( napi_env env, napi_callback_info info ) {
-	napi_status status;
-
-	// Get callback arguments:
-	size_t argc = 1;
-	napi_value argv[ 1 ];
-	status = napi_get_cb_info( env, info, &argc, argv, NULL, NULL );
-	assert( status == napi_ok );
-
-	// Check whether we were provided the correct number of arguments:
-	if ( argc < 1 ) {
-		status = napi_throw_error( env, NULL, "invalid invocation. Insufficient arguments." );
-		assert( status == napi_ok );
-		return NULL;
-	}
-	if ( argc > 1 ) {
-		status = napi_throw_error( env, NULL, "invalid invocation. Too many arguments." );
-		assert( status == napi_ok );
-		return NULL;
-	}
-
-	napi_valuetype vtype0;
-	status = napi_typeof( env, argv[ 0 ], &vtype0 );
-	assert( status == napi_ok );
-	if ( vtype0 != napi_number ) {
-		status = napi_throw_type_error( env, NULL, "invalid argument. First argument must be a number." );
-		assert( status == napi_ok );
-		return NULL;
-	}
-
-	double x;
-	status = napi_get_value_double( env, argv[ 0 ], &x );
-	assert( status == napi_ok );
-
-	bool result = stdlib_base_is_evenf( (float)x );
-
-	napi_value v;
-	status = napi_create_int32( env, (int32_t)result, &v );
-	assert( status == napi_ok );
-
-	return v;
+	STDLIB_NAPI_ARGV( env, info, argv, argc, 1 );
+	STDLIB_NAPI_ARGV_FLOAT( env, x, argv, 0 );
+	STDLIB_NAPI_CREATE_INT32( env, stdlib_base_is_evenf( x ), out );
+	return out;
 }
 
-/**
-* Initializes a Node-API module.
-*
-* @param env      environment under which the function is invoked
-* @param exports  exports object
-* @return         main export
-*/
-static napi_value init( napi_env env, napi_value exports ) {
-	napi_value fcn;
-	napi_status status = napi_create_function( env, "exports", NAPI_AUTO_LENGTH, addon, NULL, &fcn );
-	assert( status == napi_ok );
-	return fcn;
-}
-
-NAPI_MODULE( NODE_GYP_MODULE_NAME, init )
+STDLIB_NAPI_MODULE_EXPORT_FCN( addon )


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   addresses suggestions from https://github.com/stdlib-js/stdlib/commit/c664da7d6354c3324c68b4dd92744c51f213e5d5, for [`math/base/assert/is-evenf`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/assert/is-evenf).
-   replaces the whole logic in `addon.c` by macros.
-   updates JS examples.
-   adds missing C headers.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves https://github.com/stdlib-js/todo/issues/2294

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
