### PR TITLE
feat: add `copyWithin` method to `array/fixed-endian-factory`

### DIFF
--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
@@ -229,6 +229,27 @@ var len = arr.length;
 
 ### Typed Array Methods
 
+<a name="method-copy-within"></a>
+
+#### TypedArrayFE.prototype.copyWithin( target, start\[, end] )
+
+Copies a sequence of elements within the array starting at `start` and ending at `end` (non-inclusive) to the position starting at `target`.
+
+```javascript
+var Float64ArrayFE = fixedEndianFactory( 'float64' );
+
+var arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+
+arr.copyWithin( 0, 3 );
+
+var out = arr.get( 0 );
+// returns 4.0
+
+out = arr.get( 1 );
+// returns 5.0
+```
+
+
 <a name="static-method-from"></a>
 
 #### TypedArrayFE.from( endianness, src\[, map\[, thisArg]] )

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.copy_within.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.copy_within.js
@@ -1,0 +1,54 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var factory = require( './../lib' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var Float64ArrayFE = factory( 'float64' );
+
+
+// MAIN //
+
+bench( pkg+':copyWithin', function benchmark( b ) {
+	var arr;
+	var i;
+
+	arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0 ] );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr.copyWithin( 0, 6 );
+		if ( arr.get( 0 ) !== 7.0 ) {
+			b.fail( 'unexpected result' );
+		}
+	}
+	b.toc();
+	if ( arr.at( 0 ) !== arr.at( 0 ) ) {
+		b.fail( 'should not be NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark_copy_within.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark_copy_within.length.js
@@ -45,8 +45,8 @@ function createBenchmark( len ) {
 		var arr;
 		var i;
 
-		function generateArray(len) {
-			return new Array(len).fill(0).map(function mapFn(_, idx) {
+		function generateArray( len ) {
+			return new Array( len ).fill( 0 ).map(function mapFn( _, idx ) {
 				return idx + 1;
 			});
 		}

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark_copy_within.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark_copy_within.length.js
@@ -22,7 +22,6 @@
 
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
-var zeroTo = require( '@stdlib/array/zero-to' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
 
@@ -46,7 +45,13 @@ function createBenchmark( len ) {
 		var arr;
 		var i;
 
-		arr = new Float64ArrayFE( 'little-endian', zeroTo( len ) );
+		function generateArray(len) {
+			return new Array(len).fill(0).map(function mapFn(_, idx) {
+				return idx + 1;
+			});
+		}
+
+		arr = new Float64ArrayFE( 'little-endian', generateArray( len ) );
 
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark_copy_within.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark_copy_within.length.js
@@ -1,0 +1,93 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var zeroTo = require( '@stdlib/array/zero-to' );
+var pkg = require( './../package.json' ).name;
+var factory = require( './../lib' );
+
+
+// VARIABLES //
+
+var Float64ArrayFE = factory( 'float64' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	return function benchmark( b ) {
+		var arr;
+		var i;
+
+		arr = new Float64ArrayFE( 'little-endian', zeroTo( len ) );
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			arr.copyWithin( 0, len - 1 );
+			if ( arr.get( 0 ) !== len ) {
+				b.fail( 'unexpected result' );
+			}
+		}
+		b.toc();
+		if ( arr.at( 0 ) !== arr.at( 0 ) ) {
+			b.fail( 'should not be NaN' );
+		}
+
+		b.pass( 'benchmark finished' );
+		b.end();
+	};
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg + ':copyWithin:len=' + len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
@@ -44,6 +44,8 @@ var contains = require( '@stdlib/array/base/assert/contains' ).factory;
 var bytesPerElement = require( '@stdlib/ndarray/base/bytes-per-element' );
 var capitalize = require( '@stdlib/string/base/capitalize' );
 var format = require( '@stdlib/string/format' );
+var max = require( '@stdlib/math/base/special/max' );
+var min = require( '@stdlib/math/base/special/min' );
 var fromIterator = require( './from_iterator.js' );
 var fromIteratorMap = require( './from_iterator_map.js' );
 
@@ -486,6 +488,92 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 			return;
 		}
 		return this._buffer[ GETTER ]( idx * BYTES_PER_ELEMENT, this._isLE );
+	});
+
+	/**
+ 	* Copies a sequence of array elements from `start` to `end` within the array to the position starting at `target`.
+ 	*
+ 	* @private
+ 	* @name copyWithin
+ 	* @memberof TypedArray.prototype
+ 	* @type {Function}
+ 	* @param {integer} target - index at which to copy the sequence to
+ 	* @param {integer} start - index at which to start copying the sequence from
+ 	* @param {integer} end - index at which to end copying the sequence (optional)
+ 	* @throws {TypeError} `this` is not a typed array
+ 	* @throws {TypeError} `target` must be an integer
+ 	* @throws {TypeError} `start` must be an integer
+ 	* @throws {TypeError} `end` must be an integer
+ 	* @returns {void}
+ 	*/
+	setReadOnly( TypedArray.prototype, 'copyWithin', function copyWithin( target, start ) {
+		var copyDirection;
+		var len;
+		var end;
+		var cnt;
+		var buf;
+
+		if ( !isTypedArray( this ) ) {
+			throw new TypeError( format( 'invalid invocation. `this` is not %s %s.', CHAR2ARTICLE[ dtype[0] ], CTOR_NAME ) );
+		}
+		if ( arguments.length < 2 || arguments.length > 3 ) {
+			throw new TypeError( format( 'invalid invocation. Unsupported number of arguments. Value: `%s`.', arguments.length ) );
+		}
+		if ( !isInteger( target ) ) {
+			throw new TypeError( format( 'invalid argument. Must provide an integer. Value: `%s`.', target ) );
+		}
+		if ( !isInteger( start ) ) {
+			throw new TypeError( format( 'invalid argument. Must provide an integer. Value: `%s`.', start ) );
+		}
+
+		len = this._length;
+
+		if ( target >= len || start >= len ) {
+			return;
+		}
+
+		if ( arguments.length === 3 ) {
+			end = arguments[ 2 ];
+			if ( !isInteger( end ) ) {
+				throw new TypeError( format( 'invalid argument. Must provide an integer. Value: `%s`.', end ) );
+			}
+			if ( end < 0 ) {
+				end = max(len + end, 0);
+			}
+			end = min( end, len );
+		} else {
+			end = len;
+		}
+
+		if ( target < 0 ) {
+			target = max(len + target, 0);
+		}
+		if ( start < 0 ) {
+			start = max(len + start, 0);
+		}
+
+		cnt = min( end - start, len - target );
+
+		if ( cnt <= 0 ) {
+			return;
+		}
+
+		buf = this._buffer;
+
+		if ( start < target && target < ( start + cnt ) ) {
+			copyDirection = -1;
+			start = start + cnt - 1;
+			target = target + cnt - 1;
+		} else {
+			copyDirection = 1;
+		}
+
+		while ( cnt > 0 ) {
+			buf[ SETTER ]( target*BYTES_PER_ELEMENT, buf[ GETTER ]( start*BYTES_PER_ELEMENT, this._isLE ), this._isLE );
+			target += copyDirection;
+			start += copyDirection;
+			cnt -= 1;
+		}
 	});
 
 	/**

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/test/test.copy_within.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/test/test.copy_within.js
@@ -1,0 +1,322 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var factory = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof factory, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns a function', function test( t ) {
+	var ctor = factory( 'float64' );
+	t.strictEqual( isFunction( ctor ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the returned function is an `copyWithin` method', function test( t ) {
+	var ctor = factory( 'float64' );
+	t.strictEqual( hasOwnProp( ctor.prototype, 'copyWithin' ), true, 'returns expected value' );
+	t.strictEqual( isFunction( ctor.prototype.at ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a typed array instance', function test( t ) {
+	var values;
+	var ctor;
+	var arr;
+	var i;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.copyWithin.call( value, 0, 2 );
+		};
+	}
+});
+
+tape( 'the method throws an error if provided an `target` argument which is not an integer', function test( t ) {
+	var values;
+	var ctor;
+	var arr;
+	var i;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0 ] );
+
+	values = [
+		'5',
+		3.14,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.copyWithin( value, 0 );
+		};
+	}
+});
+
+tape( 'the method throws an error if provided an `start` argument which is not an integer', function test( t ) {
+	var values;
+	var ctor;
+	var arr;
+	var i;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0 ] );
+
+	values = [
+		'5',
+		3.14,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.copyWithin( 0, value );
+		};
+	}
+});
+
+tape( 'the method throws an error if provided an `end` argument which is not an integer', function test( t ) {
+	var values;
+	var ctor;
+	var arr;
+	var i;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0 ] );
+
+	values = [
+		'5',
+		3.14,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.copyWithin( 0, 1, value );
+		};
+	}
+});
+
+tape( 'the method copies a sequence of elements within an array', function test( t ) {
+	var ctor;
+	var arr;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0 ] );
+
+	arr.copyWithin( 0, 5 );
+
+	// Overwritten:
+	t.strictEqual( arr.get( 0 ), 6.0, 'returns expected value' );
+	t.strictEqual( arr.get( 1 ), 7.0, 'returns expected value' );
+
+	// // Remain the same:
+	t.strictEqual( arr.get( 2 ), 3.0, 'returns expected value' );
+	t.strictEqual( arr.get( 3 ), 4.0, 'returns expected value' );
+	t.strictEqual( arr.get( 4 ), 5.0, 'returns expected value' );
+	t.strictEqual( arr.get( 5 ), 6.0, 'returns expected value' );
+	t.strictEqual( arr.get( 6 ), 7.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the method copies a sequence of elements within an array (negative target)', function test( t ) {
+	var ctor;
+	var arr;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0 ] );
+
+	arr.copyWithin( -arr.length, 5 );
+
+	// Overwritten:
+	t.strictEqual( arr.get( 0 ), 6.0, 'returns expected value' );
+	t.strictEqual( arr.get( 1 ), 7.0, 'returns expected value' );
+
+	// Remain the same:
+	t.strictEqual( arr.get( 2 ), 3.0, 'returns expected value' );
+	t.strictEqual( arr.get( 3 ), 4.0, 'returns expected value' );
+	t.strictEqual( arr.get( 4 ), 5.0, 'returns expected value' );
+	t.strictEqual( arr.get( 5 ), 6.0, 'returns expected value' );
+	t.strictEqual( arr.get( 6 ), 7.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the method copies a sequence of elements within an array (negative start)', function test( t ) {
+	var ctor;
+	var arr;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0 ] );
+
+	arr.copyWithin( 0, -2 );
+
+	// Overwritten:
+	t.strictEqual( arr.get( 0 ), 6.0, 'returns expected value' );
+	t.strictEqual( arr.get( 1 ), 7.0, 'returns expected value' );
+
+	// Remain the same:
+	t.strictEqual( arr.get( 2 ), 3.0, 'returns expected value' );
+	t.strictEqual( arr.get( 3 ), 4.0, 'returns expected value' );
+	t.strictEqual( arr.get( 4 ), 5.0, 'returns expected value' );
+	t.strictEqual( arr.get( 5 ), 6.0, 'returns expected value' );
+	t.strictEqual( arr.get( 6 ), 7.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the method copies a sequence of elements within an array (end=length)', function test( t ) {
+	var ctor;
+	var arr;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0 ] );
+
+	arr.copyWithin( 0, 5, arr.length );
+
+	// Overwritten:
+	t.strictEqual( arr.get( 0 ), 6.0, 'returns expected value' );
+	t.strictEqual( arr.get( 1 ), 7.0, 'returns expected value' );
+
+	// Remain the same:
+	t.strictEqual( arr.get( 2 ), 3.0, 'returns expected value' );
+	t.strictEqual( arr.get( 3 ), 4.0, 'returns expected value' );
+	t.strictEqual( arr.get( 4 ), 5.0, 'returns expected value' );
+	t.strictEqual( arr.get( 5 ), 6.0, 'returns expected value' );
+	t.strictEqual( arr.get( 6 ), 7.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the method copies a sequence of elements within an array (non-inclusive end)', function test( t ) {
+	var ctor;
+	var arr;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0 ] );
+
+	arr.copyWithin( 2, 0, 2 );
+
+	// Remain the same:
+	t.strictEqual( arr.get( 0 ), 1.0, 'returns expected value' );
+	t.strictEqual( arr.get( 1 ), 2.0, 'returns expected value' );
+
+	// Overwritten:
+	t.strictEqual( arr.get( 2 ), 1.0, 'returns expected value' );
+	t.strictEqual( arr.get( 3 ), 2.0, 'returns expected value' );
+
+	// Remain the same:
+	t.strictEqual( arr.get( 4 ), 5.0, 'returns expected value' );
+	t.strictEqual( arr.get( 5 ), 6.0, 'returns expected value' );
+	t.strictEqual( arr.get( 6 ), 7.0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the method copies a sequence of elements within an array (negative end)', function test( t ) {
+	var ctor;
+	var arr;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0 ] );
+
+	arr.copyWithin( 2, 0, -3 );
+
+	// Remain the same:
+	t.strictEqual( arr.get( 0 ), 1.0, 'returns expected value' );
+	t.strictEqual( arr.get( 1 ), 2.0, 'returns expected value' );
+
+	// Overwritten:
+	t.strictEqual( arr.get( 2 ), 1.0, 'returns expected value' );
+	t.strictEqual( arr.get( 3 ), 2.0, 'returns expected value' );
+
+	// Remain the same:
+	t.strictEqual( arr.get( 4 ), 3.0, 'returns expected value' );
+	t.strictEqual( arr.get( 5 ), 4.0, 'returns expected value' );
+	t.strictEqual( arr.get( 6 ), 7.0, 'returns expected value' );
+
+	t.end();
+});


### PR DESCRIPTION
Resolves #3136 

## Description

> What is the purpose of this pull request?

This pull request:

-   adds support for a copyWithin method to [@stdlib/array/fixed-endian-factory](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/fixed-endian-factory).

## Related Issues

> Does this pull request have any related issues?

#3136 

This pull request:

-   resolves #3136 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
