### PR TITLE
feat: add `constants/float32/sqrt-half`

### DIFF
--- a/lib/node_modules/@stdlib/constants/float32/sqrt-half/README.md
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-half/README.md
@@ -1,0 +1,147 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# FLOAT32_SQRT_HALF
+
+> [Square root][@stdlib/math/base/special/sqrtf] of `1/2` as a single-precision floating-point number.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var FLOAT32_SQRT_HALF = require( '@stdlib/constants/float32/sqrt-half' );
+```
+
+#### FLOAT32_SQRT_HALF
+
+[Square root][@stdlib/math/base/special/sqrtf] of `1/2` as a single-precision floating-point number.
+
+```javascript
+var bool = ( FLOAT32_SQRT_HALF === 0.7071067690849304 );
+// returns true
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- TODO: better example -->
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var FLOAT32_SQRT_HALF = require( '@stdlib/constants/float32/sqrt-half' );
+
+console.log( FLOAT32_SQRT_HALF );
+// => 0.7071067690849304
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/constants/float32/sqrt_half.h"
+```
+
+#### STDLIB_CONSTANT_FLOAT64_SQRT_HALF
+
+Macro for the [square root][@stdlib/math/base/special/sqrtf] of `1/2` as a single-precision floating-point number.
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/constants/float32/ln-two`][@stdlib/constants/float32/ln-two]</span><span class="delimiter">: </span><span class="description">natural logarithm of 2.</span>
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[@stdlib/math/base/special/sqrtf]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/sqrtf
+
+<!-- <related-links> -->
+
+[@stdlib/constants/float32/ln-two]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/constants/float32/ln-two
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-half/README.md
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-half/README.md
@@ -120,12 +120,6 @@ Macro for the [square root][@stdlib/math/base/special/sqrtf] of `1/2` as a singl
 
 <section class="related">
 
-* * *
-
-## See Also
-
--   <span class="package-name">[`@stdlib/constants/float32/ln-two`][@stdlib/constants/float32/ln-two]</span><span class="delimiter">: </span><span class="description">natural logarithm of 2.</span>
-
 </section>
 
 <!-- /.related -->
@@ -137,8 +131,6 @@ Macro for the [square root][@stdlib/math/base/special/sqrtf] of `1/2` as a singl
 [@stdlib/math/base/special/sqrtf]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/sqrtf
 
 <!-- <related-links> -->
-
-[@stdlib/constants/float32/ln-two]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/constants/float32/ln-two
 
 <!-- </related-links> -->
 

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-half/docs/repl.txt
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-half/docs/repl.txt
@@ -1,0 +1,12 @@
+
+{{alias}}
+    Square root of `1/2` as a single-precision floating-point number.
+
+    Examples
+    --------
+    > {{alias}}
+    0.7071067690849304
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-half/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-half/docs/types/index.d.ts
@@ -1,0 +1,33 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Square root of `1/2` as a single-precision floating-point number.
+*
+* @example
+* var val = FLOAT32_SQRT_HALF;
+* // returns 0.7071067690849304
+*/
+declare const FLOAT32_SQRT_HALF: number;
+
+
+// EXPORTS //
+
+export = FLOAT32_SQRT_HALF;

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-half/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-half/docs/types/test.ts
@@ -1,0 +1,28 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import FLOAT32_SQRT_HALF = require( './index' );
+
+
+// TESTS //
+
+// The export is a number...
+{
+	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+	FLOAT32_SQRT_HALF; // $ExpectType number
+}

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-half/examples/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-half/examples/index.js
@@ -1,0 +1,24 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var FLOAT32_SQRT_HALF = require( './../lib' );
+
+console.log( FLOAT32_SQRT_HALF );
+// => 0.7071067690849304

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-half/include/stdlib/constants/float64/sqrt_half.h
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-half/include/stdlib/constants/float64/sqrt_half.h
@@ -1,0 +1,27 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_CONSTANTS_FLOAT32_SQRT_HALF_H
+#define STDLIB_CONSTANTS_FLOAT32_SQRT_HALF_H
+
+/**
+* Macro for the square root of 1/2 as a single-precision floating-point number.
+*/
+#define STDLIB_CONSTANT_FLOAT32_SQRT_HALF 0.7071067690849304f
+
+#endif // !STDLIB_CONSTANTS_FLOAT32_SQRT_HALF_H

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-half/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-half/lib/index.js
@@ -1,0 +1,51 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Square root of `1/2` as a single-precision floating-point number.
+*
+* @module @stdlib/constants/float32/sqrt-half
+* @type {number}
+*
+* @example
+* var FLOAT32_SQRT_HALF = require( '@stdlib/constants/float32/sqrt-half' );
+* // returns 0.7071067690849304
+*/
+
+
+// MAIN //
+
+/**
+* Square root of `1/2` as a single-precision floating-point number.
+*
+* ```tex
+* \sqrt{\frac{1}{2}}
+* ```
+*
+* @constant
+* @type {number}
+* @default 0.7071067690849304
+*/
+var FLOAT32_SQRT_HALF = 0.7071067690849304;
+
+
+// EXPORTS //
+
+module.exports = FLOAT32_SQRT_HALF;

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-half/manifest.json
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-half/manifest.json
@@ -1,0 +1,36 @@
+{
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": []
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-half/package.json
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-half/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@stdlib/constants/float32/sqrt-half",
+  "version": "0.0.0",
+  "description": "Square root of 1/2 as a single-precision floating-point number.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "constant",
+    "const",
+    "mathematics",
+    "math",
+    "sqrt",
+    "square",
+    "root",
+    "half",
+    "sqrt1_2",
+    "math.sqrt1_2",
+    "ieee754",
+    "single",
+    "floating-point",
+    "float32"
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-half/test/test.js
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-half/test/test.js
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var sqrtf = require( '@stdlib/math/base/special/sqrtf' );
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var FLOAT32_SQRT_HALF = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a number', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof FLOAT32_SQRT_HALF, 'number', 'main export is a number' );
+	t.end();
+});
+
+tape( 'the exported value is a single-precision floating-point number equal to the square root of 1/2', function test( t ) {
+	t.equal( FLOAT32_SQRT_HALF, float64ToFloat32( sqrtf( 1/2 ) ), 'equals sqrtf(1/2)' );
+	t.end();
+});


### PR DESCRIPTION

## Description

> What is the purpose of this pull request?

This pull request:

-   adds constants/float32/sqrt-half, which would be the single-precision equivalent for [constants/float64/sqrt-half](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/constants/float64/sqrt-half).

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
