### PR TITLE
fix: add support for handling `NewExpression` in `_tools/eslint/rules/eol-open-bracket-spacing`

### DIFF
--- a/lib/node_modules/@stdlib/_tools/eslint/rules/eol-open-bracket-spacing/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/eol-open-bracket-spacing/lib/main.js
@@ -81,7 +81,7 @@ function main( context ) {
 		var args;
 
 		if (
-			node.type === 'CallExpression' &&
+			( node.type === 'CallExpression' || node.type === 'NewExpression' ) &&
 			node.arguments.length > 0
 		) {
 			args = node.arguments;
@@ -97,7 +97,10 @@ function main( context ) {
 				) {
 					report( node, prevToken, tokenAfter );
 				}
-			} else if ( args[ 0 ].type === 'ArrayExpression' ) {
+			} else if (
+				args[ 0 ].type === 'ArrayExpression' &&
+				args[ 0 ].elements.length > 0
+			) {
 				elem = args[ 0 ].elements[ 0 ];
 				if (
 					elem.type === 'ObjectExpression' &&
@@ -150,6 +153,7 @@ function main( context ) {
 
 	return {
 		'CallExpression': validate,
+		'NewExpression': validate,
 		'ArrayExpression': validate
 	};
 }

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/eol-open-bracket-spacing/test/fixtures/invalid.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/eol-open-bracket-spacing/test/fixtures/invalid.js
@@ -18,7 +18,7 @@
 
 'use strict';
 
-var valid = [];
+var invalid = [];
 var test;
 
 test = {
@@ -39,7 +39,7 @@ test = {
 		'}];'
 	].join( '\n' )
 };
-valid.push( test );
+invalid.push( test );
 
 test = {
 	'code': [
@@ -77,7 +77,7 @@ test = {
 		']);'
 	].join( '\n' )
 };
-valid.push( test );
+invalid.push( test );
 
 test = {
 	'code': [
@@ -107,7 +107,7 @@ test = {
 		'}]);'
 	].join( '\n' )
 };
-valid.push( test);
+invalid.push( test);
 
 test = {
 	'code': [
@@ -137,7 +137,7 @@ test = {
 		'}]);'
 	].join( '\n' )
 };
-valid.push( test);
+invalid.push( test);
 
 test = {
 	'code': [
@@ -170,7 +170,7 @@ test = {
 		'}]);'
 	].join( '\n' )
 };
-valid.push( test);
+invalid.push( test);
 
 test = {
 	'code': [
@@ -202,7 +202,7 @@ test = {
 		'*/'
 	].join( '\n' )
 };
-valid.push( test );
+invalid.push( test );
 
 test = {
 	'code': [
@@ -222,9 +222,45 @@ test = {
 		'});'
 	].join( '\n' )
 };
-valid.push( test );
+invalid.push( test );
+
+test = {
+	'code': [
+		'  var v = new ndindex( { // eslint-disable-line no-unused-vars',
+		'    \'kind\': \'linear\'',
+		'  });'
+	].join( '\n' ),
+	'errors': [{
+		'message': 'No spaces allowed between an opening parenthesis or bracket and a nested object or array expression at the end of a line',
+		'type': null
+	}],
+	'output': [
+		'  var v = new ndindex({ // eslint-disable-line no-unused-vars',
+		'    \'kind\': \'linear\'',
+		'  });'
+	].join( '\n' )
+};
+invalid.push( test );
+
+test = {
+	'code': [
+		'  var v = new ndindex( {',
+		'    \'kind\': \'linear\'',
+		'  });'
+	].join( '\n' ),
+	'errors': [{
+		'message': 'No spaces allowed between an opening parenthesis or bracket and a nested object or array expression at the end of a line',
+		'type': null
+	}],
+	'output': [
+		'  var v = new ndindex({',
+		'    \'kind\': \'linear\'',
+		'  });'
+	].join( '\n' )
+};
+invalid.push( test );
 
 
 // EXPORTS //
 
-module.exports = valid;
+module.exports = invalid;

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/eol-open-bracket-spacing/test/fixtures/invalid.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/eol-open-bracket-spacing/test/fixtures/invalid.js
@@ -107,7 +107,7 @@ test = {
 		'}]);'
 	].join( '\n' )
 };
-invalid.push( test);
+invalid.push( test );
 
 test = {
 	'code': [
@@ -137,7 +137,7 @@ test = {
 		'}]);'
 	].join( '\n' )
 };
-invalid.push( test);
+invalid.push( test );
 
 test = {
 	'code': [
@@ -170,7 +170,7 @@ test = {
 		'}]);'
 	].join( '\n' )
 };
-invalid.push( test);
+invalid.push( test );
 
 test = {
 	'code': [

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/eol-open-bracket-spacing/test/fixtures/unvalidated.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/eol-open-bracket-spacing/test/fixtures/unvalidated.js
@@ -107,6 +107,34 @@ test = {
 };
 valid.push( test );
 
+test = {
+	'code': [
+		'  var x = array( [ {} ] );'
+	].join( '\n' )
+};
+valid.push( test );
+
+test = {
+	'code': [
+		'  var x = new Float64Array( [ 1, 2, 3, 4 ] );'
+	].join( '\n' )
+};
+valid.push( test );
+
+test = {
+	'code': [
+		'  var x = new Float64Array(',
+		'    [',
+		'      1,',
+		'      2,',
+		'      3,',
+		'      4',
+		'    ]',
+		'  );'
+	].join( '\n' )
+};
+valid.push( test );
+
 
 // EXPORTS //
 

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/eol-open-bracket-spacing/test/fixtures/valid.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/eol-open-bracket-spacing/test/fixtures/valid.js
@@ -48,7 +48,7 @@ test = {
 		']);'
 	].join( '\n' )
 };
-valid.push( test);
+valid.push( test );
 
 test = {
 	'code': [
@@ -63,7 +63,7 @@ test = {
 		'}]);'
 	].join( '\n' )
 };
-valid.push( test);
+valid.push( test );
 
 test = {
 	'code': [

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/eol-open-bracket-spacing/test/fixtures/valid.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/eol-open-bracket-spacing/test/fixtures/valid.js
@@ -91,6 +91,24 @@ test = {
 };
 valid.push( test );
 
+test = {
+	'code': [
+		'  var v = new ndindex({ // eslint-disable-line no-unused-vars',
+		'    \'kind\': \'linear\'',
+		'  });'
+	].join( '\n' )
+};
+valid.push( test );
+
+test = {
+	'code': [
+		'  var v = new ndindex({',
+		'    \'kind\': \'linear\'',
+		'  });'
+	].join( '\n' )
+};
+valid.push( test );
+
 
 // EXPORTS //
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   add support for handling `NewExpression`
-   add additional test cases

## Related Issues

> Does this pull request have any related issues?

No. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
