### PR TITLE
fix: extract the scalar constant as a float in `blas/ext/base/dsapxsumpw`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dsapxsumpw/manifest.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsapxsumpw/manifest.json
@@ -41,7 +41,7 @@
         "@stdlib/napi/export",
         "@stdlib/napi/argv",
         "@stdlib/napi/argv-int64",
-        "@stdlib/napi/argv-double",
+        "@stdlib/napi/argv-float",
         "@stdlib/napi/argv-strided-float32array",
         "@stdlib/napi/create-double"
       ]

--- a/lib/node_modules/@stdlib/blas/ext/base/dsapxsumpw/src/addon.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsapxsumpw/src/addon.c
@@ -21,7 +21,7 @@
 #include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
-#include "stdlib/napi/argv_double.h"
+#include "stdlib/napi/argv_float.h"
 #include "stdlib/napi/argv_int64.h"
 #include "stdlib/napi/argv_strided_float32array.h"
 #include "stdlib/napi/create_double.h"
@@ -37,7 +37,7 @@
 static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV( env, info, argv, argc, 4 );
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
-	STDLIB_NAPI_ARGV_DOUBLE( env, alpha, argv, 1 );
+	STDLIB_NAPI_ARGV_FLOAT( env, alpha, argv, 1 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 2 );
 	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dsapxsumpw)( N, alpha, X, strideX ), v );
@@ -54,7 +54,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV( env, info, argv, argc, 5 );
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
-	STDLIB_NAPI_ARGV_DOUBLE( env, alpha, argv, 1 );
+	STDLIB_NAPI_ARGV_FLOAT( env, alpha, argv, 1 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 3 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 4 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 2 );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   fix the data type of the scalar constant in `blas/ext/base/dsapxsumpw`

## Related Issues

> Does this pull request have any related issues?

No. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
