### PR TITLE
feat: add `constants/float32/sqrt-pi`

### DIFF
--- a/lib/node_modules/@stdlib/constants/float32/sqrt-pi/README.md
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-pi/README.md
@@ -1,0 +1,139 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# FLOAT32_SQRT_PI
+
+> Square root of single-precision floating-point mathematical constant [π][@stdlib/constants/float64/pi].
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var FLOAT32_SQRT_PI = require( '@stdlib/constants/float32/sqrt-pi' );
+```
+
+#### FLOAT32_SQRT_PI
+
+Square root of single-precision floating-point mathematical constant [π][@stdlib/constants/float64/pi].
+
+```javascript
+var bool = ( FLOAT32_SQRT_PI === 1.7724539041519165 );
+// returns true
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- TODO: better example -->
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var FLOAT32_SQRT_PI = require( '@stdlib/constants/float32/sqrt-pi' );
+
+console.log( FLOAT32_SQRT_PI );
+// => 1.7724539041519165
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/constants/float32/sqrt_pi.h"
+```
+
+#### STDLIB_CONSTANT_FLOAT32_SQRT_PI
+
+Macro for the square root of single-precision floating-point mathematical constant [π][@stdlib/constants/float64/pi].
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+<!-- <related-links> -->
+
+[@stdlib/constants/float64/pi]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/constants/float64/pi
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-pi/README.md
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-pi/README.md
@@ -128,9 +128,9 @@ Macro for the square root of the mathematical constant [π][@stdlib/constants/fl
 
 <section class="links">
 
-<!-- <related-links> -->
-
 [@stdlib/constants/float32/pi]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/constants/float32/pi
+
+<!-- <related-links> -->
 
 <!-- </related-links> -->
 

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-pi/README.md
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-pi/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # FLOAT32_SQRT_PI
 
-> Square root of single-precision floating-point mathematical constant [π][@stdlib/constants/float64/pi].
+> Square root of the mathematical constant [π][@stdlib/constants/float32/pi] as a single-precision floating-point number.
 
 <section class="usage">
 
@@ -32,7 +32,7 @@ var FLOAT32_SQRT_PI = require( '@stdlib/constants/float32/sqrt-pi' );
 
 #### FLOAT32_SQRT_PI
 
-Square root of single-precision floating-point mathematical constant [π][@stdlib/constants/float64/pi].
+Square root of the mathematical constant [π][@stdlib/constants/float32/pi] as a single-precision floating-point number.
 
 ```javascript
 var bool = ( FLOAT32_SQRT_PI === 1.7724539041519165 );
@@ -90,7 +90,7 @@ console.log( FLOAT32_SQRT_PI );
 
 #### STDLIB_CONSTANT_FLOAT32_SQRT_PI
 
-Macro for the square root of single-precision floating-point mathematical constant [π][@stdlib/constants/float64/pi].
+Macro for the square root of the mathematical constant [π][@stdlib/constants/float32/pi] as a single-precision floating-point number.
 
 </section>
 
@@ -130,7 +130,7 @@ Macro for the square root of single-precision floating-point mathematical consta
 
 <!-- <related-links> -->
 
-[@stdlib/constants/float64/pi]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/constants/float64/pi
+[@stdlib/constants/float32/pi]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/constants/float32/pi
 
 <!-- </related-links> -->
 

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-pi/docs/repl.txt
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-pi/docs/repl.txt
@@ -1,6 +1,7 @@
 
 {{alias}}
-    Square root of single-precision floating-point mathematical constant `π`.
+    Square root of the mathematical constant `π` as a single-precision
+    floating-point number.
 
     Examples
     --------

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-pi/docs/repl.txt
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-pi/docs/repl.txt
@@ -1,0 +1,12 @@
+
+{{alias}}
+    Square root of single-precision floating-point mathematical constant π.
+
+    Examples
+    --------
+    > {{alias}}
+    1.7724539041519165
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-pi/docs/repl.txt
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-pi/docs/repl.txt
@@ -1,6 +1,6 @@
 
 {{alias}}
-    Square root of single-precision floating-point mathematical constant π.
+    Square root of single-precision floating-point mathematical constant `π`.
 
     Examples
     --------

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-pi/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-pi/docs/types/index.d.ts
@@ -1,0 +1,33 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Square root of single-precision floating-point mathematical constant π.
+*
+* @example
+* var val = FLOAT32_SQRT_PI;
+* // returns 1.7724539041519165
+*/
+declare const FLOAT32_SQRT_PI: number;
+
+
+// EXPORTS //
+
+export = FLOAT32_SQRT_PI;

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-pi/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-pi/docs/types/index.d.ts
@@ -19,7 +19,7 @@
 // TypeScript Version: 4.1
 
 /**
-* Square root of single-precision floating-point mathematical constant π.
+* Square root of single-precision floating-point mathematical constant `π`.
 *
 * @example
 * var val = FLOAT32_SQRT_PI;

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-pi/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-pi/docs/types/index.d.ts
@@ -19,7 +19,7 @@
 // TypeScript Version: 4.1
 
 /**
-* Square root of single-precision floating-point mathematical constant `π`.
+* Square root of the mathematical constant `π` as a single-precision floating-point number.
 *
 * @example
 * var val = FLOAT32_SQRT_PI;

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-pi/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-pi/docs/types/test.ts
@@ -1,0 +1,28 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import FLOAT32_SQRT_PI = require( './index' );
+
+
+// TESTS //
+
+// The export is a number...
+{
+	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+	FLOAT32_SQRT_PI; // $ExpectType number
+}

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-pi/examples/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-pi/examples/index.js
@@ -1,0 +1,24 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var FLOAT32_SQRT_PI = require( './../lib' );
+
+console.log( FLOAT32_SQRT_PI );
+// => 1.7724539041519165

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-pi/include/stdlib/constants/float32/sqrt_pi.h
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-pi/include/stdlib/constants/float32/sqrt_pi.h
@@ -20,7 +20,7 @@
 #define STDLIB_CONSTANTS_FLOAT32_SQRT_PI_H
 
 /**
-* Macro for the square root of single-precision floating-point mathematical constant π.
+* Macro for the square root of single-precision floating-point mathematical constant `π`.
 */
 #define STDLIB_CONSTANT_FLOAT32_SQRT_PI 1.7724539041519165f
 

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-pi/include/stdlib/constants/float32/sqrt_pi.h
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-pi/include/stdlib/constants/float32/sqrt_pi.h
@@ -1,0 +1,27 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_CONSTANTS_FLOAT32_SQRT_PI_H
+#define STDLIB_CONSTANTS_FLOAT32_SQRT_PI_H
+
+/**
+* Macro for the square root of single-precision floating-point mathematical constant π.
+*/
+#define STDLIB_CONSTANT_FLOAT32_SQRT_PI 1.7724539041519165f
+
+#endif // !STDLIB_CONSTANTS_FLOAT32_SQRT_PI_H

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-pi/include/stdlib/constants/float32/sqrt_pi.h
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-pi/include/stdlib/constants/float32/sqrt_pi.h
@@ -20,7 +20,7 @@
 #define STDLIB_CONSTANTS_FLOAT32_SQRT_PI_H
 
 /**
-* Macro for the square root of single-precision floating-point mathematical constant `π`.
+* Macro for the square root of the mathematical constant `π` as a single-precision floating-point number.
 */
 #define STDLIB_CONSTANT_FLOAT32_SQRT_PI 1.7724539041519165f
 

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-pi/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-pi/lib/index.js
@@ -1,0 +1,53 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Square root of single-precision floating-point mathematical constant `π`.
+*
+* @module @stdlib/constants/float32/sqrt-pi
+* @type {number}
+*
+* @example
+* var FLOAT32_SQRT_PI = require( '@stdlib/constants/float32/sqrt-pi' );
+* // returns 1.7724539041519165
+*/
+
+// MODULES //
+
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+
+
+// MAIN //
+
+/**
+* Square root of single-precision floating-point mathematical constant `π`.
+*
+* @constant
+* @type {number}
+* @default 1.7724539041519165
+* @see [OEIS]{@link https://oeis.org/A002161}
+* @see [Wikipedia]{@link https://en.wikipedia.org/wiki/Pi}
+*/
+var FLOAT32_SQRT_PI = float64ToFloat32( 1.772453850905516027298167483341145182797549456122387128213 );
+
+
+// EXPORTS //
+
+module.exports = FLOAT32_SQRT_PI;

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-pi/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-pi/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Square root of single-precision floating-point mathematical constant `π`.
+* Square root of the mathematical constant `π` as a single-precision floating-point number.
 *
 * @module @stdlib/constants/float32/sqrt-pi
 * @type {number}
@@ -37,7 +37,7 @@ var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 // MAIN //
 
 /**
-* Square root of single-precision floating-point mathematical constant `π`.
+* Square root of the mathematical constant `π` as a single-precision floating-point number.
 *
 * @constant
 * @type {number}
@@ -45,7 +45,7 @@ var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 * @see [OEIS]{@link https://oeis.org/A002161}
 * @see [Wikipedia]{@link https://en.wikipedia.org/wiki/Pi}
 */
-var FLOAT32_SQRT_PI = float64ToFloat32( 1.772453850905516027298167483341145182797549456122387128213 );
+var FLOAT32_SQRT_PI = float64ToFloat32( 1.772453850905516027298167483341145182797549456122387128213 ); // eslint-disable-line max-len
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-pi/manifest.json
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-pi/manifest.json
@@ -1,0 +1,36 @@
+{
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": []
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-pi/package.json
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-pi/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@stdlib/constants/float32/sqrt-pi",
+  "version": "0.0.0",
+  "description": "Square root of single-precision floating-point mathematical constant π.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "constant",
+    "const",
+    "mathematics",
+    "math",
+    "pi",
+    "sqrt",
+    "square",
+    "root",
+    "ieee754",
+    "single",
+    "precision",
+    "floating-point",
+    "float32"
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-pi/package.json
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-pi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/constants/float32/sqrt-pi",
   "version": "0.0.0",
-  "description": "Square root of the mathematical constant `π` as a single-precision floating-point number.",
+  "description": "Square root of the mathematical constant π as a single-precision floating-point number.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-pi/package.json
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-pi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/constants/float32/sqrt-pi",
   "version": "0.0.0",
-  "description": "Square root of single-precision floating-point mathematical constant π.",
+  "description": "Square root of the mathematical constant `π` as a single-precision floating-point number.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-pi/test/test.js
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-pi/test/test.js
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var FLOAT32_SQRT_PI = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a number', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof FLOAT32_SQRT_PI, 'number', 'main export is a number' );
+	t.end();
+});
+
+tape( 'export is a single-precision floating-point number equal to `1.7724539041519165`', function test( t ) {
+	t.equal( FLOAT32_SQRT_PI, 1.7724539041519165, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
Resolves #3325.

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR adds the package @stdlib/constants/float32/sqrt-pi returning square root of single-precision floating-point mathematical constant π.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
