### PR TITLE
feat: add `map` method to `array/fixed-endian-factory`

### DIFF
--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
@@ -490,15 +490,16 @@ var v = arr.get( 100 );
 Returns a new array with each element being the result of a provided callback function.
 
 ```javascript
-function invert( v ) {
-    return v * -1;
+function fcn( v ) {
+    return -v;
 }
 
 var Float64ArrayFE = fixedEndianFactory( 'float64' );
+
 var arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 3.0 ] );
 // returns <Float64ArrayFE>
 
-var out = arr.map( invert );
+var out = arr.map( fcn );
 // returns <Float64ArrayFE>
 
 var z = out.get( 0 );
@@ -520,12 +521,13 @@ The callback function is provided three arguments:
 To set the function execution context, provide a `thisArg`.
 
 ```javascript
-function invert( v, i ) {
+function fcn( v, i ) {
     this.count += i;
-    return v * -1;
+    return -v;
 }
 
 var Float64ArrayFE = fixedEndianFactory( 'float64' );
+
 var arr = new Float64ArrayFE( 'little-endian', 3 );
 
 arr.set( -1.0, 0 );
@@ -536,7 +538,7 @@ var context = {
     'count': 0
 };
 
-var out = arr.map( invert, context );
+var out = arr.map( fcn, context );
 // returns <Float64ArrayFE>
 
 var count = context.count;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
@@ -483,6 +483,66 @@ var v = arr.get( 100 );
 // returns undefined
 ```
 
+<a name="method-map"></a>
+
+#### TypedArray.prototype.map( callbackFn\[, thisArg] )
+
+Returns a new array with each element being the result of a provided callback function.
+
+```javascript
+function invert( v ) {
+    return v * -1;
+}
+
+var Float64ArrayFE = fixedEndianFactory( 'float64' );
+var arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 3.0 ] );
+// returns <Float64ArrayFE>
+
+var out = arr.map( invert );
+// returns <Float64ArrayFE>
+
+var z = out.get( 0 );
+// returns -1.0
+
+z = out.get( 1 );
+// returns -2.0
+
+z = out.get( 2 );
+// returns -3.0
+```
+
+The callback function is provided three arguments:
+
+-   **value**: current array element.
+-   **index**: current array element index.
+-   **arr**: the array on which this method was called.
+
+To set the function execution context, provide a `thisArg`.
+
+```javascript
+function invert( v, i ) {
+    this.count += i;
+    return v * -1;
+}
+
+var Float64ArrayFE = fixedEndianFactory( 'float64' );
+var arr = new Float64ArrayFE( 'little-endian', 3 );
+
+arr.set( -1.0, 0 );
+arr.set( 1.0, 1 );
+arr.set( -1.0, 2 );
+
+var context = {
+    'count': 0
+};
+
+var out = arr.map( invert, context );
+// returns <Float64ArrayFE>
+
+var count = context.count;
+// returns 3;
+```
+
 <a name="method-set"></a>
 
 #### TypedArrayFE.prototype.set( arr\[, offset] )

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.map.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.map.js
@@ -21,8 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var pkg = require( '@stdlib/array/fixed-endian-factory/package.json' ).name;
-var factory = require( '@stdlib/array/fixed-endian-factory/lib' );
+var pkg = require( './../package.json' ).name;
+var factory = require( './../lib' );
 
 
 // VARIABLES //

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.map.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.map.js
@@ -1,0 +1,59 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pkg = require( '@stdlib/array/fixed-endian-factory/package.json' ).name;
+var factory = require( '@stdlib/array/fixed-endian-factory/lib' );
+
+
+// VARIABLES //
+
+var Float64ArrayFE = factory( 'float64' );
+
+
+// MAIN //
+
+bench( pkg+':map', function benchmark( b ) {
+	var out;
+	var arr;
+	var i;
+
+	arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 2.0, 1.0 ] );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = arr.map( identity );
+		if ( typeof out !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+	if ( !( out instanceof Float64ArrayFE ) ) {
+		b.fail( 'should return a typed array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+
+	function identity( v ) {
+		return v;
+	}
+});

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.map.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.map.length.js
@@ -23,8 +23,8 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var zeroTo = require( '@stdlib/array/zero-to' );
-var pkg = require( '@stdlib/array/fixed-endian-factory/package.json' ).name;
-var factory = require( '@stdlib/array/fixed-endian-factory/lib' );
+var pkg = require( './../package.json' ).name;
+var factory = require( './../lib' );
 
 
 // VARIABLES //
@@ -41,7 +41,7 @@ var Float64ArrayFE = factory( 'float64' );
 * @param {number} value - array element
 * @param {NonNegativeInteger} idx - array element index
 * @param {TypedArray} arr - array instance
-* @returns {number} the same number
+* @returns {number} input array element
 */
 function identity( value ) {
 	return value;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.map.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.map.length.js
@@ -1,0 +1,112 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var zeroTo = require( '@stdlib/array/zero-to' );
+var pkg = require( '@stdlib/array/fixed-endian-factory/package.json' ).name;
+var factory = require( '@stdlib/array/fixed-endian-factory/lib' );
+
+
+// VARIABLES //
+
+var Float64ArrayFE = factory( 'float64' );
+
+
+// FUNCTIONS //
+
+/**
+* Identity function.
+*
+* @private
+* @param {number} value - array element
+* @param {NonNegativeInteger} idx - array element index
+* @param {TypedArray} arr - array instance
+* @returns {number} the same number
+*/
+function identity( value ) {
+	return value;
+}
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var arr = new Float64ArrayFE( 'little-endian', zeroTo( len ) );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var out;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			out = arr.map( identity );
+			if ( typeof out !== 'object' ) {
+				b.fail( 'should return an object' );
+			}
+		}
+		b.toc();
+		if ( !(out instanceof Float64ArrayFE) ) {
+			b.fail( 'should return a TypedArray' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':map:len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.map.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.map.length.js
@@ -76,7 +76,7 @@ function createBenchmark( len ) {
 			}
 		}
 		b.toc();
-		if ( !(out instanceof Float64ArrayFE) ) {
+		if ( !( out instanceof Float64ArrayFE ) ) {
 			b.fail( 'should return a TypedArray' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
@@ -633,6 +633,7 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 	* @throws {TypeError} first argument must be a function
 	*/
 	setReadOnly( TypedArray.prototype, 'map', function map( fcn, thisArg ) {
+		var order;
 		var out;
 		var buf;
 		var i;
@@ -643,8 +644,13 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 		if ( !isFunction( fcn ) ) {
 			throw new TypeError( format( 'invalid argument. First argument must be a function. Value: `%s`.', fcn ) );
 		}
+		if ( this._isLE ) {
+			order = 'little-endian';
+		} else {
+			order = 'big-endian';
+		}
 		buf = this._buffer;
-		out = new this.constructor( 'little-endian', this._length );
+		out = new this.constructor( order, this._length );
 		for ( i = 0; i < this._length; i++ ) {
 			x = fcn.call( thisArg, buf[ GETTER ]( i*BYTES_PER_ELEMENT, this._isLE ), i, this );
 			out._buffer[ SETTER ]( i*BYTES_PER_ELEMENT, x, this._isLE); // eslint-disable-line no-underscore-dangle

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
@@ -51,6 +51,8 @@ var fromIteratorMap = require( './from_iterator_map.js' );
 // VARIABLES //
 
 var HAS_ITERATOR_SYMBOL = hasIteratorSymbolSupport();
+var LITTLE_ENDIAN = 'little-endian';
+var BIG_ENDIAN = 'big-endian';
 var DTYPES = [ 'float64', 'float32', 'int32', 'int16', 'uint32', 'uint16' ];
 var DTYPE2SET = {
 	'float64': 'setFloat64',
@@ -99,7 +101,18 @@ function byteOrder( value ) {
 * @returns {boolean} boolean indicating whether a byte order is little-endian byte order
 */
 function isLittleEndian( value ) {
-	return ( value === 'little-endian' );
+	return ( value === LITTLE_ENDIAN );
+}
+
+/**
+* Resolves a byte order string from a boolean flag.
+*
+* @private
+* @param {boolean} isLE - flag indicating whether an array is little-endian
+* @returns {string} resolved byte order
+*/
+function flag2byteOrder( isLE ) {
+	return ( isLE ) ? LITTLE_ENDIAN : BIG_ENDIAN;
 }
 
 /**
@@ -622,44 +635,6 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 	});
 
 	/**
-	* Returns a new array with each element being the result of a provided callback function.
-	*
-	* @name map
-	* @memberof TypedArray.prototype
-	* @type {Function}
-	* @param {Function} fcn - function to invoke
-	* @param {*} [thisArg] - function invocation context
-	* @throws {TypeError} `this` must be a typed array instance
-	* @throws {TypeError} first argument must be a function
-	* @returns {TypedArray} new array
-	*/
-	setReadOnly( TypedArray.prototype, 'map', function map( fcn, thisArg ) {
-		var order;
-		var out;
-		var buf;
-		var i;
-		var x;
-		if ( !isTypedArray( this ) ) {
-			throw new TypeError( format( 'invalid invocation. `this` is not %s %s.', CHAR2ARTICLE[ dtype[0] ], CTOR_NAME ) );
-		}
-		if ( !isFunction( fcn ) ) {
-			throw new TypeError( format( 'invalid argument. First argument must be a function. Value: `%s`.', fcn ) );
-		}
-		if ( this._isLE ) {
-			order = 'little-endian';
-		} else {
-			order = 'big-endian';
-		}
-		buf = this._buffer;
-		out = new this.constructor( order, this._length );
-		for ( i = 0; i < this._length; i++ ) {
-			x = fcn.call( thisArg, buf[ GETTER ]( i*BYTES_PER_ELEMENT, this._isLE ), i, this );
-			out._buffer[ SETTER ]( i*BYTES_PER_ELEMENT, x, this._isLE); // eslint-disable-line no-underscore-dangle
-		}
-		return out;
-	});
-
-	/**
 	* Number of array elements.
 	*
 	* @private
@@ -670,6 +645,41 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 	*/
 	setReadOnlyAccessor( TypedArray.prototype, 'length', function get() {
 		return this._length;
+	});
+
+	/**
+	* Returns a new array with each element being the result of a provided callback function.
+	*
+	* @private
+	* @name map
+	* @memberof TypedArray.prototype
+	* @type {Function}
+	* @param {Function} fcn - function to invoke
+	* @param {*} [thisArg] - function invocation context
+	* @throws {TypeError} `this` must be a typed array instance
+	* @throws {TypeError} first argument must be a function
+	* @returns {TypedArray} new typed array
+	*/
+	setReadOnly( TypedArray.prototype, 'map', function map( fcn, thisArg ) {
+		var obuf;
+		var out;
+		var buf;
+		var i;
+		var v;
+		if ( !isTypedArray( this ) ) {
+			throw new TypeError( format( 'invalid invocation. `this` is not %s %s.', CHAR2ARTICLE[ dtype[0] ], CTOR_NAME ) );
+		}
+		if ( !isFunction( fcn ) ) {
+			throw new TypeError( format( 'invalid argument. First argument must be a function. Value: `%s`.', fcn ) );
+		}
+		buf = this._buffer;
+		out = new this.constructor( flag2byteOrder( this._isLE ), this._length );
+		obuf = out._buffer; // eslint-disable-line no-underscore-dangle
+		for ( i = 0; i < this._length; i++ ) {
+			v = fcn.call( thisArg, buf[ GETTER ]( i * BYTES_PER_ELEMENT, this._isLE ), i, this );
+			obuf[ SETTER ]( i * BYTES_PER_ELEMENT, v, this._isLE );
+		}
+		return out;
 	});
 
 	/**

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
@@ -631,6 +631,7 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 	* @param {*} [thisArg] - function invocation context
 	* @throws {TypeError} `this` must be a typed array instance
 	* @throws {TypeError} first argument must be a function
+	* @returns {TypedArray} new array
 	*/
 	setReadOnly( TypedArray.prototype, 'map', function map( fcn, thisArg ) {
 		var order;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
@@ -622,6 +622,37 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 	});
 
 	/**
+	* Returns a new array with each element being the result of a provided callback function.
+	*
+	* @name map
+	* @memberof TypedArray.prototype
+	* @type {Function}
+	* @param {Function} fcn - function to invoke
+	* @param {*} [thisArg] - function invocation context
+	* @throws {TypeError} `this` must be a typed array instance
+	* @throws {TypeError} first argument must be a function
+	*/
+	setReadOnly( TypedArray.prototype, 'map', function map( fcn, thisArg ) {
+		var out;
+		var buf;
+		var i;
+		var x;
+		if ( !isTypedArray( this ) ) {
+			throw new TypeError( format( 'invalid invocation. `this` is not %s %s.', CHAR2ARTICLE[ dtype[0] ], CTOR_NAME ) );
+		}
+		if ( !isFunction( fcn ) ) {
+			throw new TypeError( format( 'invalid argument. First argument must be a function. Value: `%s`.', fcn ) );
+		}
+		buf = this._buffer;
+		out = new this.constructor( 'little-endian', this._length );
+		for ( i = 0; i < this._length; i++ ) {
+			x = fcn.call( thisArg, buf[ GETTER ]( i*BYTES_PER_ELEMENT, this._isLE ), i, this );
+			out._buffer[ SETTER ]( i*BYTES_PER_ELEMENT, x, this._isLE); // eslint-disable-line no-underscore-dangle
+		}
+		return out;
+	});
+
+	/**
 	* Number of array elements.
 	*
 	* @private

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/test/test.map.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/test/test.map.js
@@ -128,21 +128,25 @@ tape( 'the method returns an empty array if operating on an empty array', functi
 	t.end();
 });
 
-tape( 'the method returns a new boolean array containing elements which are the result of a provided callback function', function test( t ) {
+tape( 'the method returns a new typed array containing elements which are the result of a provided callback function', function test( t ) {
 	var expected;
 	var actual;
 	var ctor;
 	var arr;
 
 	ctor = factory( 'float64' );
-	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0 ]);
-	expected = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0 ] );
-	actual = arr.map( identity );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0 ] );
+	expected = new ctor( 'little-endian', [ 2.0, 4.0, 6.0, 8.0 ] );
+	actual = arr.map( scale );
 
 	t.strictEqual( actual instanceof ctor, true, 'returns expected value' );
 	t.strictEqual( actual.length, expected.length, 'returns expected value' );
 	t.notEqual( actual, arr, 'returns a new instance' );
 	t.end();
+
+	function scale( v ) {
+		return v * 2.0;
+	}
 });
 
 tape( 'the method supports providing an execution context', function test( t ) {
@@ -153,21 +157,21 @@ tape( 'the method supports providing an execution context', function test( t ) {
 	var ctx;
 
 	ctor = factory( 'float64' );
-
 	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0 ] );
 	expected = new ctor( 'little-endian', [ -1.0, -2.0, -3.0, -4.0 ] );
+
 	ctx = {
 		'count': 0
 	};
-	actual = arr.map( invert, ctx );
+	actual = arr.map( fcn, ctx );
 
 	t.strictEqual( actual instanceof ctor, true, 'returns expected value' );
 	t.strictEqual( actual.length, expected.length, 'returns expected value' );
 	t.strictEqual( ctx.count, 6, 'returns expected value' );
 	t.end();
 
-	function invert( v, i ) {
+	function fcn( v, i ) {
 		this.count += i; // eslint-disable-line no-invalid-this
-		return v * -1;
+		return -v;
 	}
 });

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/test/test.map.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/test/test.map.js
@@ -1,0 +1,173 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var identity = require( '@stdlib/utils/identity-function' );
+var factory = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof factory, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns a function', function test( t ) {
+	var ctor = factory( 'float64' );
+	t.strictEqual( isFunction( ctor ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the returned function is a `map` method', function test( t ) {
+	var ctor = factory( 'float64' );
+	t.strictEqual( hasOwnProp( ctor.prototype, 'map' ), true, 'returns expected value' );
+	t.strictEqual( isFunction( ctor.prototype.map ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a typed array instance', function test( t ) {
+	var values;
+	var ctor;
+	var arr;
+	var i;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.map.call( value, identity );
+		};
+	}
+});
+
+tape( 'the method throws an error if provided a first argument which is not a function', function test( t ) {
+	var values;
+	var ctor;
+	var arr;
+	var i;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0 ] );
+
+	values = [
+		'5',
+		3.14,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[]
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.map( value );
+		};
+	}
+});
+
+tape( 'the method returns an empty array if operating on an empty array', function test( t ) {
+	var ctor;
+	var arr;
+	var out;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian' );
+	out = arr.map( identity );
+
+	t.strictEqual( out instanceof ctor, true, 'returns expected value' );
+	t.strictEqual( out.length, 0, 'returns expected value' );
+	t.notEqual( out, arr, 'returns a new instance' );
+	t.end();
+});
+
+tape( 'the method returns a new boolean array containing elements which are the result of a provided callback function', function test( t ) {
+	var expected;
+	var actual;
+	var ctor;
+	var arr;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0 ]);
+	expected = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0 ] );
+	actual = arr.map( identity );
+
+	t.strictEqual( actual instanceof ctor, true, 'returns expected value' );
+	t.strictEqual( actual.length, expected.length, 'returns expected value' );
+	t.notEqual( actual, arr, 'returns a new instance' );
+	t.end();
+});
+
+tape( 'the method supports providing an execution context', function test( t ) {
+	var expected;
+	var actual;
+	var ctor;
+	var arr;
+	var ctx;
+
+	ctor = factory( 'float64' );
+
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0 ] );
+	expected = new ctor( 'little-endian', [ -1.0, -2.0, -3.0, -4.0 ] );
+	ctx = {
+		'count': 0
+	};
+	actual = arr.map( invert, ctx );
+
+	t.strictEqual( actual instanceof ctor, true, 'returns expected value' );
+	t.strictEqual( actual.length, expected.length, 'returns expected value' );
+	t.strictEqual( ctx.count, 6, 'returns expected value' );
+	t.end();
+
+	function invert( v, i ) {
+		this.count += i; // eslint-disable-line no-invalid-this
+		return v * -1;
+	}
+});


### PR DESCRIPTION
Resolves #3150 

## Description

> What is the purpose of this pull request?

This pull request:

- adds `map` method to `array/fixed-endian-factory`
- adds tests and benchmarks for the added function

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #3150  

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
