### PR TITLE
refactor: use `stdlib_base_round` instead of builtin in `math/base/special/cround`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cround/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/cround/benchmark/c/benchmark.c
@@ -90,20 +90,23 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double re;
-	double im;
+	double re[ 100 ];
+	double im[ 100 ];
 	double t;
 	int i;
 
 	double complex z;
 	double complex y;
 
+	for ( i = 0; i < 100; i++ ) {
+		re[ i ] = ( 1000.0 * rand_double() ) - 500.0;
+		im[ i ] = ( 1000.0 * rand_double() ) - 500.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		re = ( 1000.0*rand_double() ) - 500.0;
-		im = ( 1000.0*rand_double() ) - 500.0;
-		z = re + im*I;
-		y = round( creal(z) ) + round( cimag(z) )*I;
+		z = re[ i % 100 ] + im[ i % 100 ]*I;
+		y = round( creal( z ) ) + round( cimag( z ) )*I;
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/cround/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/cround/benchmark/c/native/benchmark.c
@@ -93,19 +93,22 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
+	double v[ 100 ];
 	double re;
 	double im;
 	double t;
-	double v;
 	int i;
 
 	stdlib_complex128_t x;
 	stdlib_complex128_t y;
 
+	for ( i = 0; i < 100; i++ ) {
+		v[ i ] = ( 1000.0 * rand_double() ) - 500.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		v = ( 1000.0*rand_double() ) - 500.0;
-		x = stdlib_complex128( v, v );
+		x = stdlib_complex128( v[ i % 100 ], v[ i % 100 ] );
 		y = stdlib_base_cround( x );
 		stdlib_complex128_reim( y, &re, &im );
 		if ( re != re ) {

--- a/lib/node_modules/@stdlib/math/base/special/cround/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/cround/manifest.json
@@ -38,7 +38,8 @@
       "dependencies": [
         "@stdlib/math/base/napi/unary",
         "@stdlib/complex/float64/ctor",
-        "@stdlib/complex/float64/reim"
+        "@stdlib/complex/float64/reim",
+        "@stdlib/math/base/special/round"
       ]
     },
     {
@@ -53,7 +54,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/complex/float64/ctor",
-        "@stdlib/complex/float64/reim"
+        "@stdlib/complex/float64/reim",
+        "@stdlib/math/base/special/round"
       ]
     },
     {
@@ -68,7 +70,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/complex/float64/ctor",
-        "@stdlib/complex/float64/reim"
+        "@stdlib/complex/float64/reim",
+        "@stdlib/math/base/special/round"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/cround/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/cround/src/main.c
@@ -19,7 +19,7 @@
 #include "stdlib/math/base/special/cround.h"
 #include "stdlib/complex/float64/ctor.h"
 #include "stdlib/complex/float64/reim.h"
-#include <math.h>
+#include "stdlib/math/base/special/round.h"
 
 /**
 * Rounds each component of a double-precision complex floating-point number to the nearest integer.
@@ -48,7 +48,7 @@ stdlib_complex128_t stdlib_base_cround( const stdlib_complex128_t z ) {
 
 	stdlib_complex128_reim( z, &re, &im );
 
-	re = round( re ); // TODO: replace with stdlib function once available
-	im = round( im ); // TODO: replace with stdlib function once available
+	re = stdlib_base_round( re );
+	im = stdlib_base_round( im );
 	return stdlib_complex128( re, im );
 }


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Completes the TODO to use `stdlib_base_round` instead of builtin in the C implementation of [`math/base/special/cround`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/cround).
-   updates C benchmarks to follow latest conventions.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
