### PR TITLE
feat: add `constants/float32/sqrt-two`

### DIFF
--- a/lib/node_modules/@stdlib/constants/float32/sqrt-two/README.md
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-two/README.md
@@ -1,0 +1,139 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# FLOAT32_SQRT2
+
+> [Square root][@stdlib/math/base/special/sqrt] of single-precision floating-point number `2`.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var FLOAT32_SQRT2 = require( '@stdlib/constants/float32/sqrt-two' );
+```
+
+#### FLOAT32_SQRT2
+
+[Square root][@stdlib/math/base/special/sqrt] of single-precision floating-point number `2`.
+
+```javascript
+var bool = ( FLOAT32_SQRT2 === 1.4142135381698608 );
+// returns true
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- TODO: better example -->
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var FLOAT32_SQRT2 = require( '@stdlib/constants/float32/sqrt-two' );
+
+console.log( FLOAT32_SQRT2 );
+// => 1.4142135381698608
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/constants/float32/sqrt_two.h"
+```
+
+#### STDLIB_CONSTANT_FLOAT32_SQRT2
+
+Macro for the [square root][@stdlib/math/base/special/sqrt] of single-precision floating-point number `2`.
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[@stdlib/math/base/special/sqrt]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/sqrt
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-two/README.md
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-two/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # FLOAT32_SQRT2
 
-> [Square root][@stdlib/math/base/special/sqrt] of single-precision floating-point number `2`.
+> [Square root][@stdlib/math/base/special/sqrtf] of `2` as a single-precision floating-point number.
 
 <section class="usage">
 
@@ -32,7 +32,7 @@ var FLOAT32_SQRT2 = require( '@stdlib/constants/float32/sqrt-two' );
 
 #### FLOAT32_SQRT2
 
-[Square root][@stdlib/math/base/special/sqrt] of single-precision floating-point number `2`.
+[Square root][@stdlib/math/base/special/sqrtf] of `2` as a single-precision floating-point number.
 
 ```javascript
 var bool = ( FLOAT32_SQRT2 === 1.4142135381698608 );
@@ -90,7 +90,7 @@ console.log( FLOAT32_SQRT2 );
 
 #### STDLIB_CONSTANT_FLOAT32_SQRT2
 
-Macro for the [square root][@stdlib/math/base/special/sqrt] of single-precision floating-point number `2`.
+Macro for the [square root][@stdlib/math/base/special/sqrtf] of `2` as a single-precision floating-point number.
 
 </section>
 
@@ -128,7 +128,7 @@ Macro for the [square root][@stdlib/math/base/special/sqrt] of single-precision 
 
 <section class="links">
 
-[@stdlib/math/base/special/sqrt]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/sqrt
+[@stdlib/math/base/special/sqrtf]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/sqrtf
 
 <!-- <related-links> -->
 

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-two/docs/repl.txt
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-two/docs/repl.txt
@@ -1,0 +1,12 @@
+
+{{alias}}
+    Square root of single-precision floating-point number `2`.
+
+    Examples
+    --------
+    > {{alias}}
+    1.4142135381698608
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-two/docs/repl.txt
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-two/docs/repl.txt
@@ -1,6 +1,6 @@
 
 {{alias}}
-    Square root of single-precision floating-point number `2`.
+    Square root of `2` as a single-precision floating-point number.
 
     Examples
     --------

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-two/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-two/docs/types/index.d.ts
@@ -19,7 +19,7 @@
 // TypeScript Version: 4.1
 
 /**
-* Square root of single-precision floating-point number `2`.
+* Square root of `2` as a single-precision floating-point number.
 *
 * @example
 * var val = FLOAT32_SQRT2;

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-two/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-two/docs/types/index.d.ts
@@ -1,0 +1,33 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Square root of single-precision floating-point number `2`.
+*
+* @example
+* var val = FLOAT32_SQRT2;
+* // returns 1.4142135381698608
+*/
+declare const FLOAT32_SQRT2: number;
+
+
+// EXPORTS //
+
+export = FLOAT32_SQRT2;

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-two/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-two/docs/types/test.ts
@@ -1,0 +1,28 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import FLOAT32_SQRT2 = require( './index' );
+
+
+// TESTS //
+
+// The export is a number...
+{
+	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+	FLOAT32_SQRT2; // $ExpectType number
+}

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-two/examples/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-two/examples/index.js
@@ -1,0 +1,24 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var FLOAT32_SQRT2 = require( './../lib' );
+
+console.log( FLOAT32_SQRT2 );
+// => 1.4142135381698608

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-two/include/stdlib/constants/float32/sqrt_two.h
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-two/include/stdlib/constants/float32/sqrt_two.h
@@ -20,7 +20,7 @@
 #define STDLIB_CONSTANTS_FLOAT32_SQRT_TWO_H
 
 /**
-* Macro for the square root of single-precision floating-point number 2.
+* Macro for the square root of `2` as a single-precision floating-point number.
 */
 #define STDLIB_CONSTANT_FLOAT32_SQRT2 1.4142135381698608f
 

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-two/include/stdlib/constants/float32/sqrt_two.h
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-two/include/stdlib/constants/float32/sqrt_two.h
@@ -1,0 +1,27 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_CONSTANTS_FLOAT32_SQRT_TWO_H
+#define STDLIB_CONSTANTS_FLOAT32_SQRT_TWO_H
+
+/**
+* Macro for the square root of single-precision floating-point number 2.
+*/
+#define STDLIB_CONSTANT_FLOAT32_SQRT2 1.4142135381698608f
+
+#endif // !STDLIB_CONSTANTS_FLOAT32_SQRT_TWO_H

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-two/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-two/lib/index.js
@@ -1,0 +1,55 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Square root of single-precision floating-point number `2`.
+*
+* @module @stdlib/constants/float32/sqrt-two
+* @type {number}
+*
+* @example
+* var FLOAT32_SQRT2 = require( '@stdlib/constants/float32/sqrt-two' );
+* // returns 1.4142135381698608
+*/
+
+// MODULES //
+
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+
+
+// MAIN //
+
+/**
+* Square root of single-precision floating-point number `2`.
+*
+* ```tex
+* \sqrt{2}
+* ```
+*
+* @constant
+* @type {number}
+* @default 1.4142135381698608
+*/
+var FLOAT32_SQRT2 = float64ToFloat32( 1.41421356237309504880168872420969807856967187537694807317667973799073247846210703885038753432764157273501384623e+00 ); // eslint-disable-line max-len
+
+
+// EXPORTS //
+
+module.exports = FLOAT32_SQRT2;

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-two/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-two/lib/index.js
@@ -19,7 +19,7 @@
 'use strict';
 
 /**
-* Square root of single-precision floating-point number `2`.
+* Square root of `2` as a single-precision floating-point number.
 *
 * @module @stdlib/constants/float32/sqrt-two
 * @type {number}
@@ -37,7 +37,7 @@ var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 // MAIN //
 
 /**
-* Square root of single-precision floating-point number `2`.
+* Square root of `2` as a single-precision floating-point number.
 *
 * ```tex
 * \sqrt{2}

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-two/manifest.json
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-two/manifest.json
@@ -1,0 +1,36 @@
+{
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": []
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-two/package.json
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-two/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@stdlib/constants/float32/sqrt-two",
+  "version": "0.0.0",
+  "description": "Square root of single-precision floating-point number 2.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "constant",
+    "const",
+    "mathematics",
+    "math",
+    "sqrt",
+    "square",
+    "root",
+    "two",
+    "sqrt2",
+    "math.sqrt2",
+    "ieee754",
+    "single",
+    "floating-point",
+    "float32"
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-two/package.json
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-two/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/constants/float32/sqrt-two",
   "version": "0.0.0",
-  "description": "Square root of single-precision floating-point number 2.",
+  "description": "Square root of `2` as a single-precision floating-point number.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-two/test/test.js
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-two/test/test.js
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var sqrtf = require( '@stdlib/math/base/special/sqrtf' );
+var FLOAT32_SQRT2 = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a number', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof FLOAT32_SQRT2, 'number', 'main export is a number' );
+	t.end();
+});
+
+tape( 'the exported value is a single-precision floating-point number equal to the square root of 2', function test( t ) {
+	var expected = sqrtf( 2 );
+	t.equal( FLOAT32_SQRT2, expected, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
Resolves #3327.

## Description

> What is the purpose of this pull request?

This pull request:

-   This RFC proposes adding the package @stdlib/constants/float32/sqrt-two returning square root of single-precision floating-point number 2.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
