### PR TITLE
fix: incorrect macro name in `constants/float32/max-safe-nth-lucas`

### DIFF
--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-lucas/include/stdlib/constants/float32/max_safe_nth_lucas.h
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-lucas/include/stdlib/constants/float32/max_safe_nth_lucas.h
@@ -22,6 +22,6 @@
 /**
 * Macro for the maximum safe nth Lucas number when stored in single-precision floating-point format.
 */
-#define STDLIB_CONSTANT_FLOAT64_MAX_SAFE_NTH_LUCAS 34
+#define STDLIB_CONSTANT_FLOAT32_MAX_SAFE_NTH_LUCAS 34
 
 #endif // !STDLIB_CONSTANTS_FLOAT32_MAX_SAFE_NTH_LUCAS_H


### PR DESCRIPTION
Resolves None.

## Description

> What is the purpose of this pull request?

This pull request:

-   fix for incorrect macro name in `constants/float32/max-safe-nth-lucas`

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
