### PR TITLE
refactor: use constant package in `math/base/special/fmodf`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/fmodf/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/fmodf/manifest.json
@@ -43,7 +43,8 @@
         "@stdlib/constants/float32/exponent-bias",
         "@stdlib/constants/float32/exponent-mask",
         "@stdlib/constants/float32/abs-mask",
-        "@stdlib/constants/float32/min-base2-exponent"
+        "@stdlib/constants/float32/min-base2-exponent",
+        "@stdlib/constants/float32/precision"
       ]
     },
     {
@@ -63,7 +64,8 @@
         "@stdlib/constants/float32/exponent-bias",
         "@stdlib/constants/float32/exponent-mask",
         "@stdlib/constants/float32/abs-mask",
-        "@stdlib/constants/float32/min-base2-exponent"
+        "@stdlib/constants/float32/min-base2-exponent",
+        "@stdlib/constants/float32/precision"
       ]
     },
     {
@@ -83,7 +85,8 @@
         "@stdlib/constants/float32/exponent-bias",
         "@stdlib/constants/float32/exponent-mask",
         "@stdlib/constants/float32/abs-mask",
-        "@stdlib/constants/float32/min-base2-exponent"
+        "@stdlib/constants/float32/min-base2-exponent",
+        "@stdlib/constants/float32/precision"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/fmodf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/fmodf/src/main.c
@@ -38,7 +38,10 @@
 #include "stdlib/constants/float32/exponent_mask.h"
 #include "stdlib/constants/float32/exponent_bias.h"
 #include "stdlib/constants/float32/min_base2_exponent.h"
+#include "stdlib/constants/float32/precision.h"
 #include <stdint.h>
+
+static const float ZERO[] = { 0.0f, -0.0f };
 
 /**
 * Evaluates the modulus function for single-precision floating-point numbers.
@@ -52,7 +55,6 @@
 * // returns 2.9f
 */
 float stdlib_base_fmodf( const float x, const float y ) {
-	const float ZERO[] = { 0.0f, -0.0f };
 	uint32_t uhx;
 	uint32_t uhy;
 	int32_t hx;
@@ -101,7 +103,7 @@ float stdlib_base_fmodf( const float x, const float y ) {
 			ix -= 1;
 		}
 	} else {
-		ix = ( hx >> 23 ) - STDLIB_CONSTANT_FLOAT32_EXPONENT_BIAS;
+		ix = ( hx >> ( STDLIB_CONSTANT_FLOAT32_PRECISION - 1 ) ) - STDLIB_CONSTANT_FLOAT32_EXPONENT_BIAS;
 	}
 
 	// determine iy = ilogb(y)
@@ -111,7 +113,9 @@ float stdlib_base_fmodf( const float x, const float y ) {
 		for ( i = ( hy << 8 ); i >= 0; i <<= 1 ) {
 			iy -= 1;
 		}
-	} else iy = ( hy >> 23 ) - STDLIB_CONSTANT_FLOAT32_EXPONENT_BIAS;
+	} else {
+		iy = ( hy >> ( STDLIB_CONSTANT_FLOAT32_PRECISION - 1 ) ) - STDLIB_CONSTANT_FLOAT32_EXPONENT_BIAS;
+	}
 
 	// set up {hx,lx}, {hy,ly} and align y to x
 	if ( ix >= STDLIB_CONSTANT_FLOAT32_MIN_BASE2_EXPONENT ) {
@@ -160,7 +164,7 @@ float stdlib_base_fmodf( const float x, const float y ) {
 	}
 	if ( iy >= STDLIB_CONSTANT_FLOAT32_MIN_BASE2_EXPONENT ) {
 		// normalize output
-		hx = ( ( hx - 0x00800000 ) | ( ( iy + STDLIB_CONSTANT_FLOAT32_EXPONENT_BIAS ) << 23 ) );
+		hx = ( ( hx - 0x00800000 ) | ( ( iy + STDLIB_CONSTANT_FLOAT32_EXPONENT_BIAS ) << ( STDLIB_CONSTANT_FLOAT32_PRECISION - 1 ) ) );
 		stdlib_base_float32_from_word( (uint32_t)( hx | sx ), &xc );
 	} else {
 		// subnormal output

--- a/lib/node_modules/@stdlib/math/base/special/fmodf/test/fixtures/julia/runner.jl
+++ b/lib/node_modules/@stdlib/math/base/special/fmodf/test/fixtures/julia/runner.jl
@@ -39,8 +39,8 @@ julia> gen( x, y, \"data.json\" );
 """
 function gen( x, y, name )
 	z = Array{Float32}( undef, length( x ) );
-	for i in eachindex(x)
-		z[ i ] = Float32(rem( Float32(x[ i ]), Float32(y[ i ])) )
+	for i in eachindex( x )
+		z[ i ] = Float32( rem( Float32( x[ i ] ), Float32( y[ i ] ) ) );
 	end
 
 	# Store data to be written to file as a collection:
@@ -67,13 +67,13 @@ file = @__FILE__;
 dir = dirname( file );
 
 # Subnormal results:
-x = range(1.18e-38, stop = 1.0e-45, length = 2001)
-y = range(1.18e-38, stop = 1.0e-45, length = 2001)
+x = range( 1.18e-38, stop = 1.0e-45, length = 2001 );
+y = range( 1.18e-38, stop = 1.0e-45, length = 2001 );
 gen( x, y, "subnormal_results.json" );
 
 # x small, y small:
-x = rand( 5001 ) .* 100
-y = rand( 5001 ) .* 100
+x = rand( 5001 ) .* 100;
+y = rand( 5001 ) .* 100;
 gen( x, y, "small_small.json" );
 
 # x small, y large:


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   addresses suggestions on https://github.com/stdlib-js/stdlib/commit/7fd112c799e3a864d975357b2066e45f4196653e, for [`math/base/special/fmodf`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/fmodf).
-   replaces the magic number `23` by [`constants/float32/precision`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/constants/float32/precision).
-   adds missing spaces and semicolons in `runner.jl`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves [#{{TODO: add issue number}} ](https://github.com/stdlib-js/todo/issues/2300).

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
