### PR TITLE
chore: add missing `@private` in benchmarks of `stats/base/*`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/snanmax/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/snanmax/benchmark/benchmark.js
@@ -35,6 +35,7 @@ var snanmax = require( './../lib/snanmax.js' );
 /**
 * Returns a random value or `NaN`.
 *
+* @private
 * @returns {number} random number or `NaN`
 */
 function rand() {

--- a/lib/node_modules/@stdlib/stats/base/snanmax/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/snanmax/benchmark/benchmark.native.js
@@ -44,6 +44,7 @@ var opts = {
 /**
 * Returns a random value or `NaN`.
 *
+* @private
 * @returns {number} random number or `NaN`
 */
 function rand() {

--- a/lib/node_modules/@stdlib/stats/base/snanmax/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/base/snanmax/benchmark/benchmark.ndarray.js
@@ -35,6 +35,7 @@ var snanmax = require( './../lib/ndarray.js' );
 /**
 * Returns a random value or `NaN`.
 *
+* @private
 * @returns {number} random number or `NaN`
 */
 function rand() {

--- a/lib/node_modules/@stdlib/stats/base/snanmax/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/stats/base/snanmax/benchmark/benchmark.ndarray.native.js
@@ -44,6 +44,7 @@ var opts = {
 /**
 * Returns a random value or `NaN`.
 *
+* @private
 * @returns {number} random number or `NaN`
 */
 function rand() {

--- a/lib/node_modules/@stdlib/stats/base/snanmin/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/snanmin/benchmark/benchmark.js
@@ -35,6 +35,7 @@ var snanmin = require( './../lib/snanmin.js' );
 /**
 * Returns a random value or `NaN`.
 *
+* @private
 * @returns {number} random number or `NaN`
 */
 function rand() {

--- a/lib/node_modules/@stdlib/stats/base/snanmin/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/snanmin/benchmark/benchmark.native.js
@@ -44,6 +44,7 @@ var opts = {
 /**
 * Returns a random value or `NaN`.
 *
+* @private
 * @returns {number} random number or `NaN`
 */
 function rand() {

--- a/lib/node_modules/@stdlib/stats/base/snanmin/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/base/snanmin/benchmark/benchmark.ndarray.js
@@ -35,6 +35,7 @@ var snanmin = require( './../lib/ndarray.js' );
 /**
 * Returns a random value or `NaN`.
 *
+* @private
 * @returns {number} random number or `NaN`
 */
 function rand() {

--- a/lib/node_modules/@stdlib/stats/base/snanmin/benchmark/benchmark.ndarray.native.js
+++ b/lib/node_modules/@stdlib/stats/base/snanmin/benchmark/benchmark.ndarray.native.js
@@ -44,6 +44,7 @@ var opts = {
 /**
 * Returns a random value or `NaN`.
 *
+* @private
 * @returns {number} random number or `NaN`
 */
 function rand() {


### PR DESCRIPTION
Resolves None

## Description

> What is the purpose of this pull request?

This pull request:

-   adds missing `@private` annotation in benchmarks of `stats/base/snanmax`

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
