### PR TITLE
feat: add `math/base/assert/is-oddf`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/README.md
@@ -86,7 +86,7 @@ bool = isOddf( NaN );
 
 ```javascript
 var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var roundf = require( '@stdlib/math/base/special/roundf' );
 var isOddf = require( '@stdlib/math/base/assert/is-oddf' );
 
 var bool;
@@ -94,7 +94,7 @@ var x;
 var i;
 
 for ( i = 0; i < 100; i++ ) {
-    x = round( randu() * 100.0 );
+    x = roundf( randu() * 100.0 );
     bool = isOddf( x );
     console.log( '%d is %s', x, ( bool ) ? 'odd' : 'not odd' );
 }

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # isOddf
 
-> Test if a finite single-precision floating-point number is an odd number.
+> Test if a finite single-precision floating-point nummeric value is an odd number.
 
 <section class="usage">
 
@@ -32,7 +32,7 @@ var isOddf = require( '@stdlib/math/base/assert/is-oddf' );
 
 #### isOddf( x )
 
-Tests if a **finite** single-precision floating-point number is an odd number.
+Tests if a **finite** single-precision floating-point numeric value is an odd number.
 
 ```javascript
 var bool = isOddf( 5.0 );
@@ -132,7 +132,7 @@ for ( i = 0; i < 100; i++ ) {
 
 #### stdlib_base_is_oddf( x )
 
-Tests if a finite single-precision floating-point number is an odd number.
+Tests if a finite single-precision floating-point numeric value is an odd number.
 
 ```c
 #include <stdbool.h>

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # isOddf
 
-> Test if a finite single-precision floating-point nummeric value is an odd number.
+> Test if a finite single-precision floating-point number is an odd number.
 
 <section class="usage">
 

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/README.md
@@ -1,0 +1,216 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# isOddf
+
+> Test if a finite single-precision floating-point number is an odd number.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var isOddf = require( '@stdlib/math/base/assert/is-oddf' );
+```
+
+#### isOddf( x )
+
+Tests if a **finite** single-precision floating-point number is an odd number.
+
+```javascript
+var bool = isOddf( 5.0 );
+// returns true
+
+bool = isOddf( -2.0 );
+// returns false
+
+bool = isOddf( 0.0 );
+// returns false
+
+bool = isOddf( NaN );
+// returns false
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   The function assumes a **finite** `number`. If provided positive or negative `infinity`, the function will return `true`, when, in fact, the result is undefined. If `x` can be `infinite`, wrap the implementation as follows:
+
+    ```javascript
+    function check( x ) {
+        return (
+            x < Infinity &&
+            x > -Infinity &&
+            isOddf( x )
+        );
+    }
+
+    var bool = check( Infinity );
+    // returns false
+
+    bool = check( -Infinity );
+    // returns false
+    ```
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var randu = require( '@stdlib/random/base/randu' );
+var round = require( '@stdlib/math/base/special/round' );
+var isOddf = require( '@stdlib/math/base/assert/is-oddf' );
+
+var bool;
+var x;
+var i;
+
+for ( i = 0; i < 100; i++ ) {
+    x = round( randu() * 100.0 );
+    bool = isOddf( x );
+    console.log( '%d is %s', x, ( bool ) ? 'odd' : 'not odd' );
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/math/base/assert/is_oddf.h"
+```
+
+#### stdlib_base_is_oddf( x )
+
+Tests if a finite single-precision floating-point number is an odd number.
+
+```c
+#include <stdbool.h>
+
+bool out = stdlib_base_is_oddf( 1.0f );
+// returns true
+
+out = stdlib_base_is_oddf( 4.0f );
+// returns false
+```
+
+The function accepts the following arguments:
+
+-   **x**: `[in] float` input value.
+
+```c
+bool stdlib_base_is_oddf( const float x );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/math/base/assert/is_oddf.h"
+#include <stdio.h>
+#include <stdbool.h>
+
+int main( void ) {
+    const float x[] = { 5.0f, -5.0f, 3.14f, -3.14f, 0.0f, 0.0f / 0.0f };
+
+    bool b;
+    int i;
+    for ( i = 0; i < 6; i++ ) {
+        b = stdlib_base_is_oddf( x[ i ] );
+        printf( "Value: %f. Is Odd? %s.\n", x[ i ], ( b ) ? "True" : "False" );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/README.md
@@ -95,8 +95,8 @@ var i;
 x = randu( 100, -50, 50 );
 
 for ( i = 0; i < 100; i++ ) {
-	bool = isOddf( x[ i % 100 ] );
-	console.log( '%d is %s', x[ i % 100 ], ( bool ) ? 'odd' : 'not odd' );
+    bool = isOddf( x[ i % 100 ] );
+    console.log( '%d is %s', x[ i % 100 ], ( bool ) ? 'odd' : 'not odd' );
 }
 ```
 

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/README.md
@@ -86,7 +86,7 @@ bool = isOddf( NaN );
 
 ```javascript
 var randu = require( '@stdlib/random/array/discrete-uniform' );
-var isOddf = require( './../lib' );
+var isOddf = require( '@stdlib/math/base/assert/is-oddf' );
 
 var bool;
 var x;

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/README.md
@@ -85,18 +85,18 @@ bool = isOddf( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var roundf = require( '@stdlib/math/base/special/roundf' );
-var isOddf = require( '@stdlib/math/base/assert/is-oddf' );
+var randu = require( '@stdlib/random/array/discrete-uniform' );
+var isOddf = require( './../lib' );
 
 var bool;
 var x;
 var i;
 
+x = randu( 100, -50, 50 );
+
 for ( i = 0; i < 100; i++ ) {
-    x = roundf( randu() * 100.0 );
-    bool = isOddf( x );
-    console.log( '%d is %s', x, ( bool ) ? 'odd' : 'not odd' );
+	bool = isOddf( x[ i % 100 ] );
+	console.log( '%d is %s', x[ i % 100 ], ( bool ) ? 'odd' : 'not odd' );
 }
 ```
 

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var randu = require( '@stdlib/random/array/discrete-uniform' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var pkg = require( './../package.json' ).name;
 var isOddf = require( './../lib' );

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/benchmark/benchmark.js
@@ -1,0 +1,52 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var roundf = require( '@stdlib/math/base/special/roundf' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var pkg = require( './../package.json' ).name;
+var isOddf = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		x = roundf( (randu() * 1.0e7) - 5.0e6 );
+		y = isOddf( x );
+		if ( typeof y !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( y ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/benchmark/benchmark.js
@@ -37,7 +37,7 @@ bench( pkg, function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = roundf( (randu() * 1.0e7) - 5.0e6 );
+		x = roundf( ( randu() * 1.0e7 ) - 5.0e6 );
 		y = isOddf( x );
 		if ( typeof y !== 'boolean' ) {
 			b.fail( 'should return a boolean' );

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/benchmark/benchmark.js
@@ -22,7 +22,6 @@
 
 var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/base/randu' );
-var roundf = require( '@stdlib/math/base/special/roundf' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var pkg = require( './../package.json' ).name;
 var isOddf = require( './../lib' );
@@ -35,10 +34,11 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = randu( 100, -50, 50 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = roundf( ( randu() * 1.0e7 ) - 5.0e6 );
-		y = isOddf( x );
+		y = isOddf( x[ i % 100 ] );
 		if ( typeof y !== 'boolean' ) {
 			b.fail( 'should return a boolean' );
 		}

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/benchmark/benchmark.native.js
@@ -23,7 +23,6 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var randu = require( '@stdlib/random/base/randu' );
-var roundf = require( '@stdlib/math/base/special/roundf' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -44,10 +43,11 @@ bench( pkg, opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = randu( 100, -50, 50 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = roundf( ( randu() * 1.0e7 ) - 5.0e6 );
-		y = isOddf( x );
+		y = isOddf( x[ i % 100 ] );
 		if ( typeof y !== 'boolean' ) {
 			b.fail( 'should return a boolean' );
 		}

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/benchmark/benchmark.native.js
@@ -1,0 +1,61 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var roundf = require( '@stdlib/math/base/special/roundf' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var isOddf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( isOddf instanceof Error )
+};
+
+
+// MAIN //
+
+bench( pkg, opts, function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		x = roundf( (randu() * 1.0e7) - 5.0e6 );
+		y = isOddf( x );
+		if ( typeof y !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( y ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/benchmark/benchmark.native.js
@@ -46,7 +46,7 @@ bench( pkg, opts, function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = roundf( (randu() * 1.0e7) - 5.0e6 );
+		x = roundf( ( randu() * 1.0e7 ) - 5.0e6 );
 		y = isOddf( x );
 		if ( typeof y !== 'boolean' ) {
 			b.fail( 'should return a boolean' );

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var randu = require( '@stdlib/random/array/discrete-uniform' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/benchmark/c/native/Makefile
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/benchmark/c/native/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/benchmark/c/native/benchmark.c
@@ -1,0 +1,134 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/assert/is_oddf.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "is-oddf"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+static void print_version( void ) {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+static void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+static void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+static double tic( void ) {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1).
+*
+* @return random number
+*/
+static float rand_float( void ) {
+	int r = rand();
+	return (float)r / ( (float)RAND_MAX + 1.0f );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+static double benchmark( void ) {
+	double elapsed;
+	float x;
+	double t;
+	bool b;
+	int i;
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		x = ( rand_float() * 200.0f ) - 100.0f;
+		b = stdlib_base_is_oddf( x );
+		if ( b != true && b != false ) {
+			printf( "should return either true or false\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( b != true && b != false ) {
+		printf( "should return either true or false\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::native::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/benchmark/c/native/benchmark.c
@@ -92,15 +92,18 @@ static float rand_float( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	float x;
+	float x[ 100 ];
 	double t;
 	bool b;
 	int i;
 
+	for ( i = 0 ; i < 100 ; i++ ) {
+		x[ i ] = ( rand_float() * 200.0f ) - 100.0f;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( rand_float() * 200.0f ) - 100.0f;
-		b = stdlib_base_is_oddf( x );
+		b = stdlib_base_is_oddf( x[ i % 100 ] );
 		if ( b != true && b != false ) {
 			printf( "should return either true or false\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/binding.gyp
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/docs/repl.txt
@@ -1,0 +1,33 @@
+
+{{alias}}( x )
+    Tests if a finite single-precision floating-point
+    numeric value is an odd number.
+
+    The function assumes a finite number. If provided positive or negative
+    infinity, the function will return `true`, when, in fact, the result is
+    undefined.
+
+    Parameters
+    ----------
+    x: number
+        Value to test.
+
+    Returns
+    -------
+    bool: boolean
+        Boolean indicating whether the value is an odd number.
+
+    Examples
+    --------
+    > var bool = {{alias}}( 5.0 )
+    true
+    > bool = {{alias}}( -2.0 )
+    false
+    > bool = {{alias}}( 0.0 )
+    false
+    > bool = {{alias}}( NaN )
+    false
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/docs/repl.txt
@@ -1,7 +1,7 @@
 
 {{alias}}( x )
     Tests if a finite single-precision floating-point
-    numeric value is an odd number.
+    number is an odd number.
 
     The function assumes a finite number. If provided positive or negative
     infinity, the function will return `true`, when, in fact, the result is

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/docs/repl.txt
@@ -1,7 +1,6 @@
 
 {{alias}}( x )
-    Tests if a finite single-precision floating-point
-    number is an odd number.
+    Tests if a finite single-precision floating-point number is an odd number.
 
     The function assumes a finite number. If provided positive or negative
     infinity, the function will return `true`, when, in fact, the result is

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/docs/types/index.d.ts
@@ -1,0 +1,52 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Tests if a finite single-precision floating-point numeric value is an odd number.
+*
+* ## Notes
+*
+* -   The function assumes a finite number. If provided positive or negative infinity, the function will return `true`, when, in fact, the result is undefined.
+*
+* @param x - value to test
+* @returns boolean indicating whether the value is an odd number
+*
+* @example
+* var bool = isOddf( 5.0 );
+* // returns true
+*
+* @example
+* var bool = isOddf( -2.0 );
+* // returns false
+*
+* @example
+* var bool = isOddf( 0.0 );
+* // returns false
+*
+* @example
+* var bool = isOddf( NaN );
+* // returns false
+*/
+declare function isOddf( x: number ): boolean;
+
+
+// EXPORTS //
+
+export = isOddf;

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/docs/types/index.d.ts
@@ -19,7 +19,7 @@
 // TypeScript Version: 4.1
 
 /**
-* Tests if a finite single-precision floating-point numeric value is an odd number.
+* Tests if a finite single-precision floating-point number is an odd number.
 *
 * ## Notes
 *

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/docs/types/test.ts
@@ -1,0 +1,45 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import isOddf = require( './index' );
+
+
+// TESTS //
+
+// The function returns a boolean...
+{
+	isOddf( 2 ); // $ExpectType boolean
+	isOddf( 3 ); // $ExpectType boolean
+}
+
+// The compiler throws an error if the function is provided a value other than a number...
+{
+	isOddf( true ); // $ExpectError
+	isOddf( false ); // $ExpectError
+	isOddf( null ); // $ExpectError
+	isOddf( undefined ); // $ExpectError
+	isOddf( [] ); // $ExpectError
+	isOddf( {} ); // $ExpectError
+	isOddf( ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	isOddf(); // $ExpectError
+	isOddf( undefined, 123 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/examples/c/example.c
@@ -1,0 +1,32 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/assert/is_oddf.h"
+#include <stdio.h>
+#include <stdbool.h>
+
+int main( void ) {
+	const float x[] = { 5.0f, -5.0f, 3.14f, -3.14f, 0.0f, 0.0f / 0.0f };
+
+	bool b;
+	int i;
+	for ( i = 0; i < 6; i++ ) {
+		b = stdlib_base_is_oddf( x[ i ] );
+		printf( "Value: %f. Is Odd? %s.\n", x[ i ], ( b ) ? "True" : "False" );
+	}
+}

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/examples/index.js
@@ -1,0 +1,33 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var randu = require( '@stdlib/random/base/randu' );
+var roundf = require( '@stdlib/math/base/special/roundf' );
+var isOddf = require( './../lib' );
+
+var bool;
+var x;
+var i;
+
+for ( i = 0; i < 100; i++ ) {
+	x = roundf( randu() * 100.0 );
+	bool = isOddf( x );
+	console.log( '%d is %s', x, ( bool ) ? 'odd' : 'not odd' );
+}

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/examples/index.js
@@ -29,5 +29,5 @@ x = randu( 100, -50, 50 );
 
 for ( i = 0; i < 100; i++ ) {
 	bool = isOddf( x[ i % 100 ] );
-	console.log( '%d is %s', x, ( bool ) ? 'odd' : 'not odd' );
+	console.log( '%d is %s', x[ i % 100 ], ( bool ) ? 'odd' : 'not odd' );
 }

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/examples/index.js
@@ -18,7 +18,7 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var randu = require( '@stdlib/random/array/discrete-uniform' );
 var roundf = require( '@stdlib/math/base/special/roundf' );
 var isOddf = require( './../lib' );
 
@@ -26,8 +26,9 @@ var bool;
 var x;
 var i;
 
+x = randu( 100, -50, 50 );
+
 for ( i = 0; i < 100; i++ ) {
-	x = roundf( randu() * 100.0 );
-	bool = isOddf( x );
+	bool = isOddf( x[ i % 100 ] );
 	console.log( '%d is %s', x, ( bool ) ? 'odd' : 'not odd' );
 }

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/examples/index.js
@@ -19,7 +19,6 @@
 'use strict';
 
 var randu = require( '@stdlib/random/array/discrete-uniform' );
-var roundf = require( '@stdlib/math/base/special/roundf' );
 var isOddf = require( './../lib' );
 
 var bool;

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/include.gypi
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/include/stdlib/math/base/assert/is_oddf.h
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/include/stdlib/math/base/assert/is_oddf.h
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_MATH_BASE_ASSERT_IS_ODDF_H
+#define STDLIB_MATH_BASE_ASSERT_IS_ODDF_H
+
+#include <stdbool.h>
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Tests if a finite single-precision floating-point number is an odd number.
+*/
+bool stdlib_base_is_oddf( const float x );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_MATH_BASE_ASSERT_IS_ODDF_H

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/lib/index.js
@@ -1,0 +1,49 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Test if a finite single-precision floating-point number is an odd number.
+*
+* @module @stdlib/math/base/assert/is-oddf
+*
+* @example
+* var isOddf = require( '@stdlib/math/base/assert/is-oddf' );
+*
+* var bool = isOddf( 5.0 );
+* // returns true
+*
+* bool = isOddf( -2.0 );
+* // returns false
+*
+* bool = isOddf( 0.0 );
+* // returns false
+*
+* bool = isOddf( NaN );
+* // returns false
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Test if a finite single-precision floating-point numeric value is an odd number.
+* Test if a finite single-precision floating-point number is an odd number.
 *
 * @module @stdlib/math/base/assert/is-oddf
 *

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Test if a finite single-precision floating-point number is an odd number.
+* Test if a finite single-precision floating-point numeric value is an odd number.
 *
 * @module @stdlib/math/base/assert/is-oddf
 *

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/lib/main.js
@@ -26,7 +26,7 @@ var isEvenf = require( '@stdlib/math/base/assert/is-evenf' );
 // MAIN //
 
 /**
-* Tests if a finite single-precision floating-point numeric value is an odd number.
+* Tests if a finite single-precision floating-point number is an odd number.
 *
 * @param {number} x - value to test
 * @returns {boolean} boolean indicating whether the value is an odd number

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/lib/main.js
@@ -1,0 +1,61 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isEvenf = require( '@stdlib/math/base/assert/is-evenf' );
+
+
+// MAIN //
+
+/**
+* Tests if a finite single-precision floating-point number is an odd number.
+*
+* @param {number} x - value to test
+* @returns {boolean} boolean indicating whether the value is an odd number
+*
+* @example
+* var bool = isOddf( 5.0 );
+* // returns true
+*
+* @example
+* var bool = isOddf( -2.0 );
+* // returns false
+*
+* @example
+* var bool = isOddf( 0.0 );
+* // returns false
+*
+* @example
+* var bool = isOddf( NaN );
+* // returns false
+*/
+function isOddf( x ) {
+	// Check sign to prevent overflow...
+	if ( x > 0.0 ) {
+		return isEvenf( x - 1.0 );
+	}
+	return isEvenf( x + 1.0 );
+}
+
+
+// EXPORTS //
+
+module.exports = isOddf;

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/lib/main.js
@@ -26,7 +26,7 @@ var isEvenf = require( '@stdlib/math/base/assert/is-evenf' );
 // MAIN //
 
 /**
-* Tests if a finite single-precision floating-point number is an odd number.
+* Tests if a finite single-precision floating-point numeric value is an odd number.
 *
 * @param {number} x - value to test
 * @returns {boolean} boolean indicating whether the value is an odd number

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/lib/native.js
@@ -1,0 +1,51 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var Boolean = require( '@stdlib/boolean/ctor' );
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Tests if a finite single-precision floating-point number is an odd number.
+*
+* @private
+* @param {number} x - value to test
+* @returns {boolean} boolean indicating whether the number is odd
+*
+* @example
+* var bool = isOddf( 2.0 );
+* // returns false
+*
+* @example
+* var bool = isOddf( 5.0 );
+* // returns true
+*/
+function isOddf( x ) {
+	return Boolean( addon( x ) );
+}
+
+
+// EXPORTS //
+
+module.exports = isOddf;

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/lib/native.js
@@ -27,7 +27,7 @@ var addon = require( './../src/addon.node' );
 // MAIN //
 
 /**
-* Tests if a finite single-precision floating-point number is an odd number.
+* Tests if a finite single-precision floating-point numeric value is an odd number.
 *
 * @private
 * @param {number} x - value to test

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/lib/native.js
@@ -27,7 +27,7 @@ var addon = require( './../src/addon.node' );
 // MAIN //
 
 /**
-* Tests if a finite single-precision floating-point numeric value is an odd number.
+* Tests if a finite single-precision floating-point number is an odd number.
 *
 * @private
 * @param {number} x - value to test

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/manifest.json
@@ -1,0 +1,40 @@
+{
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-even"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/manifest.json
@@ -33,7 +33,7 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-        "@stdlib/math/base/assert/is-even"
+        "@stdlib/math/base/assert/is-evenf"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/manifest.json
@@ -1,5 +1,7 @@
 {
-  "options": {},
+  "options": {
+    "task": "build"
+  },
   "fields": [
     {
       "field": "src",
@@ -24,6 +26,39 @@
   ],
   "confs": [
     {
+      "task": "build",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/napi/argv",
+        "@stdlib/napi/argv-float",
+        "@stdlib/napi/create-int32",
+        "@stdlib/napi/export",
+        "@stdlib/math/base/assert/is-evenf"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-evenf"
+      ]
+    },
+    {
+      "task": "examples",
       "src": [
         "./src/main.c"
       ],

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/package.json
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/math/base/assert/is-oddf",
   "version": "0.0.0",
-  "description": "Test if a finite single-precision floating-point numeric value is an odd number.",
+  "description": "Test if a finite single-precision floating-point number is an odd number.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/package.json
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/package.json
@@ -63,13 +63,11 @@
     "math",
     "mathematics",
     "float",
-    "double",
-    "dbl",
     "number",
     "numeric",
     "odd",
     "is",
-    "isodd",
+    "isoddf",
     "type",
     "check"
   ]

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/package.json
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/package.json
@@ -1,0 +1,76 @@
+{
+  "name": "@stdlib/math/base/assert/is-oddf",
+  "version": "0.0.0",
+  "description": "Test if a finite single-precision floating-point numeric value is an odd number.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "gypfile": true,
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "src": "./src",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "assertion",
+    "assert",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "math",
+    "mathematics",
+    "float",
+    "double",
+    "dbl",
+    "number",
+    "numeric",
+    "odd",
+    "is",
+    "isodd",
+    "type",
+    "check"
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/src/addon.c
@@ -17,9 +17,12 @@
 */
 
 #include "stdlib/math/base/assert/is_oddf.h"
+#include "stdlib/napi/argv.h"
+#include "stdlib/napi/argv_float.h"
+#include "stdlib/napi/create_int32.h"
+#include "stdlib/napi/export.h"
 #include <node_api.h>
 #include <stdint.h>
-#include <assert.h>
 
 /**
 * Receives JavaScript callback invocation data.
@@ -29,60 +32,10 @@
 * @return       Node-API value
 */
 static napi_value addon( napi_env env, napi_callback_info info ) {
-	napi_status status;
-
-	// Get callback arguments:
-	size_t argc = 1;
-	napi_value argv[ 1 ];
-	status = napi_get_cb_info( env, info, &argc, argv, NULL, NULL );
-	assert( status == napi_ok );
-
-	// Check whether we were provided the correct number of arguments:
-	if ( argc < 1 ) {
-		status = napi_throw_error( env, NULL, "invalid invocation. Insufficient arguments." );
-		assert( status == napi_ok );
-		return NULL;
-	}
-	if ( argc > 1 ) {
-		status = napi_throw_error( env, NULL, "invalid invocation. Too many arguments." );
-		assert( status == napi_ok );
-		return NULL;
-	}
-
-	napi_valuetype vtype0;
-	status = napi_typeof( env, argv[ 0 ], &vtype0 );
-	assert( status == napi_ok );
-	if ( vtype0 != napi_number ) {
-		status = napi_throw_type_error( env, NULL, "invalid argument. First argument must be a number." );
-		assert( status == napi_ok );
-		return NULL;
-	}
-
-	double x;
-	status = napi_get_value_double( env, argv[ 0 ], &x );
-	assert( status == napi_ok );
-
-	bool result = stdlib_base_is_oddf( (float)x );
-
-	napi_value v;
-	status = napi_create_int32( env, (int32_t)result, &v );
-	assert( status == napi_ok );
-
-	return v;
+	STDLIB_NAPI_ARGV( env, info, argv, argc, 1 );
+	STDLIB_NAPI_ARGV_FLOAT( env, x, argv, 0 );
+	STDLIB_NAPI_CREATE_INT32( env, (int32_t)stdlib_base_is_oddf( x ), out );
+	return out;
 }
 
-/**
-* Initializes a Node-API module.
-*
-* @param env      environment under which the function is invoked
-* @param exports  exports object
-* @return         main export
-*/
-static napi_value init( napi_env env, napi_value exports ) {
-	napi_value fcn;
-	napi_status status = napi_create_function( env, "exports", NAPI_AUTO_LENGTH, addon, NULL, &fcn );
-	assert( status == napi_ok );
-	return fcn;
-}
-
-NAPI_MODULE( NODE_GYP_MODULE_NAME, init )
+STDLIB_NAPI_MODULE_EXPORT_FCN( addon )

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/src/addon.c
@@ -58,11 +58,11 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 		return NULL;
 	}
 
-	float x;
-	status = napi_get_value_float( env, argv[ 0 ], &x );
+	double x;
+	status = napi_get_value_double( env, argv[ 0 ], &x );
 	assert( status == napi_ok );
 
-	bool result = stdlib_base_is_oddf( x );
+	bool result = stdlib_base_is_oddf( (float)x );
 
 	napi_value v;
 	status = napi_create_int32( env, (int32_t)result, &v );

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/src/addon.c
@@ -1,0 +1,88 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/assert/is_oddf.h"
+#include <node_api.h>
+#include <stdint.h>
+#include <assert.h>
+
+/**
+* Receives JavaScript callback invocation data.
+*
+* @param env    environment under which the function is invoked
+* @param info   callback data
+* @return       Node-API value
+*/
+static napi_value addon( napi_env env, napi_callback_info info ) {
+	napi_status status;
+
+	// Get callback arguments:
+	size_t argc = 1;
+	napi_value argv[ 1 ];
+	status = napi_get_cb_info( env, info, &argc, argv, NULL, NULL );
+	assert( status == napi_ok );
+
+	// Check whether we were provided the correct number of arguments:
+	if ( argc < 1 ) {
+		status = napi_throw_error( env, NULL, "invalid invocation. Insufficient arguments." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+	if ( argc > 1 ) {
+		status = napi_throw_error( env, NULL, "invalid invocation. Too many arguments." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	napi_valuetype vtype0;
+	status = napi_typeof( env, argv[ 0 ], &vtype0 );
+	assert( status == napi_ok );
+	if ( vtype0 != napi_number ) {
+		status = napi_throw_type_error( env, NULL, "invalid argument. First argument must be a number." );
+		assert( status == napi_ok );
+		return NULL;
+	}
+
+	float x;
+	status = napi_get_value_float( env, argv[ 0 ], &x );
+	assert( status == napi_ok );
+
+	bool result = stdlib_base_is_oddf( x );
+
+	napi_value v;
+	status = napi_create_int32( env, (int32_t)result, &v );
+	assert( status == napi_ok );
+
+	return v;
+}
+
+/**
+* Initializes a Node-API module.
+*
+* @param env      environment under which the function is invoked
+* @param exports  exports object
+* @return         main export
+*/
+static napi_value init( napi_env env, napi_value exports ) {
+	napi_value fcn;
+	napi_status status = napi_create_function( env, "exports", NAPI_AUTO_LENGTH, addon, NULL, &fcn );
+	assert( status == napi_ok );
+	return fcn;
+}
+
+NAPI_MODULE( NODE_GYP_MODULE_NAME, init )

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/src/main.c
@@ -23,7 +23,7 @@
 * Tests if a finite single-precision floating-point number is an odd number.
 *
 * @param x    input value
-* @return	  output value
+* @return     output value
 *
 * @example
 * #include <stdbool.h>

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/src/main.c
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/assert/is_oddf.h"
+#include "stdlib/math/base/assert/is_evenf.h"
+
+/**
+* Tests if a finite single-precision floating-point number is an odd number.
+*
+* @param x    input value
+* @return	  output value
+*
+* @example
+* #include <stdbool.h>
+*
+* bool out = stdlib_base_is_oddf( 3.0f );
+* // returns true
+*/
+bool stdlib_base_is_oddf( const float x ) {
+	// Check sign to prevent overflow...
+	if ( x > 0.0f ) {
+		return stdlib_base_is_evenf( x - 1.0f );
+	}
+	return stdlib_base_is_evenf( x + 1.0f );
+}

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/test/test.js
@@ -1,0 +1,87 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var PINF = require( '@stdlib/constants/float32/pinf' );
+var NINF = require( '@stdlib/constants/float32/ninf' );
+var randu = require( '@stdlib/random/base/randu' );
+var roundf = require( '@stdlib/math/base/special/roundf' );
+var isOddf = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof isOddf, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `false` if provided an even number', function test( t ) {
+	var bool;
+	var x;
+	var i;
+	for ( i = 0; i < 1000; i++ ) {
+		x = roundf( randu() * 1.0e6 ) - 5.0e5;
+		x *= 2; // always even
+		bool = isOddf( x );
+		t.equal( bool, false, 'returns false when provided '+x );
+	}
+	t.end();
+});
+
+tape( 'the function returns `true` if provided an odd number', function test( t ) {
+	var bool;
+	var x;
+	var i;
+	for ( i = 0; i < 1000; i++ ) {
+		x = roundf( randu() * 1.0e6 ) - 5.0e5;
+		if ( x%2 === 0 ) {
+			x += 1;
+		}
+		bool = isOddf( x );
+		t.equal( bool, true, 'returns true when provided '+x );
+	}
+	t.end();
+});
+
+tape( 'the function returns `false` if provided `+-0`', function test( t ) {
+	t.equal( isOddf( +0.0 ), false, 'returns false' );
+	t.equal( isOddf( -0.0 ), false, 'returns false' );
+	t.end();
+});
+
+tape( 'WARNING: the function returns `true` if provided `+infinity`', function test( t ) {
+	t.equal( isOddf( PINF ), true, 'returns true' );
+	t.end();
+});
+
+tape( 'WARNING: the function returns `true` if provided `-infinity`', function test( t ) {
+	t.equal( isOddf( NINF ), true, 'returns true' );
+	t.end();
+});
+
+tape( 'the function returns `false` if provided `NaN`', function test( t ) {
+	t.equal( isOddf( NaN ), false, 'returns false' );
+	t.equal( isOddf( 0.0/0.0 ), false, 'returns false' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/test/test.js
@@ -44,7 +44,7 @@ tape( 'the function returns `false` if provided an even number', function test( 
 		x = roundf( randu() * 1.0e6 ) - 5.0e5;
 		x *= 2; // always even
 		bool = isOddf( x );
-		t.equal( bool, false, 'returns false when provided '+x );
+		t.equal( bool, false, 'returns expected value when provided '+x );
 	}
 	t.end();
 });
@@ -59,7 +59,7 @@ tape( 'the function returns `true` if provided an odd number', function test( t 
 			x += 1;
 		}
 		bool = isOddf( x );
-		t.equal( bool, true, 'returns true when provided '+x );
+		t.equal( bool, true, 'returns expected value when provided '+x );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/test/test.js
@@ -82,6 +82,6 @@ tape( 'WARNING: the function returns `true` if provided `-infinity`', function t
 
 tape( 'the function returns `false` if provided `NaN`', function test( t ) {
 	t.equal( isOddf( NaN ), false, 'returns false' );
-	t.equal( isOddf( 0.0/0.0 ), false, 'returns false' );
+	t.equal( isOddf( 0.0 / 0.0 ), false, 'returns false' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/test/test.js
@@ -55,7 +55,7 @@ tape( 'the function returns `true` if provided an odd number', function test( t 
 	var i;
 	for ( i = 0; i < 1000; i++ ) {
 		x = roundf( randu() * 1.0e6 ) - 5.0e5;
-		if ( x%2 === 0 ) {
+		if ( x % 2 === 0 ) {
 			x += 1;
 		}
 		bool = isOddf( x );

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/test/test.js
@@ -65,23 +65,23 @@ tape( 'the function returns `true` if provided an odd number', function test( t 
 });
 
 tape( 'the function returns `false` if provided `+-0`', function test( t ) {
-	t.equal( isOddf( +0.0 ), false, 'returns false' );
-	t.equal( isOddf( -0.0 ), false, 'returns false' );
+	t.equal( isOddf( +0.0 ), false, 'returns expected value' );
+	t.equal( isOddf( -0.0 ), false, 'returns expected value' );
 	t.end();
 });
 
 tape( 'WARNING: the function returns `true` if provided `+infinity`', function test( t ) {
-	t.equal( isOddf( PINF ), true, 'returns true' );
+	t.equal( isOddf( PINF ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'WARNING: the function returns `true` if provided `-infinity`', function test( t ) {
-	t.equal( isOddf( NINF ), true, 'returns true' );
+	t.equal( isOddf( NINF ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `false` if provided `NaN`', function test( t ) {
-	t.equal( isOddf( NaN ), false, 'returns false' );
-	t.equal( isOddf( 0.0 / 0.0 ), false, 'returns false' );
+	t.equal( isOddf( NaN ), false, 'returns expected value' );
+	t.equal( isOddf( 0.0 / 0.0 ), false, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/test/test.native.js
@@ -64,7 +64,7 @@ tape( 'the function returns `true` if provided an odd number', opts, function te
 	var i;
 	for ( i = 0; i < 1000; i++ ) {
 		x = roundf( randu() * 1.0e6 ) - 5.0e5;
-		if ( x%2 === 0 ) {
+		if ( x % 2 === 0 ) {
 			x += 1;
 		}
 		bool = isOddf( x );
@@ -91,6 +91,6 @@ tape( 'WARNING: the function returns `true` if provided `-infinity`', opts, func
 
 tape( 'the function returns `false` if provided `NaN`', opts, function test( t ) {
 	t.equal( isOddf( NaN ), false, 'returns expected value' );
-	t.equal( isOddf( 0.0/0.0 ), false, 'returns expected value' );
+	t.equal( isOddf( 0.0 / 0.0 ), false, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/test/test.native.js
@@ -74,23 +74,23 @@ tape( 'the function returns `true` if provided an odd number', opts, function te
 });
 
 tape( 'the function returns `false` if provided `+-0`', opts, function test( t ) {
-	t.equal( isOddf( +0.0 ), false, 'returns false' );
-	t.equal( isOddf( -0.0 ), false, 'returns false' );
+	t.equal( isOddf( +0.0 ), false, 'returns expected value' );
+	t.equal( isOddf( -0.0 ), false, 'returns expected value' );
 	t.end();
 });
 
 tape( 'WARNING: the function returns `true` if provided `+infinity`', opts, function test( t ) {
-	t.equal( isOddf( PINF ), true, 'returns true' );
+	t.equal( isOddf( PINF ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'WARNING: the function returns `true` if provided `-infinity`', opts, function test( t ) {
-	t.equal( isOddf( NINF ), true, 'returns true' );
+	t.equal( isOddf( NINF ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `false` if provided `NaN`', opts, function test( t ) {
-	t.equal( isOddf( NaN ), false, 'returns false' );
-	t.equal( isOddf( 0.0/0.0 ), false, 'returns false' );
+	t.equal( isOddf( NaN ), false, 'returns expected value' );
+	t.equal( isOddf( 0.0/0.0 ), false, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/test/test.native.js
@@ -53,7 +53,7 @@ tape( 'the function returns `false` if provided an even number', opts, function 
 		x = roundf( randu() * 1.0e6 ) - 5.0e5;
 		x *= 2; // always even
 		bool = isOddf( x );
-		t.equal( bool, false, 'returns false when provided '+x );
+		t.equal( bool, false, 'returns expected value when provided '+x );
 	}
 	t.end();
 });
@@ -68,7 +68,7 @@ tape( 'the function returns `true` if provided an odd number', opts, function te
 			x += 1;
 		}
 		bool = isOddf( x );
-		t.equal( bool, true, 'returns true when provided '+x );
+		t.equal( bool, true, 'returns expected value when provided '+x );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/test/test.native.js
@@ -1,0 +1,96 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var randu = require( '@stdlib/random/base/randu' );
+var roundf = require( '@stdlib/math/base/special/roundf' );
+var PINF = require( '@stdlib/constants/float32/pinf' );
+var NINF = require( '@stdlib/constants/float32/ninf' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var isOddf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( isOddf instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof isOddf, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `false` if provided an even number', opts, function test( t ) {
+	var bool;
+	var x;
+	var i;
+	for ( i = 0; i < 1000; i++ ) {
+		x = roundf( randu() * 1.0e6 ) - 5.0e5;
+		x *= 2; // always even
+		bool = isOddf( x );
+		t.equal( bool, false, 'returns false when provided '+x );
+	}
+	t.end();
+});
+
+tape( 'the function returns `true` if provided an odd number', opts, function test( t ) {
+	var bool;
+	var x;
+	var i;
+	for ( i = 0; i < 1000; i++ ) {
+		x = roundf( randu() * 1.0e6 ) - 5.0e5;
+		if ( x%2 === 0 ) {
+			x += 1;
+		}
+		bool = isOddf( x );
+		t.equal( bool, true, 'returns true when provided '+x );
+	}
+	t.end();
+});
+
+tape( 'the function returns `false` if provided `+-0`', opts, function test( t ) {
+	t.equal( isOddf( +0.0 ), false, 'returns false' );
+	t.equal( isOddf( -0.0 ), false, 'returns false' );
+	t.end();
+});
+
+tape( 'WARNING: the function returns `true` if provided `+infinity`', opts, function test( t ) {
+	t.equal( isOddf( PINF ), true, 'returns true' );
+	t.end();
+});
+
+tape( 'WARNING: the function returns `true` if provided `-infinity`', opts, function test( t ) {
+	t.equal( isOddf( NINF ), true, 'returns true' );
+	t.end();
+});
+
+tape( 'the function returns `false` if provided `NaN`', opts, function test( t ) {
+	t.equal( isOddf( NaN ), false, 'returns false' );
+	t.equal( isOddf( 0.0/0.0 ), false, 'returns false' );
+	t.end();
+});


### PR DESCRIPTION
Resolves #3313

## Description

> What is the purpose of this pull request?

This pull request:

-   adds `math/base/assert/is-oddf`

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #3313

## Questions

> Any questions for reviewers of this pull request?

There wasn't a macro for the addon of this particular function so I've just explicitly type-casted the double value to a float, is that correct? (please see `src/addon.c`)

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
