### PR TITLE
refactor: update `stride` handling and function documentation for `blas/ext/base/dapxsumors`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/README.md
@@ -44,9 +44,8 @@ Adds a scalar constant to each double-precision floating-point strided array ele
 var Float64Array = require( '@stdlib/array/float64' );
 
 var x = new Float64Array( [ 1.0, -2.0, 2.0 ] );
-var N = x.length;
 
-var v = dapxsumors( N, 5.0, x, 1 );
+var v = dapxsumors( x.length, 5.0, x, 1 );
 // returns 16.0
 ```
 
@@ -55,9 +54,9 @@ The function has the following parameters:
 -   **N**: number of indexed elements.
 -   **alpha**: scalar constant.
 -   **x**: input [`Float64Array`][@stdlib/array/float64].
--   **strideX**: index increment for `x`.
+-   **strideX**: stride length for `x`.
 
-The `N` and stride parameters determine which elements in the strided array are accessed at runtime. For example, to access every other element in `x`,
+The `N` and stride parameters determine which elements in the strided array are accessed at runtime. For example, to access every other element:
 
 ```javascript
 var Float64Array = require( '@stdlib/array/float64' );
@@ -90,9 +89,8 @@ Adds a scalar constant to each double-precision floating-point strided array ele
 var Float64Array = require( '@stdlib/array/float64' );
 
 var x = new Float64Array( [ 1.0, -2.0, 2.0 ] );
-var N = x.length;
 
-var v = dapxsumors.ndarray( N, 5.0, x, 1, 0 );
+var v = dapxsumors.ndarray( x.length, 5.0, x, 1, 0 );
 // returns 16.0
 ```
 
@@ -100,7 +98,7 @@ The function has the following additional parameters:
 
 -   **offsetX**: starting index for `x`.
 
-While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying buffer, the offset parameter supports indexing semantics based on a starting index. For example, to access every other value in `x` starting from the second value
+While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying buffer, the offset parameter supports indexing semantics based on a starting index. For example, to access every other element starting from the second element:
 
 ```javascript
 var Float64Array = require( '@stdlib/array/float64' );
@@ -191,7 +189,7 @@ The function accepts the following arguments:
 -   **N**: `[in] CBLAS_INT` number of indexed elements.
 -   **alpha**: `[in] double` scalar constant.
 -   **X**: `[in] double*` input array.
--   **strideX**: `[in] CBLAS_INT` index increment for `X`.
+-   **strideX**: `[in] CBLAS_INT` stride length for `X`.
 
 ```c
 double stdlib_strided_dapxsumors( const CBLAS_INT N, const double alpha, const double *X, const CBLAS_INT strideX );
@@ -213,7 +211,7 @@ The function accepts the following arguments:
 -   **N**: `[in] CBLAS_INT` number of indexed elements.
 -   **alpha**: `[in] double` scalar constant.
 -   **X**: `[in] double*` input array.
--   **strideX**: `[in] CBLAS_INT` index increment for `X`.
+-   **strideX**: `[in] CBLAS_INT` stride length for `X`.
 -   **offsetX**: `[in] CBLAS_INT` starting index for `X`.
 
 ```c

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/benchmark/c/benchmark.length.c
@@ -107,6 +107,7 @@ static double benchmark1( int iterations, int len ) {
 	v = 0.0;
 	t = tic();
 	for ( i = 0; i < iterations; i++ ) {
+		// cppcheck-suppress uninitvar
 		v = stdlib_strided_dapxsumors( len, 5.0, x, 1 );
 		if ( v != v ) {
 			printf( "should not return NaN\n" );
@@ -140,6 +141,7 @@ static double benchmark2( int iterations, int len ) {
 	v = 0.0;
 	t = tic();
 	for ( i = 0; i < iterations; i++ ) {
+		// cppcheck-suppress uninitvar
 		v = stdlib_strided_dapxsumors_ndarray( len, 5.0, x, 1, 0 );
 		if ( v != v ) {
 			printf( "should not return NaN\n" );
@@ -180,7 +182,7 @@ int main( void ) {
 			printf( "ok %d benchmark finished\n", count );
 		}
 	}
-		for ( i = MIN; i <= MAX; i++ ) {
+	for ( i = MIN; i <= MAX; i++ ) {
 		len = pow( 10, i );
 		iter = ITERATIONS / pow( 10, i-1 );
 		for ( j = 0; j < REPEATS; j++ ) {

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/docs/repl.txt
@@ -37,7 +37,7 @@
     > {{alias}}( x.length, 5.0, x, 1 )
     16.0
 
-    // Using `N` and `stride` parameters:
+    // Using `N` and stride parameters:
     > x = new {{alias:@stdlib/array/float64}}( [ -2.0, 1.0, 1.0, -5.0, 2.0, -1.0 ] );
     > {{alias}}( 3, 5.0, x, 2 )
     16.0

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/docs/repl.txt
@@ -3,8 +3,8 @@
     Adds a scalar constant to each double-precision floating-point strided
     array element and computes the sum using ordinary recursive summation.
 
-    The `N` and stride parameters determine which elements in the strided
-    array are accessed at runtime.
+    The `N` and stride parameters determine which elements in the strided array
+    are accessed at runtime.
 
     Indexing is relative to the first index. To introduce an offset, use a typed
     array view.
@@ -17,13 +17,13 @@
         Number of indexed elements.
 
     alpha: number
-        Constant.
+        Scalar constant.
 
     x: Float64Array
         Input array.
 
     strideX: integer
-        Index increment.
+        Stride length.
 
     Returns
     -------
@@ -64,13 +64,13 @@
         Number of indexed elements.
 
     alpha: number
-        Constant.
+        Scalar constant.
 
     x: Float64Array
         Input array.
 
     strideX: integer
-        Index increment.
+        Stride length.
 
     offsetX: integer
         Starting index.

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/docs/types/index.d.ts
@@ -26,7 +26,7 @@ interface Routine {
 	* Adds a scalar constant to each double-precision floating-point strided array element and computes the sum using ordinary recursive summation.
 	*
 	* @param N - number of indexed elements
-	* @param alpha - constant
+	* @param alpha - scalar constant
 	* @param x - input array
 	* @param strideX - stride length
 	* @returns sum
@@ -45,7 +45,7 @@ interface Routine {
 	* Adds a scalar constant to each double-precision floating-point strided array element and computes the sum using ordinary recursive summation and alternative indexing semantics.
 	*
 	* @param N - number of indexed elements
-	* @param alpha - constant
+	* @param alpha - scalar constant
 	* @param x - input array
 	* @param strideX - stride length
 	* @param offsetX - starting index
@@ -66,7 +66,7 @@ interface Routine {
 * Adds a scalar constant to each double-precision floating-point strided array element and computes the sum using ordinary recursive summation.
 *
 * @param N - number of indexed elements
-* @param alpha - constant
+* @param alpha - scalar constant
 * @param x - input array
 * @param strideX - stride length
 * @returns sum

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/examples/c/example.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/examples/c/example.c
@@ -27,10 +27,10 @@ int main( void ) {
 	const int N = 4;
 
 	// Specify the stride length:
-	const int stride = 2;
+	const int strideX = 2;
 
 	// Compute the sum:
-	double v = stdlib_strided_dapxsumors( N, 5.0, x, stride );
+	double v = stdlib_strided_dapxsumors( N, 5.0, x, strideX );
 
 	// Print the result:
 	printf( "sum: %lf\n", v );

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/lib/dapxsumors.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/lib/dapxsumors.js
@@ -30,7 +30,7 @@ var ndarray = require( './ndarray.js' );
 * Adds a scalar constant to each double-precision floating-point strided array element and computes the sum using ordinary recursive summation.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - constant
+* @param {number} alpha - scalar constant
 * @param {Float64Array} x - input array
 * @param {integer} strideX - stride length
 * @returns {number} sum
@@ -39,9 +39,8 @@ var ndarray = require( './ndarray.js' );
 * var Float64Array = require( '@stdlib/array/float64' );
 *
 * var x = new Float64Array( [ 1.0, -2.0, 2.0 ] );
-* var N = x.length;
 *
-* var v = dapxsumors( N, 5.0, x, 1 );
+* var v = dapxsumors( x.length, 5.0, x, 1 );
 * // returns 16.0
 */
 function dapxsumors( N, alpha, x, strideX ) {

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/lib/dapxsumors.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/lib/dapxsumors.native.js
@@ -29,7 +29,7 @@ var addon = require( './../src/addon.node' );
 * Adds a scalar constant to each double-precision floating-point strided array element and computes the sum using ordinary recursive summation.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - constant
+* @param {number} alpha - scalar constant
 * @param {Float64Array} x - input array
 * @param {integer} strideX - stride length
 * @returns {number} sum
@@ -38,9 +38,8 @@ var addon = require( './../src/addon.node' );
 * var Float64Array = require( '@stdlib/array/float64' );
 *
 * var x = new Float64Array( [ 1.0, -2.0, 2.0 ] );
-* var N = x.length;
 *
-* var v = dapxsumors( N, 5.0, x, 1 );
+* var v = dapxsumors( x.length, 5.0, x, 1 );
 * // returns 16.0
 */
 function dapxsumors( N, alpha, x, strideX ) {

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/lib/index.js
@@ -29,7 +29,7 @@
 *
 * var x = new Float64Array( [ 1.0, -2.0, 2.0 ] );
 *
-* var v = dapxsumors( 3, 5.0, x, 1 );
+* var v = dapxsumors( x.length, 5.0, x, 1 );
 * // returns 16.0
 *
 * @example

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/lib/ndarray.js
@@ -24,7 +24,7 @@
 * Adds a scalar constant to each double-precision floating-point strided array element and computes the sum using ordinary recursive summation.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - constant
+* @param {number} alpha - scalar constant
 * @param {Float64Array} x - input array
 * @param {integer} strideX - stride length
 * @param {NonNegativeInteger} offsetX - starting index
@@ -46,10 +46,10 @@ function dapxsumors( N, alpha, x, strideX, offsetX ) {
 	if ( N <= 0 ) {
 		return 0.0;
 	}
-	if ( N === 1 || strideX === 0 ) {
-		return alpha + x[ 0 ];
-	}
 	ix = offsetX;
+	if ( strideX === 0 ) {
+		return N * ( alpha + x[ ix ] );
+	}
 	sum = 0.0;
 	for ( i = 0; i < N; i++ ) {
 		sum += alpha + x[ ix ];

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/lib/ndarray.native.js
@@ -29,7 +29,7 @@ var addon = require( './../src/addon.node' );
 * Adds a scalar constant to each double-precision floating-point strided array element and computes the sum using ordinary recursive summation.
 *
 * @param {PositiveInteger} N - number of indexed elements
-* @param {number} alpha - constant
+* @param {number} alpha - scalar constant
 * @param {Float64Array} x - input array
 * @param {integer} strideX - stride length
 * @param {NonNegativeInteger} offsetX - starting index

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/src/main.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/src/main.c
@@ -40,21 +40,21 @@ double API_SUFFIX(stdlib_strided_dapxsumors)( const CBLAS_INT N, const double al
 * @param N        number of indexed elements
 * @param alpha    scalar constant
 * @param X        input array
-* @param strideX  index increment
+* @param strideX  stride length
 * @param offsetX  starting index
 */
 double API_SUFFIX(stdlib_strided_dapxsumors_ndarray)( const CBLAS_INT N, const double alpha, const double *X, const CBLAS_INT strideX, const CBLAS_INT offsetX ) {
-	double sum;
 	CBLAS_INT ix;
 	CBLAS_INT i;
+	double sum;
 
 	if ( N <= 0 ) {
 		return 0.0;
 	}
-	if ( N == 1 || strideX == 0 ) {
-		return alpha + X[ 0 ];
-	}
 	ix = offsetX;
+	if ( strideX == 0 ) {
+		return N * ( alpha + X[ ix ] );
+	}
 	sum = 0.0;
 	for ( i = 0; i < N; i++ ) {
 		sum += alpha + X[ ix ];

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/test/test.dapxsumors.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/test/test.dapxsumors.js
@@ -135,14 +135,14 @@ tape( 'the function supports a negative `stride` parameter', function test( t ) 
 	t.end();
 });
 
-tape( 'if provided a `stride` parameter equal to `0`, the function returns the first element plus a constant', function test( t ) {
+tape( 'if provided a `stride` parameter equal to `0`, the function returns the first element plus a constant repeated N times', function test( t ) {
 	var x;
 	var v;
 
 	x = new Float64Array( [ 1.0, -2.0, -4.0, 5.0, 3.0 ] );
 
 	v = dapxsumors( x.length, 5.0, x, 0 );
-	t.strictEqual( v, 6.0, 'returns expected value' );
+	t.strictEqual( v, x.length * (x[0]+5.0), 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/test/test.dapxsumors.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/test/test.dapxsumors.native.js
@@ -253,14 +253,14 @@ tape( 'the function supports a negative `stride` parameter', opts, function test
 	t.end();
 });
 
-tape( 'if provided a `stride` parameter equal to `0`, the function returns the first element plus a constant', opts, function test( t ) {
+tape( 'if provided a `stride` parameter equal to `0`, the function returns the first element plus a constant repeated N times', opts, function test( t ) {
 	var x;
 	var v;
 
 	x = new Float64Array( [ 1.0, -2.0, -4.0, 5.0, 3.0 ] );
 
 	v = dapxsumors( x.length, 5.0, x, 0 );
-	t.strictEqual( v, 6.0, 'returns expected value' );
+	t.strictEqual( v, x.length * (x[0]+5.0), 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/test/test.ndarray.js
@@ -135,14 +135,14 @@ tape( 'the function supports a negative `stride` parameter', function test( t ) 
 	t.end();
 });
 
-tape( 'if provided a `stride` parameter equal to `0`, the function returns the first indexed element plus a constant', function test( t ) {
+tape( 'if provided a `stride` parameter equal to `0`, the function returns the first element plus a constant repeated N times', function test( t ) {
 	var x;
 	var v;
 
 	x = new Float64Array( [ 1.0, -2.0, -4.0, 5.0, 3.0 ] );
 
 	v = dapxsumors( x.length, 5.0, x, 0, 0 );
-	t.strictEqual( v, 6.0, 'returns expected value' );
+	t.strictEqual( v, x.length * (x[0]+5.0), 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/test/test.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumors/test/test.ndarray.native.js
@@ -144,14 +144,14 @@ tape( 'the function supports a negative `stride` parameter', opts, function test
 	t.end();
 });
 
-tape( 'if provided a `stride` parameter equal to `0`, the function returns the first indexed element plus a constant', opts, function test( t ) {
+tape( 'if provided a `stride` parameter equal to `0`, the function returns the first element plus a constant repeated N times', opts, function test( t ) {
 	var x;
 	var v;
 
 	x = new Float64Array( [ 1.0, -2.0, -4.0, 5.0, 3.0 ] );
 
 	v = dapxsumors( x.length, 5.0, x, 0, 0 );
-	t.strictEqual( v, 6.0, 'returns expected value' );
+	t.strictEqual( v, x.length * (x[0]+5.0), 'returns expected value' );
 
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   update `stride` handling when `stride` is equal to zero.
-   update function documentation
-   update test case where `stride` is equal to zero.

## Related Issues

> Does this pull request have any related issues?

No. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
