### PR TITLE
feat: add toReversed method to array/fixed endian factory

### DIFF
--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
@@ -679,6 +679,31 @@ var count = context.count;
 // returns 3
 ```
 
+<a name="method-to-reversed"></a>
+
+#### TypedArray.prototype.toReversed()
+
+Returns a new typed array containing the elements in reversed order.
+
+```javascript
+var Float64ArrayFE = fixedEndianFactory( 'float64' );
+
+var arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 3.0 ] );
+// returns <Float64ArrayFE>
+
+var out = arr.toReversed();
+// returns <Float64ArrayFE>
+
+var v = out.get( 0 );
+// returns 3.0
+
+v = out.get( 1 );
+// returns 2.0
+
+v = out.get( 2 );
+// returns 1.0
+```
+
 <a name="method-to-string"></a>
 
 #### TypedArrayFE.prototype.toString()

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.to_reversed.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.to_reversed.js
@@ -1,0 +1,55 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pkg = require( './../package.json' ).name;
+var factory = require( './../lib' );
+
+
+// VARIABLES //
+
+var Float64ArrayFE = factory( 'float64' );
+
+
+// MAIN //
+
+bench( pkg+':toReversed', function benchmark( b ) {
+	var out;
+	var arr;
+	var i;
+
+	arr = new Float64ArrayFE( 'little-endian', [ 1.0, 2.0, 2.0, 1.0 ] );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = arr.toReversed();
+		if ( typeof out !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+	if ( !( out instanceof Float64ArrayFE) ) {
+		b.fail( 'should return a Typed Array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.to_reversed.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.to_reversed.length.js
@@ -1,0 +1,101 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var zeroTo = require( '@stdlib/array/zero-to' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var pkg = require( './../package.json' ).name;
+var factory = require( './../lib' );
+
+
+// VARIABLES //
+
+var Float64ArrayFE = factory( 'float64' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var arr;
+
+	arr = new Float64ArrayFE( 'little-endian', zeroTo( len ) );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var out;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			out = arr.toReversed();
+			if ( typeof out !== 'object' ) {
+				b.fail( 'should return an object' );
+			}
+		}
+		b.toc();
+		if ( !( out instanceof Float64ArrayFE ) ) {
+			b.fail( 'should return a Complex64Array' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':toReversed:len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
@@ -725,6 +725,56 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 	});
 
 	/**
+	* Returns a new typed array containing the elements in reversed order.
+	*
+	* @name toReversed
+	* @memberof TypedArray.prototype
+	* @type {Function}
+	* @throws {TypeError} `this` is not a typed array
+	* @returns {TypedArray} reversed array
+	*
+	* @example
+	* var Float64ArrayFE = factory( 'float64' );
+	*
+	* var arr = new Float64ArrayFE( 'little-endian', [1.0, 2.0, 3.0] );
+	*
+	* var out = arr.toReversed();
+	* // returns <TypedArray>
+	*
+	* var v = out.get( 0 );
+	* // returns 1.0
+	*
+	* v = out.get( 1 );
+	* // returns 2.0
+	*
+	* v = out.get( 2 );
+	* // returns 3.0
+	*/
+	setReadOnly( TypedArray.prototype, 'toReversed', function toReversed() {
+		var obuf;
+		var out;
+		var len;
+		var buf;
+		var i;
+		var v;
+
+		if ( !isTypedArray( this ) ) {
+			throw new TypeError( 'invalid invocation. `this` is not a typed array.' );
+		}
+
+		len = this._length;
+		out = new this.constructor( flag2byteOrder( this._isLE ), len );
+		buf = this._buffer;
+		obuf = out._buffer; // eslint-disable-line no-underscore-dangle
+		for ( i = 0; i < len; i++ ) {
+			v = buf[ GETTER ]( ( ( len - 1 ) * BYTES_PER_ELEMENT ) - ( i * BYTES_PER_ELEMENT ), this._isLE );
+			obuf[ SETTER ]( i * BYTES_PER_ELEMENT, v, this._isLE );
+		}
+
+		return out;
+	});
+
+	/**
 	* Sets an array element.
 	*
 	* ## Notes

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/test/test.to_reversed.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/test/test.to_reversed.js
@@ -1,0 +1,120 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var instanceOf = require( '@stdlib/assert/instance-of' );
+var Uint8Array = require( '@stdlib/array/uint8' );
+var factory = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof factory, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the main export is a `toReversed` method', function test( t ) {
+	var ctor = factory( 'float64' );
+	t.strictEqual( hasOwnProp( ctor.prototype, 'toReversed' ), true, 'returns expected value' );
+	t.strictEqual( isFunction( ctor.prototype.toReversed ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a typed array instance', function test( t ) {
+	var values;
+	var ctor;
+	var arr;
+	var i;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', 5 );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.toReversed.call( value );
+		};
+	}
+	t.end();
+});
+
+tape( 'the method returns an empty array if operating on an empty typed array', function test( t ) {
+	var ctor;
+	var arr;
+	var out;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian' );
+	out = arr.toReversed();
+
+	t.strictEqual(out.length, 0, 'returns expected value');
+	t.end();
+});
+
+tape( 'the method returns a new typed array containing elements in reverse order', function test( t ) {
+	var expected;
+	var ctor;
+	var arr;
+	var out;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0, 4.0 ] );
+	expected = new Uint8Array( [ 4.0, 3.0, 2.0, 1.0 ] );
+	out = arr.toReversed();
+
+	t.strictEqual( instanceOf( out, ctor ), true, 'returns expected value' );
+	t.notEqual( out, arr, 'returns a new instance' );
+	t.strictEqual( out.length, expected.length, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method does not change the array length', function test( t ) {
+	var ctor;
+	var arr;
+	var out;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', 10 );
+	out = arr.toReversed();
+
+	t.strictEqual( out.length, 10, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
Resolves #3159 .

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds toReversed method to main.js
-   Adds tests for toReversed method in new file test.to_reversed.js
-   Adds two benchmark files for toReversed method, one measuring baseline performance and the other measuring performance as array length increases
-   Added documentation and updated README.md file for toReversed method

## Related Issues

> Does this pull request have any related issues?
No

This pull request:

-   resolves #3159 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Reversing a typed array using:
```javascript
	for ( i = 0; i < len; i++ ) {
		v = buf[ GETTER ]( ( ( len - 1 ) * BYTES_PER_ELEMENT ) - ( i * BYTES_PER_ELEMENT ), this._isLE );
		obuf[ SETTER ]( i * BYTES_PER_ELEMENT, v, this._isLE );
	}
```
seems to perform faster (around ≈7-10 ms) in benchmarking and test results than:
```javascript
	for ( i = 0; i < len; i++ ) {
		obuf[ i ] = buf[ len - i - 1 ];
	}
```

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
