### PR TITLE
refactor: replace built-in with `stdlib_base_atan2` in `math/base/special/cphase`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cphase/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/benchmark/c/benchmark.c
@@ -90,17 +90,20 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double re;
-	double im;
+	double re[ 100 ];
+	double im[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		re[ i ] = ( 1000.0 * rand_double() ) - 500.0;
+		im[ i ] = ( 1000.0 * rand_double() ) - 500.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		re = ( 1000.0*rand_double() ) - 500.0;
-		im = ( 1000.0*rand_double() ) - 500.0;
-		double complex z = re + im*I;
+		double complex z = re[ i % 100 ] + im[ i % 100 ] * I;
 		y = carg( z );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );

--- a/lib/node_modules/@stdlib/math/base/special/cphase/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/benchmark/c/native/benchmark.c
@@ -93,19 +93,22 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double re;
-	double im;
+	double re[ 100 ];
+	double im[ 100 ];
 	double y;
 	double t;
 	int i;
 
 	stdlib_complex128_t z;
 
+	for ( i = 0; i < 100; i++ ) {
+		re[ i ] = ( 1000.0 * rand_double() ) - 500.0;
+		im[ i ] = ( 1000.0 * rand_double() ) - 500.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		re = ( 1000.0*rand_double() ) - 500.0;
-		im = ( 1000.0*rand_double() ) - 500.0;
-		z = stdlib_complex128( re, im );
+		z = stdlib_complex128( re[ i % 100 ], im[ i % 100 ] );
 		y = stdlib_base_cphase( z );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );

--- a/lib/node_modules/@stdlib/math/base/special/cphase/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/manifest.json
@@ -38,7 +38,8 @@
       "dependencies": [
         "@stdlib/math/base/napi/unary",
         "@stdlib/complex/float64/ctor",
-        "@stdlib/complex/float64/reim"
+        "@stdlib/complex/float64/reim",
+        "@stdlib/math/base/special/atan2"
       ]
     },
     {
@@ -53,7 +54,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/complex/float64/ctor",
-        "@stdlib/complex/float64/reim"
+        "@stdlib/complex/float64/reim",
+        "@stdlib/math/base/special/atan2"
       ]
     },
     {
@@ -68,7 +70,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/complex/float64/ctor",
-        "@stdlib/complex/float64/reim"
+        "@stdlib/complex/float64/reim",
+        "@stdlib/math/base/special/atan2"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/cphase/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/src/main.c
@@ -19,7 +19,7 @@
 #include "stdlib/math/base/special/cphase.h"
 #include "stdlib/complex/float64/ctor.h"
 #include "stdlib/complex/float64/reim.h"
-#include <math.h>
+#include "stdlib/math/base/special/atan2.h"
 
 /**
 * Computes the argument of a complex double-precision complex floating-point number in radians.
@@ -41,5 +41,5 @@ double stdlib_base_cphase( const stdlib_complex128_t z ) {
 	double im;
 
 	stdlib_complex128_reim( z, &re, &im );
-	return atan2( im, re ); // TODO: replace with stdlib function once available
+	return stdlib_base_atan2( im, re );
 }

--- a/lib/node_modules/@stdlib/math/base/special/cphase/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/test/test.js
@@ -48,113 +48,113 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'the function returns `NaN` if provided `NaN` as either of the arguments', function test( t ) {
-	t.strictEqual( isnan( cphase( new Complex128( 2.0, NaN ) ) ), true, 'returns NaN' );
-	t.strictEqual( isnan( cphase( new Complex128( NaN, 3.0 ) ) ), true, 'returns NaN' );
+	t.strictEqual( isnan( cphase( new Complex128( 2.0, NaN ) ) ), true, 'returns expected value' );
+	t.strictEqual( isnan( cphase( new Complex128( NaN, 3.0 ) ) ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+0` if provided `im = +0.0` and `re >= 0`', function test( t ) {
-	t.strictEqual( cphase( new Complex128( 0.0, +0.0) ), +0.0, 'returns +0' );
-	t.strictEqual( cphase( new Complex128( 2.0, +0.0) ), +0.0, 'returns +0' );
-	t.strictEqual( cphase( new Complex128( 4.0, +0.0) ), +0.0, 'returns +0' );
-	t.strictEqual( cphase( new Complex128( 5.0, +0.0) ), +0.0, 'returns +0' );
-	t.strictEqual( cphase( new Complex128( 10.0, +0.0) ), +0.0, 'returns +0' );
+	t.strictEqual( cphase( new Complex128( 0.0, +0.0) ), +0.0, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( 2.0, +0.0) ), +0.0, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( 4.0, +0.0) ), +0.0, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( 5.0, +0.0) ), +0.0, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( 10.0, +0.0) ), +0.0, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-0` if provided `im = -0.0` and `re >= 0`', function test( t ) {
-	t.strictEqual( isNegativeZero( cphase( new Complex128( 0.0, -0.0 ) ) ), true, 'returns -0' );
-	t.strictEqual( isNegativeZero( cphase( new Complex128( 2.0, -0.0 ) ) ), true, 'returns -0' );
-	t.strictEqual( isNegativeZero( cphase( new Complex128( 4.0, -0.0 ) ) ), true, 'returns -0' );
-	t.strictEqual( isNegativeZero( cphase( new Complex128( 5.0, -0.0 ) ) ), true, 'returns -0' );
-	t.strictEqual( isNegativeZero( cphase( new Complex128( 10.0, -0.0 ) ) ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( cphase( new Complex128( 0.0, -0.0 ) ) ), true, 'returns expected value' );
+	t.strictEqual( isNegativeZero( cphase( new Complex128( 2.0, -0.0 ) ) ), true, 'returns expected value' );
+	t.strictEqual( isNegativeZero( cphase( new Complex128( 4.0, -0.0 ) ) ), true, 'returns expected value' );
+	t.strictEqual( isNegativeZero( cphase( new Complex128( 5.0, -0.0 ) ) ), true, 'returns expected value' );
+	t.strictEqual( isNegativeZero( cphase( new Complex128( 10.0, -0.0 ) ) ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `PI` if provided `im = +0.0` and `re <= -0.0`', function test( t ) {
-	t.strictEqual( cphase( new Complex128( -0.0, +0.0 ) ), +PI, 'returns +PI' );
-	t.strictEqual( cphase( new Complex128( -2.0, +0.0 ) ), +PI, 'returns +PI' );
-	t.strictEqual( cphase( new Complex128( -4.0, +0.0 ) ), +PI, 'returns +PI' );
-	t.strictEqual( cphase( new Complex128( -5.0, +0.0 ) ), +PI, 'returns +PI' );
-	t.strictEqual( cphase( new Complex128( -10.0, +0.0 ) ), +PI, 'returns +PI' );
+	t.strictEqual( cphase( new Complex128( -0.0, +0.0 ) ), +PI, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( -2.0, +0.0 ) ), +PI, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( -4.0, +0.0 ) ), +PI, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( -5.0, +0.0 ) ), +PI, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( -10.0, +0.0 ) ), +PI, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-PI` if provided `im = -0.0` and `re <= -0.0`', function test( t ) {
-	t.strictEqual( cphase( new Complex128( -0.0, -0.0 ) ), -PI, 'returns -PI' );
-	t.strictEqual( cphase( new Complex128( -2.0, -0.0 ) ), -PI, 'returns -PI' );
-	t.strictEqual( cphase( new Complex128( -4.0, -0.0 ) ), -PI, 'returns -PI' );
-	t.strictEqual( cphase( new Complex128( -5.0, -0.0 ) ), -PI, 'returns -PI' );
-	t.strictEqual( cphase( new Complex128( -10.0, -0.0 ) ), -PI, 'returns -PI' );
+	t.strictEqual( cphase( new Complex128( -0.0, -0.0 ) ), -PI, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( -2.0, -0.0 ) ), -PI, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( -4.0, -0.0 ) ), -PI, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( -5.0, -0.0 ) ), -PI, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( -10.0, -0.0 ) ), -PI, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+PI/4` if provided `re = im = +infinity`', function test( t ) {
-	t.strictEqual( cphase( new Complex128( PINF, PINF ) ), +PI/4.0, 'returns +PI/4' );
+	t.strictEqual( cphase( new Complex128( PINF, PINF ) ), +PI/4.0, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-PI/4` if provided `re = -im = +infinity`', function test( t ) {
-	t.strictEqual( cphase( new Complex128( PINF, NINF ) ), -PI/4.0, 'returns -PI/4' );
+	t.strictEqual( cphase( new Complex128( PINF, NINF ) ), -PI/4.0, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `*3*PI/4` if provided `-re = im = +infinity`', function test( t ) {
-	t.strictEqual( cphase( new Complex128( NINF, PINF ) ), +3.0*PI/4.0, 'returns +3*PI/4' );
+	t.strictEqual( cphase( new Complex128( NINF, PINF ) ), +3.0*PI/4.0, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-3*PI/4` if provided `re = im = -infinity`', function test( t ) {
-	t.strictEqual( cphase( new Complex128( NINF, NINF ) ), -3.0*PI/4.0, 'returns -3*PI/4' );
+	t.strictEqual( cphase( new Complex128( NINF, NINF ) ), -3.0*PI/4.0, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `0.0` when `re = +infinity`', function test( t ) {
-	t.strictEqual( cphase( new Complex128( PINF, -2.0 ) ), 0.0, 'returns 0.0' );
-	t.strictEqual( cphase( new Complex128( PINF, 0.0 ) ), 0.0, 'returns 0.0' );
-	t.strictEqual( cphase( new Complex128( PINF, 2.0 ) ), 0.0, 'returns 0.0' );
+	t.strictEqual( cphase( new Complex128( PINF, -2.0 ) ), 0.0, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( PINF, 0.0 ) ), 0.0, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( PINF, 2.0 ) ), 0.0, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+PI` when `im > 0` and `re = -infinity`', function test( t ) {
-	t.strictEqual( cphase( new Complex128( NINF, 1.0 ) ), PI, 'returns PI' );
-	t.strictEqual( cphase( new Complex128( NINF, 2.0 ) ), PI, 'returns PI' );
-	t.strictEqual( cphase( new Complex128( NINF, 3.0 ) ), PI, 'returns PI' );
+	t.strictEqual( cphase( new Complex128( NINF, 1.0 ) ), PI, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( NINF, 2.0 ) ), PI, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( NINF, 3.0 ) ), PI, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-PI` when `im < 0` and `re = -infinity`', function test( t ) {
-	t.strictEqual( cphase( new Complex128( NINF, -1.0 ) ), -PI, 'returns -PI' );
-	t.strictEqual( cphase( new Complex128( NINF, -2.0 ) ), -PI, 'returns -PI' );
-	t.strictEqual( cphase( new Complex128( NINF, -3.0 ) ), -PI, 'returns -PI' );
+	t.strictEqual( cphase( new Complex128( NINF, -1.0 ) ), -PI, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( NINF, -2.0 ) ), -PI, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( NINF, -3.0 ) ), -PI, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+PI/2` when `im = +infinity`', function test( t ) {
-	t.strictEqual( cphase( new Complex128( -1.0, PINF ) ), PI/2.0, 'returns PI/2' );
-	t.strictEqual( cphase( new Complex128( 0.0, PINF ) ), PI/2.0, 'returns PI/2' );
-	t.strictEqual( cphase( new Complex128( 2.0, PINF ) ), PI/2.0, 'returns PI/2' );
+	t.strictEqual( cphase( new Complex128( -1.0, PINF ) ), PI/2.0, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( 0.0, PINF ) ), PI/2.0, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( 2.0, PINF ) ), PI/2.0, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-PI/2` when `im = -infinity`', function test( t ) {
-	t.strictEqual( cphase( new Complex128( -1.0, NINF ) ), -PI/2.0, 'returns -PI/2' );
-	t.strictEqual( cphase( new Complex128( 0.0, NINF ) ), -PI/2.0, 'returns -PI/2' );
-	t.strictEqual( cphase( new Complex128( 2.0, NINF ) ), -PI/2.0, 'returns -PI/2' );
+	t.strictEqual( cphase( new Complex128( -1.0, NINF ) ), -PI/2.0, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( 0.0, NINF ) ), -PI/2.0, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( 2.0, NINF ) ), -PI/2.0, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `PI/2` if provided a positive `im` and `re=0`', function test( t ) {
-	t.strictEqual( cphase( new Complex128( 0.0, 2.0 ) ), PI/2.0, 'returns PI/2' );
-	t.strictEqual( cphase( new Complex128( 0.0, 1.0 ) ), PI/2.0, 'returns PI/2' );
-	t.strictEqual( cphase( new Complex128( 0.0, 0.5 ) ), PI/2.0, 'returns PI/2' );
+	t.strictEqual( cphase( new Complex128( 0.0, 2.0 ) ), PI/2.0, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( 0.0, 1.0 ) ), PI/2.0, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( 0.0, 0.5 ) ), PI/2.0, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-PI/2` if provided a negative `im` and `re=0`', function test( t ) {
-	t.strictEqual( cphase( new Complex128( 0.0, -2.0 ) ), -PI/2.0, 'returns PI/2' );
-	t.strictEqual( cphase( new Complex128( 0.0, -1.0 ) ), -PI/2.0, 'returns PI/2' );
-	t.strictEqual( cphase( new Complex128( 0.0, -0.5 ) ), -PI/2.0, 'returns PI/2' );
+	t.strictEqual( cphase( new Complex128( 0.0, -2.0 ) ), -PI/2.0, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( 0.0, -1.0 ) ), -PI/2.0, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( 0.0, -0.5 ) ), -PI/2.0, 'returns expected value' );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/math/base/special/cphase/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/test/test.native.js
@@ -57,113 +57,113 @@ tape( 'main export is a function', opts, function test( t ) {
 });
 
 tape( 'the function returns `NaN` if provided `NaN` as either of the arguments', opts, function test( t ) {
-	t.strictEqual( isnan( cphase( new Complex128( 2.0, NaN ) ) ), true, 'returns NaN' );
-	t.strictEqual( isnan( cphase( new Complex128( NaN, 3.0 ) ) ), true, 'returns NaN' );
+	t.strictEqual( isnan( cphase( new Complex128( 2.0, NaN ) ) ), true, 'returns expected value' );
+	t.strictEqual( isnan( cphase( new Complex128( NaN, 3.0 ) ) ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+0` if provided `im = +0.0` and `re >= 0`', opts, function test( t ) {
-	t.strictEqual( cphase( new Complex128( 0.0, +0.0) ), +0.0, 'returns +0' );
-	t.strictEqual( cphase( new Complex128( 2.0, +0.0) ), +0.0, 'returns +0' );
-	t.strictEqual( cphase( new Complex128( 4.0, +0.0) ), +0.0, 'returns +0' );
-	t.strictEqual( cphase( new Complex128( 5.0, +0.0) ), +0.0, 'returns +0' );
-	t.strictEqual( cphase( new Complex128( 10.0, +0.0) ), +0.0, 'returns +0' );
+	t.strictEqual( cphase( new Complex128( 0.0, +0.0) ), +0.0, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( 2.0, +0.0) ), +0.0, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( 4.0, +0.0) ), +0.0, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( 5.0, +0.0) ), +0.0, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( 10.0, +0.0) ), +0.0, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-0` if provided `im = -0.0` and `re >= 0`', opts, function test( t ) {
-	t.strictEqual( isNegativeZero( cphase( new Complex128( 0.0, -0.0 ) ) ), true, 'returns -0' );
-	t.strictEqual( isNegativeZero( cphase( new Complex128( 2.0, -0.0 ) ) ), true, 'returns -0' );
-	t.strictEqual( isNegativeZero( cphase( new Complex128( 4.0, -0.0 ) ) ), true, 'returns -0' );
-	t.strictEqual( isNegativeZero( cphase( new Complex128( 5.0, -0.0 ) ) ), true, 'returns -0' );
-	t.strictEqual( isNegativeZero( cphase( new Complex128( 10.0, -0.0 ) ) ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( cphase( new Complex128( 0.0, -0.0 ) ) ), true, 'returns expected value' );
+	t.strictEqual( isNegativeZero( cphase( new Complex128( 2.0, -0.0 ) ) ), true, 'returns expected value' );
+	t.strictEqual( isNegativeZero( cphase( new Complex128( 4.0, -0.0 ) ) ), true, 'returns expected value' );
+	t.strictEqual( isNegativeZero( cphase( new Complex128( 5.0, -0.0 ) ) ), true, 'returns expected value' );
+	t.strictEqual( isNegativeZero( cphase( new Complex128( 10.0, -0.0 ) ) ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `PI` if provided `im = +0.0` and `re <= -0.0`', opts, function test( t ) {
-	t.strictEqual( cphase( new Complex128( -0.0, +0.0 ) ), +PI, 'returns +PI' );
-	t.strictEqual( cphase( new Complex128( -2.0, +0.0 ) ), +PI, 'returns +PI' );
-	t.strictEqual( cphase( new Complex128( -4.0, +0.0 ) ), +PI, 'returns +PI' );
-	t.strictEqual( cphase( new Complex128( -5.0, +0.0 ) ), +PI, 'returns +PI' );
-	t.strictEqual( cphase( new Complex128( -10.0, +0.0 ) ), +PI, 'returns +PI' );
+	t.strictEqual( cphase( new Complex128( -0.0, +0.0 ) ), +PI, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( -2.0, +0.0 ) ), +PI, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( -4.0, +0.0 ) ), +PI, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( -5.0, +0.0 ) ), +PI, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( -10.0, +0.0 ) ), +PI, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-PI` if provided `im = -0.0` and `re <= -0.0`', opts, function test( t ) {
-	t.strictEqual( cphase( new Complex128( -0.0, -0.0 ) ), -PI, 'returns -PI' );
-	t.strictEqual( cphase( new Complex128( -2.0, -0.0 ) ), -PI, 'returns -PI' );
-	t.strictEqual( cphase( new Complex128( -4.0, -0.0 ) ), -PI, 'returns -PI' );
-	t.strictEqual( cphase( new Complex128( -5.0, -0.0 ) ), -PI, 'returns -PI' );
-	t.strictEqual( cphase( new Complex128( -10.0, -0.0 ) ), -PI, 'returns -PI' );
+	t.strictEqual( cphase( new Complex128( -0.0, -0.0 ) ), -PI, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( -2.0, -0.0 ) ), -PI, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( -4.0, -0.0 ) ), -PI, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( -5.0, -0.0 ) ), -PI, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( -10.0, -0.0 ) ), -PI, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+PI/4` if provided `re = im = +infinity`', opts, function test( t ) {
-	t.strictEqual( cphase( new Complex128( PINF, PINF ) ), +PI/4.0, 'returns +PI/4' );
+	t.strictEqual( cphase( new Complex128( PINF, PINF ) ), +PI/4.0, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-PI/4` if provided `re = -im = +infinity`', opts, function test( t ) {
-	t.strictEqual( cphase( new Complex128( PINF, NINF ) ), -PI/4.0, 'returns -PI/4' );
+	t.strictEqual( cphase( new Complex128( PINF, NINF ) ), -PI/4.0, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `*3*PI/4` if provided `-re = im = +infinity`', opts, function test( t ) {
-	t.strictEqual( cphase( new Complex128( NINF, PINF ) ), +3.0*PI/4.0, 'returns +3*PI/4' );
+	t.strictEqual( cphase( new Complex128( NINF, PINF ) ), +3.0*PI/4.0, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-3*PI/4` if provided `re = im = -infinity`', opts, function test( t ) {
-	t.strictEqual( cphase( new Complex128( NINF, NINF ) ), -3.0*PI/4.0, 'returns -3*PI/4' );
+	t.strictEqual( cphase( new Complex128( NINF, NINF ) ), -3.0*PI/4.0, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `0.0` when `re = +infinity`', opts, function test( t ) {
-	t.strictEqual( cphase( new Complex128( PINF, -2.0 ) ), 0.0, 'returns 0.0' );
-	t.strictEqual( cphase( new Complex128( PINF, 0.0 ) ), 0.0, 'returns 0.0' );
-	t.strictEqual( cphase( new Complex128( PINF, 2.0 ) ), 0.0, 'returns 0.0' );
+	t.strictEqual( cphase( new Complex128( PINF, -2.0 ) ), 0.0, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( PINF, 0.0 ) ), 0.0, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( PINF, 2.0 ) ), 0.0, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+PI` when `im > 0` and `re = -infinity`', opts, function test( t ) {
-	t.strictEqual( cphase( new Complex128( NINF, 1.0 ) ), PI, 'returns PI' );
-	t.strictEqual( cphase( new Complex128( NINF, 2.0 ) ), PI, 'returns PI' );
-	t.strictEqual( cphase( new Complex128( NINF, 3.0 ) ), PI, 'returns PI' );
+	t.strictEqual( cphase( new Complex128( NINF, 1.0 ) ), PI, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( NINF, 2.0 ) ), PI, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( NINF, 3.0 ) ), PI, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-PI` when `im < 0` and `re = -infinity`', opts, function test( t ) {
-	t.strictEqual( cphase( new Complex128( NINF, -1.0 ) ), -PI, 'returns -PI' );
-	t.strictEqual( cphase( new Complex128( NINF, -2.0 ) ), -PI, 'returns -PI' );
-	t.strictEqual( cphase( new Complex128( NINF, -3.0 ) ), -PI, 'returns -PI' );
+	t.strictEqual( cphase( new Complex128( NINF, -1.0 ) ), -PI, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( NINF, -2.0 ) ), -PI, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( NINF, -3.0 ) ), -PI, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+PI/2` when `im = +infinity`', opts, function test( t ) {
-	t.strictEqual( cphase( new Complex128( -1.0, PINF ) ), PI/2.0, 'returns PI/2' );
-	t.strictEqual( cphase( new Complex128( 0.0, PINF ) ), PI/2.0, 'returns PI/2' );
-	t.strictEqual( cphase( new Complex128( 2.0, PINF ) ), PI/2.0, 'returns PI/2' );
+	t.strictEqual( cphase( new Complex128( -1.0, PINF ) ), PI/2.0, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( 0.0, PINF ) ), PI/2.0, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( 2.0, PINF ) ), PI/2.0, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-PI/2` when `im = -infinity`', opts, function test( t ) {
-	t.strictEqual( cphase( new Complex128( -1.0, NINF ) ), -PI/2.0, 'returns -PI/2' );
-	t.strictEqual( cphase( new Complex128( 0.0, NINF ) ), -PI/2.0, 'returns -PI/2' );
-	t.strictEqual( cphase( new Complex128( 2.0, NINF ) ), -PI/2.0, 'returns -PI/2' );
+	t.strictEqual( cphase( new Complex128( -1.0, NINF ) ), -PI/2.0, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( 0.0, NINF ) ), -PI/2.0, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( 2.0, NINF ) ), -PI/2.0, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `PI/2` if provided a positive `im` and `re=0`', opts, function test( t ) {
-	t.strictEqual( cphase( new Complex128( 0.0, 2.0 ) ), PI/2.0, 'returns PI/2' );
-	t.strictEqual( cphase( new Complex128( 0.0, 1.0 ) ), PI/2.0, 'returns PI/2' );
-	t.strictEqual( cphase( new Complex128( 0.0, 0.5 ) ), PI/2.0, 'returns PI/2' );
+	t.strictEqual( cphase( new Complex128( 0.0, 2.0 ) ), PI/2.0, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( 0.0, 1.0 ) ), PI/2.0, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( 0.0, 0.5 ) ), PI/2.0, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-PI/2` if provided a negative `im` and `re=0`', opts, function test( t ) {
-	t.strictEqual( cphase( new Complex128( 0.0, -2.0 ) ), -PI/2.0, 'returns PI/2' );
-	t.strictEqual( cphase( new Complex128( 0.0, -1.0 ) ), -PI/2.0, 'returns PI/2' );
-	t.strictEqual( cphase( new Complex128( 0.0, -0.5 ) ), -PI/2.0, 'returns PI/2' );
+	t.strictEqual( cphase( new Complex128( 0.0, -2.0 ) ), -PI/2.0, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( 0.0, -1.0 ) ), -PI/2.0, 'returns expected value' );
+	t.strictEqual( cphase( new Complex128( 0.0, -0.5 ) ), -PI/2.0, 'returns expected value' );
 	t.end();
 });
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   completes the TODO to replace the use of built-in function with `stdib_base_atan2`  in [`math/base/special/cphase`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/cphase).
-   updates benchmarks and tests to follow latest conventions.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
