### PR TITLE
refactor: remove unnecessary variable declaration from `blas/ext/base/dnannsumkbn2`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dnannsumkbn2/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/dnannsumkbn2/benchmark/c/benchmark.length.c
@@ -114,6 +114,7 @@ static double benchmark1( int iterations, int len ) {
 	n = 0;
 	t = tic();
 	for ( i = 0; i < iterations; i++ ) {
+		// cppcheck-suppress uninitvar
 		v = stdlib_strided_dnannsumkbn2( len, x, 1, &n );
 		if ( v != v || n < 0  ) {
 			printf( "should not return NaN\n" );
@@ -153,6 +154,7 @@ static double benchmark2( int iterations, int len ) {
 	n = 0;
 	t = tic();
 	for ( i = 0; i < iterations; i++ ) {
+		// cppcheck-suppress uninitvar
 		v = stdlib_strided_dnannsumkbn2_ndarray( len, x, 1, 0, &n );
 		if ( v != v || n < 0  ) {
 			printf( "should not return NaN\n" );

--- a/lib/node_modules/@stdlib/blas/ext/base/dnannsumkbn2/src/addon.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/dnannsumkbn2/src/addon.c
@@ -42,10 +42,9 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, Out, 2, strideOut, argv, 3 );
 
 	int64_t io = stdlib_strided_stride2offset( 2, strideOut );
-	double *out = Out;
 	CBLAS_INT n;
-	out[ io ] = API_SUFFIX(stdlib_strided_dnannsumkbn2)( N, X, strideX, &n );
-	out[ io+strideOut ] = (double)n;
+	Out[ io ] = API_SUFFIX(stdlib_strided_dnannsumkbn2)( N, X, strideX, &n );
+	Out[ io+strideOut ] = (double)n;
 
 	return NULL;
 }
@@ -67,10 +66,9 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, Out, 2, strideOut, argv, 4 );
 
-	double *out = Out;
 	CBLAS_INT n;
-	out[ offsetOut ] = API_SUFFIX(stdlib_strided_dnannsumkbn2_ndarray)( N, X, strideX, offsetX, &n );
-	out[ offsetOut+strideOut ] = (double)n;
+	Out[ offsetOut ] = API_SUFFIX(stdlib_strided_dnannsumkbn2_ndarray)( N, X, strideX, offsetX, &n );
+	Out[ offsetOut+strideOut ] = (double)n;
 
 	return NULL;
 }


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   remove unnecessary variable declarations in `addon.c`
-   suppress C lint warning form `benchmark.length.c`

## Related Issues

> Does this pull request have any related issues?

No. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
