### PR TITLE
feat: add `includes` method to `array/fixed-endian-factory`

### DIFF
--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
@@ -519,7 +519,7 @@ var idx = arr.indexOf( 5.0 );
 
 #### TypedArrayFE.prototype.includes( searchElement\[, fromIndex] )
 
-Returns `true` if element can be found.
+Returns `true` if the specified `searchElement` is present in the array.
 
 ```javascript
 var Float64ArrayFE = fixedEndianFactory( 'float64' );

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
@@ -483,6 +483,30 @@ var v = arr.get( 100 );
 // returns undefined
 ```
 
+<a name="method-includes"></a>
+
+#### TypedArrayFE.prototype.includes( searchElement\[, fromIndex] )
+
+Returns a boolean indicating whether an array includes a provided value.
+
+```javascript
+var Float64ArrayFE = fixedEndianFactory( 'float64' );
+
+var arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 2.0 ] );
+
+var idx = arr.includes( 2.0 );
+// returns true
+
+idx = arr.includes( 2.0, 2 );
+// returns true
+
+idx = arr.includes( 2.0, -4 );
+// returns true
+
+idx = arr.includes( 5.0 );
+// returns false
+```
+
 <a name="method-index-of"></a>
 
 #### TypedArrayFE.prototype.indexOf( searchElement\[, fromIndex] )
@@ -513,30 +537,6 @@ var arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 2.0 ] );
 
 var idx = arr.indexOf( 5.0 );
 // returns -1
-```
-
-<a name="method-includes"></a>
-
-#### TypedArrayFE.prototype.includes( searchElement\[, fromIndex] )
-
-Returns a boolean indicating whether an array includes a provided value.
-
-```javascript
-var Float64ArrayFE = fixedEndianFactory( 'float64' );
-
-var arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 2.0 ] );
-
-var idx = arr.includes( 2.0 );
-// returns true
-
-idx = arr.includes( 2.0, 2 );
-// returns true
-
-idx = arr.includes( 2.0, -4 );
-// returns true
-
-idx = arr.includes( 5.0 );
-// returns false
 ```
 
 <a name="method-map"></a>

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
@@ -519,7 +519,7 @@ var idx = arr.indexOf( 5.0 );
 
 #### TypedArrayFE.prototype.includes( searchElement\[, fromIndex] )
 
-Returns `true` if the specified `searchElement` is present in the array.
+Returns a boolean indicating whether an array includes a provided value.
 
 ```javascript
 var Float64ArrayFE = fixedEndianFactory( 'float64' );
@@ -534,16 +534,8 @@ idx = arr.includes( 2.0, 2 );
 
 idx = arr.includes( 2.0, -4 );
 // returns true
-```
 
-If the specified `searchElement` is not present in the array, the method returns `false`.
-
-```javascript
-var Float64ArrayFE = fixedEndianFactory( 'float64' );
-
-var arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 2.0 ] );
-
-var idx = arr.includes( 5.0 );
+idx = arr.includes( 5.0 );
 // returns false
 ```
 

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
@@ -536,7 +536,7 @@ idx = arr.includes( 2.0, -4 );
 // returns true
 ```
 
-If `searchElement` is not present in the array, the method returns `false`.
+If the specified `searchElement` is not present in the array, the method returns `false`.
 
 ```javascript
 var Float64ArrayFE = fixedEndianFactory( 'float64' );

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
@@ -515,6 +515,38 @@ var idx = arr.indexOf( 5.0 );
 // returns -1
 ```
 
+<a name="method-includes"></a>
+
+#### TypedArrayFE.prototype.includes( searchElement\[, fromIndex] )
+
+Returns `true` if element can be found.
+
+```javascript
+var Float64ArrayFE = fixedEndianFactory( 'float64' );
+
+var arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 2.0 ] );
+
+var idx = arr.includes( 2.0 );
+// returns true
+
+idx = arr.includes( 2.0, 2 );
+// returns true
+
+idx = arr.includes( 2.0, -4 );
+// returns true
+```
+
+If `searchElement` is not present in the array, the method returns `false`.
+
+```javascript
+var Float64ArrayFE = fixedEndianFactory( 'float64' );
+
+var arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 2.0 ] );
+
+var idx = arr.includes( 5.0 );
+// returns false
+```
+
 <a name="method-map"></a>
 
 #### TypedArray.prototype.map( callbackFn\[, thisArg] )

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.includes.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.includes.js
@@ -1,0 +1,56 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var factory = require( './../lib' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var Float64ArrayFE = factory( 'float64' );
+
+
+// MAIN //
+
+bench( pkg+':includes', function benchmark( b ) {
+	var result;
+	var arr;
+	var i;
+
+	arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0 ] );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		result = arr.includes( 5.0, 0 );
+		if ( typeof result !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( result ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.includes.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.includes.length.js
@@ -1,0 +1,103 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var zeroTo = require( '@stdlib/array/zero-to' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var factory = require( './../lib' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var Float64ArrayFE = factory( 'float64' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var arr = new Float64ArrayFE( 'little-endian', zeroTo( len ) );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var result;
+		var v;
+		var i;
+
+		v = len - 1;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			result = arr.includes( v );
+			if ( typeof result !== 'boolean' ) {
+				b.fail( 'should return a boolean' );
+			}
+		}
+		b.toc();
+		if ( !isBoolean( result ) ) {
+			b.fail( 'should return a boolean' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':includes:len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
@@ -635,48 +635,6 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 	});
 
 	/**
-	* Returns the index of the first occurrence of a given element.
-	*
-	* @private
-	* @name indexOf
-	* @memberof TypedArray.prototype
-	* @type {Function}
-	* @param {*} searchElement - element to search for
-	* @param {integer} [fromIndex=0] - starting index (inclusive)
-	* @throws {TypeError} `this` must be a typed array instance
-	* @throws {TypeError} second argument must be an integer
-	* @returns {integer} index or -1
-	*/
-	setReadOnly( TypedArray.prototype, 'indexOf', function indexOf( searchElement, fromIndex ) {
-		var buf;
-		var i;
-
-		if ( !isTypedArray( this ) ) {
-			throw new TypeError( format( 'invalid invocation. `this` is not %s %s.', CHAR2ARTICLE[ dtype[0] ], CTOR_NAME ) );
-		}
-		if ( arguments.length > 1 ) {
-			if ( !isInteger( fromIndex ) ) {
-				throw new TypeError( format( 'invalid argument. Second argument must be an integer. Value: `%s`.', fromIndex ) );
-			}
-			if ( fromIndex < 0 ) {
-				fromIndex += this._length;
-				if ( fromIndex < 0 ) {
-					fromIndex = 0;
-				}
-			}
-		} else {
-			fromIndex = 0;
-		}
-		buf = this._buffer;
-		for ( i = fromIndex; i < this._length; i++ ) {
-			if ( buf[ GETTER ]( i * BYTES_PER_ELEMENT, this._isLE ) === searchElement ) {
-				return i;
-			}
-		}
-		return -1;
-	});
-
-	/**
 	* Returns a boolean indicating whether an array includes a provided value.
 	*
 	* @private
@@ -716,6 +674,48 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 			}
 		}
 		return false;
+	});
+
+	/**
+	* Returns the index of the first occurrence of a given element.
+	*
+	* @private
+	* @name indexOf
+	* @memberof TypedArray.prototype
+	* @type {Function}
+	* @param {*} searchElement - element to search for
+	* @param {integer} [fromIndex=0] - starting index (inclusive)
+	* @throws {TypeError} `this` must be a typed array instance
+	* @throws {TypeError} second argument must be an integer
+	* @returns {integer} index or -1
+	*/
+	setReadOnly( TypedArray.prototype, 'indexOf', function indexOf( searchElement, fromIndex ) {
+		var buf;
+		var i;
+
+		if ( !isTypedArray( this ) ) {
+			throw new TypeError( format( 'invalid invocation. `this` is not %s %s.', CHAR2ARTICLE[ dtype[0] ], CTOR_NAME ) );
+		}
+		if ( arguments.length > 1 ) {
+			if ( !isInteger( fromIndex ) ) {
+				throw new TypeError( format( 'invalid argument. Second argument must be an integer. Value: `%s`.', fromIndex ) );
+			}
+			if ( fromIndex < 0 ) {
+				fromIndex += this._length;
+				if ( fromIndex < 0 ) {
+					fromIndex = 0;
+				}
+			}
+		} else {
+			fromIndex = 0;
+		}
+		buf = this._buffer;
+		for ( i = fromIndex; i < this._length; i++ ) {
+			if ( buf[ GETTER ]( i * BYTES_PER_ELEMENT, this._isLE ) === searchElement ) {
+				return i;
+			}
+		}
+		return -1;
 	});
 
 	/**

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
@@ -676,7 +676,7 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 		return -1;
 	});
 	/**
-	* A boolean value which is true if the value `searchElement` is found.
+	* Returns `true` if the specified `searchElement` is present in the array.
 	*
 	* @private
 	* @name includes

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
@@ -675,6 +675,47 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 		}
 		return -1;
 	});
+	/**
+	* A boolean value which is true if the value `searchElement` is found.
+	*
+	* @private
+	* @name includes
+	* @memberof TypedArray.prototype
+	* @type {Function}
+	* @param {*} searchElement - element to search for
+	* @param {integer} [fromIndex=0] - starting index (inclusive)
+	* @throws {TypeError} `this` must be a typed array instance
+	* @throws {TypeError} second argument must be an integer
+	* @returns {boolean} boolean indicating that `searchElement` is found
+	*/
+	setReadOnly( TypedArray.prototype, 'includes', function includes( searchElement, fromIndex ) {
+		var buf;
+		var i;
+
+		if ( !isTypedArray( this ) ) {
+			throw new TypeError( format( 'invalid invocation. `this` is not %s %s.', CHAR2ARTICLE[ dtype[0] ], CTOR_NAME ) );
+		}
+		if ( arguments.length > 1 ) {
+			if ( !isInteger( fromIndex ) ) {
+				throw new TypeError( format( 'invalid argument. Second argument must be an integer. Value: `%s`.', fromIndex ) );
+			}
+			if ( fromIndex < 0 ) {
+				fromIndex += this._length;
+				if ( fromIndex < 0 ) {
+					fromIndex = 0;
+				}
+			}
+		} else {
+			fromIndex = 0;
+		}
+		buf = this._buffer;
+		for ( i = fromIndex; i < this._length; i++ ) {
+			if ( buf[ GETTER ]( i * BYTES_PER_ELEMENT, this._isLE ) === searchElement ) {
+				return true;
+			}
+		}
+		return false;
+	});
 
 	/**
 	* Number of array elements.

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
@@ -675,18 +675,19 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 		}
 		return -1;
 	});
+
 	/**
-	* Returns `true` if the specified `searchElement` is present in the array.
+	* Returns a boolean indicating whether an array includes a provided value.
 	*
 	* @private
 	* @name includes
 	* @memberof TypedArray.prototype
 	* @type {Function}
-	* @param {*} searchElement - element to search for
+	* @param {*} searchElement - search element
 	* @param {integer} [fromIndex=0] - starting index (inclusive)
 	* @throws {TypeError} `this` must be a typed array instance
 	* @throws {TypeError} second argument must be an integer
-	* @returns {boolean} boolean indicating that `searchElement` is found
+	* @returns {boolean} boolean indicating whether an array includes a provided value
 	*/
 	setReadOnly( TypedArray.prototype, 'includes', function includes( searchElement, fromIndex ) {
 		var buf;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/test/test.includes.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/test/test.includes.js
@@ -1,0 +1,226 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var factory = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof factory, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns a function', function test( t ) {
+	var ctor = factory( 'float64' );
+	t.strictEqual( isFunction( ctor ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the returned function is an `includes` method', function test( t ) {
+	var ctor = factory( 'float64' );
+	t.strictEqual( hasOwnProp( ctor.prototype, 'includes' ), true, 'returns expected value' );
+	t.strictEqual( isFunction( ctor.prototype.includes ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a typed array instance', function test( t ) {
+	var values;
+	var ctor;
+	var arr;
+	var i;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.includes.call( value, 0 );
+		};
+	}
+});
+
+tape( 'the method throws an error if provided a second argument which is not an integer', function test( t ) {
+	var values;
+	var ctor;
+	var arr;
+	var i;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0 ] );
+
+	values = [
+		'5',
+		3.14,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.includes( 1.0, value );
+		};
+	}
+});
+
+tape( 'the method returns `false` if provided a second argument which exceeds array dimensions', function test( t ) {
+	var ctor;
+	var arr;
+	var v;
+	var i;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0 ] );
+
+	for ( i = arr.length; i < arr.length+5; i++ ) {
+		v = arr.includes( 1.0, i );
+		t.strictEqual( v, false, 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the method returns `false` if operating on an empty array', function test( t ) {
+	var ctor;
+	var arr;
+	var v;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [] );
+
+	v = arr.includes( 1.0 );
+	t.strictEqual( v, false, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the method returns `false` if a search element is not found', function test( t ) {
+	var ctor;
+	var arr;
+	var v;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+
+	v = arr.includes( 10.0 );
+	t.strictEqual( v, false, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the method returns `true`  if an element is found', function test( t ) {
+	var ctor;
+	var arr;
+	var v;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 2.0 ] );
+
+	v = arr.includes( 2.0 );
+	t.strictEqual( v, true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the method supports specifying a starting search index', function test( t ) {
+	var ctor;
+	var arr;
+	var v;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 2.0 ] );
+
+	v = arr.includes( 2.0, 0 );
+	t.strictEqual( v, true, 'returns expected value' );
+
+	v = arr.includes( 2.0, 2 );
+	t.strictEqual( v, true, 'returns expected value' );
+
+	v = arr.includes( 1.0, 4 );
+	t.strictEqual( v, false, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the method supports specifying a starting search index (negative)', function test( t ) {
+	var ctor;
+	var arr;
+	var v;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 2.0 ] );
+
+	v = arr.includes( 2.0, -3 );
+	t.strictEqual( v, true, 'returns expected value' );
+
+	v = arr.includes( 1.0, -3 );
+	t.strictEqual( v, false, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'when provided a starting index which resolves to an index less than zero, the method searches from the first array element', function test( t ) {
+	var ctor;
+	var arr;
+	var v;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 2.0 ] );
+
+	v = arr.includes( 2.0, -10 );
+	t.strictEqual( v, true, 'returns expected value' );
+
+	v = arr.includes( 1.0, -10 );
+	t.strictEqual( v, true, 'returns expected value' );
+
+	t.end();
+});


### PR DESCRIPTION
Resolves #3145 .

## Description

> What is the purpose of this pull request?

This pull request:

-   support includes method to [@stdlib/array/fixed-endian-factory](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/fixed-endian-factory).

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #3145 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
