### PR TITLE
feat: add `constants/float32/sqrt-half-pi`

### DIFF
--- a/lib/node_modules/@stdlib/constants/float32/sqrt-half-pi/README.md
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-half-pi/README.md
@@ -1,0 +1,145 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# FLOAT32_SQRT_HALF_PI
+
+> Square root of the mathematical constant [π][@stdlib/constants/float32/pi] divided by 2 as a single-precision floating-point number.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var FLOAT32_SQRT_HALF_PI = require( '@stdlib/constants/float32/sqrt-half-pi' );
+```
+
+#### FLOAT32_SQRT_HALF_PI
+
+Square root of the mathematical constant [π][@stdlib/constants/float32/pi] divided by `2` as a single-precision floating-point number.
+
+```javascript
+var bool = ( FLOAT32_SQRT_HALF_PI === 1.2533141374588013 );
+// returns true
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- TODO: better example -->
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var FLOAT32_SQRT_HALF_PI = require( '@stdlib/constants/float32/sqrt-half-pi' );
+
+console.log( FLOAT32_SQRT_HALF_PI );
+// => 1.2533141374588013
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/constants/float32/sqrt_half_pi.h"
+```
+
+#### STDLIB_CONSTANT_FLOAT32_SQRT_HALF_PI
+
+Macro for the square root of the mathematical constant [π][@stdlib/constants/float32/pi] divided by `2` as a single-precision floating-point number.
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/constants/float32/pi`][@stdlib/constants/float32/pi]</span><span class="delimiter">: </span><span class="description">π.</span>
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+<!-- <related-links> -->
+
+[@stdlib/constants/float32/pi]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/constants/float32/pi
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-half-pi/docs/repl.txt
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-half-pi/docs/repl.txt
@@ -1,0 +1,12 @@
+
+{{alias}}
+    Square root of `π` divided by `2` as a single-precision 
+    floating-point number.
+
+    Examples
+    --------
+    > {{alias}}
+    1.2533141374588013
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-half-pi/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-half-pi/docs/types/index.d.ts
@@ -1,0 +1,33 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Square root of the mathematical constant `π` divided by `2` as a single-precision floating-point number.
+*
+* @example
+* var val = FLOAT32_SQRT_HALF_PI;
+* // returns 1.2533141374588013
+*/
+declare const FLOAT32_SQRT_HALF_PI: number;
+
+
+// EXPORTS //
+
+export = FLOAT32_SQRT_HALF_PI;

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-half-pi/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-half-pi/docs/types/test.ts
@@ -1,0 +1,28 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import FLOAT32_SQRT_HALF_PI = require( './index' );
+
+
+// TESTS //
+
+// The export is a number...
+{
+	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+	FLOAT32_SQRT_HALF_PI; // $ExpectType number
+}

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-half-pi/examples/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-half-pi/examples/index.js
@@ -1,0 +1,24 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var FLOAT32_SQRT_HALF_PI = require( './../lib' );
+
+console.log( FLOAT32_SQRT_HALF_PI );
+// => 1.2533141374588013

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-half-pi/include/stdlib/constants/float64/sqrt_half_pi.h
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-half-pi/include/stdlib/constants/float64/sqrt_half_pi.h
@@ -1,0 +1,27 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_CONSTANTS_FLOAT32_SQRT_HALF_PI_H
+#define STDLIB_CONSTANTS_FLOAT32_SQRT_HALF_PI_H
+
+/**
+* Macro for the square root of 0.5π as a single-precision floating-point number.
+*/
+#define STDLIB_CONSTANT_FLOAT32_SQRT_HALF_PI 1.2533141374588013f
+
+#endif // !STDLIB_CONSTANTS_FLOAT32_SQRT_HALF_PI_H

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-half-pi/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-half-pi/lib/index.js
@@ -1,0 +1,48 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Square root of the mathematical constant `π` divided by `2` as a single-precision floating-point number.
+*
+* @module @stdlib/constants/float32/sqrt-half-pi
+* @type {number}
+*
+* @example
+* var FLOAT32_SQRT_HALF_PI = require( '@stdlib/constants/float32/sqrt-half-pi' );
+* // returns 1.2533141374588013
+*/
+
+
+// MAIN //
+
+/**
+* Square root of the mathematical constant `π` divided by `2` as a single-precision floating-point numbe.
+*
+* @constant
+* @type {number}
+* @default 1.2533141374588013
+* @see [Wikipedia]{@link https://en.wikipedia.org/wiki/Pi}
+*/
+var FLOAT32_SQRT_HALF_PI = 1.2533141374588013;
+
+
+// EXPORTS //
+
+module.exports = FLOAT32_SQRT_HALF_PI;

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-half-pi/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-half-pi/lib/index.js
@@ -33,7 +33,7 @@
 // MAIN //
 
 /**
-* Square root of the mathematical constant `π` divided by `2` as a single-precision floating-point numbe.
+* Square root of the mathematical constant `π` divided by `2` as a single-precision floating-point number.
 *
 * @constant
 * @type {number}

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-half-pi/manifest.json
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-half-pi/manifest.json
@@ -1,0 +1,36 @@
+{
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": []
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-half-pi/package.json
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-half-pi/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@stdlib/constants/float32/sqrt-half-pi",
+  "version": "0.0.0",
+  "description": "Square root of 0.5π as a single-precision floating-point number.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "constant",
+    "const",
+    "mathematics",
+    "math",
+    "pi",
+    "0.5pi",
+    "half",
+    "sqrt",
+    "square",
+    "root",
+    "ieee754",
+    "single",
+    "precision",
+    "floating-point",
+    "float32"
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float32/sqrt-half-pi/test/test.js
+++ b/lib/node_modules/@stdlib/constants/float32/sqrt-half-pi/test/test.js
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var FLOAT32_SQRT_HALF_PI = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a number', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof FLOAT32_SQRT_HALF_PI, 'number', 'main export is a number' );
+	t.end();
+});
+
+tape( 'the exported value is a single-precision floating-point number equal to `1.2533141374588013`', function test( t ) {
+	t.equal( FLOAT32_SQRT_HALF_PI, 1.2533141374588013, 'equals 1.2533141374588013' );
+	t.end();
+});


### PR DESCRIPTION

## Description

> What is the purpose of this pull request?

This pull request:

-  adds constants/float32/sqrt-half-pi, which would be the single-precision equivalent for [constants/float64/sqrt-half-pi](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/constants/float64/sqrt-half-pi).

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
