### PR TITLE
fix: extract the scalar constant as a float in `blas/ext/base/dsapxsum`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dsapxsum/src/addon.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsapxsum/src/addon.c
@@ -21,7 +21,7 @@
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
-#include "stdlib/napi/argv_double.h"
+#include "stdlib/napi/argv_float.h"
 #include "stdlib/napi/argv_strided_float32array.h"
 #include "stdlib/napi/create_double.h"
 #include <node_api.h>
@@ -36,7 +36,7 @@
 static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV( env, info, argv, argc, 4 );
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
-	STDLIB_NAPI_ARGV_DOUBLE( env, alpha, argv, 1 );
+	STDLIB_NAPI_ARGV_FLOAT( env, alpha, argv, 1 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 2 );
 	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dsapxsum)( N, alpha, X, strideX ), v );
@@ -53,7 +53,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV( env, info, argv, argc, 5 );
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
-	STDLIB_NAPI_ARGV_DOUBLE( env, alpha, argv, 1 );
+	STDLIB_NAPI_ARGV_FLOAT( env, alpha, argv, 1 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 3 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 4 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 2 );

--- a/lib/node_modules/@stdlib/blas/ext/base/dsapxsum/src/main.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsapxsum/src/main.c
@@ -24,11 +24,11 @@
 /**
 * Adds a scalar constant to each single-precision floating-point strided array element, and computes the sum using extended accumulation and returning an extended precision result.
 *
-* @param N       number of indexed elements
-* @param alpha   scalar constant
-* @param X       input array
+* @param N        number of indexed elements
+* @param alpha    scalar constant
+* @param X        input array
 * @param strideX  stride length
-* @return        output value
+* @return         output value
 */
 double API_SUFFIX(stdlib_strided_dsapxsum)( const CBLAS_INT N, const float alpha, const float *X, const CBLAS_INT strideX ) {
 	CBLAS_INT ox = stdlib_strided_stride2offset( N, strideX );
@@ -38,12 +38,12 @@ double API_SUFFIX(stdlib_strided_dsapxsum)( const CBLAS_INT N, const float alpha
 /**
 * Adds a scalar constant to each single-precision floating-point strided array element, and computes the sum using extended accumulation and using alternative indexing semantics and returning an extended precision result.
 *
-* @param N       number of indexed elements
-* @param alpha   scalar constant
-* @param X       input array
+* @param N        number of indexed elements
+* @param alpha    scalar constant
+* @param X        input array
 * @param strideX  stride length
 * @param offsetX  starting index
-* @return        output value
+* @return         output value
 */
 double API_SUFFIX(stdlib_strided_dsapxsum_ndarray)( const CBLAS_INT N, const float alpha, const float *X, const CBLAS_INT strideX, const CBLAS_INT offsetX ) {
 	return API_SUFFIX(stdlib_strided_dsapxsumpw_ndarray)( N, alpha, X, strideX, offsetX );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   fix the data type of the scalar constant in `blas/ext/base/dsapxsum`

## Related Issues

> Does this pull request have any related issues?

No. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
