### PR TITLE
feat: add C implementation for `stats/base/dist/weibull/mean`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/README.md
@@ -170,7 +170,7 @@ for ( i = 0; i < 10; i++ ) {
 #include "stdlib/stats/base/dists/weibull/mean.h"
 ```
 
-#### stdlib_base_dists_weibull_mean( mu, b )
+#### stdlib_base_dists_weibull_mean( k, lambda )
 
 Evaluates the mean for an weibull distribution.
 

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/README.md
@@ -144,6 +144,96 @@ for ( i = 0; i < 10; i++ ) {
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/stats/base/dists/weibull/mean.h"
+```
+
+#### stdlib_base_dists_weibull_mean( mu, b )
+
+Evaluates the mean for an weibull distribution.
+
+```c
+double out = stdlib_base_dists_weibull_mean( 4.0, 12.0 );
+// returns ~10.877
+```
+
+The function accepts the following arguments:
+
+-   **k**: `[in] double` shape parameter.
+-   **λ**: `[in] double` scale parameter.
+
+```c
+double stdlib_base_dists_weibull_mean( const double k, const double λ );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/stats/base/dists/weibull/mean.h"
+#include "stdlib/constants/float64/eps.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+static double random_uniform( const double min, const double max ) {
+    double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+    return min + ( v*(max-min) );
+}
+
+int main( void ) {
+    double lambda;
+    double k;
+    double y;
+    int i;
+
+    for ( i = 0; i < 25; i++ ) {
+        k = random_uniform( 0.0, 10.0 ) + STDLIB_CONSTANT_FLOAT64_EPS;
+        lambda = random_uniform( 0.0, 10.0 ) + STDLIB_CONSTANT_FLOAT64_EPS;
+        y = stdlib_base_dists_weibull_mean( k, lambda );
+        printf( "k: %lf, λ: %lf, E(X;k,λ): %lf\n", k, lambda, y );
+    }
+}
+```
+
+</section>
+
 <!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 
 <section class="references">

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/benchmark/benchmark.native.js
@@ -31,7 +31,7 @@ var mean = require( './../lib' );
 
 // MAIN //
 
-bench( pkg+'::native", function benchmark( b ) {
+bench( pkg+'::native', function benchmark( b ) {
 	var lambda;
 	var len;
 	var k;

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/benchmark/benchmark.native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2024 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -22,9 +22,9 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
+var EPS = require( '@stdlib/constants/float64/eps' );
 var randu = require( '@stdlib/random/base/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
 var mean = require( './../lib' );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/benchmark/benchmark.native.js
@@ -31,7 +31,7 @@ var mean = require( './../lib' );
 
 // MAIN //
 
-bench( pkg, function benchmark( b ) {
+bench( pkg+'::native", function benchmark( b ) {
 	var lambda;
 	var len;
 	var k;

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/benchmark/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/benchmark/c/benchmark.c
@@ -87,47 +87,55 @@ static double random_uniform( const double min, const double max ) {
 	return min + ( v*(max-min) );
 }
 
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
 static double benchmark( void ) {
-    double elapsed;
-    double lambda;
-	double k;
-    double y;
-    double t;
-    int i;
+	double elapsed;
+	double lambda[ 100 ];
+	double k[ 100 ];
+	double y;
+	double t;
+	int i;
 
-    t = tic();
-    for ( i = 0; i < ITERATIONS; i++ ) {
-		lambda = random_uniform( 0.0, 10.0 ) + STDLIB_CONSTANT_FLOAT64_EPS;
-		k = random_uniform( 0.0, 10.0 ) + STDLIB_CONSTANT_FLOAT64_EPS;
-        y = stdlib_base_dists_weibull_mean( lambda, k );
-        if ( y != y ) {
-            printf( "should not return NaN\n" );
-            break;
-        }
-    }
-    elapsed = tic() - t;
-    if ( y != y ) {
-        printf( "should not return NaN\n" );
-    }
-    return elapsed;
+	for ( i = 0; i < 100; i++ ) {
+		lambda[ i ] = random_uniform( 0.0, 1.0 ) + STDLIB_CONSTANT_FLOAT64_EPS;
+		k[ i ] = random_uniform( 0.0, 1.0 ) + STDLIB_CONSTANT_FLOAT64_EPS;
+	}
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		y = stdlib_base_dists_weibull_mean( k[ i%100 ], lambda[ i%100 ] );
+		if ( y != y ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( y != y ) {
+		printf( "should not return NaN\n" );
+	}
+	return elapsed;
 }
 
 /**
 * Main execution sequence.
 */
 int main( void ) {
-    double elapsed;
-    int i;
+	double elapsed;
+	int i;
 
-    // Use the current time to seed the random number generator:
-    srand( time( NULL ) );
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
 
-    print_version();
-    for ( i = 0; i < REPEATS; i++ ) {
-        printf( "# c::%s\n", NAME );
-        elapsed = benchmark();
-        print_results( elapsed );
-        printf( "ok %d benchmark finished\n", i+1 );
-    }
-    print_summary( REPEATS, REPEATS );
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/benchmark/c/benchmark.c
@@ -1,0 +1,133 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/weibull/mean.h"
+#include "stdlib/constants/float64/eps.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "weibull-mean"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+static void print_version( void ) {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+static void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+static void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+static double tic( void ) {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [min,max).
+*
+* @param min    minikm value (inclusive)
+* @param max    maxikm value (exclusive)
+* @return       random number
+*/
+static double random_uniform( const double min, const double max ) {
+	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+	return min + ( v*(max-min) );
+}
+
+static double benchmark( void ) {
+    double elapsed;
+    double lambda;
+	double k;
+    double y;
+    double t;
+    int i;
+
+    t = tic();
+    for ( i = 0; i < ITERATIONS; i++ ) {
+		lambda = random_uniform( 0.0, 10.0 ) + STDLIB_CONSTANT_FLOAT64_EPS;
+		k = random_uniform( 0.0, 10.0 ) + STDLIB_CONSTANT_FLOAT64_EPS;
+        y = stdlib_base_dists_weibull_mean( lambda, k );
+        if ( y != y ) {
+            printf( "should not return NaN\n" );
+            break;
+        }
+    }
+    elapsed = tic() - t;
+    if ( y != y ) {
+        printf( "should not return NaN\n" );
+    }
+    return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+    double elapsed;
+    int i;
+
+    // Use the current time to seed the random number generator:
+    srand( time( NULL ) );
+
+    print_version();
+    for ( i = 0; i < REPEATS; i++ ) {
+        printf( "# c::%s\n", NAME );
+        elapsed = benchmark();
+        print_results( elapsed );
+        printf( "ok %d benchmark finished\n", i+1 );
+    }
+    print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/binding.gyp
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/examples/c/example.c
@@ -1,0 +1,41 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/weibull/mean.h"
+#include "stdlib/constants/float64/eps.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+static double random_uniform( const double min, const double max ) {
+	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+	return min + ( v*(max-min) );
+}
+
+int main( void ) {
+	double lambda;
+	double k;
+	double y;
+	int i;
+
+	for ( i = 0; i < 25; i++ ) {
+		k = random_uniform( 0.0, 10.0 ) + STDLIB_CONSTANT_FLOAT64_EPS;
+		lambda = random_uniform( 0.0, 10.0 ) + STDLIB_CONSTANT_FLOAT64_EPS;
+		y = stdlib_base_dists_weibull_mean( k, lambda );
+		printf( "k: %lf, λ: %lf, E(X;k,λ): %lf\n", k, lambda, y );
+	}
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/include.gypi
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/include/stdlib/stats/base/dists/weibull/mean.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/include/stdlib/stats/base/dists/weibull/mean.h
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_STATS_BASE_DISTS_WEIBULL_MEAN_H
+#define STDLIB_STATS_BASE_DISTS_WEIBULL_MEAN_H
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Returns the mean of an weibull distribution.
+*/
+double stdlib_base_dists_weibull_mean( const double k, const double lambda );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_STATS_BASE_DISTS_WEIBULL_MEAN_H

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/lib/native.js
@@ -1,0 +1,70 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Returns the expected value of a Weibull distribution.
+*
+* @private
+* @param {PositiveNumber} k - shape parameter
+* @param {PositiveNumber} lambda - scale parameter
+* @returns {PositiveNumber} expected value
+*
+* @example
+* var v = mean( 1.0, 1.0 );
+* // returns 1.0
+*
+* @example
+* var v = mean( 4.0, 12.0 );
+* // returns ~10.877
+*
+* @example
+* var v = mean( 8.0, 2.0 );
+* // returns ~1.883
+*
+* @example
+* var v = mean( 1.0, -0.1 );
+* // returns NaN
+*
+* @example
+* var v = mean( -0.1, 1.0 );
+* // returns NaN
+*
+* @example
+* var v = mean( 2.0, NaN );
+* // returns NaN
+*
+* @example
+* var v = mean( NaN, 2.0 );
+* // returns NaN
+*/function mean( k, lambda ) {
+	return addon( k, lambda );
+}
+
+
+// EXPORTS //
+
+module.exports = mean;

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/manifest.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/manifest.json
@@ -39,7 +39,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/napi/binary",
-        "@stdlib/math/base/assert/is-nan"
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/special/gamma"
       ]
     },
     {

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/manifest.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/manifest.json
@@ -1,0 +1,80 @@
+{
+  "options": {
+    "task": "build",
+    "wasm": false
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/napi/binary",
+        "@stdlib/math/base/assert/is-nan"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/eps",
+        "@stdlib/math/base/special/gamma"
+      ]
+    },
+    {
+      "task": "examples",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/eps",
+        "@stdlib/math/base/special/gamma"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/package.json
@@ -14,11 +14,14 @@
     }
   ],
   "main": "./lib",
+  "gypfile": true,
   "directories": {
     "benchmark": "./benchmark",
     "doc": "./docs",
     "example": "./examples",
+    "include": "./include",
     "lib": "./lib",
+    "src": "./src",
     "test": "./test"
   },
   "types": "./docs/types",

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/src/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/src/addon.c
@@ -1,0 +1,23 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/weibull/mean.h"
+#include "stdlib/math/base/napi/binary.h"
+
+// cppcheck-suppress shadowFunction
+STDLIB_MATH_BASE_NAPI_MODULE_DD_D( stdlib_base_dists_weibull_mean )

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/src/main.c
@@ -1,0 +1,68 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/weibull/mean.h"
+#include "stdlib/math/base/assert/is_nan.h"
+#include "stdlib/math/base/special/gamma.h"
+
+/**
+* Returns the expected value of a Weibull distribution.
+*
+* @param k  	 shape parameter
+* @param lambda	 scale parameter
+* @returns 		 expected value
+*
+* @example
+* var v = mean( 1.0, 1.0 );
+* // returns 1.0
+*
+* @example
+* var v = mean( 4.0, 12.0 );
+* // returns ~10.877
+*
+* @example
+* var v = mean( 8.0, 2.0 );
+* // returns ~1.883
+*
+* @example
+* var v = mean( 1.0, -0.1 );
+* // returns NaN
+*
+* @example
+* var v = mean( -0.1, 1.0 );
+* // returns NaN
+*
+* @example
+* var v = mean( 2.0, NaN );
+* // returns NaN
+*
+* @example
+* var v = mean( NaN, 2.0 );
+* // returns NaN
+*/
+double stdlib_base_dists_weibull_mean( const double k, const double lambda ) {
+	if (
+		stdlib_base_is_nan( k ) ||
+		stdlib_base_is_nan( lambda ) ||
+		k <= 0.0 ||
+		lambda <= 0.0
+	 ) {
+		return 0.0 / 0.0; // NaN
+	}
+	return lambda * stdlib_base_gamma( 1.0 + (1.0/k) );
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/src/main.c
@@ -23,37 +23,13 @@
 /**
 * Returns the expected value of a Weibull distribution.
 *
-* @param k  	 shape parameter
-* @param lambda	 scale parameter
-* @returns 		 expected value
+* @param k        shape parameter
+* @param lambda   scale parameter
+* @returns        expected value
 *
 * @example
-* var v = mean( 1.0, 1.0 );
+* double v = mean( 1.0, 1.0 );
 * // returns 1.0
-*
-* @example
-* var v = mean( 4.0, 12.0 );
-* // returns ~10.877
-*
-* @example
-* var v = mean( 8.0, 2.0 );
-* // returns ~1.883
-*
-* @example
-* var v = mean( 1.0, -0.1 );
-* // returns NaN
-*
-* @example
-* var v = mean( -0.1, 1.0 );
-* // returns NaN
-*
-* @example
-* var v = mean( 2.0, NaN );
-* // returns NaN
-*
-* @example
-* var v = mean( NaN, 2.0 );
-* // returns NaN
 */
 double stdlib_base_dists_weibull_mean( const double k, const double lambda ) {
 	if (

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/test/test.native.js
@@ -1,0 +1,129 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var abs = require( '@stdlib/math/base/special/abs' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+var EPS = require( '@stdlib/constants/float64/eps' );
+
+
+// VARIABLES //
+
+var mean = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( mean instanceof Error )
+};
+
+
+// FIXTURES //
+
+var data = require( './fixtures/julia/data.json' );
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof mean, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'if provided `NaN` for any parameter, the function returns `NaN`', opts, function test( t ) {
+	var v = mean( NaN, 0.5 );
+	t.equal( isnan( v ), true, 'returns NaN' );
+
+	v = mean( 10.0, NaN );
+	t.equal( isnan( v ), true, 'returns NaN' );
+
+	t.end();
+});
+
+tape( 'if provided `k <= 0`, the function returns `NaN`', opts, function test( t ) {
+	var y;
+
+	y = mean( -1.0, 2.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = mean( NINF, 1.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = mean( NINF, PINF );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = mean( NINF, NINF );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = mean( NINF, NaN );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	t.end();
+});
+
+tape( 'if provided `lambda <= 0`, the function returns `NaN`', opts, function test( t ) {
+	var y;
+
+	y = mean( 2.0, -1.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = mean( 1.0, NINF );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = mean( PINF, NINF );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = mean( NINF, NINF );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = mean( NaN, NINF );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	t.end();
+});
+
+tape( 'the function returns the mean of a Weibull distribution', opts, function test( t ) {
+	var expected;
+	var lambda;
+	var delta;
+	var tol;
+	var k;
+	var i;
+	var y;
+
+	expected = data.expected;
+	k = data.k;
+	lambda = data.lambda;
+	for ( i = 0; i < expected.length; i++ ) {
+		y = mean( k[i], lambda[i] );
+		if ( y === expected[i] ) {
+			t.equal( y, expected[i], 'k: '+k[i]+', lambda: '+lambda[i]+', y: '+y+', expected: '+expected[i] );
+		} else {
+			delta = abs( y - expected[ i ] );
+			tol = 3.0 * EPS * abs( expected[ i ] );
+			t.ok( delta <= tol, 'within tolerance. k: '+k[i]+'. lambda: '+lambda[i]+'. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+		}
+	}
+	t.end();
+});


### PR DESCRIPTION
Resolves #3843

## Description

- adds C implementation for @stdlib/stats/base/dists/weibull/mean along with relevant tests, benchmarks and examples

This pull request:

-  progresses: #3843

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
