### PR TITLE
feat: add C implementation for `dist/triangular/median`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/README.md
@@ -169,7 +169,7 @@ for ( i = 0; i < 10; i++ ) {
 
 #### stdlib_base_dists_triangular_median( a, b, c)
 
-Evaluates the [median][median] for a [triangular][triangular-distribution] distribution with parameters `a` (lowe limit), `b` (upper limit) and `c` (mode).
+Evaluates the [median][median] for a [triangular][triangular-distribution] distribution with parameters `a` (lower limit), `b` (upper limit) and `c` (mode).
 
 ```c
 double out = stdlib_base_dists_triangular_median( 0.0, 1.0, 0.8 );
@@ -183,7 +183,7 @@ The function accepts the following arguments:
 -   **c**: `[in] double` mode.
 
 ```c
-double stdlib_base_dists_triangular_median( const double x, const double a, const double b );
+double stdlib_base_dists_triangular_median( const double a, const double b, const double c );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/README.md
@@ -167,7 +167,7 @@ for ( i = 0; i < 10; i++ ) {
 #include "stdlib/stats/base/dists/triangular/median.h"
 ```
 
-#### stdlib_base_dists_triangular_median( a, b, c)
+#### stdlib_base_dists_triangular_median( a, b, c )
 
 Evaluates the [median][median] for a [triangular][triangular-distribution] distribution with parameters `a` (lower limit), `b` (upper limit) and `c` (mode).
 
@@ -209,6 +209,11 @@ double stdlib_base_dists_triangular_median( const double a, const double b, cons
 #include <stdlib.h>
 #include <stdio.h>
 
+static double random_uniform( const double min, const double max ) {
+    double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+    return min + ( v*(max-min) );
+}
+
 int main( void ) {
     double a;
     double b;
@@ -217,9 +222,9 @@ int main( void ) {
     int i;
 
     for ( i = 0; i < 25; i++ ) {
-        a = 10.0*(double)rand() / ( (double)RAND_MAX + 1.0 );
-        b = 10.0*(double)rand() / ( (double)RAND_MAX + 1.0 ) + a;
-        c = ( b-a )*(double)rand() / ( (double)RAND_MAX + 1.0 ) + a;
+        a = random_uniform( 0.0, 10.0 );
+        b = random_uniform( a, a+10.0 );
+        c = random_uniform( a, b );
         v = stdlib_base_dists_triangular_median( a, b, c );
         printf( "a: %lf, b: %lf, c: %lf, Median(X;a,b,c): %lf\n", a, b, c, v );
     }

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/README.md
@@ -141,6 +141,95 @@ for ( i = 0; i < 10; i++ ) {
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/stats/base/dists/triangular/median.h"
+```
+
+#### stdlib_base_dists_triangular_median( a, b, c)
+
+Evaluates the [median][median] for a [triangular][triangular-distribution] distribution with parameters `a` (lowe limit), `b` (upper limit) and `c` (mode).
+
+```c
+double out = stdlib_base_dists_triangular_median( 0.0, 1.0, 0.8 );
+// returns ~0.632
+```
+
+The function accepts the following arguments:
+
+-   **a**: `[in] double` lower limit.
+-   **b**: `[in] double` upper limit.
+-   **c**: `[in] double` mode.
+
+```c
+double stdlib_base_dists_triangular_median( const double x, const double a, const double b );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/stats/base/dists/triangular/median.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+int main( void ) {
+    double a;
+    double b;
+    double c;
+    double v;
+    int i;
+
+    for ( i = 0; i < 25; i++ ) {
+        a = 10.0*(double)rand() / ( (double)RAND_MAX + 1.0 );
+        b = 10.0*(double)rand() / ( (double)RAND_MAX + 1.0 ) + a;
+        c = ( b-a )*(double)rand() / ( (double)RAND_MAX + 1.0 ) + a;
+        v = stdlib_base_dists_triangular_median( a, b, c );
+        printf( "a: %lf, b: %lf, c: %lf, Median(X;a,b,c): %lf\n", a, b, c, v );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
 <!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 
 <section class="references">

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/benchmark/benchmark.native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -20,18 +20,27 @@
 
 // MODULES //
 
+var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var randu = require( '@stdlib/random/base/randu' );
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
-var median = require( './../lib' );
+
+
+// VARIABLES //
+
+var pdf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( pdf instanceof Error )
+};
 
 
 // MAIN //
 
-bench( pkg, function benchmark( b ) {
+bench( pkg+'::native', opts, function benchmark( b ) {
 	var mode;
 	var len;
 	var min;
@@ -51,7 +60,7 @@ bench( pkg, function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = median( min[ i % len], max[ i % len], mode[ i % len] );
+		y = pdf( min[ i % len ], max[ i % len ], mode[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/benchmark/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/benchmark/c/benchmark.c
@@ -1,0 +1,130 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/triangular/median.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "triangular-median"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+static void print_version( void ) {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+static void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+static void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+static double tic( void ) {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+static double benchmark( void ) {
+	double elapsed;
+	double min[ 100 ];
+	double max[ 100 ];
+	double mode[ 100 ];
+	double y;
+	double t;
+	int i;
+
+	for ( i = 0; i < 100; i++ ) {
+		min[ i ] = 10.0*(double)rand() / ( (double)RAND_MAX + 1.0 );
+		max[ i ] = 10.0*(double)rand() / ( (double)RAND_MAX + 1.0 ) + min[ i ];
+		mode[ i ] = ( max[ i ]-min[ i ] )*(double)rand() / ( (double)RAND_MAX + 1.0 ) + min[ i ];
+	}
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		y = stdlib_base_dists_triangular_median( min[ i%100 ], max[ i%100 ], mode[ i%100 ] );
+		if ( y != y ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( y != y ) {
+		printf( "should not return NaN\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/benchmark/c/benchmark.c
@@ -75,6 +75,18 @@ static double tic( void ) {
 }
 
 /**
+* Generates a random number on the interval [min,max).
+*
+* @param min    minimum value (inclusive)
+* @param max    maximum value (exclusive)
+* @return       random number
+*/
+static double random_uniform( const double min, const double max ) {
+	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+	return min + ( v*(max-min) );
+}
+
+/**
 * Runs a benchmark.
 *
 * @return elapsed time in seconds
@@ -89,9 +101,9 @@ static double benchmark( void ) {
 	int i;
 
 	for ( i = 0; i < 100; i++ ) {
-		min[ i ] = 10.0*(double)rand() / ( (double)RAND_MAX + 1.0 );
-		max[ i ] = 10.0*(double)rand() / ( (double)RAND_MAX + 1.0 ) + min[ i ];
-		mode[ i ] = ( max[ i ]-min[ i ] )*(double)rand() / ( (double)RAND_MAX + 1.0 ) + min[ i ];
+		min[ i ] = random_uniform( 0.0, 10.0 );
+		max[ i ] = random_uniform( min[ i ], min[ i ]+10.0 );
+		mode[ i ] = random_uniform( min[ i ], max[ i ] );
 	}
 
 	t = tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/binding.gyp
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/examples/c/example.c
@@ -21,8 +21,8 @@
 #include <stdio.h>
 
 static double random_uniform( const double min, const double max ) {
-    double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
-    return min + ( v*(max-min) );
+	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+	return min + ( v*(max-min) );
 }
 
 int main( void ) {

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/examples/c/example.c
@@ -20,6 +20,11 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+static double random_uniform( const double min, const double max ) {
+    double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+    return min + ( v*(max-min) );
+}
+
 int main( void ) {
 	double a;
 	double b;
@@ -28,9 +33,9 @@ int main( void ) {
 	int i;
 
 	for ( i = 0; i < 25; i++ ) {
-		a = 10.0*(double)rand() / ( (double)RAND_MAX + 1.0 );
-		b = 10.0*(double)rand() / ( (double)RAND_MAX + 1.0 ) + a;
-		c = ( b-a )*(double)rand() / ( (double)RAND_MAX + 1.0 ) + a;
+		a = random_uniform( 0.0, 10.0 );
+		b = random_uniform( a, a+10.0 );
+		c = random_uniform( a, b );
 		v = stdlib_base_dists_triangular_median( a, b, c );
 		printf( "a: %lf, b: %lf, c: %lf, Median(X;a,b,c): %lf\n", a, b, c, v );
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/examples/c/example.c
@@ -1,0 +1,37 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/triangular/median.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+int main( void ) {
+	double a;
+	double b;
+	double c;
+	double v;
+	int i;
+
+	for ( i = 0; i < 25; i++ ) {
+		a = 10.0*(double)rand() / ( (double)RAND_MAX + 1.0 );
+		b = 10.0*(double)rand() / ( (double)RAND_MAX + 1.0 ) + a;
+		c = ( b-a )*(double)rand() / ( (double)RAND_MAX + 1.0 ) + a;
+		v = stdlib_base_dists_triangular_median( a, b, c );
+		printf( "a: %lf, b: %lf, c: %lf, Median(X;a,b,c): %lf\n", a, b, c, v );
+	}
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/include.gypi
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/include/stdlib/stats/base/dists/triangular/median.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/include/stdlib/stats/base/dists/triangular/median.h
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_STATS_BASE_DISTS_TRIANGULAR_MEDIAN_H
+#define STDLIB_STATS_BASE_DISTS_TRIANGULAR_MEDIAN_H
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Evaluates the median for a triangular distribution with minimum support `a` and maximum support `b` with mode `c`.
+*/
+double stdlib_base_dists_triangular_median( const double a, const double b, const double c );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_STATS_BASE_DISTS_TRIANGULAR_MEDIAN_H

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/lib/native.js
@@ -1,0 +1,75 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Returns the median of a triangular distribution.
+*
+* @param {number} a - minimum support
+* @param {number} b - maximum support
+* @param {number} c - mode
+* @returns {number} median
+*
+* @example
+* var v = median( 0.0, 1.0, 0.5 );
+* // returns 0.5
+*
+* @example
+* var v = median( 4.0, 12.0, 9.0 );
+* // returns ~8.472
+*
+* @example
+* var v = median( -4.0, 4.0, -1.0 );
+* // returns ~-0.472
+*
+* @example
+* var v = median( 1.0, -0.1, 0.5 );
+* // returns NaN
+*
+* @example
+* var v = median( 0.0, 1.0, 2.0 );
+* // returns NaN
+*
+* @example
+* var v = median( NaN, 4.0, 2.0 );
+* // returns NaN
+*
+* @example
+* var v = median( 0.0, NaN, 2.0 );
+* // returns NaN
+*
+* @example
+* var v = median( 0.0, 4.0, NaN );
+* // returns NaN
+*/
+function median( a, b, c ) {
+	return addon( a, b, c );
+}
+
+
+// EXPORTS //
+
+module.exports = median;

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/lib/native.js
@@ -28,6 +28,7 @@ var addon = require( './../src/addon.node' );
 /**
 * Returns the median of a triangular distribution.
 *
+* @private
 * @param {number} a - minimum support
 * @param {number} b - maximum support
 * @param {number} c - mode
@@ -46,23 +47,11 @@ var addon = require( './../src/addon.node' );
 * // returns ~-0.472
 *
 * @example
-* var v = median( 1.0, -0.1, 0.5 );
-* // returns NaN
-*
-* @example
 * var v = median( 0.0, 1.0, 2.0 );
 * // returns NaN
 *
 * @example
 * var v = median( NaN, 4.0, 2.0 );
-* // returns NaN
-*
-* @example
-* var v = median( 0.0, NaN, 2.0 );
-* // returns NaN
-*
-* @example
-* var v = median( 0.0, 4.0, NaN );
 * // returns NaN
 */
 function median( a, b, c ) {

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/manifest.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/manifest.json
@@ -1,0 +1,79 @@
+{
+  "options": {
+    "task": "build",
+    "wasm": false
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/napi/ternary",
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/special/sqrt"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/special/sqrt"
+      ]
+    },
+    {
+      "task": "examples",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/special/sqrt"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/package.json
@@ -14,11 +14,14 @@
     }
   ],
   "main": "./lib",
+  "gypfile": true,
   "directories": {
     "benchmark": "./benchmark",
     "doc": "./docs",
     "example": "./examples",
+    "include": "./include",
     "lib": "./lib",
+    "src": "./src",
     "test": "./test"
   },
   "types": "./docs/types",

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/src/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/src/addon.c
@@ -20,4 +20,4 @@
 #include "stdlib/math/base/napi/ternary.h"
 
 // cppcheck-suppress shadowFunction
-STDLIB_MATH_BASE_NAPI_MODULE_DD_D( stdlib_base_dists_triangular_median )
+STDLIB_MATH_BASE_NAPI_MODULE_DDD_D( stdlib_base_dists_triangular_median )

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/src/addon.c
@@ -1,0 +1,23 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/triangular/median.h"
+#include "stdlib/math/base/napi/ternary.h"
+
+// cppcheck-suppress shadowFunction
+STDLIB_MATH_BASE_NAPI_MODULE_DD_D( stdlib_base_dists_triangular_median )

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/src/main.c
@@ -21,44 +21,16 @@
 #include "stdlib/math/base/special/sqrt.h"
 
 /**
-* Returns the median of a triangular distribution.
+* Returns the median of a Triangular distribution.
 *
-* @param {number} a - minimum support
-* @param {number} b - maximum support
-* @param {number} c - mode
-* @returns {number} median
+* @param a    minimum support
+* @param b    maximum support
+* @param c    mode
+* @return     median
 *
 * @example
-* var v = median( 0.0, 1.0, 0.5 );
+* double y = stdlib_base_triangular_median( 0.0, 1.0, 0.5 );
 * // returns 0.5
-*
-* @example
-* var v = median( 4.0, 12.0, 9.0 );
-* // returns ~8.472
-*
-* @example
-* var v = median( -4.0, 4.0, -1.0 );
-* // returns ~-0.472
-*
-* @example
-* var v = median( 1.0, -0.1, 0.5 );
-* // returns NaN
-*
-* @example
-* var v = median( 0.0, 1.0, 2.0 );
-* // returns NaN
-*
-* @example
-* var v = median( NaN, 4.0, 2.0 );
-* // returns NaN
-*
-* @example
-* var v = median( 0.0, NaN, 2.0 );
-* // returns NaN
-*
-* @example
-* var v = median( 0.0, 4.0, NaN );
-* // returns NaN
 */
 double stdlib_base_dists_triangular_median( const double a, const double b, const double c ) {
 	if (

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/src/main.c
@@ -21,7 +21,7 @@
 #include "stdlib/math/base/special/sqrt.h"
 
 /**
-* Returns the median of a Triangular distribution.
+* Returns the median of a triangular distribution.
 *
 * @param a    minimum support
 * @param b    maximum support

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/src/main.c
@@ -1,0 +1,76 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/triangular/median.h"
+#include "stdlib/math/base/assert/is_nan.h"
+#include "stdlib/math/base/special/sqrt.h"
+
+/**
+* Returns the median of a triangular distribution.
+*
+* @param {number} a - minimum support
+* @param {number} b - maximum support
+* @param {number} c - mode
+* @returns {number} median
+*
+* @example
+* var v = median( 0.0, 1.0, 0.5 );
+* // returns 0.5
+*
+* @example
+* var v = median( 4.0, 12.0, 9.0 );
+* // returns ~8.472
+*
+* @example
+* var v = median( -4.0, 4.0, -1.0 );
+* // returns ~-0.472
+*
+* @example
+* var v = median( 1.0, -0.1, 0.5 );
+* // returns NaN
+*
+* @example
+* var v = median( 0.0, 1.0, 2.0 );
+* // returns NaN
+*
+* @example
+* var v = median( NaN, 4.0, 2.0 );
+* // returns NaN
+*
+* @example
+* var v = median( 0.0, NaN, 2.0 );
+* // returns NaN
+*
+* @example
+* var v = median( 0.0, 4.0, NaN );
+* // returns NaN
+*/
+double stdlib_base_dists_triangular_median( const double a, const double b, const double c ) {
+	if (
+		stdlib_base_is_nan( a ) ||
+		stdlib_base_is_nan( b ) ||
+		stdlib_base_is_nan( c ) ||
+		!( a <= c && c <= b )
+	) {
+		return 0.0/0.0; // NaN
+	}
+	if ( c >= ( a+b ) / 2.0 ) {
+		return a + stdlib_base_sqrt( 0.5 * ( b-a ) * ( c-a ) );
+	}
+	return b - stdlib_base_sqrt( 0.5 * ( b-a ) * ( b-c ) );
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/test/test.native.js
@@ -1,0 +1,108 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var abs = require( '@stdlib/math/base/special/abs' );
+var EPS = require( '@stdlib/constants/float64/eps' );
+
+
+// FIXTURES //
+
+var data = require( './fixtures/julia/data.json' );
+
+
+// VARIABLES //
+
+var median = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( median instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof median, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'if provided `NaN` for any parameter, the function returns `NaN`', opts, function test( t ) {
+	var v = median( NaN, 1.0, 0.5 );
+	t.equal( isnan( v ), true, 'returns NaN' );
+
+	v = median( 0.0, NaN, 0.5 );
+	t.equal( isnan( v ), true, 'returns NaN' );
+
+	v = median( 0.0, 10.0, NaN );
+	t.equal( isnan( v ), true, 'returns NaN' );
+
+	t.end();
+});
+
+tape( 'if provided parameters not satisfying `a <= c <= b`, the function returns `NaN`', opts, function test( t ) {
+	var y;
+
+	y = median( -1.0, -1.1, -1.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = median( 3.0, 2.0, 2.5 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = median( 0.0, 1.0, -1.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = median( 0.0, 1.0, 2.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	t.end();
+});
+
+tape( 'the function returns the median of a triangular distribution', opts, function test( t ) {
+	var expected;
+	var delta;
+	var tol;
+	var a;
+	var b;
+	var c;
+	var i;
+	var y;
+
+	expected = data.expected;
+	a = data.a;
+	b = data.b;
+	c = data.c;
+	for ( i = 0; i < expected.length; i++ ) {
+		y = median( a[i], b[i], c[i] );
+		if ( y === expected[i] ) {
+			t.equal( y, expected[i], 'a: '+a[i]+', b: '+b[i]+', c: '+c[i]+', y: '+y+', expected: '+expected[i] );
+		} else {
+			delta = abs( y - expected[ i ] );
+			tol = 1.0 * EPS * abs( expected[ i ] );
+			t.ok( delta <= tol, 'within tolerance. a: '+a[i]+'. b: '+b[i]+'. c: '+c[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+		}
+	}
+	t.end();
+});


### PR DESCRIPTION
Resolves #3817

## Description

- adds C implementation for @stdlib/stats/base/dists/triangular/median along with relevant tests, benchmarks and examples

This pull request:

-  progresses: #3817 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
