### PR TITLE
docs: use correct image link for the talk

### DIFF
--- a/docs/talks.md
+++ b/docs/talks.md
@@ -182,7 +182,7 @@ limitations under the License.
 
 <div class="image" align="center">
     <a title="Advanced Mathematics and Data Analysis with JavaScript" href="https://youtu.be/7sejh8DguBU?t=19919">
-        <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@66d46fdc5aa64c904479c36c7ed3b069ecd7039d/docs/assets/talks/jsnation_us_2024_gunj_joshi.png" alt="Advanced Mathematics and Data Analysis with JavaScript">
+        <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@fa25196d70829930020772d9e8de37a5a000b396/docs/assets/talks/jsnation_us_2024_gunj_joshi.png" alt="Advanced Mathematics and Data Analysis with JavaScript">
     </a>
     <br>
 </div>


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   changes the link to the image of the talk, with the correct commit hash, in [`docs/talks.md`](https://github.com/stdlib-js/stdlib/blob/develop/docs/talks.md?plain=1#L185).

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
