### PR TITLE
refactor: remove unused header, update benchmarks in `math/base/special/croundf`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/croundf/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/benchmark/c/benchmark.c
@@ -91,19 +91,22 @@ static float rand_float( void ) {
 static double benchmark( void ) {
 	double elapsed;
 	double t;
-	float re;
-	float im;
+	float re[ 100 ];
+	float im[ 100 ];
 	int i;
 
 	float complex z;
 	float complex y;
 
+	for ( i = 0; i < 100; i++ ) {
+		re[ i ] = ( 1000.0f * rand_float() ) - 500.0f;
+		im[ i ] = ( 1000.0f * rand_float() ) - 500.0f;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		re = ( 1000.0*rand_float() ) - 500.0;
-		im = ( 1000.0*rand_float() ) - 500.0;
-		z = re + im*I;
-		y = roundf( crealf(z) ) + roundf( cimagf(z) )*I;
+		z = re[ i % 100 ] + im[ i % 100 ]*I;
+		y = roundf( crealf( z ) ) + roundf( cimagf( z ) )*I;
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/croundf/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/benchmark/c/native/benchmark.c
@@ -93,19 +93,22 @@ static float rand_float( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
+	float v[ 100 ];
 	double t;
 	float re;
 	float im;
-	float v;
 	int i;
 
 	stdlib_complex64_t x;
 	stdlib_complex64_t y;
 
+	for ( i = 0; i < 100; i++ ) {
+		v[ i ] = ( 1000.0f * rand_float() ) - 500.0f;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		v = ( 1000.0*rand_float() ) - 500.0;
-		x = stdlib_complex64( v, v );
+		x = stdlib_complex64( v[ i % 100 ], v[ i % 100 ] );
 		y = stdlib_base_croundf( x );
 		stdlib_complex64_reim( y, &re, &im );
 		if ( re != re ) {

--- a/lib/node_modules/@stdlib/math/base/special/croundf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/src/main.c
@@ -20,7 +20,6 @@
 #include "stdlib/math/base/special/roundf.h"
 #include "stdlib/complex/float32/ctor.h"
 #include "stdlib/complex/float32/reim.h"
-#include <math.h>
 
 /**
 * Rounds each component of a single-precision complex floating-point number to the nearest integer.


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   removes unused `math.h` header in [`math/base/special/croundf`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/croundf).
-   updates C benchmarks to follow latest conventions.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
