### PR TITLE
docs: fix missing license header for `blas/base/cscal-wasm`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/cscal-wasm/src/main.wat
+++ b/lib/node_modules/@stdlib/blas/base/cscal-wasm/src/main.wat
@@ -1,3 +1,19 @@
+;; @license Apache-2.0
+;;
+;; Copyright (c) 2024 The Stdlib Authors.
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;    http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
 (module
   (type (;0;) (func))
   (type (;1;) (func (param i32 i32 i32 i32)))


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request adds a missing license header for `.wat` file. 

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
