### PR TITLE
feat: add `join` method to `array/fixed-endian-factory`

### DIFF
--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
@@ -720,8 +720,8 @@ var Float64ArrayFE = fixedEndianFactory( 'float64' );
 
 var arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 3.0 ] );
 
-var str = arr.join( 123 );
-// returns '112321233'
+var str = arr.join( 0 );
+// returns '10203'
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
@@ -695,6 +695,35 @@ var str = arr.toString();
 // returns '1,2,3'
 ```
 
+<a name="method-join"></a>
+
+#### TypedArrayFE.prototype.join( \[separator] )
+
+Serializes the array elements into a string, with elements separated by the specified `separator`. If no `separator` is provided, a comma (`,`) is used as the default.
+
+```javascript
+var Float64ArrayFE = fixedEndianFactory( 'float64' );
+
+var arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 3.0 ] );
+
+var str = arr.join();
+// returns '1,2,3'
+
+str = arr.join( ' - ' );
+// returns '1 - 2 - 3'
+```
+
+If the provided `separator` is not a string, it is coerced to a string.
+
+```javascript
+var Float64ArrayFE = fixedEndianFactory( 'float64' );
+
+var arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 3.0 ] );
+
+var str = arr.join( 123 );
+// returns '112321233'
+```
+
 </section>
 
 <!-- /.usage -->

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.join.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.join.js
@@ -1,0 +1,55 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var factory = require( './../lib' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var Float64ArrayFE = factory( 'float64' );
+
+
+// MAIN //
+
+bench( pkg+':join', function benchmark( b ) {
+	var out;
+	var arr;
+	var i;
+
+	arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = arr.join();
+		if ( typeof out !== 'string' ) {
+			b.fail( 'should return a string' );
+		}
+	}
+	b.toc();
+	if ( typeof out !== 'string' ) {
+		b.fail( 'should return a string' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.join.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.join.length.js
@@ -1,0 +1,100 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var zeroTo = require( '@stdlib/array/zero-to' );
+var factory = require( './../lib' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var Float64ArrayFE = factory( 'float64' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var arr;
+	arr = new Float64ArrayFE( 'little-endian', zeroTo( len ) );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var out;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			out = arr.join( '/' );
+			if ( typeof out !== 'string' ) {
+				b.fail( 'should return a string' );
+			}
+		}
+		b.toc();
+		if ( typeof out !== 'string' ) {
+			b.fail( 'should return a string' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':join:len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
@@ -882,7 +882,7 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 	* @name join
 	* @memberof TypedArray.prototype
 	* @type {Function}
-	* @param {string} [separator=','] - string used to separate each element
+	* @param {string} [separator=','] - string used to separate consecutive elements
 	* @throws {TypeError} `this` must be a typed array instance
 	* @returns {string} joined string
 	*/
@@ -897,7 +897,7 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 		}
 
 		if ( arguments.length > 0 ) {
-			sep = String(separator);
+			sep = String( separator );
 		} else {
 			sep = ',';
 		}

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
@@ -875,6 +875,42 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 		return out.join( ',' );
 	});
 
+	/**
+	* Serializes the array elements into a string, with elements separated by the specified `separator`.
+	*
+	* @private
+	* @name join
+	* @memberof TypedArray.prototype
+	* @type {Function}
+	* @param {string} [separator=','] - string used to separate each element
+	* @throws {TypeError} `this` must be a typed array instance
+	* @returns {string} joined string
+	*/
+	setReadOnly( TypedArray.prototype, 'join', function join( separator ) {
+		var out;
+		var buf;
+		var sep;
+		var i;
+
+		if ( !isTypedArray( this ) ) {
+			throw new TypeError( format( 'invalid invocation. `this` is not %s %s.', CHAR2ARTICLE[ dtype[0] ], CTOR_NAME ) );
+		}
+
+		if ( arguments.length > 0 ) {
+			sep = String(separator);
+		} else {
+			sep = ',';
+		}
+
+		out = [];
+		buf = this._buffer;
+		for ( i = 0; i < this._length; i++ ) {
+			out.push( buf[ GETTER ]( i * BYTES_PER_ELEMENT, this._isLE ) );
+		}
+
+		return out.join( sep );
+	});
+
 	return TypedArray;
 
 	/**

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/test/test.join.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/test/test.join.js
@@ -1,0 +1,167 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var factory = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof factory, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the returned function is a `join` method', function test( t ) {
+	var ctor = factory( 'float64' );
+	t.strictEqual( hasOwnProp( ctor.prototype, 'join' ), true, 'has property' );
+	t.strictEqual( isFunction( ctor.prototype.join ), true, 'has method' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a typed array instance', function test( t ) {
+	var values;
+	var ctor;
+	var arr;
+	var i;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided ' + values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.join.call( value );
+		};
+	}
+});
+
+tape( 'the method returns an empty string if invoked on an empty array', function test( t ) {
+	var ctor;
+	var str;
+	var arr;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [] );
+
+	str = arr.join();
+	t.strictEqual( str, '', 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method returns a string representation of a typed array with elements separated by a separator', function test( t ) {
+	var expected;
+	var ctor;
+	var str;
+	var arr;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0 ] );
+	expected = '1@2@3@4';
+
+	str = arr.join( '@' );
+
+	t.strictEqual( str, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method returns a string representation of a typed array with elements separated by a separator (single element)', function test( t ) {
+	var expected;
+	var ctor;
+	var str;
+	var arr;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0 ] );
+	expected = '1';
+
+	str = arr.join();
+
+	t.strictEqual( str, expected, 'returns expected value' );
+
+	arr = new ctor( 'little-endian', [ 2.0 ] );
+	expected = '2';
+
+	str = arr.join( ';' );
+
+	t.strictEqual( str, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'if the method is invoked without a separator argument, the method returns a string representation of a typed array with elements separated by a comma', function test( t ) {
+	var expected;
+	var ctor;
+	var str;
+	var arr;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0 ] );
+	expected = '1,2,3,4';
+
+	str = arr.join();
+
+	t.strictEqual( str, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method coerces non-string separators to strings', function test( t ) {
+	var expected;
+	var ctor;
+	var str;
+	var arr;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0 ] );
+
+	expected = '1true2true3';
+	str = arr.join( true );
+	t.strictEqual( str, expected, 'returns expected value' );
+
+	expected = '1null2null3';
+	str = arr.join( null );
+	t.strictEqual( str, expected, 'returns expected value' );
+
+	expected = '1[object Object]2[object Object]3';
+	str = arr.join( {} );
+	t.strictEqual( str, expected, 'returns expected value' );
+
+	t.end();
+});


### PR DESCRIPTION
Resolves #3147 

## Description

> What is the purpose of this pull request?

This pull request:

-   adds support for a join method to [@stdlib/array/fixed-endian-factory](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/fixed-endian-factory).

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves  #3147 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
