### PR TITLE
fix: guard against proxy traps raising exceptions in REPL tokenizer

### DIFF
--- a/lib/node_modules/@stdlib/repl/lib/tokenizer.js
+++ b/lib/node_modules/@stdlib/repl/lib/tokenizer.js
@@ -24,6 +24,7 @@
 
 var parse = require( 'acorn-loose' ).parse;
 var walk = require( 'acorn-walk' );
+var hasProp = require( '@stdlib/assert/has-property' );
 var linkedList = require( '@stdlib/utils/linked-list' );
 var contains = require( '@stdlib/array/base/assert/contains' );
 var resolveLocalScopes = require( './resolve_local_scopes.js' );
@@ -227,7 +228,7 @@ function tokenizer( line, context ) {
 		for ( i = 0; i < COMMANDS.length; i++ ) {
 			command = COMMANDS[ i ];
 			if ( node.name === command[ 0 ] ) {
-				tokens.push( {
+				tokens.push({
 					'value': node.name,
 					'type': 'command',
 					'start': node.start,
@@ -240,14 +241,14 @@ function tokenizer( line, context ) {
 		identifier = context[ node.name ];
 		if ( identifier ) {
 			if ( isLiteralType( typeof identifier ) ) {
-				tokens.push( {
+				tokens.push({
 					'value': node.name,
 					'type': 'variable',
 					'start': node.start,
 					'end': node.end
 				});
 			} else {
-				tokens.push( {
+				tokens.push({
 					'value': node.name,
 					'type': typeof identifier,
 					'start': node.start,
@@ -313,21 +314,21 @@ function tokenizer( line, context ) {
 			}
 			// Case: 'bar' in `foo['bar']` - property already pushed as a string token. Ignore...
 			if ( property.value.type === 'Literal' ) {
-				obj = obj[ property.value.value ];
-				if ( !obj ) {
+				if ( !hasProp( obj, property.value.value ) ) {
 					// Property not found in context:
 					break;
 				}
+				obj = obj[ property.value.value ];
 				property = properties.next();
 				continue;
 			}
 			// Case: `foo.bar` - resolve property and push it as a token...
 			if ( property.value.type === 'Identifier' ) {
-				obj = obj[ property.value.name ];
-				if ( !obj ) {
+				if ( !hasProp( obj, property.value.name ) ) {
 					// Property not found in context:
 					break;
 				}
+				obj = obj[ property.value.name ];
 				if ( !compute ) {
 					// Push token if property exists in context:
 					if ( isLiteralType( typeof obj ) ) {
@@ -356,11 +357,11 @@ function tokenizer( line, context ) {
 					// Couldn't compute the internal `MemberExpression` into a definite name:
 					break;
 				}
-				obj = obj[ computed ];
-				if ( !obj ) {
+				if ( !hasProp( obj, computed ) ) {
 					// Property not found in context:
 					break;
 				}
+				obj = obj[ computed ];
 				property = properties.next();
 				continue;
 			}

--- a/lib/node_modules/@stdlib/repl/lib/tokenizer.js
+++ b/lib/node_modules/@stdlib/repl/lib/tokenizer.js
@@ -314,21 +314,29 @@ function tokenizer( line, context ) {
 			}
 			// Case: 'bar' in `foo['bar']` - property already pushed as a string token. Ignore...
 			if ( property.value.type === 'Literal' ) {
-				if ( !hasProp( obj, property.value.value ) ) {
-					// Property not found in context:
+				try {
+					if ( !hasProp( obj, property.value.value ) ) {
+						// Property not found in context:
+						break;
+					}
+					obj = obj[ property.value.value ];
+				} catch ( error ) { // eslint-disable-line no-unused-vars
 					break;
 				}
-				obj = obj[ property.value.value ];
 				property = properties.next();
 				continue;
 			}
 			// Case: `foo.bar` - resolve property and push it as a token...
 			if ( property.value.type === 'Identifier' ) {
-				if ( !hasProp( obj, property.value.name ) ) {
-					// Property not found in context:
+				try {
+					if ( !hasProp( obj, property.value.name ) ) {
+						// Property not found in context:
+						break;
+					}
+					obj = obj[ property.value.name ];
+				} catch ( error ) { // eslint-disable-line no-unused-vars
 					break;
 				}
-				obj = obj[ property.value.name ];
 				if ( !compute ) {
 					// Push token if property exists in context:
 					if ( isLiteralType( typeof obj ) ) {
@@ -357,11 +365,15 @@ function tokenizer( line, context ) {
 					// Couldn't compute the internal `MemberExpression` into a definite name:
 					break;
 				}
-				if ( !hasProp( obj, computed ) ) {
-					// Property not found in context:
+				try {
+					if ( !hasProp( obj, computed ) ) {
+						// Property not found in context:
+						break;
+					}
+					obj = obj[ computed ];
+				} catch ( error ) { // eslint-disable-line no-unused-vars
 					break;
 				}
-				obj = obj[ computed ];
 				property = properties.next();
 				continue;
 			}


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   Here's the updated behavior:
```
In [1]: var z = ndarray2fancy(ndempty([2,2]))
Out[1]: "ndarray( 'float64', new Float64Array( [ 0, 0, 0, 0 ] ), [ 2, 2 ], [ 2, 1 ], 0, 'row-major' )"

In [2]: z[':']
Error: invalid operation. Number of slice dimensions does not match the number of array dimensions. Array shape: (2,2). Slice dimensions: 1.
```
Typing `z[':']` doesn't crash anything anymore as previously we were eagerly trying to evaluate the member expression, which ends up triggering proxy traps, crashing the REPL. Everything works as expected now, and you gracefully see the error *after* you press ENTER and actually run the statement.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   relates to #2412

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
