### PR TITLE
refactor: use inbuilt macro instead of new variable for `MAX_SAFE_NTH_LUCAS` in `math/base/special/negalucasf`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/negalucasf/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/negalucasf/lib/main.js
@@ -23,12 +23,8 @@
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var isIntegerf = require( '@stdlib/math/base/assert/is-integerf' );
 var absf = require( '@stdlib/math/base/special/absf' );
+var MAX_LUCAS = require( '@stdlib/constants/float32/max-safe-nth-lucas' );
 var NEGALUCAS = require( './negalucas.json' );
-
-
-// VARIABLES //
-
-var MAX_LUCAS = 34;
 
 
 // MAIN //

--- a/lib/node_modules/@stdlib/math/base/special/negalucasf/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/negalucasf/manifest.json
@@ -37,7 +37,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/napi/unary",
-        "@stdlib/math/base/special/labs"
+        "@stdlib/math/base/special/labs",
+        "@stdlib/constants/float32/max-safe-nth-lucas"
       ]
     },
     {
@@ -51,7 +52,8 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-        "@stdlib/math/base/special/labs"
+        "@stdlib/math/base/special/labs",
+        "@stdlib/constants/float32/max-safe-nth-lucas"
       ]
     },
     {
@@ -65,7 +67,8 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-        "@stdlib/math/base/special/labs"
+        "@stdlib/math/base/special/labs",
+        "@stdlib/constants/float32/max-safe-nth-lucas"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/negalucasf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/negalucasf/src/main.c
@@ -18,7 +18,7 @@
 
 #include "stdlib/math/base/special/negalucasf.h"
 #include "stdlib/math/base/special/labs.h"
-#define STDLIB_CONSTANT_FLOAT32_MAX_SAFE_NTH_LUCAS 34
+#include "stdlib/constants/float32/max_safe_nth_lucas.h"
 
 static const int32_t negalucasf_value[ 35 ] = {
 	2,


### PR DESCRIPTION
Resolves None.

## Description

> What is the purpose of this pull request?

This pull request:

-   Makes use of the recently merged `STDLIB_CONSTANT_FLOAT32_MAX_SAFE_NTH_LUCAS` macro instead of a new variable in js and C files

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
