### PR TITLE
feat: add `at` method to `array/fixed-endian-factory`

### DIFF
--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
@@ -306,6 +306,38 @@ var v = arr.get( 0 );
 // returns 1.0
 ```
 
+<a name="method-at"></a>
+
+#### TypedArrayFE.prototype.at( i )
+
+Returns an array element located at integer position (index) `i`, with support for both nonnegative and negative integer positions.
+
+```javascript
+var Float64ArrayFE = fixedEndianFactory( 'float64' );
+
+var arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 3.0 ] );
+
+var out = arr.at( 0 );
+// returns 1.0
+
+out = arr.at( -1 );
+// returns 3.0
+```
+
+If provided an out-of-bounds index, the method returns `undefined`.
+
+```javascript
+var Float64ArrayFE = fixedEndianFactory( 'float64' );
+
+var arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 3.0 ] );
+
+var v = arr.at( 100 );
+// returns undefined
+
+v = arr.at( -100 );
+// returns undefined
+```
+
 <a name="method-for-each"></a>
 
 #### TypedArrayFE.prototype.forEach( callbackFn\[, thisArg] )
@@ -460,38 +492,6 @@ var arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 3.0 ] );
 
 var str = arr.toString();
 // returns '1,2,3'
-```
-
-<a name="method-at"></a>
-
-#### TypedArrayFE.prototype.at( i )
-
-Returns an array element located at integer position (index) `i`, with support for both nonnegative and negative integer positions.
-
-```javascript
-var Float64ArrayFE = fixedEndianFactory( 'float64' );
-
-var arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 3.0 ] );
-
-var out = arr.at( 0 );
-// returns 1.0
-
-out = arr.at( -1 );
-// returns 3.0
-```
-
-If provided an out-of-bounds index, the method returns `undefined`.
-
-```javascript
-var Float64ArrayFE = fixedEndianFactory( 'float64' );
-
-var arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 3.0 ] );
-
-var v = arr.at( 100 );
-// returns undefined
-
-v = arr.at( -100 );
-// returns undefined
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
@@ -462,6 +462,38 @@ var str = arr.toString();
 // returns '1,2,3'
 ```
 
+<a name="method-at"></a>
+
+#### TypedArrayFE.prototype.at( i )
+
+Returns an array element located at integer position (index) `i`, with support for both nonnegative and negative integer positions.
+
+```javascript
+var Float64ArrayFE = fixedEndianFactory( 'float64' );
+
+var arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 3.0 ] );
+
+var out = arr.at( 0 );
+// returns 1.0
+
+out = arr.at( -1 );
+// returns 3.0
+```
+
+If provided an out-of-bounds index, the method returns `undefined`.
+
+```javascript
+var Float64ArrayFE = fixedEndianFactory( 'float64' );
+
+var arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 3.0 ] );
+
+var v = arr.at( 100 );
+// returns undefined
+
+v = arr.at( -100 );
+// returns undefined
+```
+
 </section>
 
 <!-- /.usage -->

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.at.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.at.js
@@ -1,0 +1,146 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isNumber = require( '@stdlib/assert/is-number' ).isPrimitive;
+var pkg = require( './../package.json' ).name;
+var factory = require( './../lib' );
+
+
+// VARIABLES //
+
+var Float64ArrayFE = factory( 'float64' );
+
+
+// MAIN //
+
+bench( pkg+':at:endianness=little-endian', function benchmark( b ) {
+	var arr;
+	var N;
+	var v;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < 10; i++ ) {
+		arr.push( i );
+	}
+	arr = new Float64ArrayFE( 'little-endian', arr );
+	N = arr.length;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		v = arr.at( i % N );
+		if ( typeof v !== 'number' ) {
+			b.fail( 'should return a number' );
+		}
+	}
+	b.toc();
+	if ( !isNumber( v ) ) {
+		b.fail( 'should return a number' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+':at:endianness=little-endian', function benchmark( b ) {
+	var arr;
+	var N;
+	var v;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < 10; i++ ) {
+		arr.push( i );
+	}
+	arr = new Float64ArrayFE( 'little-endian', arr );
+	N = arr.length;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		v = arr.at( -( i % N ) - 1 );
+		if ( typeof v !== 'number' ) {
+			b.fail( 'should return a number' );
+		}
+	}
+	b.toc();
+	if ( !isNumber( v ) ) {
+		b.fail( 'should return a number' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+':at:endianness=big-endian', function benchmark( b ) {
+	var arr;
+	var N;
+	var v;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < 1000; i++ ) {
+		arr.push( i );
+	}
+	arr = new Float64ArrayFE( 'big-endian', arr );
+	N = arr.length;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		v = arr.at( i % N );
+		if ( typeof v !== 'number' ) {
+			b.fail( 'should return a number' );
+		}
+	}
+	b.toc();
+	if ( !isNumber( v ) ) {
+		b.fail( 'should return a number' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+':at:endianness=big-endian', function benchmark( b ) {
+	var arr;
+	var N;
+	var v;
+	var i;
+
+	arr = [];
+	for ( i = 0; i < 1000; i++ ) {
+		arr.push( i );
+	}
+	arr = new Float64ArrayFE( 'big-endian', arr );
+	N = arr.length;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		v = arr.at( -( i % N ) - 1 );
+		if ( typeof v !== 'number' ) {
+			b.fail( 'should return a number' );
+		}
+	}
+	b.toc();
+	if ( !isNumber( v ) ) {
+		b.fail( 'should return a number' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.at.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.at.js
@@ -33,7 +33,7 @@ var Float64ArrayFE = factory( 'float64' );
 
 // MAIN //
 
-bench( pkg+':at:endianness=little-endian', function benchmark( b ) {
+bench( pkg+'::nonnegative_indices:at:endianness=little-endian', function benchmark( b ) {
 	var arr;
 	var N;
 	var v;
@@ -61,7 +61,7 @@ bench( pkg+':at:endianness=little-endian', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':at:endianness=little-endian', function benchmark( b ) {
+bench( pkg+'::negative_indices:at:endianness=little-endian', function benchmark( b ) {
 	var arr;
 	var N;
 	var v;
@@ -89,7 +89,7 @@ bench( pkg+':at:endianness=little-endian', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':at:endianness=big-endian', function benchmark( b ) {
+bench( pkg+'::nonnegative_indices:at:endianness=big-endian', function benchmark( b ) {
 	var arr;
 	var N;
 	var v;
@@ -117,7 +117,7 @@ bench( pkg+':at:endianness=big-endian', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':at:endianness=big-endian', function benchmark( b ) {
+bench( pkg+'::negative_indices:at:endianness=big-endian', function benchmark( b ) {
 	var arr;
 	var N;
 	var v;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
@@ -23,6 +23,7 @@
 // MODULES //
 
 var isNonNegativeInteger = require( '@stdlib/assert/is-nonnegative-integer' ).isPrimitive;
+var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var isCollection = require( '@stdlib/assert/is-collection' );
 var isArrayBuffer = require( '@stdlib/assert/is-arraybuffer' );
 var isObject = require( '@stdlib/assert/is-object' );
@@ -690,6 +691,37 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 			out.push( buf[ GETTER ]( i*BYTES_PER_ELEMENT, this._isLE ) );
 		}
 		return out.join( ',' );
+	});
+
+	/**
+	* Takes an integer value and returns the data at that index.
+	*
+	* @private
+	* @name at
+	* @memberof TypedArray.prototype
+	* @type {Function}
+	* @param {integer} idx - required index
+	* @param {*} [thisArg] function invocation context
+	* @throws {TypeError} `this` must be a typed array instance
+	* @throws {TypeError} first argument must be an integer
+	* @returns {(*|void)} array element
+	*/
+	setReadOnly( TypedArray.prototype, 'at', function at( idx ) {
+		var len;
+		if ( !isTypedArray( this ) ) {
+			throw new TypeError( format( 'invalid invocation. `this` is not %s %s.', CHAR2ARTICLE[ dtype[0] ], CTOR_NAME ) );
+		}
+		if ( !isInteger( idx ) ) {
+			throw new TypeError( format( 'invalid argument. Must provide a nonnegative integer. Value: `%s`.', idx ) );
+		}
+		len = this._length;
+		if ( idx < 0 ) {
+			idx += len;
+		}
+		if ( idx >= this._length || idx < 0 ) {
+			return;
+		}
+		return this._buffer[ GETTER ]( idx * BYTES_PER_ELEMENT, this._isLE );
 	});
 
 	return TypedArray;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
@@ -459,6 +459,36 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 	});
 
 	/**
+	* Returns an array element located at integer position (index) `i`, with support for both nonnegative and negative integer indices.
+	*
+	* @private
+	* @name at
+	* @memberof TypedArray.prototype
+	* @type {Function}
+	* @param {integer} idx - element index
+	* @throws {TypeError} `this` must be a typed array instance
+	* @throws {TypeError} must provide an integer
+	* @returns {(*|void)} array element
+	*/
+	setReadOnly( TypedArray.prototype, 'at', function at( idx ) {
+		var len;
+		if ( !isTypedArray( this ) ) {
+			throw new TypeError( format( 'invalid invocation. `this` is not %s %s.', CHAR2ARTICLE[ dtype[0] ], CTOR_NAME ) );
+		}
+		if ( !isInteger( idx ) ) {
+			throw new TypeError( format( 'invalid argument. Must provide an integer. Value: `%s`.', idx ) );
+		}
+		len = this._length;
+		if ( idx < 0 ) {
+			idx += len;
+		}
+		if ( idx < 0 || idx >= len ) {
+			return;
+		}
+		return this._buffer[ GETTER ]( idx * BYTES_PER_ELEMENT, this._isLE );
+	});
+
+	/**
 	* Pointer to the underlying data buffer.
 	*
 	* @private
@@ -691,36 +721,6 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 			out.push( buf[ GETTER ]( i*BYTES_PER_ELEMENT, this._isLE ) );
 		}
 		return out.join( ',' );
-	});
-
-	/**
-	* Returns an array element located at integer position (index) `i`, with support for both nonnegative and negative integer indices.
-	*
-	* @private
-	* @name at
-	* @memberof TypedArray.prototype
-	* @type {Function}
-	* @param {integer} idx - element index
-	* @throws {TypeError} `this` must be a typed array instance
-	* @throws {TypeError} must provide an integer
-	* @returns {(*|void)} array element
-	*/
-	setReadOnly( TypedArray.prototype, 'at', function at( idx ) {
-		var len;
-		if ( !isTypedArray( this ) ) {
-			throw new TypeError( format( 'invalid invocation. `this` is not %s %s.', CHAR2ARTICLE[ dtype[0] ], CTOR_NAME ) );
-		}
-		if ( !isInteger( idx ) ) {
-			throw new TypeError( format( 'invalid argument. Must provide an integer. Value: `%s`.', idx ) );
-		}
-		len = this._length;
-		if ( idx < 0 ) {
-			idx += len;
-		}
-		if ( idx < 0 || idx >= len ) {
-			return;
-		}
-		return this._buffer[ GETTER ]( idx * BYTES_PER_ELEMENT, this._isLE );
 	});
 
 	return TypedArray;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
@@ -694,16 +694,16 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 	});
 
 	/**
-	* Takes an integer value and returns the data at that index.
+	* Returns an array element located at integer position (index) `i`, with support for both nonnegative and negative integer indices.
 	*
 	* @private
 	* @name at
 	* @memberof TypedArray.prototype
 	* @type {Function}
-	* @param {integer} idx - required index
+	* @param {integer} idx - element index
 	* @param {*} [thisArg] function invocation context
 	* @throws {TypeError} `this` must be a typed array instance
-	* @throws {TypeError} first argument must be an integer
+	* @throws {TypeError} must provide an integer
 	* @returns {(*|void)} array element
 	*/
 	setReadOnly( TypedArray.prototype, 'at', function at( idx ) {
@@ -712,13 +712,13 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 			throw new TypeError( format( 'invalid invocation. `this` is not %s %s.', CHAR2ARTICLE[ dtype[0] ], CTOR_NAME ) );
 		}
 		if ( !isInteger( idx ) ) {
-			throw new TypeError( format( 'invalid argument. Must provide a nonnegative integer. Value: `%s`.', idx ) );
+			throw new TypeError( format( 'invalid argument. Must provide an integer. Value: `%s`.', idx ) );
 		}
 		len = this._length;
 		if ( idx < 0 ) {
 			idx += len;
 		}
-		if ( idx >= this._length || idx < 0 ) {
+		if ( idx < 0 || idx >= len ) {
 			return;
 		}
 		return this._buffer[ GETTER ]( idx * BYTES_PER_ELEMENT, this._isLE );

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
@@ -701,7 +701,6 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 	* @memberof TypedArray.prototype
 	* @type {Function}
 	* @param {integer} idx - element index
-	* @param {*} [thisArg] function invocation context
 	* @throws {TypeError} `this` must be a typed array instance
 	* @throws {TypeError} must provide an integer
 	* @returns {(*|void)} array element

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/test/test.at.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/test/test.at.js
@@ -1,0 +1,153 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var factory = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof factory, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns a function', function test( t ) {
+	var ctor = factory( 'float64' );
+	t.strictEqual( isFunction( ctor ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the returned function is an `at` method', function test( t ) {
+	var ctor = factory( 'float64' );
+	t.strictEqual( hasOwnProp( ctor.prototype, 'at' ), true, 'returns expected value' );
+	t.strictEqual( isFunction( ctor.prototype.at ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a typed array instance', function test( t ) {
+	var values;
+	var ctor;
+	var arr;
+	var i;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.at.call( value, 0 );
+		};
+	}
+});
+
+tape( 'the method throws an error if provided an index argument which is not an integer', function test( t ) {
+	var values;
+	var ctor;
+	var arr;
+	var i;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0 ] );
+
+	values = [
+		'5',
+		3.14,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.at( value );
+		};
+	}
+});
+
+tape( 'the method returns `undefined` if provided an index which exceeds array dimensions', function test( t ) {
+	var ctor;
+	var arr;
+	var v;
+	var i;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ] );
+
+	for ( i = -arr.length; i < arr.length; i++ ) {
+		if ( i < 0 ) {
+			v = arr.at( i - arr.length );
+			t.strictEqual( v, void 0, 'returns expected value for index '+(i-arr.length) );
+		} else {
+			v = arr.at( arr.length+i );
+			t.strictEqual( v, void 0, 'returns expected value for index '+(arr.length+i) );
+		}
+	}
+	t.end();
+});
+
+tape( 'the method returns an array element', function test( t ) {
+	var expected;
+	var ctor;
+	var arr;
+	var v;
+	var i;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+	expected = [ 1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 2.0, 3.0, 4.0, 5.0 ];
+
+	for ( i = -arr.length; i < arr.length; i++ ) {
+		v = arr.at( i );
+		t.strictEqual( v, expected[ i + arr.length ], 'returns expected value' );
+	}
+	t.end();
+});


### PR DESCRIPTION
Resolves #3135 .

## Description

> What is the purpose of this pull request?

This pull request:

-   adds `at` method to `array/fixed-endian-factory`
-   adds the respective benchmarks and tests
-   updates README

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #3135  

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

the `at` method in `@stdlib/array/bool` had its benchmarks written in a single file so i followed that convention. kindly let me know if we need any changes.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
