### PR TITLE
fix: add the missing `type` property to the meta for `eslint/rule/no-multiple-empty-lines`

### DIFF
--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-multiple-empty-lines/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-multiple-empty-lines/lib/main.js
@@ -169,6 +169,7 @@ function main( context ) {
 
 rule = {
 	'meta': {
+		'type': 'layout',
 		'docs': {
 			'description': 'enforce that code does not contain multiple blank lines'
 		},


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   add the missing `type` property to the rules' meta, to allow auto-fixing.

## Related Issues

> Does this pull request have any related issues?

No. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
