### PR TITLE
refactor: replace built-ins by stdlib packages, update benchmarks in `math/base/special/trunc`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/trunc/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/trunc/README.md
@@ -71,9 +71,8 @@ v = trunc( -Infinity );
 var randu = require( '@stdlib/random/array/uniform' );
 var trunc = require( '@stdlib/math/base/special/trunc' );
 
-var i;
 var x = randu( 100, -50.0, 50.0 );
-
+var i;
 for ( i = 0; i < x.length; i++ ) {
     console.log( 'trunc(%d) = %d', x[ i ], trunc( x[ i ] ) );
 }

--- a/lib/node_modules/@stdlib/math/base/special/trunc/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/trunc/README.md
@@ -68,15 +68,14 @@ v = trunc( -Infinity );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var randu = require( '@stdlib/random/array/uniform' );
 var trunc = require( '@stdlib/math/base/special/trunc' );
 
-var x;
 var i;
+var x = randu( 100, -50.0, 50.0 );
 
-for ( i = 0; i < 100; i++ ) {
-    x = (randu()*100.0) - 50.0;
-    console.log( 'trunc(%d) = %d', x, trunc( x ) );
+for ( i = 0; i < x.length; i++ ) {
+    console.log( 'trunc(%d) = %d', x[ i ], trunc( x[ i ] ) );
 }
 ```
 

--- a/lib/node_modules/@stdlib/math/base/special/trunc/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/trunc/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var randu = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var trunc = require( './../lib' );
@@ -41,10 +41,11 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = randu( 100, -500.0, 500.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 500.0;
-		y = trunc( x );
+		y = trunc( x[ i % x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -62,10 +63,11 @@ bench( pkg+'::built-in', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = randu( 100, -500.0, 500.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 500.0;
-		y = Math.trunc( x ); // eslint-disable-line stdlib/no-builtin-math
+		y = Math.trunc( x[ i % x.length ] ); // eslint-disable-line stdlib/no-builtin-math
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/trunc/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/trunc/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var randu = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -43,10 +43,11 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = randu( 100, -500.0, 500.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 500.0;
-		y = trunc( x );
+		y = trunc( x[ i % x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/trunc/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/trunc/benchmark/c/benchmark.c
@@ -89,16 +89,19 @@ static double rand_double( void ) {
 * @return elapsed time in seconds
 */
 static double benchmark( void ) {
+	double x[ 100 ];
 	double elapsed;
-	double x;
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0 * rand_double() ) - 500.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) - 500.0;
-		y = trunc( x );
+		y = trunc( x[ i % 100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/trunc/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/trunc/benchmark/c/native/benchmark.c
@@ -90,16 +90,19 @@ static double rand_double( void ) {
 * @return elapsed time in seconds
 */
 static double benchmark( void ) {
+	double x[ 100 ];
 	double elapsed;
-	double x;
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0 * rand_double() ) - 500.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) - 500.0;
-		y = stdlib_base_trunc( x );
+		y = stdlib_base_trunc( x[ i % 100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/trunc/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/trunc/examples/index.js
@@ -21,9 +21,8 @@
 var randu = require( '@stdlib/random/array/uniform' );
 var trunc = require( './../lib' );
 
-var i;
 var x = randu( 100, -50.0, 50.0 );
-
+var i;
 for ( i = 0; i < x.length; i++ ) {
 	console.log( 'trunc(%d) = %d', x[ i ], trunc( x[ i ] ) );
 }

--- a/lib/node_modules/@stdlib/math/base/special/trunc/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/trunc/examples/index.js
@@ -18,13 +18,12 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var trunc = require( './../lib' );
 
-var x;
 var i;
+var x = uniform( 100, -50.0, 50.0 );
 
-for ( i = 0; i < 100; i++ ) {
-	x = (randu()*100.0) - 50.0;
-	console.log( 'trunc(%d) = %d', x, trunc( x ) );
+for ( i = 0; i < x.length; i++ ) {
+	console.log( 'trunc(%d) = %d', x[ i ], trunc( x[ i ] ) );
 }

--- a/lib/node_modules/@stdlib/math/base/special/trunc/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/trunc/examples/index.js
@@ -18,11 +18,11 @@
 
 'use strict';
 
-var uniform = require( '@stdlib/random/array/uniform' );
+var randu = require( '@stdlib/random/array/uniform' );
 var trunc = require( './../lib' );
 
 var i;
-var x = uniform( 100, -50.0, 50.0 );
+var x = randu( 100, -50.0, 50.0 );
 
 for ( i = 0; i < x.length; i++ ) {
 	console.log( 'trunc(%d) = %d', x[ i ], trunc( x[ i ] ) );

--- a/lib/node_modules/@stdlib/math/base/special/trunc/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/trunc/manifest.json
@@ -1,7 +1,6 @@
 {
   "options": {
-    "task": "build",
-    "wasm": false
+    "task": "build"
   },
   "fields": [
     {
@@ -28,9 +27,8 @@
   "confs": [
     {
       "task": "build",
-      "wasm": false,
       "src": [
-        "./src/trunc.c"
+        "./src/main.c"
       ],
       "include": [
         "./include"
@@ -40,14 +38,15 @@
       ],
       "libpath": [],
       "dependencies": [
-        "@stdlib/math/base/napi/unary"
+        "@stdlib/math/base/napi/unary",
+        "@stdlib/math/base/special/ceil",
+        "@stdlib/math/base/special/floor"
       ]
     },
     {
       "task": "benchmark",
-      "wasm": false,
       "src": [
-        "./src/trunc.c"
+        "./src/main.c"
       ],
       "include": [
         "./include"
@@ -56,13 +55,15 @@
         "-lm"
       ],
       "libpath": [],
-      "dependencies": []
+      "dependencies": [
+        "@stdlib/math/base/special/ceil",
+        "@stdlib/math/base/special/floor"
+      ]
     },
     {
       "task": "examples",
-      "wasm": false,
       "src": [
-        "./src/trunc.c"
+        "./src/main.c"
       ],
       "include": [
         "./include"
@@ -71,22 +72,10 @@
         "-lm"
       ],
       "libpath": [],
-      "dependencies": []
-    },
-    {
-      "task": "build",
-      "wasm": true,
-      "src": [
-        "./src/trunc.c"
-      ],
-      "include": [
-        "./include"
-      ],
-      "libraries": [
-        "-lm"
-      ],
-      "libpath": [],
-      "dependencies": []
+      "dependencies": [
+        "@stdlib/math/base/special/ceil",
+        "@stdlib/math/base/special/floor"
+      ]
     }
   ]
 }

--- a/lib/node_modules/@stdlib/math/base/special/trunc/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/trunc/manifest.json
@@ -1,6 +1,7 @@
 {
   "options": {
-    "task": "build"
+    "task": "build",
+    "wasm": false
   },
   "fields": [
     {
@@ -27,6 +28,7 @@
   "confs": [
     {
       "task": "build",
+      "wasm": false,
       "src": [
         "./src/main.c"
       ],
@@ -39,12 +41,13 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/napi/unary",
-        "@stdlib/math/base/special/ceil",
-        "@stdlib/math/base/special/floor"
+        "@stdlib/math/base/special/floor",
+        "@stdlib/math/base/special/ceil"
       ]
     },
     {
       "task": "benchmark",
+      "wasm": false,
       "src": [
         "./src/main.c"
       ],
@@ -56,12 +59,13 @@
       ],
       "libpath": [],
       "dependencies": [
-        "@stdlib/math/base/special/ceil",
-        "@stdlib/math/base/special/floor"
+        "@stdlib/math/base/special/floor",
+        "@stdlib/math/base/special/ceil"
       ]
     },
     {
       "task": "examples",
+      "wasm": false,
       "src": [
         "./src/main.c"
       ],
@@ -73,8 +77,26 @@
       ],
       "libpath": [],
       "dependencies": [
-        "@stdlib/math/base/special/ceil",
-        "@stdlib/math/base/special/floor"
+        "@stdlib/math/base/special/floor",
+        "@stdlib/math/base/special/ceil"
+      ]
+    },
+    {
+      "task": "build",
+      "wasm": true,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [
+        "-lm"
+      ],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/floor",
+        "@stdlib/math/base/special/ceil"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/trunc/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/trunc/src/main.c
@@ -17,7 +17,8 @@
 */
 
 #include "stdlib/math/base/special/trunc.h"
-#include <math.h>
+#include "stdlib/math/base/special/floor.h"
+#include "stdlib/math/base/special/ceil.h"
 
 /**
 * Rounds a double-precision floating-point number toward zero.
@@ -30,5 +31,8 @@
 * // returns 3.0
 */
 double stdlib_base_trunc( const double x ) {
-	return trunc( x );
+	if ( x < 0.0 ) {
+		return stdlib_base_ceil( x );
+	}
+	return stdlib_base_floor( x );
 }

--- a/lib/node_modules/@stdlib/math/base/special/trunc/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/trunc/test/test.js
@@ -38,37 +38,37 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'the function rounds a numeric value toward 0', function test( t ) {
-	t.strictEqual( trunc( -4.2 ), -4.0, 'equals -4' );
-	t.strictEqual( trunc( 9.99999 ), 9.0, 'equals 9' );
+	t.strictEqual( trunc( -4.2 ), -4.0, 'returns expected value' );
+	t.strictEqual( trunc( 9.99999 ), 9.0, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided `+0`, the function returns `+0`', function test( t ) {
 	var v = trunc( 0.0 );
-	t.strictEqual( isPositiveZero( v ), true, 'equals +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided `-0`, the function returns `-0`', function test( t ) {
 	var v = trunc( -0.0 );
-	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( v ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `NaN` if provided `NaN`', function test( t ) {
 	var v = trunc( NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+infinity` if provided `+infinity`', function test( t ) {
 	var v = trunc( PINF );
-	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.strictEqual( v, PINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-infinity` if provided `-infinity`', function test( t ) {
 	var v = trunc( NINF );
-	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.strictEqual( v, NINF, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/trunc/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/trunc/test/test.native.js
@@ -47,37 +47,37 @@ tape( 'main export is a function', opts, function test( t ) {
 });
 
 tape( 'the function rounds a numeric value toward 0', opts, function test( t ) {
-	t.strictEqual( trunc( -4.2 ), -4.0, 'equals -4' );
-	t.strictEqual( trunc( 9.99999 ), 9.0, 'equals 9' );
+	t.strictEqual( trunc( -4.2 ), -4.0, 'returns expected value' );
+	t.strictEqual( trunc( 9.99999 ), 9.0, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided `+0`, the function returns `+0`', opts, function test( t ) {
 	var v = trunc( 0.0 );
-	t.strictEqual( isPositiveZero( v ), true, 'equals +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided `-0`, the function returns `-0`', opts, function test( t ) {
 	var v = trunc( -0.0 );
-	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( v ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `NaN` if provided `NaN`', opts, function test( t ) {
 	var v = trunc( NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+infinity` if provided `+infinity`', opts, function test( t ) {
 	var v = trunc( PINF );
-	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.strictEqual( v, PINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-infinity` if provided `-infinity`', opts, function test( t ) {
 	var v = trunc( NINF );
-	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.strictEqual( v, NINF, 'returns expected value' );
 	t.end();
 });


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

- replaces the use of `math.h` in the [C implementation](https://github.com/stdlib-js/stdlib/blob/develop/lib/node_modules/%40stdlib/math/base/special/trunc/src/trunc.c) of [`math/base/special/trunc`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/trunc) by using `stdlib_base_ceil` and `stdlib_base_floor`, similar to the [JS implementation](https://github.com/stdlib-js/stdlib/blob/develop/lib/node_modules/%40stdlib/math/base/special/trunc/lib/main.js).
- updates examples, benchmarks, manifest.json and tests to follow latest conventions.
- renames `trunc.c` to `main.c`.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
