### PR TITLE
refactor: use external constant in `math/base/special/tribonacci`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/tribonacci/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/tribonacci/lib/main.js
@@ -22,12 +22,8 @@
 
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isInteger = require( '@stdlib/math/base/assert/is-integer' );
+var FLOAT64_MAX_SAFE_NTH_TRIBONACCI = require( '@stdlib/constants/float64/max-safe-nth-tribonacci' ); // eslint-disable-line id-length
 var TRIBONACCI = require( './tribonacci.json' );
-
-
-// VARIABLES //
-
-var MAX_TRIBONACCI = 63;
 
 
 // MAIN //
@@ -83,7 +79,7 @@ function tribonacci( n ) {
 		isnan( n ) ||
 		isInteger( n ) === false ||
 		n < 0 ||
-		n > MAX_TRIBONACCI
+		n > FLOAT64_MAX_SAFE_NTH_TRIBONACCI
 	) {
 		return NaN;
 	}

--- a/lib/node_modules/@stdlib/math/base/special/tribonacci/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/tribonacci/manifest.json
@@ -36,7 +36,8 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-        "@stdlib/math/base/napi/unary"
+        "@stdlib/math/base/napi/unary",
+        "@stdlib/constants/float64/max-safe-nth-tribonacci"
       ]
     },
     {
@@ -49,7 +50,9 @@
       ],
       "libraries": [],
       "libpath": [],
-      "dependencies": []
+      "dependencies": [
+        "@stdlib/constants/float64/max-safe-nth-tribonacci"
+      ]
     },
     {
       "task": "examples",
@@ -61,7 +64,9 @@
       ],
       "libraries": [],
       "libpath": [],
-      "dependencies": []
+      "dependencies": [
+        "@stdlib/constants/float64/max-safe-nth-tribonacci"
+      ]
     }
   ]
 }

--- a/lib/node_modules/@stdlib/math/base/special/tribonacci/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/tribonacci/src/main.c
@@ -17,8 +17,8 @@
 */
 
 #include "stdlib/math/base/special/tribonacci.h"
+#include "stdlib/constants/float64/max_safe_nth_tribonacci.h"
 
-static const int32_t STDLIB_CONSTANTS_FLOAT64_MAX_SAFE_NTH_TRIBONACCI = 63; // TODO: consider making a package similar to `@stdlib/constants/float64/max-safe-nth-fibonacci`
 static const int64_t tribonacci_value[ 64 ] = {
         0,
         0,
@@ -96,7 +96,7 @@ static const int64_t tribonacci_value[ 64 ] = {
 * // returns 0
 */
 double stdlib_base_tribonacci( const int32_t n ) {
-    if ( n < 0 || n > STDLIB_CONSTANTS_FLOAT64_MAX_SAFE_NTH_TRIBONACCI ) {
+    if ( n < 0 || n > STDLIB_CONSTANT_FLOAT64_MAX_SAFE_NTH_TRIBONACCI ) {
         return 0.0 / 0.0; // NaN
     }
     return tribonacci_value[ n ];


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   completes the TODO to use the external constant [`constants/float64/max-safe-nth-tribonacci`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/constants/float64/max-safe-nth-tribonacci) in [`math/base/special/tribonacci`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/tribonacci)

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
