### PR TITLE
fix: update the return type and remove unnecessary branches/tests in `blas/ext/base/ssumpw`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ssumpw/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumpw/README.md
@@ -178,8 +178,8 @@ Computes the sum of single-precision floating-point strided array elements using
 ```c
 const float x[] = { 1.0f, -2.0f, 2.0f };
 
-double v = stdlib_strided_ssumpw( 3, x, 1 );
-// returns 1.0
+float v = stdlib_strided_ssumpw( 3, x, 1 );
+// returns 1.0f
 ```
 
 The function accepts the following arguments:
@@ -189,7 +189,7 @@ The function accepts the following arguments:
 -   **strideX**: `[in] CBLAS_INT` stride length for `X`.
 
 ```c
-double stdlib_strided_ssumpw( const CBLAS_INT N, const float *X, const CBLAS_INT strideX );
+float stdlib_strided_ssumpw( const CBLAS_INT N, const float *X, const CBLAS_INT strideX );
 ```
 
 #### stdlib_strided_ssumpw_ndarray( N, \*X, strideX, offsetX )
@@ -199,8 +199,8 @@ Computes the sum of single-precision floating-point strided array elements using
 ```c
 const float x[] = { 1.0f, -2.0f, 2.0f };
 
-double v = stdlib_strided_ssumpw_ndarray( 3, x, 1, 0 );
-// returns 1.0
+float v = stdlib_strided_ssumpw_ndarray( 3, x, 1, 0 );
+// returns 1.0f
 ```
 
 The function accepts the following arguments:
@@ -211,7 +211,7 @@ The function accepts the following arguments:
 -   **offsetX**: `[in] CBLAS_INT` starting index for `X`.
 
 ```c
-double stdlib_strided_ssumpw_ndarray( const CBLAS_INT N, const float *X, const CBLAS_INT strideX, const CBLAS_INT offsetX );
+float stdlib_strided_ssumpw_ndarray( const CBLAS_INT N, const float *X, const CBLAS_INT strideX, const CBLAS_INT offsetX );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/blas/ext/base/ssumpw/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumpw/benchmark/c/benchmark.length.c
@@ -131,7 +131,7 @@ static double benchmark1( int iterations, int len ) {
 static double benchmark2( int iterations, int len ) {
 	double elapsed;
 	float x[ len ];
-	double v;
+	float v;
 	double t;
 	int i;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ssumpw/include/stdlib/blas/ext/base/ssumpw.h
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumpw/include/stdlib/blas/ext/base/ssumpw.h
@@ -31,12 +31,12 @@ extern "C" {
 /**
 * Computes the sum of single-precision floating-point strided array elements using pairwise summation.
 */
-double API_SUFFIX(stdlib_strided_ssumpw)( const CBLAS_INT N, const float *X, const CBLAS_INT strideX );
+float API_SUFFIX(stdlib_strided_ssumpw)( const CBLAS_INT N, const float *X, const CBLAS_INT strideX );
 
 /**
 * Computes the sum of single-precision floating-point strided array elements using pairwise summation and alternative indexing semantics.
 */
-double API_SUFFIX(stdlib_strided_ssumpw_ndarray)( const CBLAS_INT N, const float *X, const CBLAS_INT strideX, const CBLAS_INT offsetX );
+float API_SUFFIX(stdlib_strided_ssumpw_ndarray)( const CBLAS_INT N, const float *X, const CBLAS_INT strideX, const CBLAS_INT offsetX );
 
 #ifdef __cplusplus
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/ssumpw/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumpw/lib/ndarray.js
@@ -22,7 +22,6 @@
 
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var floor = require( '@stdlib/math/base/special/floor' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
 
 
 // VARIABLES //
@@ -78,9 +77,6 @@ function ssumpw( N, x, strideX, offsetX ) {
 	}
 	ix = offsetX;
 	if ( strideX === 0 ) {
-		if ( isnan( x[ ix ] ) ) {
-			return 0.0;
-		}
 		return N * x[ ix ];
 	}
 	if ( N < 8 ) {

--- a/lib/node_modules/@stdlib/blas/ext/base/ssumpw/manifest.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumpw/manifest.json
@@ -41,7 +41,6 @@
         "@stdlib/napi/argv-int64",
         "@stdlib/napi/argv-strided-float32array",
         "@stdlib/napi/create-double",
-        "@stdlib/math/base/assert/is-nanf",
         "@stdlib/blas/base/shared",
         "@stdlib/strided/base/stride2offset"
       ]
@@ -57,7 +56,6 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-        "@stdlib/math/base/assert/is-nanf",
         "@stdlib/blas/base/shared",
         "@stdlib/strided/base/stride2offset"
       ]
@@ -73,7 +71,6 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-        "@stdlib/math/base/assert/is-nanf",
         "@stdlib/blas/base/shared",
         "@stdlib/strided/base/stride2offset"
       ]

--- a/lib/node_modules/@stdlib/blas/ext/base/ssumpw/src/addon.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumpw/src/addon.c
@@ -37,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_ssumpw)( N, X, strideX ), v )
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_ssumpw)( N, X, strideX ), v )
 	return v;
 }
 
@@ -54,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_ssumpw_ndarray)( N, X, strideX, offsetX ), v )
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_ssumpw_ndarray)( N, X, strideX, offsetX ), v )
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ssumpw/src/main.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumpw/src/main.c
@@ -17,7 +17,6 @@
 */
 
 #include "stdlib/blas/ext/base/ssumpw.h"
-#include "stdlib/math/base/assert/is_nanf.h"
 #include "stdlib/blas/base/shared.h"
 #include "stdlib/strided/base/stride2offset.h"
 

--- a/lib/node_modules/@stdlib/blas/ext/base/ssumpw/src/main.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumpw/src/main.c
@@ -37,9 +37,9 @@
 * @param strideX  stride length
 * @return         output value
 */
-double API_SUFFIX(stdlib_strided_ssumpw)( const CBLAS_INT N, const float *X, const CBLAS_INT strideX ) {
+float API_SUFFIX(stdlib_strided_ssumpw)( const CBLAS_INT N, const float *X, const CBLAS_INT strideX ) {
 	CBLAS_INT ox = stdlib_strided_stride2offset( N, strideX );
-	API_SUFFIX(stdlib_strided_ssumpw_ndarray)( N, X, strideX, ox );
+	return API_SUFFIX(stdlib_strided_ssumpw_ndarray)( N, X, strideX, ox );
 }
 
 /**
@@ -59,29 +59,26 @@ double API_SUFFIX(stdlib_strided_ssumpw)( const CBLAS_INT N, const float *X, con
 * @param offsetX  starting index
 * @return         output value
 */
-double API_SUFFIX(stdlib_strided_ssumpw_ndarray)( const CBLAS_INT N, const float *X, const CBLAS_INT strideX, const CBLAS_INT offsetX ) {
+float API_SUFFIX(stdlib_strided_ssumpw_ndarray)( const CBLAS_INT N, const float *X, const CBLAS_INT strideX, const CBLAS_INT offsetX ) {
 	CBLAS_INT ix;
 	CBLAS_INT M;
 	CBLAS_INT n;
 	CBLAS_INT i;
-	double sum;
-	double s0;
-	double s1;
-	double s2;
-	double s3;
-	double s4;
-	double s5;
-	double s6;
-	double s7;
+	float sum;
+	float s0;
+	float s1;
+	float s2;
+	float s3;
+	float s4;
+	float s5;
+	float s6;
+	float s7;
 
 	if ( N <= 0 ) {
 		return 0.0f;
 	}
 	ix = offsetX;
 	if ( strideX == 0 ) {
-		if ( stdlib_base_is_nanf( X[ ix ] ) ) {
-			return 0.0f;
-		}
 		return N * X[ ix ];
 	}
 	if ( N < 8 ) {

--- a/lib/node_modules/@stdlib/blas/ext/base/ssumpw/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumpw/test/test.ndarray.js
@@ -168,18 +168,6 @@ tape( 'if provided a `stride` parameter equal to `0`, the function returns the s
 	t.end();
 });
 
-tape( 'if provided a `stride` parameter equal to `0` and the first element is `NaN`, the function returns 0.0', function test( t ) {
-	var x;
-	var v;
-
-	x = new Float32Array( [ NaN, -2.0, -4.0, 5.0, 3.0 ] );
-
-	v = ssumpw( x.length, x, 0, 0 );
-	t.strictEqual( v, 0.0, 'returns expected value' );
-
-	t.end();
-});
-
 tape( 'the function supports an `offset` parameter', function test( t ) {
 	var N;
 	var x;

--- a/lib/node_modules/@stdlib/blas/ext/base/ssumpw/test/test.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumpw/test/test.ndarray.native.js
@@ -177,18 +177,6 @@ tape( 'if provided a `stride` parameter equal to `0`, the function returns the s
 	t.end();
 });
 
-tape( 'if provided a `stride` parameter equal to `0` and the first element is `NaN`, the function returns 0.0', opts, function test( t ) {
-	var x;
-	var v;
-
-	x = new Float32Array( [ NaN, -2.0, -4.0, 5.0, 3.0 ] );
-
-	v = ssumpw( x.length, x, 0, 0 );
-	t.strictEqual( v, 0.0, 'returns expected value' );
-
-	t.end();
-});
-
 tape( 'the function supports an `offset` parameter', opts, function test( t ) {
 	var N;
 	var x;

--- a/lib/node_modules/@stdlib/blas/ext/base/ssumpw/test/test.ssumpw.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumpw/test/test.ssumpw.js
@@ -168,18 +168,6 @@ tape( 'if provided a `stride` parameter equal to `0`, the function returns the s
 	t.end();
 });
 
-tape( 'if provided a `stride` parameter equal to `0` and the first element is `NaN`, the function returns 0.0', function test( t ) {
-	var x;
-	var v;
-
-	x = new Float32Array( [ NaN, -2.0, -4.0, 5.0, 3.0 ] );
-
-	v = ssumpw( x.length, x, 0 );
-	t.strictEqual( v, 0.0, 'returns expected value' );
-
-	t.end();
-});
-
 tape( 'the function supports view offsets', function test( t ) {
 	var x0;
 	var x1;

--- a/lib/node_modules/@stdlib/blas/ext/base/ssumpw/test/test.ssumpw.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ssumpw/test/test.ssumpw.native.js
@@ -259,18 +259,6 @@ tape( 'if provided a `stride` parameter equal to `0`, the function returns the s
 	t.end();
 });
 
-tape( 'if provided a `stride` parameter equal to `0` and the first element is `NaN`, the function returns 0.0', opts, function test( t ) {
-	var x;
-	var v;
-
-	x = new Float32Array( [ NaN, -2.0, -4.0, 5.0, 3.0 ] );
-
-	v = ssumpw( x.length, x, 0 );
-	t.strictEqual( v, 0.0, 'returns expected value' );
-
-	t.end();
-});
-
 tape( 'the function supports view offsets', opts, function test( t ) {
 	var x0;
 	var x1;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   update the return type of the `blas/ext/base/ssumpw`
-   remove redundant branches and related test cases

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
