### PR TITLE
feat: add C implementation for `stats/base/dists/t/pdf`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/README.md
@@ -132,6 +132,101 @@ for ( i = 0; i < 10; i++ ) {
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/stats/base/dists/t/pdf.h"
+```
+
+#### stdlib_base_dists_t_pdf( x, v )
+
+Evaluates the [probability density function][pdf] (PDF) for a [Student's t][t-distribution] distribution with degrees of freedom `v`.
+
+```c
+double out = stdlib_base_dists_t_pdf( 0.5, 2.0 );
+// returns ~0.352
+```
+
+The function accepts the following arguments:
+
+-   **x**: `[in] double` input value.
+-   **v**: `[in] double` degree of freedom.
+
+```c
+double stdlib_base_dists_t_pdf( const double x, const double v );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/stats/base/dists/t/pdf.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+static double random_uniform( const double min, const double max ) {
+    double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+    return min + ( v*(max-min) );
+}
+
+int main( void ) {
+    double x;
+    double v;
+    double y;
+    int i;
+
+    for ( i = 0; i < 25; i++ ) {
+        x = random_uniform( -10.0, 10.0 );
+        v = random_uniform( 0.1, 10.0 );
+        y = stdlib_base_dists_t_pdf( x, v );
+        printf( "x: %lf, v: %lf, f(x;v): %lf\n", x, v, y );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/benchmark/benchmark.js
@@ -21,7 +21,6 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/benchmark/benchmark.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2018 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var randu = require( '@stdlib/random/base/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var pdf = require( './../lib' );
@@ -39,12 +38,8 @@ bench( pkg, function benchmark( b ) {
 	var i;
 
 	len = 100;
-	x = new Float64Array( len );
-	v = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu() * 20.0 ) - 10.0;
-		v[ i ] = ( randu() * 10.0 ) + 0.1;
-	}
+	x = uniform( len, -10.0, 10.0 );
+	v = uniform( len, 0.1, 10.0 );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
@@ -61,7 +56,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg + ':factory', function benchmark( b ) {
+bench( pkg+':factory', function benchmark( b ) {
 	var mypdf;
 	var v;
 	var x;

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/benchmark/benchmark.native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/benchmark/benchmark.native.js
@@ -20,18 +20,26 @@
 
 // MODULES //
 
+var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require( '@stdlib/random/array/uniform' );
 var randu = require( '@stdlib/random/base/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
-var pdf = require( './../lib' );
+
+
+// VARIABLES //
+
+var pdf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( pdf instanceof Error )
+};
 
 
 // MAIN //
 
-bench( pkg, function benchmark( b ) {
+bench( pkg + '::native', opts, function benchmark( b ) {
 	var len;
 	var x;
 	var v;
@@ -49,32 +57,6 @@ bench( pkg, function benchmark( b ) {
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
 		y = pdf( x[ i % len ], v[ i % len ] );
-		if ( isnan( y ) ) {
-			b.fail( 'should not return NaN' );
-		}
-	}
-	b.toc();
-	if ( isnan( y ) ) {
-		b.fail( 'should not return NaN' );
-	}
-	b.pass( 'benchmark finished' );
-	b.end();
-});
-
-bench( pkg + ':factory', function benchmark( b ) {
-	var mypdf;
-	var v;
-	var x;
-	var y;
-	var i;
-
-	v = 2.0;
-	mypdf = pdf.factory( v );
-	x = uniform( 100, -2.0, 2.0 );
-
-	b.tic();
-	for ( i = 0; i < b.iterations; i++ ) {
-		y = mypdf( x[ i % x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -47,12 +47,8 @@ bench( pkg + '::native', opts, function benchmark( b ) {
 	var i;
 
 	len = 100;
-	x = new Float64Array( len );
-	v = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu() * 20.0 ) - 10.0;
-		v[ i ] = ( randu() * 10.0 ) + 0.1;
-	}
+	x = uniform( len, -10.0, 10.0 );
+	v = uniform( len, 0.1, 10.0 );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/benchmark/benchmark.native.js
@@ -22,7 +22,6 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/benchmark/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/benchmark/c/Makefile
@@ -1,7 +1,7 @@
 #/
 # @license Apache-2.0
 #
-# Copyright (c) 2024 The Stdlib Authors.
+# Copyright (c) 2025 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/benchmark/c/benchmark.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/benchmark/c/benchmark.c
@@ -1,0 +1,140 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include <sys/time.h>
+#include "stdlib/stats/base/dists/t/pdf.h"
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#define NAME "t-pdf"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+static void print_version( void ) {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+static void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+static void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+static double tic( void ) {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec / 1.0e6;
+}
+
+/**
+* Generates a random number on the interval [min,max).
+*
+* @param min    minimum value (inclusive)
+* @param max    maximum value (exclusive)
+* @return       random number
+*/
+static double random_uniform( const double min, const double max ) {
+	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+	return min + ( v * ( max - min ) );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+static double benchmark( void ) {
+	double elapsed;
+	double x[ 100 ];
+	double v[ 100 ];
+	double y;
+	double t;
+	int i;
+
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = random_uniform( -10.0, 10.0 );
+		v[ i ] = random_uniform( 0.1, 10.0 );
+	}
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		y = stdlib_base_dists_t_pdf( x[ i % 100 ], v[ i % 100 ] );
+		if ( y != y ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( y != y ) {
+		printf( "should not return NaN\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i + 1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/benchmark/c/benchmark.c
@@ -16,12 +16,12 @@
 * limitations under the License.
 */
 
-#include <sys/time.h>
 #include "stdlib/stats/base/dists/t/pdf.h"
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
+#include <sys/time.h>
 
 #define NAME "t-pdf"
 #define ITERATIONS 1000000

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/binding.gyp
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/binding.gyp
@@ -1,6 +1,6 @@
 # @license Apache-2.0
 #
-# Copyright (c) 2024 The Stdlib Authors.
+# Copyright (c) 2025 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/binding.gyp
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/examples/c/Makefile
@@ -1,7 +1,7 @@
 #/
 # @license Apache-2.0
 #
-# Copyright (c) 2024 The Stdlib Authors.
+# Copyright (c) 2025 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/examples/c/example.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/examples/c/example.c
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/t/pdf.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+static double random_uniform( const double min, const double max ) {
+	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+	return min + ( v * ( max - min ) );
+}
+
+int main( void ) {
+	double x;
+	double v;
+	double y;
+	int i;
+
+	for ( i = 0; i < 25; i++ ) {
+		x = random_uniform( -10.0, 10.0 );
+		v = random_uniform( 0.1, 10.0 );
+		y = stdlib_base_dists_t_pdf( x, v );
+		printf( "x: %lf, v: %lf, f(x;v): %lf\n", x, v, y );
+	}
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/include.gypi
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/include.gypi
@@ -1,6 +1,6 @@
 # @license Apache-2.0
 #
-# Copyright (c) 2024 The Stdlib Authors.
+# Copyright (c) 2025 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/include.gypi
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/include/stdlib/stats/base/dists/t/pdf.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/include/stdlib/stats/base/dists/t/pdf.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/include/stdlib/stats/base/dists/t/pdf.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/include/stdlib/stats/base/dists/t/pdf.h
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_STATS_BASE_DISTS_T_PDF_H
+#define STDLIB_STATS_BASE_DISTS_T_PDF_H
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Evaluates the probability density function (PDF) for a Student's t-distribution with degrees of freedom `v` at a value `x`.
+*/
+double stdlib_base_dists_t_pdf( const double x, const double v );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_STATS_BASE_DISTS_T_PDF_H

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/lib/native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/lib/native.js
@@ -1,0 +1,67 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Evaluates the probability density function (PDF) for a Student's t-distribution with degrees of freedom `v` at a value `x`.
+*
+* @private
+* @param {number} x - input value
+* @param {number} v - degrees of freedom
+* @returns {number} evaluated PDF
+*
+* @example
+* var y = pdf( 2.0, 1.0 );
+* // returns ~0.0637
+*
+* @example
+* var y = pdf( 0.0, 1.0 );
+* // returns ~0.318
+*
+* @example
+* var y = pdf( -1.0, 4.0 );
+* // returns ~0.215
+*
+* @example
+* var y = pdf( NaN, 1.0 );
+* // returns NaN
+*
+* @example
+* var y = pdf( 0.0, NaN );
+* // returns NaN
+*
+* @example
+* var y = pdf( 2.0, -1.0 );
+* // returns NaN
+*/
+function pdf( x, v ) {
+	return addon( x, v );
+}
+
+
+// EXPORTS //
+
+module.exports = pdf;

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/manifest.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/manifest.json
@@ -1,0 +1,85 @@
+{
+  "options": {
+    "task": "build",
+    "wasm": false
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/napi/binary",
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/special/beta",
+        "@stdlib/math/base/special/pow",
+        "@stdlib/math/base/special/sqrt"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/special/beta",
+        "@stdlib/math/base/special/pow",
+        "@stdlib/math/base/special/sqrt"
+      ]
+    },
+    {
+      "task": "examples",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/special/beta",
+        "@stdlib/math/base/special/pow",
+        "@stdlib/math/base/special/sqrt"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/package.json
@@ -14,11 +14,14 @@
     }
   ],
   "main": "./lib",
+  "gypfile": true,
   "directories": {
     "benchmark": "./benchmark",
     "doc": "./docs",
     "example": "./examples",
+    "include": "./include",
     "lib": "./lib",
+    "src": "./src",
     "test": "./test"
   },
   "types": "./docs/types",

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/src/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/src/Makefile
@@ -1,7 +1,7 @@
 #/
 # @license Apache-2.0
 #
-# Copyright (c) 2024 The Stdlib Authors.
+# Copyright (c) 2025 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/src/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/src/addon.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/src/addon.c
@@ -1,0 +1,23 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/napi/binary.h"
+#include "stdlib/stats/base/dists/t/pdf.h"
+
+// cppcheck-suppress shadowFunction
+STDLIB_MATH_BASE_NAPI_MODULE_DD_D( stdlib_base_dists_t_pdf )

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/src/main.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/src/main.c
@@ -1,0 +1,45 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/assert/is_nan.h"
+#include "stdlib/math/base/special/beta.h"
+#include "stdlib/math/base/special/pow.h"
+#include "stdlib/math/base/special/sqrt.h"
+#include "stdlib/stats/base/dists/t/pdf.h"
+#include <math.h>
+
+/**
+* Evaluates the probability density function (PDF) for a Student's t-distribution with degrees of freedom `v` at a value `x`.
+*
+* @param x    input value
+* @param v    degrees of freedom
+* @return     evaluated PDF
+*
+* @example
+* double y = stdlib_base_dists_t_pdf( 2.0, 1.0 );
+* // returns ~0.063
+*/
+double stdlib_base_dists_t_pdf( const double x, const double v ) {
+	double betaTerm;
+
+	if ( stdlib_base_is_nan( x ) || stdlib_base_is_nan( v ) || v <= 0.0 ) {
+		return 0.0 / 0.0; // NaN
+	}
+	betaTerm = stdlib_base_sqrt( v ) * stdlib_base_beta( v / 2.0, 0.5 );
+	return stdlib_base_pow( v / ( v + stdlib_base_pow( x, 2.0 ) ), ( 1.0 + v ) / 2.0 ) / betaTerm;
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/src/main.c
@@ -16,12 +16,11 @@
 * limitations under the License.
 */
 
+#include "stdlib/stats/base/dists/t/pdf.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/special/beta.h"
 #include "stdlib/math/base/special/pow.h"
 #include "stdlib/math/base/special/sqrt.h"
-#include "stdlib/stats/base/dists/t/pdf.h"
-#include <math.h>
 
 /**
 * Evaluates the probability density function (PDF) for a Student's t-distribution with degrees of freedom `v` at a value `x`.

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/test/test.native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/t/pdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/t/pdf/test/test.native.js
@@ -1,0 +1,188 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var abs = require( '@stdlib/math/base/special/abs' );
+var max = require( '@stdlib/math/base/special/max' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+var EPS = require( '@stdlib/constants/float64/eps' );
+
+
+// FIXTURES //
+
+var smallSmall = require( './fixtures/julia/small_small.json' );
+var smallLarge = require( './fixtures/julia/small_large.json' );
+var largeSmall = require( './fixtures/julia/large_small.json' );
+var largeLarge = require( './fixtures/julia/large_large.json' );
+
+
+// VARIABLES //
+
+var pdf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( pdf instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof pdf, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'if provided `NaN` for any parameter, the function returns `NaN`', opts, function test( t ) {
+	var y = pdf( NaN, 1.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+	y = pdf( 0.0, NaN );
+	t.equal( isnan( y ), true, 'returns NaN' );
+	t.end();
+});
+
+tape( 'if provided `+infinity` for `x` and a valid `v`, the function returns `0`', opts, function test( t ) {
+	var y = pdf( PINF, 1.0 );
+	t.equal( y, 0.0, 'returns 0' );
+	t.end();
+});
+
+tape( 'if provided `-infinity` for `x` and a valid `v`, the function returns `0`', opts, function test( t ) {
+	var y = pdf( NINF, 1.0 );
+	t.equal( y, 0.0, 'returns 0' );
+	t.end();
+});
+
+tape( 'if provided `v <= 0`, the function returns `NaN`', opts, function test( t ) {
+	var y;
+
+	y = pdf( 2.0, -1.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = pdf( 0.0, 0.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	t.end();
+});
+
+tape( 'the function evaluates the pdf for `x` given a small range `v`', opts, function test( t ) {
+	var expected;
+	var delta;
+	var tol;
+	var x;
+	var v;
+	var y;
+	var i;
+
+	expected = smallSmall.expected;
+	x = smallSmall.x;
+	v = smallSmall.v;
+	for ( i = 0; i < x.length; i++ ) {
+		y = pdf( x[ i ], v[ i ] );
+		if ( y === expected[ i ] ) {
+			t.equal( y, expected[ i ], 'x: ' + x[ i ] + ', v: ' + v[ i ] + ', y: ' + y + ', expected: ' + expected[ i ] );
+		} else {
+			delta = abs( y - expected[ i ] );
+			tol = max( 2.0 * EPS * abs( expected[ i ] ), 1.0e-14 );
+			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. v: ' + v[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
+		}
+	}
+	t.end();
+});
+
+tape( 'the function evaluates the pdf for `x` given a medium range `v`', opts, function test( t ) {
+	var expected;
+	var delta;
+	var tol;
+	var x;
+	var v;
+	var y;
+	var i;
+
+	expected = smallLarge.expected;
+	x = smallLarge.x;
+	v = smallLarge.v;
+	for ( i = 0; i < x.length; i++ ) {
+		y = pdf( x[ i ], v[ i ] );
+		if ( y === expected[ i ] ) {
+			t.equal( y, expected[ i ], 'x: ' + x[ i ] + ', v: ' + v[ i ] + ', y: ' + y + ', expected: ' + expected[ i ] );
+		} else {
+			delta = abs( y - expected[ i ] );
+			tol = max( 2.0 * EPS * abs( expected[ i ] ), 1.0e-14 );
+			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. v: ' + v[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
+		}
+	}
+	t.end();
+});
+
+tape( 'the function evaluates the pdf for `x` given a large range `v`', opts, function test( t ) {
+	var expected;
+	var delta;
+	var tol;
+	var x;
+	var v;
+	var y;
+	var i;
+
+	expected = largeSmall.expected;
+	x = largeSmall.x;
+	v = largeSmall.v;
+	for ( i = 0; i < x.length; i++ ) {
+		y = pdf( x[ i ], v[ i ] );
+		if ( y === expected[ i ] ) {
+			t.equal( y, expected[ i ], 'x: ' + x[ i ] + ', v: ' + v[ i ] + ', y: ' + y + ', expected: ' + expected[ i ] );
+		} else {
+			delta = abs( y - expected[ i ] );
+			tol = max( 2.0 * EPS * abs( expected[ i ] ), 1.0e-14 );
+			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. v: ' + v[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
+		}
+	}
+	t.end();
+});
+
+tape( 'the function evaluates the pdf for `x` given a large range `v`', opts, function test( t ) {
+	var expected;
+	var delta;
+	var tol;
+	var x;
+	var v;
+	var y;
+	var i;
+
+	expected = largeLarge.expected;
+	x = largeLarge.x;
+	v = largeLarge.v;
+	for ( i = 0; i < x.length; i++ ) {
+		y = pdf( x[ i ], v[ i ] );
+		if ( y === expected[ i ] ) {
+			t.equal( y, expected[ i ], 'x: ' + x[ i ] + ', v: ' + v[ i ] + ', y: ' + y + ', expected: ' + expected[ i ] );
+		} else {
+			delta = abs( y - expected[ i ] );
+			tol = max( 2.0 * EPS * abs( expected[ i ] ), 1.0e-14 );
+			t.ok( delta <= tol, 'within tolerance. x: ' + x[ i ] + '. v: ' + v[ i ] + '. y: ' + y + '. E: ' + expected[ i ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
+		}
+	}
+	t.end();
+});


### PR DESCRIPTION
Resolves #3877.

## Description

> What is the purpose of this pull request?

This pull request:

- Adds a C implementation of the t pdf.
- Includes benchmarks for the C implementation.
- Provides examples demonstrating the usage of the t pdf in C.


## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #3877

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
