### PR TITLE
refactor: replace `fabs` with `stdlib_base_abs` in C implementation of `blas/ext/base/dapxsumkbn`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumkbn/manifest.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumkbn/manifest.json
@@ -43,7 +43,8 @@
         "@stdlib/napi/argv-int64",
         "@stdlib/napi/argv-double",
         "@stdlib/napi/argv-strided-float64array",
-        "@stdlib/napi/create-double"
+        "@stdlib/napi/create-double",
+        "@stdlib/math/base/special/abs"
       ]
     },
     {
@@ -58,7 +59,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/blas/base/shared",
-        "@stdlib/strided/base/stride2offset"
+        "@stdlib/strided/base/stride2offset",
+        "@stdlib/math/base/special/abs"
       ]
     },
     {
@@ -73,7 +75,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/blas/base/shared",
-        "@stdlib/strided/base/stride2offset"
+        "@stdlib/strided/base/stride2offset",
+        "@stdlib/math/base/special/abs"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumkbn/src/main.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumkbn/src/main.c
@@ -19,7 +19,7 @@
 #include "stdlib/blas/ext/base/dapxsumkbn.h"
 #include "stdlib/blas/base/shared.h"
 #include "stdlib/strided/base/stride2offset.h"
-#include <math.h>
+#include "stdlib/math/base/special/abs.h"
 
 /**
 * Adds a scalar constant to each double-precision floating-point strided array element and computes the sum using an improved Kahan–Babuška algorithm.
@@ -72,7 +72,7 @@ double API_SUFFIX(stdlib_strided_dapxsumkbn_ndarray)( const CBLAS_INT N, const d
 	for ( i = 0; i < N; i++ ) {
 		v = alpha + X[ ix ];
 		t = sum + v;
-		if ( fabs( sum ) >= fabs( v ) ) {
+		if ( stdlib_base_abs( sum ) >= stdlib_base_abs( v ) ) {
 			c += (sum-t) + v;
 		} else {
 			c += (v-t) + sum;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   replace the use of `fabs` with `stdlib_base_abs` in the C implementation of `blas/ext/base/dapxsumkbn`

## Related Issues

> Does this pull request have any related issues?

No. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
