### PR TITLE
feat: add `filter` method to `array/fixed-endian-factory`

### DIFF
--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
@@ -451,6 +451,68 @@ var count = context.count;
 // returns 3
 ```
 
+<a name="method-filter"></a>
+
+#### TypedArrayFE.prototype.forEach( predicate\[, thisArg] )
+
+Returns a new array containing the elements of an array which pass a test implemented by a predicate function.
+
+```javascript
+function predicate( v ) {
+    return ( v % 2 === 0 );
+}
+
+var Float64ArrayFE = fixedEndianFactory( 'float64' );
+
+var arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 3.0, 4.0 ] );
+
+var out = arr.filter( predicate );
+// returns <Float64ArrayFE>
+
+var len = out.length;
+// returns 2
+
+var v = out.get( 0 );
+// returns 2.0
+
+v = out.get( 1 );
+// return 4.0
+```
+
+The `predicate` function is provided three arguments:
+
+-   **value**: current array element.
+-   **index**: current array element index.
+-   **arr**: the array on which this method was called.
+
+To set the function execution context, provide a `thisArg`.
+
+```javascript
+function predicate( v, i ) {
+    this.count += 1;
+    return ( v % 2 === 0 );
+}
+
+var context = {
+    'count': 0
+};
+
+var Float64ArrayFE = fixedEndianFactory( 'float64' );
+
+var arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 3.0, 4.0 ] );
+
+var out = arr.filter( predicate, context );
+// returns <Float64ArrayFE>
+
+var len = out.length;
+// returns 2
+
+var count = context.count;
+// returns 4
+```
+
+
+
 <a name="method-get"></a>
 
 #### TypedArrayFE.prototype.get( i )

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
@@ -453,7 +453,7 @@ var count = context.count;
 
 <a name="method-filter"></a>
 
-#### TypedArrayFE.prototype.forEach( predicate\[, thisArg] )
+#### TypedArrayFE.prototype.filter( predicate\[, thisArg] )
 
 Returns a new array containing the elements of an array which pass a test implemented by a predicate function.
 

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
@@ -511,8 +511,6 @@ var count = context.count;
 // returns 4
 ```
 
-
-
 <a name="method-get"></a>
 
 #### TypedArrayFE.prototype.get( i )

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.filter.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.filter.js
@@ -1,0 +1,59 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pkg = require( './../package.json' ).name;
+var factory = require( './../lib' );
+
+
+// VARIABLES //
+
+var Float64ArrayFE = factory( 'float64' );
+
+
+// MAIN //
+
+bench( pkg+':filter', function benchmark( b ) {
+	var out;
+	var arr;
+	var i;
+
+	arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 2.0, 1.0 ] );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = arr.filter( predicate );
+		if ( typeof out !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+	if ( !( out instanceof Float64ArrayFE ) ) {
+		b.fail( 'should return a typed array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+
+	function predicate( v ) {
+		return v % 2 === 0;
+	}
+});

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.filter.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.filter.length.js
@@ -1,0 +1,112 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var zeroTo = require( '@stdlib/array/zero-to' );
+var pkg = require( './../package.json' ).name;
+var factory = require( './../lib' );
+
+
+// VARIABLES //
+
+var Float64ArrayFE = factory( 'float64' );
+
+
+// FUNCTIONS //
+
+/**
+* Predicate function.
+*
+* @private
+* @param {number} value - array element
+* @param {NonNegativeInteger} idx - array element index
+* @param {TypedArray} arr - array instance
+* @returns {boolean} boolean indicating whether a value passes a test
+*/
+function predicate( value ) {
+	return value % 2 === 0;
+}
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var arr = new Float64ArrayFE( 'little-endian', zeroTo( len ) );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var out;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			out = arr.filter( predicate );
+			if ( typeof out !== 'object' ) {
+				b.fail( 'should return an object' );
+			}
+		}
+		b.toc();
+		if ( !( out instanceof Float64ArrayFE ) ) {
+			b.fail( 'should return a typed array' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':filter:len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
@@ -617,7 +617,7 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 	* @type {Function}
 	* @param {Function} predicate - test function
 	* @param {*} [thisArg] - predicate function execution context
-	* @throws {TypeError} `this` must be a typed array
+	* @throws {TypeError} `this` must be a typed array instance
 	* @throws {TypeError} first argument must be a function
 	* @returns {TypedArray} typed array
 	*/

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
@@ -610,6 +610,41 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 	});
 
 	/**
+	* Returns a new array containing the elements of an array which pass a test implemented by a predicate function.
+	*
+	* @name filter
+	* @memberof TypedArray.prototype
+	* @type {Function}
+	* @param {Function} predicate - test function
+	* @param {*} [thisArg] - predicate function execution context
+	* @throws {TypeError} `this` must be a boolean array
+	* @throws {TypeError} first argument must be a function
+	* @returns {TypedArray} typed array
+	*/
+	setReadOnly( TypedArray.prototype, 'filter', function filter( predicate, thisArg ) {
+		var buf;
+		var out;
+		var i;
+		var v;
+
+		if ( !isTypedArray( this ) ) {
+			throw new TypeError( format( 'invalid invocation. `this` is not %s %s.', CHAR2ARTICLE[ dtype[0] ], CTOR_NAME ) );
+		}
+		if ( !isFunction( predicate ) ) {
+			throw new TypeError( format( 'invalid argument. First argument must be a function. Value: `%s`.', predicate ) );
+		}
+		buf = this._buffer;
+		out = [];
+		for ( i = 0; i < this._length; i++) {
+			v = buf[ GETTER ]( i*BYTES_PER_ELEMENT, this._isLE );
+			if ( predicate.call( thisArg, v, i, this ) ) {
+				out.push( v );
+			}
+		}
+		return new this.constructor( flag2byteOrder( this._isLE ), out );
+	});
+
+	/**
 	* Returns an array element.
 	*
 	* @private

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
@@ -617,7 +617,7 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 	* @type {Function}
 	* @param {Function} predicate - test function
 	* @param {*} [thisArg] - predicate function execution context
-	* @throws {TypeError} `this` must be a boolean array
+	* @throws {TypeError} `this` must be a typed array
 	* @throws {TypeError} first argument must be a function
 	* @returns {TypedArray} typed array
 	*/

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/test/test.filter.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/test/test.filter.js
@@ -1,0 +1,225 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var factory = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof factory, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns a function', function test( t ) {
+	var ctor = factory( 'float64' );
+	t.strictEqual( isFunction( ctor ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the returned function is an `filter` method', function test( t ) {
+	var ctor = factory( 'float64' );
+	t.strictEqual( hasOwnProp( ctor.prototype, 'filter' ), true, 'returns expected value' );
+	t.strictEqual( isFunction( ctor.prototype.filter ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a typed array instance', function test( t ) {
+	var values;
+	var ctor;
+	var arr;
+	var i;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.filter.call( value, predicate );
+		};
+	}
+	function predicate( v ) {
+		return v < 0;
+	}
+});
+
+tape( 'the method throws an error if provided a first argument which is not a function', function test( t ) {
+	var values;
+	var ctor;
+	var arr;
+	var i;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0 ] );
+
+	values = [
+		'5',
+		3.14,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[]
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.filter( value );
+		};
+	}
+});
+
+tape( 'the method returns an empty array if operating on an empty array', function test( t ) {
+	var ctor;
+	var arr;
+	var out;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian' );
+	out = arr.filter( predicate );
+
+	t.strictEqual( out.length, 0, 'returns expected value' );
+	t.end();
+
+	function predicate( v ) {
+		return v > 0.0;
+	}
+});
+
+tape( 'the method returns a new boolean array containing only those elements which satisfy a test condition', function test( t ) {
+	var expected;
+	var actual;
+	var ctor;
+	var arr;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ -1.0, -2.0, 3.0, 4.0 ] );
+	expected = new ctor( 'little-endian', [ 3.0, 4.0 ] );
+	actual = arr.filter( predicate );
+
+	t.strictEqual( actual instanceof ctor, true, 'returns expected value' );
+	t.strictEqual( actual.length, expected.length, 'returns expected value' );
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.end();
+
+	function predicate( v ) {
+		return v > 0;
+	}
+});
+
+tape( 'the method copies all elements to a new array if all elements satisfy a test condition', function test( t ) {
+	var expected;
+	var actual;
+	var ctor;
+	var arr;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0 ] );
+	expected = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0 ] );
+	actual = arr.filter( predicate );
+
+	t.strictEqual( actual instanceof ctor, true, 'returns expected value' );
+	t.notEqual( actual, arr, 'returns a new instance' );
+	t.strictEqual( actual.length, expected.length, 'returns expected value' );
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.end();
+
+	function predicate( v ) {
+		return v === v;
+	}
+});
+
+tape( 'the method returns an empty array if no elements satisfy a test condition', function test( t ) {
+	var expected;
+	var actual;
+	var ctor;
+	var arr;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0 ] );
+	expected = new ctor( 'little-endian' );
+	actual = arr.filter( predicate );
+
+	t.strictEqual( actual instanceof ctor, true, 'returns expected value' );
+	t.notEqual( actual, arr, 'returns a new instance' );
+	t.strictEqual( actual.length, expected.length, 'returns expected value' );
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.end();
+
+	function predicate( v ) {
+		return v !== v;
+	}
+});
+
+tape( 'the method supports providing an execution context', function test( t ) {
+	var expected;
+	var actual;
+	var ctor;
+	var arr;
+	var ctx;
+
+	ctx = {
+		'count': 0
+	};
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0 ] );
+	expected = new ctor( 'little-endian', [ 2.0, 4.0 ] );
+	actual = arr.filter( predicate, ctx );
+
+	t.strictEqual( actual instanceof ctor, true, 'returns expected value' );
+	t.strictEqual( actual.length, expected.length, 'returns expected value' );
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.strictEqual( ctx.count, 4, 'returns expected value' );
+	t.end();
+
+	function predicate( v ) {
+		this.count += 1; // eslint-disable-line no-invalid-this
+		return ( v % 2 === 0 );
+	}
+});


### PR DESCRIPTION
Resolves #3140

## Description

> What is the purpose of this pull request?

This pull request:

-   adds `filter` method to `array/fixed-endian-factory`
-   adds relevant tests and benchmarks
-   updates README with examples and documentation

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #3140 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
