### PR TITLE
feat: add `lastIndexOf` method to `array/fixed-endian-factory`

### DIFF
--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
@@ -515,6 +515,38 @@ var idx = arr.indexOf( 5.0 );
 // returns -1
 ```
 
+<a name="method-last-index-of"></a>
+
+#### TypedArrayFE.prototype.lastIndexOf( searchElement\[, fromIndex] )
+
+Returns the last index at which a given element can be found in the array.
+
+```javascript
+var Float64ArrayFE = fixedEndianFactory( 'float64' );
+
+var arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 2.0 ] );
+
+var idx = arr.lastIndexOf( 2.0 );
+// returns 4
+
+idx = arr.lastIndexOf( 2.0, 3 );
+// returns 1
+
+idx = arr.lastIndexOf( 2.0, -2 );
+// returns 1
+```
+
+If `searchElement` is not present in the array, the method returns `-1`.
+
+```javascript
+var Float64ArrayFE = fixedEndianFactory( 'float64' );
+
+var arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 2.0 ] );
+
+var idx = arr.lastIndexOf( 5.0 );
+// returns -1
+```
+
 <a name="method-map"></a>
 
 #### TypedArray.prototype.map( callbackFn\[, thisArg] )

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.last-index-of.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.last-index-of.js
@@ -1,0 +1,56 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
+var factory = require( './../lib' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var Float64ArrayFE = factory( 'float64' );
+
+
+// MAIN //
+
+bench( pkg+':lastIndexOf', function benchmark( b ) {
+	var arr;
+	var idx;
+	var i;
+
+	arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0 ] );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		idx = arr.lastIndexOf( 5.0, arr.length - 1 );
+		if ( typeof idx !== 'number' ) {
+			b.fail( 'should return an integer' );
+		}
+	}
+	b.toc();
+	if ( !isInteger( idx ) ) {
+		b.fail( 'should return an integer' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.last-index-of.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.last-index-of.length.js
@@ -1,0 +1,103 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var zeroTo = require( '@stdlib/array/zero-to' );
+var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
+var factory = require( './../lib' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var Float64ArrayFE = factory( 'float64' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var arr = new Float64ArrayFE( 'little-endian', zeroTo( len ) );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var idx;
+		var v;
+		var i;
+
+		v = len - 1;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			idx = arr.lastIndexOf( v );
+			if ( typeof idx !== 'number' ) {
+				b.fail( 'should return an integer' );
+			}
+		}
+		b.toc();
+		if ( !isInteger( idx ) ) {
+			b.fail( 'should return an integer' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':lastIndexOf:len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
@@ -684,7 +684,7 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 	* @memberof TypedArray.prototype
 	* @type {Function}
 	* @param {*} searchElement - element to search for
-	* @param {integer} [fromIndex=this._length-1] - starting index ( inclusive )
+	* @param {integer} [fromIndex=this._length-1] - starting index (inclusive)
 	* @throws {TypeError} `this` must be a typed array instance
 	* @throws {TypeError} second argument must be an integer
 	* @returns {integer} index or -1
@@ -694,7 +694,7 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 		var i;
 
 		if ( !isTypedArray( this ) ) {
-			throw new TypeError(format( 'invalid invocation. `this` is not %s %s.', CHAR2ARTICLE[ dtype[ 0 ] ], CTOR_NAME ) );
+			throw new TypeError( format( 'invalid invocation. `this` is not %s %s.', CHAR2ARTICLE[ dtype[ 0 ] ], CTOR_NAME ) );
 		}
 		if ( arguments.length > 1 ) {
 			if ( !isInteger( fromIndex ) ) {

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
@@ -677,6 +677,51 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 	});
 
 	/**
+	* Returns the index of the last occurrence of a given element.
+	*
+	* @private
+	* @name lastIndexOf
+	* @memberof TypedArray.prototype
+	* @type {Function}
+	* @param {*} searchElement - element to search for
+	* @param {integer} [fromIndex=this._length-1] - starting index ( inclusive )
+	* @throws {TypeError} `this` must be a typed array instance
+	* @throws {TypeError} second argument must be an integer
+	* @returns {integer} index or -1
+	*/
+	setReadOnly( TypedArray.prototype, 'lastIndexOf', function lastIndexOf( searchElement, fromIndex ) {
+		var buf;
+		var i;
+
+		if ( !isTypedArray( this ) ) {
+			throw new TypeError(format( 'invalid invocation. `this` is not %s %s.', CHAR2ARTICLE[ dtype[ 0 ] ], CTOR_NAME ) );
+		}
+		if ( arguments.length > 1 ) {
+			if ( !isInteger( fromIndex ) ) {
+				throw new TypeError( format( 'invalid argument. Second argument must be an integer. Value: `%s`.', fromIndex ) );
+			}
+			if ( fromIndex < 0 ) {
+				fromIndex += this._length;
+			}
+			if ( fromIndex < 0 ) {
+				return -1;
+			}
+			if ( fromIndex >= this._length ) {
+				fromIndex = this._length - 1;
+			}
+		} else {
+			fromIndex = this._length - 1;
+		}
+		buf = this._buffer;
+		for ( i = fromIndex; i >= 0; i-- ) {
+			if ( buf[ GETTER ]( i * BYTES_PER_ELEMENT, this._isLE ) === searchElement ) {
+				return i;
+			}
+		}
+		return -1;
+	});
+
+	/**
 	* Number of array elements.
 	*
 	* @private

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/test/test.last-index-of.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/test/test.last-index-of.js
@@ -1,0 +1,206 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var factory = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof factory, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns a function', function test( t ) {
+	var ctor = factory( 'float64' );
+	t.strictEqual( isFunction( ctor ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the returned function is a `lastIndexOf` method', function test( t ) {
+	var ctor = factory( 'float64' );
+	t.strictEqual( hasOwnProp( ctor.prototype, 'lastIndexOf' ), true, 'returns expected value' );
+	t.strictEqual( isFunction( ctor.prototype.lastIndexOf ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a typed array instance', function test( t ) {
+	var values;
+	var ctor;
+	var arr;
+	var i;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.lastIndexOf.call( value, 0 );
+		};
+	}
+});
+
+tape( 'the method throws an error if provided a second argument which is not an integer', function test( t ) {
+	var values;
+	var ctor;
+	var arr;
+	var i;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0 ] );
+
+	values = [
+		'5',
+		3.14,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.lastIndexOf( 1.0, value );
+		};
+	}
+});
+
+tape( 'the method returns `-1` if provided a second argument which resolves to an index less than zero', function test( t ) {
+	var ctor;
+	var arr;
+	var v;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+
+	v = arr.lastIndexOf( 1.0, -10 );
+	t.strictEqual( v, -1, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method returns `-1` if operating on an empty array', function test( t ) {
+	var ctor;
+	var arr;
+	var v;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [] );
+
+	v = arr.lastIndexOf( 1.0 );
+	t.strictEqual( v, -1, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the method returns `-1` if a search element is not found', function test( t ) {
+	var ctor;
+	var arr;
+	var v;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+
+	v = arr.lastIndexOf( 10.0 );
+	t.strictEqual( v, -1, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the method returns the index of the last match if an element is found', function test( t ) {
+	var ctor;
+	var arr;
+	var v;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 2.0 ] );
+
+	v = arr.lastIndexOf( 2.0 );
+	t.strictEqual( v, 4, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the method supports specifying a starting search index', function test( t ) {
+	var ctor;
+	var arr;
+	var v;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 2.0 ] );
+
+	v = arr.lastIndexOf( 2.0, 4 );
+	t.strictEqual( v, 4, 'returns expected value' );
+
+	v = arr.lastIndexOf( 2.0, 1 );
+	t.strictEqual( v, 1, 'returns expected value' );
+
+	v = arr.lastIndexOf( 1.0, 0 );
+	t.strictEqual( v, 0, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the method supports specifying a starting search index (negative)', function test( t ) {
+	var ctor;
+	var arr;
+	var v;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 2.0 ] );
+
+	v = arr.lastIndexOf( 2.0, -1 );
+	t.strictEqual( v, 4, 'returns expected value' );
+
+	v = arr.lastIndexOf( 1.0, -3 );
+	t.strictEqual( v, 0, 'returns expected value' );
+
+	t.end();
+});


### PR DESCRIPTION
Resolves #3149 

## Description

> What is the purpose of this pull request?

This pull request:

-   adds support for a lastIndexOf method to [@stdlib/array/fixed-endian-factory](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/fixed-endian-factory).

## Related Issues

> #3149 

This pull request:

-   resolves #3149 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
