### PR TITLE
refactor: replace built-in with `fmod` in `math/base/assert/is-prime`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/assert/is-prime/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/assert/is-prime/benchmark/c/native/benchmark.c
@@ -92,15 +92,18 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double x[ 100 ];
 	double t;
 	bool b;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 200.0 * rand_double() );
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( rand_double() * 200.0 );
-		b = stdlib_base_is_prime( x );
+		b = stdlib_base_is_prime( x[ i % 100 ] );
 		if ( b != true && b != false ) {
 			printf( "should return either true or false\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/assert/is-prime/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/assert/is-prime/manifest.json
@@ -1,5 +1,7 @@
 {
-  "options": {},
+  "options": {
+    "task": "build"
+  },
   "fields": [
     {
       "field": "src",
@@ -24,6 +26,7 @@
   ],
   "confs": [
     {
+      "task": "build",
       "src": [
         "./src/main.c"
       ],
@@ -35,7 +38,42 @@
       "dependencies": [
         "@stdlib/math/base/special/sqrt",
         "@stdlib/math/base/special/floor",
-        "@stdlib/constants/float64/max-safe-integer"
+        "@stdlib/constants/float64/max-safe-integer",
+        "@stdlib/math/base/special/fmod"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/sqrt",
+        "@stdlib/math/base/special/floor",
+        "@stdlib/constants/float64/max-safe-integer",
+        "@stdlib/math/base/special/fmod"
+      ]
+    },
+    {
+      "task": "examples",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/sqrt",
+        "@stdlib/math/base/special/floor",
+        "@stdlib/constants/float64/max-safe-integer",
+        "@stdlib/math/base/special/fmod"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/assert/is-prime/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/assert/is-prime/src/main.c
@@ -20,8 +20,8 @@
 #include "stdlib/math/base/special/sqrt.h"
 #include "stdlib/math/base/special/floor.h"
 #include "stdlib/constants/float64/max_safe_integer.h"
+#include "stdlib/math/base/special/fmod.h"
 #include <stdint.h>
-#include <math.h>
 
 static const double WHEEL_PRIMES[45] = {
     11.0, 13.0, 17.0, 19.0, 23.0, 29.0, 31.0, 37.0, 41.0, 43.0, 47.0, 53.0, 59.0, 61.0, 67.0, 71.0, 73.0, 79.0, 83.0, 89.0, 97.0,

--- a/lib/node_modules/@stdlib/math/base/assert/is-prime/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/assert/is-prime/src/main.c
@@ -20,6 +20,7 @@
 #include "stdlib/math/base/special/sqrt.h"
 #include "stdlib/math/base/special/floor.h"
 #include "stdlib/constants/float64/max_safe_integer.h"
+#include "stdlib/math/base/special/fmod.h"
 #include <stdint.h>
 #include <math.h>
 
@@ -54,7 +55,7 @@ bool stdlib_base_is_prime( const double x ) {
 		return ( x > 1.0 ); // primes: 2.0, 3.0
 	}
 	// Check whether the number is even...
-	if ( x > STDLIB_CONSTANT_FLOAT64_MAX_SAFE_INTEGER || ( fmod( x, 2.0 ) ) == 0.0 ) {
+	if ( x > STDLIB_CONSTANT_FLOAT64_MAX_SAFE_INTEGER || ( stdlib_base_fmod( x, 2.0 ) ) == 0.0 ) {
 		return false;
 	}
 	// Check for small primes...
@@ -62,15 +63,15 @@ bool stdlib_base_is_prime( const double x ) {
 		return true; // primes: 5.0, 7.0
 	}
 	// Check whether the number is evenly divisible by `3`...
-	if ( fmod( x, 3.0 ) == 0.0 ) { // TODO: replace fmod usage once we have a stdlib equivalent
+	if ( stdlib_base_fmod( x, 3.0 ) == 0.0 ) {
 		return false;
 	}
 	// Check whether the number is evenly divisible by `5`...
-	if ( fmod( x, 5.0 ) == 0.0 ) {
+	if ( stdlib_base_fmod( x, 5.0 ) == 0.0 ) {
 		return false;
 	}
 	// Check whether the number is evenly divisible by `7`...
-	if ( fmod( x, 7.0 ) == 0.0 ) {
+	if ( stdlib_base_fmod( x, 7.0 ) == 0.0 ) {
 		return false;
 	}
 	// Check whether the number is a prime number in the wheel...
@@ -83,54 +84,54 @@ bool stdlib_base_is_prime( const double x ) {
 	N = stdlib_base_floor( stdlib_base_sqrt( x ) );
 	for ( i = 11; i <= N; i += 210 ) {
 		if (
-			fmod( x, i ) == 0.0 ||           // 11
-			fmod( x, ( i + 2 ) ) == 0.0 ||   // 13
-			fmod( x, ( i + 6 ) ) == 0.0 ||   // 17
-			fmod( x, ( i + 8 ) ) == 0.0 ||   // 19
-			fmod( x, ( i + 12 ) ) == 0.0 ||  // 23
-			fmod( x, ( i + 18 ) ) == 0.0 ||  // 29
-			fmod( x, ( i + 20 ) ) == 0.0 ||  // 31
-			fmod( x, ( i + 26 ) ) == 0.0 ||  // 37
-			fmod( x, ( i + 30 ) ) == 0.0 ||  // 41
-			fmod( x, ( i + 32 ) ) == 0.0 ||  // 43
-			fmod( x, ( i + 36 ) ) == 0.0 ||  // 47
-			fmod( x, ( i + 42 ) ) == 0.0 ||  // 53
-			fmod( x, ( i + 48 ) ) == 0.0 ||  // 59
-			fmod( x, ( i + 50 ) ) == 0.0 ||  // 61
-			fmod( x, ( i + 56 ) ) == 0.0 ||  // 67
-			fmod( x, ( i + 60 ) ) == 0.0 ||  // 71
-			fmod( x, ( i + 62 ) ) == 0.0 ||  // 73
-			fmod( x, ( i + 68 ) ) == 0.0 ||  // 79
-			fmod( x, ( i + 72 ) ) == 0.0 ||  // 83
-			fmod( x, ( i + 78 ) ) == 0.0 ||  // 89
-			fmod( x, ( i + 86 ) ) == 0.0 ||  // 97
-			fmod( x, ( i + 90 ) ) == 0.0 ||  // 101
-			fmod( x, ( i + 92 ) ) == 0.0 ||  // 103
-			fmod( x, ( i + 96 ) ) == 0.0 ||  // 107
-			fmod( x, ( i + 98 ) ) == 0.0 ||  // 109
-			fmod( x, ( i + 102 ) ) == 0.0 || // 113
-			fmod( x, ( i + 110 ) ) == 0.0 || // 121 (relatively prime)
-			fmod( x, ( i + 116 ) ) == 0.0 || // 127
-			fmod( x, ( i + 120 ) ) == 0.0 || // 131
-			fmod( x, ( i + 126 ) ) == 0.0 || // 137
-			fmod( x, ( i + 128 ) ) == 0.0 || // 139
-			fmod( x, ( i + 132 ) ) == 0.0 || // 143 (relatively prime)
-			fmod( x, ( i + 138 ) ) == 0.0 || // 149
-			fmod( x, ( i + 140 ) ) == 0.0 || // 151
-			fmod( x, ( i + 146 ) ) == 0.0 || // 157
-			fmod( x, ( i + 152 ) ) == 0.0 || // 163
-			fmod( x, ( i + 156 ) ) == 0.0 || // 167
-			fmod( x, ( i + 158 ) ) == 0.0 || // 169 (relatively prime)
-			fmod( x, ( i + 162 ) ) == 0.0 || // 173
-			fmod( x, ( i + 168 ) ) == 0.0 || // 179
-			fmod( x, ( i + 170 ) ) == 0.0 || // 181
-			fmod( x, ( i + 176 ) ) == 0.0 || // 187 (relatively prime)
-			fmod( x, ( i + 180 ) ) == 0.0 || // 191
-			fmod( x, ( i + 182 ) ) == 0.0 || // 193
-			fmod( x, ( i + 186 ) ) == 0.0 || // 197
-			fmod( x, ( i + 188 ) ) == 0.0 || // 199
-			fmod( x, ( i + 198 ) ) == 0.0 || // 209 (relatively prime)
-			fmod( x, ( i + 200 ) ) == 0.0    // 211
+			stdlib_base_fmod( x, i ) == 0.0 ||           // 11
+			stdlib_base_fmod( x, ( i + 2 ) ) == 0.0 ||   // 13
+			stdlib_base_fmod( x, ( i + 6 ) ) == 0.0 ||   // 17
+			stdlib_base_fmod( x, ( i + 8 ) ) == 0.0 ||   // 19
+			stdlib_base_fmod( x, ( i + 12 ) ) == 0.0 ||  // 23
+			stdlib_base_fmod( x, ( i + 18 ) ) == 0.0 ||  // 29
+			stdlib_base_fmod( x, ( i + 20 ) ) == 0.0 ||  // 31
+			stdlib_base_fmod( x, ( i + 26 ) ) == 0.0 ||  // 37
+			stdlib_base_fmod( x, ( i + 30 ) ) == 0.0 ||  // 41
+			stdlib_base_fmod( x, ( i + 32 ) ) == 0.0 ||  // 43
+			stdlib_base_fmod( x, ( i + 36 ) ) == 0.0 ||  // 47
+			stdlib_base_fmod( x, ( i + 42 ) ) == 0.0 ||  // 53
+			stdlib_base_fmod( x, ( i + 48 ) ) == 0.0 ||  // 59
+			stdlib_base_fmod( x, ( i + 50 ) ) == 0.0 ||  // 61
+			stdlib_base_fmod( x, ( i + 56 ) ) == 0.0 ||  // 67
+			stdlib_base_fmod( x, ( i + 60 ) ) == 0.0 ||  // 71
+			stdlib_base_fmod( x, ( i + 62 ) ) == 0.0 ||  // 73
+			stdlib_base_fmod( x, ( i + 68 ) ) == 0.0 ||  // 79
+			stdlib_base_fmod( x, ( i + 72 ) ) == 0.0 ||  // 83
+			stdlib_base_fmod( x, ( i + 78 ) ) == 0.0 ||  // 89
+			stdlib_base_fmod( x, ( i + 86 ) ) == 0.0 ||  // 97
+			stdlib_base_fmod( x, ( i + 90 ) ) == 0.0 ||  // 101
+			stdlib_base_fmod( x, ( i + 92 ) ) == 0.0 ||  // 103
+			stdlib_base_fmod( x, ( i + 96 ) ) == 0.0 ||  // 107
+			stdlib_base_fmod( x, ( i + 98 ) ) == 0.0 ||  // 109
+			stdlib_base_fmod( x, ( i + 102 ) ) == 0.0 || // 113
+			stdlib_base_fmod( x, ( i + 110 ) ) == 0.0 || // 121 (relatively prime)
+			stdlib_base_fmod( x, ( i + 116 ) ) == 0.0 || // 127
+			stdlib_base_fmod( x, ( i + 120 ) ) == 0.0 || // 131
+			stdlib_base_fmod( x, ( i + 126 ) ) == 0.0 || // 137
+			stdlib_base_fmod( x, ( i + 128 ) ) == 0.0 || // 139
+			stdlib_base_fmod( x, ( i + 132 ) ) == 0.0 || // 143 (relatively prime)
+			stdlib_base_fmod( x, ( i + 138 ) ) == 0.0 || // 149
+			stdlib_base_fmod( x, ( i + 140 ) ) == 0.0 || // 151
+			stdlib_base_fmod( x, ( i + 146 ) ) == 0.0 || // 157
+			stdlib_base_fmod( x, ( i + 152 ) ) == 0.0 || // 163
+			stdlib_base_fmod( x, ( i + 156 ) ) == 0.0 || // 167
+			stdlib_base_fmod( x, ( i + 158 ) ) == 0.0 || // 169 (relatively prime)
+			stdlib_base_fmod( x, ( i + 162 ) ) == 0.0 || // 173
+			stdlib_base_fmod( x, ( i + 168 ) ) == 0.0 || // 179
+			stdlib_base_fmod( x, ( i + 170 ) ) == 0.0 || // 181
+			stdlib_base_fmod( x, ( i + 176 ) ) == 0.0 || // 187 (relatively prime)
+			stdlib_base_fmod( x, ( i + 180 ) ) == 0.0 || // 191
+			stdlib_base_fmod( x, ( i + 182 ) ) == 0.0 || // 193
+			stdlib_base_fmod( x, ( i + 186 ) ) == 0.0 || // 197
+			stdlib_base_fmod( x, ( i + 188 ) ) == 0.0 || // 199
+			stdlib_base_fmod( x, ( i + 198 ) ) == 0.0 || // 209 (relatively prime)
+			stdlib_base_fmod( x, ( i + 200 ) ) == 0.0    // 211
 		) {
 			return false;
 		}

--- a/lib/node_modules/@stdlib/math/base/assert/is-prime/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/assert/is-prime/src/main.c
@@ -20,7 +20,6 @@
 #include "stdlib/math/base/special/sqrt.h"
 #include "stdlib/math/base/special/floor.h"
 #include "stdlib/constants/float64/max_safe_integer.h"
-#include "stdlib/math/base/special/fmod.h"
 #include <stdint.h>
 #include <math.h>
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Completes the TODO to replace inbuilt `fmod` with `stdlib_base_fmod`, in [`math/base/assert/is-prime`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/assert/is-prime).

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
