### PR TITLE
feat: add C implementation for `stats/base/dists/normal/mode`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/README.md
@@ -131,13 +131,100 @@ for ( i = 0; i < 10; i++ ) {
 
 <!-- /.examples -->
 
-<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+<!-- C interface documentation. -->
 
-<section class="references">
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
 
 </section>
 
-<!-- /.references -->
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/stats/base/dists/normal/mode.h"
+```
+
+#### stdlib_base_dists_normal_mode( mu, sigma )
+
+Evaluates the mode for a normal distribution with mean `mu` and standard deviation `sigma`.
+
+```c
+double out = stdlib_base_dists_normal_mode( 0.0, 1.0 );
+// returns 0.0
+```
+
+The function accepts the following arguments:
+
+-   **mu**: `[in] double` mean.
+-   **sigma**: `[in] double` standard deviation.
+
+```c
+double stdlib_base_dists_normal_mode( const double mu, const double sigma );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/stats/base/dists/normal/mode.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+static double random_uniform( const double min, const double max ) {
+    double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+    return min + ( v*(max-min) );
+}
+
+int main( void ) {
+    double mu;
+    double sigma;
+    double y;
+    int i;
+
+    for ( i = 0; i < 10; i++ ) {
+        mu = random_uniform( -5.0, 5.0 );
+        sigma = random_uniform( 0.1, 20.0 );
+        y = stdlib_base_dists_normal_mode( mu, sigma );
+        printf("µ: %.4f, σ: %.4f, mode(X;µ,σ): %.4f\n", mu, sigma, y);
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
 
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/README.md
@@ -159,7 +159,7 @@ for ( i = 0; i < 10; i++ ) {
 
 #### stdlib_base_dists_normal_mode( mu, sigma )
 
-Evaluates the mode for a normal distribution with mean `mu` and standard deviation `sigma`.
+Returns the mode for a normal distribution with mean `mu` and standard deviation `sigma`.
 
 ```c
 double out = stdlib_base_dists_normal_mode( 0.0, 1.0 );
@@ -204,8 +204,8 @@ static double random_uniform( const double min, const double max ) {
 }
 
 int main( void ) {
-    double mu;
     double sigma;
+    double mu;
     double y;
     int i;
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	mu = new Float64Array( len );
 	sigma = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = ( randu() * 100.0 ) - 50.0;
-		sigma[ i ] = ( randu() * 20.0 ) + EPS;
+		mu[ i ] = uniform( -50.0, 50.0 );
+		sigma[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/benchmark.native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/benchmark.native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -20,18 +20,27 @@
 
 // MODULES //
 
+var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
 var Float64Array = require( '@stdlib/array/float64' );
+var randu = require( '@stdlib/random/base/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
-var mode = require( './../lib' );
+
+
+// VARIABLES //
+
+var mode = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( mode instanceof Error )
+};
 
 
 // MAIN //
 
-bench( pkg, function benchmark( b ) {
+bench( pkg+'::native', opts, function benchmark( b ) {
 	var sigma;
 	var len;
 	var mu;
@@ -45,7 +54,6 @@ bench( pkg, function benchmark( b ) {
 		mu[ i ] = ( randu() * 100.0 ) - 50.0;
 		sigma[ i ] = ( randu() * 20.0 ) + EPS;
 	}
-
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
 		y = mode( mu[ i % len ], sigma[ i % len ] );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -51,8 +51,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	mu = new Float64Array( len );
 	sigma = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = ( randu() * 100.0 ) - 50.0;
-		sigma[ i ] = ( randu() * 20.0 ) + EPS;
+		mu[ i ] = uniform( -50.0, 50.0 );
+		sigma[ i ] = uniform( EPS, 20.0 );
 	}
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/c/Makefile
@@ -1,7 +1,7 @@
 #/
 # @license Apache-2.0
 #
-# Copyright (c) 2024 The Stdlib Authors.
+# Copyright (c) 2025 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/c/benchmark.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/c/benchmark.c
@@ -1,0 +1,140 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/normal/mode.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "normal-mode"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+static void print_version( void ) {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+static void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+static void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+static double tic( void ) {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [min,max).
+*
+* @param min    minimum value (inclusive)
+* @param max    maximum value (exclusive)
+* @return       random number
+*/
+static double random_uniform( const double min, const double max ) {
+	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+	return min + ( v*(max-min) );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+static double benchmark( void ) {
+	double elapsed;
+    double mu[ 100 ];
+	double sigma[ 100 ];
+	double y;
+	double t;
+	int i;
+
+	for ( i = 0; i < 100; i++ ) {
+		mu[ i ] = random_uniform( -10.0, 10.0 );
+        sigma[ i ] = random_uniform( 0.1, 10.0 );
+	}
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		y = stdlib_base_dists_normal_mode( mu[ i%100 ], sigma[ i%100 ] );
+		if ( y != y ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( y != y ) {
+		printf( "should not return NaN\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/c/benchmark.c
@@ -101,7 +101,7 @@ static double benchmark( void ) {
 
 	for ( i = 0; i < 100; i++ ) {
 		mu[ i ] = random_uniform( -10.0, 10.0 );
-        sigma[ i ] = random_uniform( 0.1, 10.0 );
+		sigma[ i ] = random_uniform( 0.1, 10.0 );
 	}
 
 	t = tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/binding.gyp
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/binding.gyp
@@ -1,6 +1,6 @@
 # @license Apache-2.0
 #
-# Copyright (c) 2024 The Stdlib Authors.
+# Copyright (c) 2025 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/binding.gyp
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/examples/c/Makefile
@@ -1,7 +1,7 @@
 #/
 # @license Apache-2.0
 #
-# Copyright (c) 2024 The Stdlib Authors.
+# Copyright (c) 2025 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/examples/c/example.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/examples/c/example.c
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/normal/mode.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+static double random_uniform( const double min, const double max ) {
+	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+	return min + ( v*(max-min) );
+}
+
+int main( void ) {
+	double mu;
+    double sigma;
+    double y;
+    int i;
+
+	for ( i = 0; i < 10; i++ ) {
+		mu = random_uniform( -5.0, 5.0 );
+		sigma = random_uniform( 0.0, 20.0 );
+		y = stdlib_base_dists_normal_mode( mu, sigma );
+		printf("µ: %.4f, σ: %.4f, mode(X;µ,σ): %.4f\n", mu, sigma, y);
+	}
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/examples/c/example.c
@@ -26,10 +26,10 @@ static double random_uniform( const double min, const double max ) {
 }
 
 int main( void ) {
+	double sigma;
 	double mu;
-    double sigma;
-    double y;
-    int i;
+	double y;
+	int i;
 
 	for ( i = 0; i < 10; i++ ) {
 		mu = random_uniform( -5.0, 5.0 );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/include.gypi
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/include.gypi
@@ -1,6 +1,6 @@
 # @license Apache-2.0
 #
-# Copyright (c) 2024 The Stdlib Authors.
+# Copyright (c) 2025 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/include.gypi
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/include/stdlib/stats/base/dists/normal/mode.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/include/stdlib/stats/base/dists/normal/mode.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/include/stdlib/stats/base/dists/normal/mode.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/include/stdlib/stats/base/dists/normal/mode.h
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_STATS_BASE_DISTS_NORMAL_MODE_H
+#define STDLIB_STATS_BASE_DISTS_NORMAL_MODE_H
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Evaluates the mode for a normal distribution with mean `mu` and standard deviation `sigma`.
+*/
+double stdlib_base_dists_normal_mode( const double mu, const double sigma );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_STATS_BASE_DISTS_NORMAL_MODE_H

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/include/stdlib/stats/base/dists/normal/mode.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/include/stdlib/stats/base/dists/normal/mode.h
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 /**
-* Evaluates the mode for a normal distribution with mean `mu` and standard deviation `sigma`.
+* Returns the mode for a normal distribution with mean `mu` and standard deviation `sigma`.
 */
 double stdlib_base_dists_normal_mode( const double mu, const double sigma );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/lib/native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/lib/native.js
@@ -1,0 +1,63 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Evaluates the mode for a normal distribution with mean `mu` and standard deviation `sigma`.
+*
+* @private
+* @param {number} mu - mean
+* @param {PositiveNumber} sigma - standard deviation
+* @returns {number} mode
+*
+* @example
+* var y = mode( 0.0, 1.0 );
+* // returns 0.0
+*
+* @example
+* var y = mode( 5.0, 2.0 );
+* // returns 5.0
+*
+* @example
+* var y = mode( NaN, 1.0 );
+* // returns NaN
+*
+* @example
+* var y = mode( 0.0, NaN );
+* // returns NaN
+*
+* @example
+* var y = mode( 0.0, 0.0 );
+* // returns NaN
+*/
+function mode( mu, sigma ) {
+	return addon( mu, sigma );
+}
+
+
+// EXPORTS //
+
+module.exports = mode;

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/lib/native.js
@@ -26,7 +26,7 @@ var addon = require( './../src/addon.node' );
 // MAIN //
 
 /**
-* Evaluates the mode for a normal distribution with mean `mu` and standard deviation `sigma`.
+* Returns the mode for a normal distribution with mean `mu` and standard deviation `sigma`.
 *
 * @private
 * @param {number} mu - mean

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/manifest.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/manifest.json
@@ -1,0 +1,76 @@
+{
+  "options": {
+    "task": "build",
+    "wasm": false
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/napi/binary",
+        "@stdlib/math/base/assert/is-nan"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nan"
+      ]
+    },
+    {
+      "task": "examples",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nan"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/package.json
@@ -14,11 +14,14 @@
     }
   ],
   "main": "./lib",
+  "gypfile": true,
   "directories": {
     "benchmark": "./benchmark",
     "doc": "./docs",
     "example": "./examples",
+    "include": "./include",
     "lib": "./lib",
+    "src": "./src",
     "test": "./test"
   },
   "types": "./docs/types",

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/src/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/src/Makefile
@@ -1,7 +1,7 @@
 #/
 # @license Apache-2.0
 #
-# Copyright (c) 2024 The Stdlib Authors.
+# Copyright (c) 2025 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/src/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/src/addon.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/src/addon.c
@@ -1,0 +1,23 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/normal/mode.h"
+#include "stdlib/math/base/napi/binary.h"
+
+// cppcheck-suppress shadowFunction
+STDLIB_MATH_BASE_NAPI_MODULE_DD_D( stdlib_base_dists_normal_mode )

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/src/main.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/src/main.c
@@ -1,0 +1,58 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/normal/mode.h"
+#include "stdlib/math/base/assert/is_nan.h"
+
+/**
+* Returns the mode for a normal distribution with mean `mu` and standard deviation `sigma`.
+*
+* @param mu     mean of the distribution
+* @param sigma  standard deviation of the distribution
+* @return       mode of the normal distribution
+*
+* @example
+* double y = stdlib_base_dists_normal_mode( 0.0, 1.0 );
+* // returns 0.0
+*
+* @example
+* double y = stdlib_base_dists_normal_mode( 5.0, 2.0 );
+* // returns 5.0
+*
+* @example
+* double y = stdlib_base_dists_normal_mode( NAN, 1.0 );
+* // returns NaN
+*
+* @example
+* double y = stdlib_base_dists_normal_mode( 0.0, NAN );
+* // returns NaN
+*
+* @example
+* double y = stdlib_base_dists_normal_mode( 0.0, 0.0 );
+* // returns NaN
+*/
+double stdlib_base_dists_normal_mode( const double mu, const double sigma ) {
+	if (
+		stdlib_base_is_nan( mu ) ||
+		stdlib_base_is_nan( sigma ) ||
+		sigma <= 0.0
+	) {
+		return 0.0/0.0; // NaN
+	}
+	return mu;
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/src/main.c
@@ -29,22 +29,6 @@
 * @example
 * double y = stdlib_base_dists_normal_mode( 0.0, 1.0 );
 * // returns 0.0
-*
-* @example
-* double y = stdlib_base_dists_normal_mode( 5.0, 2.0 );
-* // returns 5.0
-*
-* @example
-* double y = stdlib_base_dists_normal_mode( NAN, 1.0 );
-* // returns NaN
-*
-* @example
-* double y = stdlib_base_dists_normal_mode( 0.0, NAN );
-* // returns NaN
-*
-* @example
-* double y = stdlib_base_dists_normal_mode( 0.0, 0.0 );
-* // returns NaN
 */
 double stdlib_base_dists_normal_mode( const double mu, const double sigma ) {
 	if (

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/test/test.native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/test/test.native.js
@@ -1,0 +1,111 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var abs = require( '@stdlib/math/base/special/abs' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+var EPS = require( '@stdlib/constants/float64/eps' );
+
+
+// FIXTURES //
+
+var data = require( './fixtures/julia/data.json' );
+
+
+// VARIABLES //
+
+var mode = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof mode, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'if provided `NaN` for any parameter, the function returns `NaN`', function test( t ) {
+	var y = mode( NaN, 1.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+	y = mode( 1.0, NaN );
+	t.equal( isnan( y ), true, 'returns NaN' );
+	t.end();
+});
+
+tape( 'if provided a nonpositive `sigma`, the function returns `NaN`', function test( t ) {
+	var y;
+
+	y = mode( 2.0, 0.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = mode( 2.0, -1.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = mode( 2.0, -1.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = mode( 1.0, NINF );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = mode( PINF, NINF );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = mode( NINF, NINF );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = mode( NaN, NINF );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	t.end();
+});
+
+tape( 'the function returns the mode of a normal distribution', function test( t ) {
+	var expected;
+	var delta;
+	var sigma;
+	var tol;
+	var mu;
+	var y;
+	var i;
+
+	expected = data.expected;
+	mu = data.mu;
+	sigma = data.sigma;
+	for ( i = 0; i < mu.length; i++ ) {
+		y = mode( mu[i], sigma[i] );
+		if ( expected[i] !== null) {
+			if ( y === expected[i] ) {
+				t.equal( y, expected[i], 'mu:'+mu[i]+', sigma: '+sigma[i]+', y: '+y+', expected: '+expected[i] );
+			} else {
+				delta = abs( y - expected[ i ] );
+				tol = 1.0 * EPS * abs( expected[ i ] );
+				t.ok( delta <= tol, 'within tolerance. mu: '+mu[i]+'. sigma: '+sigma[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			}
+		}
+	}
+	t.end();
+});


### PR DESCRIPTION
Resolves #3779

## Description

> What is the purpose of this pull request?

This pull request:

-   adds C implementation for stats/base/dists/normal/mode along with relevant tests, docs, examples and benchmarks.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves [[RFC]: Add C implementation for @stdlib/stats/base/dists/normal/mode  #3779](https://github.com/stdlib-js/stdlib/issues/3779)

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
