### PR TITLE
docs: add missing `f` suffixes and `stdbool` header in `math/base/assert/is-oddf`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/README.md
@@ -133,10 +133,10 @@ Tests if a finite single-precision floating-point number is an odd number.
 ```c
 #include <stdbool.h>
 
-bool out = stdlib_base_is_oddf( 1.0 );
+bool out = stdlib_base_is_oddf( 1.0f );
 // returns true
 
-out = stdlib_base_is_oddf( 4.0 );
+out = stdlib_base_is_oddf( 4.0f );
 // returns false
 ```
 

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/src/main.c
@@ -18,6 +18,7 @@
 
 #include "stdlib/math/base/assert/is_oddf.h"
 #include "stdlib/math/base/assert/is_evenf.h"
+#include <stdbool.h>
 
 /**
 * Tests if a finite single-precision floating-point number is an odd number.
@@ -28,7 +29,7 @@
 * @example
 * #include <stdbool.h>
 *
-* bool out = stdlib_base_is_oddf( 3.0 );
+* bool out = stdlib_base_is_oddf( 3.0f );
 * // returns true
 */
 bool stdlib_base_is_oddf( const float x ) {


### PR DESCRIPTION
Resolves https://github.com/stdlib-js/todo/issues/2323.

## Description

> What is the purpose of this pull request?

This pull request:

-  addresses suggestions at https://github.com/stdlib-js/stdlib/commit/ecd017d9c921c2412fe61af9a129884e0c1e85b6.
-  adds missing `f` suffixes and missing `stdbool` header in [`math/base/assert/is-oddf`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/assert/is-oddf).

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves https://github.com/stdlib-js/todo/issues/2323.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
