### PR TITLE
feat(stats): add C implementation for `stats/base/dists/negative-binomial/mgf`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/README.md
@@ -263,8 +263,6 @@ int main( void ) {
         y = stdlib_base_negative_binomial_mgf( t, r, p );
         printf( "t: %lf, r: %lf, p: %lf, M_X(t;r,p): %lf\n", t, r, p, y );
     }
-
-    return 0;
 }
 ```
 

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/README.md
@@ -204,7 +204,7 @@ for ( i = 0; i < 10; i++ ) {
 
 #### stdlib_base_negative_binomial_mgf( t, r, p )
 
-Evaluates the moment-generating function (MGF) for a negative binomial distribution.ion function (CDF) for an arcsine distribution.
+Evaluates the [moment-generating function][mgf] for a [negative binomial][negative-binomial-distribution] distribution with number of successes until experiment is stopped `r` and success probability `p`.
 
 ```c
 double out = stdlib_base_negative_binomial_mgf( 0.05, 20.0, 0.8 );
@@ -258,10 +258,10 @@ int main( void ) {
 
     for ( i = 0; i < 25; i++ ) {
         t = random_uniform( -1.0, 1.0 );
-        r = random_uniform( 1.0, 10.0 ); // r must be positive
-        p = random_uniform( 0.0, 1.0 );  // p must be between 0 and 1
+        r = random_uniform( 1.0, 10.0 );
+        p = random_uniform( 0.0, 1.0 );
         y = stdlib_base_negative_binomial_mgf( t, r, p );
-        printf( "t: %lf, r: %lf, p: %lf, MGF(t;r,p): %lf\n", t, r, p, y );
+        printf( "t: %lf, r: %lf, p: %lf, M_X(t;r,p): %lf\n", t, r, p, y );
     }
 
     return 0;

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/README.md
@@ -176,6 +176,106 @@ for ( i = 0; i < 10; i++ ) {
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/stats/base/dists/negative-binomial/mgf.h"
+```
+
+#### stdlib_base_negative_binomial_mgf( t, r, p )
+
+Evaluates the moment-generating function (MGF) for a negative binomial distribution.ion function (CDF) for an arcsine distribution.
+
+```c
+double out = stdlib_base_negative_binomial_mgf( 0.05, 20.0, 0.8 );
+// returns ~267.839
+```
+
+The function accepts the following arguments:
+
+-   **t**: `[in] double` input value.
+-   **r**: `[in] double` number of successes until experiment is stopped.
+-   **p**: `[in] double` success probability.
+
+```c
+double stdlib_base_negative_binomial_mgf(const double t, const double r, const double p );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/stats/base/dists/negative-binomial/mgf.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+static double random_uniform( const double min, const double max ) {
+    double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+    return min + ( v * ( max - min ) );
+}
+
+int main( void ) {
+    double t;
+    double r;
+    double p;
+    double y;
+    int i;
+
+    for ( i = 0; i < 25; i++ ) {
+        t = random_uniform( -1.0, 1.0 );
+        r = random_uniform( 1.0, 10.0 ); // r must be positive
+        p = random_uniform( 0.0, 1.0 );  // p must be between 0 and 1
+        y = stdlib_base_negative_binomial_mgf( t, r, p );
+        printf( "t: %lf, r: %lf, p: %lf, MGF(t;r,p): %lf\n", t, r, p, y );
+    }
+
+    return 0;
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 
 <section class="references">

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var ln = require( '@stdlib/math/base/special/ln' );
 var ceil = require( '@stdlib/math/base/special/ceil' );
 var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -42,7 +43,7 @@ bench( pkg, function benchmark( b ) {
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
 		r = ceil( randu()*100.0 );
-		p = ( randu()*1.0 ) + EPS;
+		p = uniform( EPS, 1.0 );
 		t = randu() * -ln( p );
 		y = mgf( t, r, p );
 		if ( isnan( y ) ) {

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/benchmark/benchmark.native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/benchmark/benchmark.native.js
@@ -24,7 +24,9 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var ceil = require( '@stdlib/math/base/special/ceil' );
+var ln = require( '@stdlib/math/base/special/ln' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -55,9 +57,9 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	p = new Float64Array( len );
 
 	for ( i = 0; i < len; i++ ) {
-		t[ i ] = randu() * -2.0; // t values must be negative
-		r[ i ] = ceil( randu() * 100.0 ); // r values must be positive integers
-		p[ i ] = ( randu() * (1.0 - EPS) ) + EPS; // p values in (0,1)
+		p[ i ] = uniform( EPS, 1.0 );
+		t[ i ] = randu() * -ln( p );
+		r[ i ] = ceil( randu()*100.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/benchmark/benchmark.native.js
@@ -1,0 +1,76 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var Float64Array = require( '@stdlib/array/float64' );
+var randu = require( '@stdlib/random/base/randu' );
+var ceil = require( '@stdlib/math/base/special/ceil' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var EPS = require( '@stdlib/constants/float64/eps' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var mgf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+    'skip': ( mgf instanceof Error )
+};
+
+
+// MAIN //
+
+bench( pkg+'::native', opts, function benchmark( b ) {
+    var len;
+    var t;
+    var r;
+    var p;
+    var y;
+    var i;
+
+    len = 100;
+    t = new Float64Array( len );
+    r = new Float64Array( len );
+    p = new Float64Array( len );
+
+    for ( i = 0; i < len; i++ ) {
+        t[ i ] = randu() * -2.0; // t values must be negative
+        r[ i ] = ceil( randu() * 100.0 ); // r values must be positive integers
+        p[ i ] = ( randu() * (1.0 - EPS) ) + EPS; // p values in (0,1)
+    }
+
+    b.tic();
+    for ( i = 0; i < b.iterations; i++ ) {
+        y = mgf( t[ i % len ], r[ i % len ], p[ i % len ] );
+        if ( isnan( y ) ) {
+            b.fail( 'should not return NaN' );
+        }
+    }
+    b.toc();
+    if ( isnan( y ) ) {
+        b.fail( 'should not return NaN' );
+    }
+    b.pass( 'benchmark finished' );
+    b.end();
+});

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/benchmark/benchmark.native.js
@@ -35,42 +35,42 @@ var pkg = require( './../package.json' ).name;
 
 var mgf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
 var opts = {
-    'skip': ( mgf instanceof Error )
+	'skip': ( mgf instanceof Error )
 };
 
 
 // MAIN //
 
 bench( pkg+'::native', opts, function benchmark( b ) {
-    var len;
-    var t;
-    var r;
-    var p;
-    var y;
-    var i;
+	var len;
+	var t;
+	var r;
+	var p;
+	var y;
+	var i;
 
-    len = 100;
-    t = new Float64Array( len );
-    r = new Float64Array( len );
-    p = new Float64Array( len );
+	len = 100;
+	t = new Float64Array( len );
+	r = new Float64Array( len );
+	p = new Float64Array( len );
 
-    for ( i = 0; i < len; i++ ) {
-        t[ i ] = randu() * -2.0; // t values must be negative
-        r[ i ] = ceil( randu() * 100.0 ); // r values must be positive integers
-        p[ i ] = ( randu() * (1.0 - EPS) ) + EPS; // p values in (0,1)
-    }
+	for ( i = 0; i < len; i++ ) {
+		t[ i ] = randu() * -2.0; // t values must be negative
+		r[ i ] = ceil( randu() * 100.0 ); // r values must be positive integers
+		p[ i ] = ( randu() * (1.0 - EPS) ) + EPS; // p values in (0,1)
+	}
 
-    b.tic();
-    for ( i = 0; i < b.iterations; i++ ) {
-        y = mgf( t[ i % len ], r[ i % len ], p[ i % len ] );
-        if ( isnan( y ) ) {
-            b.fail( 'should not return NaN' );
-        }
-    }
-    b.toc();
-    if ( isnan( y ) ) {
-        b.fail( 'should not return NaN' );
-    }
-    b.pass( 'benchmark finished' );
-    b.end();
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		y = mgf( t[ i % len ], r[ i % len ], p[ i % len ] );
+		if ( isnan( y ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnan( y ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/benchmark/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/benchmark/c/Makefile
@@ -1,7 +1,7 @@
 #/
 # @license Apache-2.0
 #
-# Copyright (c) 2024 The Stdlib Authors.
+# Copyright (c) 2025 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/benchmark/c/benchmark.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/benchmark/c/benchmark.c
@@ -16,12 +16,12 @@
 * limitations under the License.
 */
 
-#include "stdlib/stats/base/dists/negative-binomial/mgf.h"
-#include <stdlib.h>
-#include <stdio.h>
-#include <math.h>
-#include <time.h>
 #include <sys/time.h>
+#include "stdlib/stats/base/dists/negative-binomial/mgf.h"
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
 
 #define NAME "negative-binomial-mgf"
 #define ITERATIONS 1000000
@@ -31,7 +31,7 @@
 * Prints the TAP version.
 */
 static void print_version( void ) {
-    printf( "TAP version 13\n" );
+	printf( "TAP version 13\n" );
 }
 
 /**
@@ -41,12 +41,12 @@ static void print_version( void ) {
 * @param passing   total number of passing tests
 */
 static void print_summary( int total, int passing ) {
-    printf( "#\n" );
-    printf( "1..%d\n", total ); // TAP plan
-    printf( "# total %d\n", total );
-    printf( "# pass  %d\n", passing );
-    printf( "#\n" );
-    printf( "# ok\n" );
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
 }
 
 /**
@@ -55,12 +55,12 @@ static void print_summary( int total, int passing ) {
 * @param elapsed   elapsed time in seconds
 */
 static void print_results( double elapsed ) {
-    double rate = (double)ITERATIONS / elapsed;
-    printf( "  ---\n" );
-    printf( "  iterations: %d\n", ITERATIONS );
-    printf( "  elapsed: %0.9f\n", elapsed );
-    printf( "  rate: %0.9f\n", rate );
-    printf( "  ...\n" );
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
 }
 
 /**
@@ -69,9 +69,9 @@ static void print_results( double elapsed ) {
 * @return clock time
 */
 static double tic( void ) {
-    struct timeval now;
-    gettimeofday( &now, NULL );
-    return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec / 1.0e6;
 }
 
 /**
@@ -82,8 +82,8 @@ static double tic( void ) {
 * @return       random number
 */
 static double random_uniform( const double min, const double max ) {
-    double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
-    return min + ( v*(max-min) );
+	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+	return min + ( v * ( max - min ) );
 }
 
 /**
@@ -92,51 +92,51 @@ static double random_uniform( const double min, const double max ) {
 * @return elapsed time in seconds
 */
 static double benchmark( void ) {
-    double elapsed;
-    double t[ 100 ];
-    double r[ 100 ];
-    double p[ 100 ];
-    double y;
-    double time;
-    int i;
+	double elapsed;
+	double t[ 100 ];
+	double r[ 100 ];
+	double p[ 100 ];
+	double y;
+	double time;
+	int i;
 
-    for ( i = 0; i < 100; i++ ) {
-        t[ i ] = random_uniform( -2.0, 0.0 );
-        r[ i ] = random_uniform( 1.0, 100.0 );
-        p[ i ] = random_uniform( 0.1, 1.0 );
-    }
+	for ( i = 0; i < 100; i++ ) {
+		t[ i ] = random_uniform( -2.0, 0.0 );
+		r[ i ] = random_uniform( 1.0, 100.0 );
+		p[ i ] = random_uniform( 0.1, 1.0 );
+	}
 
-    time = tic();
-    for ( i = 0; i < ITERATIONS; i++ ) {
-        y = stdlib_base_negative_binomial_mgf( t[ i % 100 ], r[ i % 100 ], p[ i % 100 ] );
-        if ( y != y ) {
-            printf( "should not return NaN\n" );
-            break;
-        }
-    }
-    elapsed = tic() - time;
-    if ( y != y ) {
-        printf( "should not return NaN\n" );
-    }
-    return elapsed;
+	time = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		y = stdlib_base_negative_binomial_mgf( t[ i % 100 ], r[ i % 100 ], p[ i % 100 ] );
+		if ( y != y ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - time;
+	if ( y != y ) {
+		printf( "should not return NaN\n" );
+	}
+	return elapsed;
 }
 
 /**
 * Main execution sequence.
 */
 int main( void ) {
-    double elapsed;
-    int i;
+	double elapsed;
+	int i;
 
-    // Use the current time to seed the random number generator:
-    srand( time( NULL ) );
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
 
-    print_version();
-    for ( i = 0; i < REPEATS; i++ ) {
-        printf( "# c::%s\n", NAME );
-        elapsed = benchmark();
-        print_results( elapsed );
-        printf( "ok %d benchmark finished\n", i+1 );
-    }
-    print_summary( REPEATS, REPEATS );
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i + 1 );
+	}
+	print_summary( REPEATS, REPEATS );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/benchmark/c/benchmark.c
@@ -1,0 +1,142 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/negative-binomial/mgf.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "negative-binomial-mgf"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+static void print_version( void ) {
+    printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+static void print_summary( int total, int passing ) {
+    printf( "#\n" );
+    printf( "1..%d\n", total ); // TAP plan
+    printf( "# total %d\n", total );
+    printf( "# pass  %d\n", passing );
+    printf( "#\n" );
+    printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+static void print_results( double elapsed ) {
+    double rate = (double)ITERATIONS / elapsed;
+    printf( "  ---\n" );
+    printf( "  iterations: %d\n", ITERATIONS );
+    printf( "  elapsed: %0.9f\n", elapsed );
+    printf( "  rate: %0.9f\n", rate );
+    printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+static double tic( void ) {
+    struct timeval now;
+    gettimeofday( &now, NULL );
+    return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [min,max).
+*
+* @param min    minimum value (inclusive)
+* @param max    maximum value (exclusive)
+* @return       random number
+*/
+static double random_uniform( const double min, const double max ) {
+    double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+    return min + ( v*(max-min) );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+static double benchmark( void ) {
+    double elapsed;
+    double t[ 100 ];
+    double r[ 100 ];
+    double p[ 100 ];
+    double y;
+    double time;
+    int i;
+
+    for ( i = 0; i < 100; i++ ) {
+        t[ i ] = random_uniform( -2.0, 0.0 );
+        r[ i ] = random_uniform( 1.0, 100.0 );
+        p[ i ] = random_uniform( 0.1, 1.0 );
+    }
+
+    time = tic();
+    for ( i = 0; i < ITERATIONS; i++ ) {
+        y = stdlib_base_negative_binomial_mgf( t[ i % 100 ], r[ i % 100 ], p[ i % 100 ] );
+        if ( y != y ) {
+            printf( "should not return NaN\n" );
+            break;
+        }
+    }
+    elapsed = tic() - time;
+    if ( y != y ) {
+        printf( "should not return NaN\n" );
+    }
+    return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+    double elapsed;
+    int i;
+
+    // Use the current time to seed the random number generator:
+    srand( time( NULL ) );
+
+    print_version();
+    for ( i = 0; i < REPEATS; i++ ) {
+        printf( "# c::%s\n", NAME );
+        elapsed = benchmark();
+        print_results( elapsed );
+        printf( "ok %d benchmark finished\n", i+1 );
+    }
+    print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/binding.gyp
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/binding.gyp
@@ -1,6 +1,6 @@
 # @license Apache-2.0
 #
-# Copyright (c) 2024 The Stdlib Authors.
+# Copyright (c) 2025 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/binding.gyp
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/examples/c/Makefile
@@ -1,7 +1,7 @@
 #/
 # @license Apache-2.0
 #
-# Copyright (c) 2024 The Stdlib Authors.
+# Copyright (c) 2025 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/examples/c/example.c
@@ -1,7 +1,7 @@
 /**
  * @license Apache-2.0
  *
- * Copyright (c) 2024 The Stdlib Authors.
+ * Copyright (c) 2025 The Stdlib Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/examples/c/example.c
@@ -39,6 +39,4 @@ int main( void ) {
 		y = stdlib_base_negative_binomial_mgf( t, r, p );
 		printf( "t: %lf, r: %lf, p: %lf, M_X(t;r,p): %lf\n", t, r, p, y );
 	}
-
-	return 0;
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/examples/c/example.c
@@ -1,0 +1,44 @@
+/**
+ * @license Apache-2.0
+ *
+ * Copyright (c) 2024 The Stdlib Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "stdlib/stats/base/dists/negative-binomial/mgf.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+static double random_uniform( const double min, const double max ) {
+    double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+    return min + ( v * ( max - min ) );
+}
+
+int main( void ) {
+    double t;
+    double r;
+    double p;
+    double y;
+    int i;
+
+    for ( i = 0; i < 25; i++ ) {
+        t = random_uniform( -1.0, 1.0 );
+        r = random_uniform( 1.0, 10.0 ); // r must be positive
+        p = random_uniform( 0.0, 1.0 );  // p must be between 0 and 1
+        y = stdlib_base_negative_binomial_mgf( t, r, p );
+        printf( "t: %lf, r: %lf, p: %lf, MGF(t;r,p): %lf\n", t, r, p, y );
+    }
+
+    return 0;
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/examples/c/example.c
@@ -1,44 +1,44 @@
 /**
- * @license Apache-2.0
- *
- * Copyright (c) 2025 The Stdlib Authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
 #include "stdlib/stats/base/dists/negative-binomial/mgf.h"
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 static double random_uniform( const double min, const double max ) {
-    double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
-    return min + ( v * ( max - min ) );
+	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+	return min + ( v * ( max - min ) );
 }
 
 int main( void ) {
-    double t;
-    double r;
-    double p;
-    double y;
-    int i;
+	double t;
+	double r;
+	double p;
+	double y;
+	int i;
 
-    for ( i = 0; i < 25; i++ ) {
-        t = random_uniform( -1.0, 1.0 );
-        r = random_uniform( 1.0, 10.0 ); // r must be positive
-        p = random_uniform( 0.0, 1.0 );  // p must be between 0 and 1
-        y = stdlib_base_negative_binomial_mgf( t, r, p );
-        printf( "t: %lf, r: %lf, p: %lf, MGF(t;r,p): %lf\n", t, r, p, y );
-    }
+	for ( i = 0; i < 25; i++ ) {
+		t = random_uniform( -1.0, 1.0 );
+		r = random_uniform( 1.0, 10.0 );
+		p = random_uniform( 0.0, 1.0 );
+		y = stdlib_base_negative_binomial_mgf( t, r, p );
+		printf( "t: %lf, r: %lf, p: %lf, M_X(t;r,p): %lf\n", t, r, p, y );
+	}
 
-    return 0;
+	return 0;
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/include.gypi
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/include.gypi
@@ -1,6 +1,6 @@
 # @license Apache-2.0
 #
-# Copyright (c) 2024 The Stdlib Authors.
+# Copyright (c) 2025 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/include.gypi
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/include/stdlib/stats/base/dists/negative-binomial/mgf.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/include/stdlib/stats/base/dists/negative-binomial/mgf.h
@@ -1,7 +1,7 @@
 /**
  * @license Apache-2.0
  *
- * Copyright (c) 2024 The Stdlib Authors.
+ * Copyright (c) 2025 The Stdlib Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/include/stdlib/stats/base/dists/negative-binomial/mgf.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/include/stdlib/stats/base/dists/negative-binomial/mgf.h
@@ -1,20 +1,20 @@
 /**
- * @license Apache-2.0
- *
- * Copyright (c) 2025 The Stdlib Authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
 #ifndef STDLIB_STATS_BASE_DISTS_NEGATIVE_BINOMIAL_MGF_H
 #define STDLIB_STATS_BASE_DISTS_NEGATIVE_BINOMIAL_MGF_H

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/include/stdlib/stats/base/dists/negative-binomial/mgf.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/include/stdlib/stats/base/dists/negative-binomial/mgf.h
@@ -28,11 +28,6 @@ extern "C" {
 
 /**
 * Evaluates the moment-generating function (MGF) for a negative binomial distribution.
-*
-* @param t    input value
-* @param r    number of successes until experiment is stopped
-* @param p    success probability
-* @return     evaluated MGF
 */
 double stdlib_base_negative_binomial_mgf(const double t, const double r, const double p);
 

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/include/stdlib/stats/base/dists/negative-binomial/mgf.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/include/stdlib/stats/base/dists/negative-binomial/mgf.h
@@ -1,0 +1,43 @@
+/**
+ * @license Apache-2.0
+ *
+ * Copyright (c) 2024 The Stdlib Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef STDLIB_STATS_BASE_DISTS_NEGATIVE_BINOMIAL_MGF_H
+#define STDLIB_STATS_BASE_DISTS_NEGATIVE_BINOMIAL_MGF_H
+
+/*
+ * If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+ */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Evaluates the moment-generating function (MGF) for a negative binomial distribution.
+ *
+ * @param t    input value
+ * @param r    number of successes until experiment is stopped
+ * @param p    success probability
+ * @return     evaluated MGF
+ */
+double stdlib_base_negative_binomial_mgf(const double t, const double r, const double p);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_STATS_BASE_DISTS_NEGATIVE_BINOMIAL_MGF_H

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/include/stdlib/stats/base/dists/negative-binomial/mgf.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/include/stdlib/stats/base/dists/negative-binomial/mgf.h
@@ -20,20 +20,20 @@
 #define STDLIB_STATS_BASE_DISTS_NEGATIVE_BINOMIAL_MGF_H
 
 /*
- * If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
- */
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * Evaluates the moment-generating function (MGF) for a negative binomial distribution.
- *
- * @param t    input value
- * @param r    number of successes until experiment is stopped
- * @param p    success probability
- * @return     evaluated MGF
- */
+* Evaluates the moment-generating function (MGF) for a negative binomial distribution.
+*
+* @param t    input value
+* @param r    number of successes until experiment is stopped
+* @param p    success probability
+* @return     evaluated MGF
+*/
 double stdlib_base_negative_binomial_mgf(const double t, const double r, const double p);
 
 #ifdef __cplusplus

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/lib/native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/lib/native.js
@@ -1,20 +1,20 @@
 /**
- * @license Apache-2.0
- *
- * Copyright (c) 2024 The Stdlib Authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
 'use strict';
 
@@ -26,36 +26,36 @@ var addon = require( './../src/addon.node' );
 // MAIN //
 
 /**
- * Evaluates the moment-generating function (MGF) for a negative binomial distribution.
- *
- * @private
- * @param {number} t - input value
- * @param {PositiveNumber} r - number of successes until experiment is stopped
- * @param {Probability} p - success probability
- * @returns {number} evaluated MGF
- *
- * @example
- * var y = mgf( 0.05, 20.0, 0.8 );
- * // returns ~267.839
- *
- * @example
- * var y = mgf( 0.1, 20.0, 0.1 );
- * // returns ~9.347
- *
- * @example
- * var y = mgf( 0.5, 10.0, 0.4 );
- * // returns ~42822.023
- *
- * @example
- * var y = mgf( 0.1, 0.0, 0.5 );
- * // returns NaN
- *
- * @example
- * var y = mgf( NaN, 20.0, 0.5 );
- * // returns NaN
- */
+* Evaluates the moment-generating function (MGF) for a negativebinomial distribution.
+*
+* @private
+* @param {number} t - input value
+* @param {PositiveNumber} r - number of successes untilexperiment is stopped
+* @param {Probability} p - success probability
+* @returns {number} evaluated MGF
+*
+* @example
+* var y = mgf( 0.05, 20.0, 0.8 );
+* // returns ~267.839
+*
+* @example
+* var y = mgf( 0.1, 20.0, 0.1 );
+* // returns ~9.347
+*
+* @example
+* var y = mgf( 0.5, 10.0, 0.4 );
+* // returns ~42822.023
+*
+* @example
+* var y = mgf( 0.1, 0.0, 0.5 );
+* // returns NaN
+*
+* @example
+* var y = mgf( NaN, 20.0, 0.5 );
+* // returns NaN
+*/
 function mgf( t, r, p ) {
-    return addon( t, r, p );
+	return addon( t, r, p );
 }
 
 

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/lib/native.js
@@ -1,0 +1,64 @@
+/**
+ * @license Apache-2.0
+ *
+ * Copyright (c) 2024 The Stdlib Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+ * Evaluates the moment-generating function (MGF) for a negative binomial distribution.
+ *
+ * @private
+ * @param {number} t - input value
+ * @param {PositiveNumber} r - number of successes until experiment is stopped
+ * @param {Probability} p - success probability
+ * @returns {number} evaluated MGF
+ *
+ * @example
+ * var y = mgf( 0.05, 20.0, 0.8 );
+ * // returns ~267.839
+ *
+ * @example
+ * var y = mgf( 0.1, 20.0, 0.1 );
+ * // returns ~9.347
+ *
+ * @example
+ * var y = mgf( 0.5, 10.0, 0.4 );
+ * // returns ~42822.023
+ *
+ * @example
+ * var y = mgf( 0.1, 0.0, 0.5 );
+ * // returns NaN
+ *
+ * @example
+ * var y = mgf( NaN, 20.0, 0.5 );
+ * // returns NaN
+ */
+function mgf( t, r, p ) {
+    return addon( t, r, p );
+}
+
+
+// EXPORTS //
+
+module.exports = mgf;

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/lib/native.js
@@ -26,7 +26,7 @@ var addon = require( './../src/addon.node' );
 // MAIN //
 
 /**
-* Evaluates the moment-generating function (MGF) for a negativebinomial distribution.
+* Evaluates the moment-generating function (MGF) for a negative binomial distribution.
 *
 * @private
 * @param {number} t - input value

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/manifest.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/manifest.json
@@ -1,0 +1,85 @@
+{
+  "options": {
+    "task": "build",
+    "wasm": false
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/napi/ternary",
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/special/exp",
+        "@stdlib/math/base/special/pow",
+        "@stdlib/math/base/special/ln"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/special/exp",
+        "@stdlib/math/base/special/pow",
+        "@stdlib/math/base/special/ln"
+      ]
+    },
+    {
+      "task": "examples",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/special/exp",
+        "@stdlib/math/base/special/pow",
+        "@stdlib/math/base/special/ln"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/package.json
@@ -14,11 +14,14 @@
     }
   ],
   "main": "./lib",
+  "gypfile": true,
   "directories": {
     "benchmark": "./benchmark",
     "doc": "./docs",
     "example": "./examples",
+    "include": "./include",
     "lib": "./lib",
+    "src": "./src",
     "test": "./test"
   },
   "types": "./docs/types",

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/src/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/src/Makefile
@@ -1,7 +1,7 @@
 #/
 # @license Apache-2.0
 #
-# Copyright (c) 2024 The Stdlib Authors.
+# Copyright (c) 2025 The Stdlib Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/src/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2024 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/src/addon.c
@@ -1,7 +1,7 @@
 /**
  * @license Apache-2.0
  *
- * Copyright (c) 2024 The Stdlib Authors.
+ * Copyright (c) 2025 The Stdlib Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/src/addon.c
@@ -1,20 +1,20 @@
 /**
- * @license Apache-2.0
- *
- * Copyright (c) 2025 The Stdlib Authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
 #include "stdlib/stats/base/dists/negative-binomial/mgf.h"
 #include "stdlib/math/base/napi/ternary.h"

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/src/addon.c
@@ -1,0 +1,23 @@
+/**
+ * @license Apache-2.0
+ *
+ * Copyright (c) 2024 The Stdlib Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "stdlib/stats/base/dists/negative-binomial/mgf.h"
+#include "stdlib/math/base/napi/ternary.h"
+
+// cppcheck-suppress shadowFunction
+STDLIB_MATH_BASE_NAPI_MODULE_DDD_D( stdlib_base_negative_binomial_mgf )

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/src/main.c
@@ -1,7 +1,7 @@
 /**
  * @license Apache-2.0
  *
- * Copyright (c) 2024 The Stdlib Authors.
+ * Copyright (c) 2025 The Stdlib Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/src/main.c
@@ -16,11 +16,11 @@
 * limitations under the License.
 */
 
+#include "stdlib/stats/base/dists/negative-binomial/mgf.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/special/exp.h"
 #include "stdlib/math/base/special/ln.h"
 #include "stdlib/math/base/special/pow.h"
-#include "stdlib/stats/base/dists/negative-binomial/mgf.h"
 
 /**
 * Evaluates the moment-generating function (MGF) for a negative binomial distribution.

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/src/main.c
@@ -20,6 +20,7 @@
 #include "stdlib/math/base/special/exp.h"
 #include "stdlib/math/base/special/ln.h"
 #include "stdlib/math/base/special/pow.h"
+#include "stdlib/stats/base/dists/negative-binomial/mgf.h"
 
 /**
 * Evaluates the moment-generating function (MGF) for a negative binomial distribution.

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/src/main.c
@@ -1,57 +1,41 @@
 /**
- * @license Apache-2.0
- *
- * Copyright (c) 2025 The Stdlib Authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/special/exp.h"
-#include "stdlib/math/base/special/pow.h"
 #include "stdlib/math/base/special/ln.h"
+#include "stdlib/math/base/special/pow.h"
 
 /**
- * Evaluates the moment-generating function (MGF) for a negative binomial distribution.
- *
- * @param t    input value
- * @param r    number of successes until experiment is stopped
- * @param p    success probability
- * @return     evaluated MGF
- *
- * @example
- * double y = stdlib_base_negative_binomial_mgf( 0.05, 20.0, 0.8 );
- * // returns ~267.839
- */
-double stdlib_base_negative_binomial_mgf(const double t, const double r, const double p) {
-    // Check for invalid input values:
-    if (
-        stdlib_base_is_nan(t) ||
-        stdlib_base_is_nan(r) ||
-        stdlib_base_is_nan(p) ||
-        r <= 0.0 ||
-        p < 0.0 ||
-        p > 1.0 ||
-        t >= -stdlib_base_ln(p)
-    ) {
-        return 0.0 / 0.0; // NaN
-    }
-
-    // Compute the MGF value:
-    double exp_t = stdlib_base_exp(t);
-    double numerator = (1.0 - p) * exp_t;
-    double denominator = 1.0 - (p * exp_t);
-    double ratio = numerator / denominator;
-
-    return stdlib_base_pow(ratio, r);
+* Evaluates the moment-generating function (MGF) for a negative binomial distribution.
+*
+* @param t    input value
+* @param r    number of successes until experiment is stopped
+* @param p    success probability
+* @return     evaluated MGF
+*
+* @example
+* double y = stdlib_base_negative_binomial_mgf( 0.05, 20.0, 0.8 );
+* // returns ~267.839
+*/
+double stdlib_base_negative_binomial_mgf( const double t, const double r, const double p ) {
+	if ( stdlib_base_is_nan( t ) || stdlib_base_is_nan( r ) || stdlib_base_is_nan( p ) || r <= 0.0 || p < 0.0 || p > 1.0 || t >= -stdlib_base_ln( p ) ) {
+		return 0.0 / 0.0; // NaN
+	}
+	return stdlib_base_pow( ( ( 1.0 - p ) * stdlib_base_exp( t ) ) / ( 1.0 - ( p * stdlib_base_exp( t ) ) ), r );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/src/main.c
@@ -1,0 +1,57 @@
+/**
+ * @license Apache-2.0
+ *
+ * Copyright (c) 2024 The Stdlib Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "stdlib/math/base/assert/is_nan.h"
+#include "stdlib/math/base/special/exp.h"
+#include "stdlib/math/base/special/pow.h"
+#include "stdlib/math/base/special/ln.h"
+
+/**
+ * Evaluates the moment-generating function (MGF) for a negative binomial distribution.
+ *
+ * @param t    input value
+ * @param r    number of successes until experiment is stopped
+ * @param p    success probability
+ * @return     evaluated MGF
+ *
+ * @example
+ * double y = stdlib_base_negative_binomial_mgf( 0.05, 20.0, 0.8 );
+ * // returns ~267.839
+ */
+double stdlib_base_negative_binomial_mgf(const double t, const double r, const double p) {
+    // Check for invalid input values:
+    if (
+        stdlib_base_is_nan(t) ||
+        stdlib_base_is_nan(r) ||
+        stdlib_base_is_nan(p) ||
+        r <= 0.0 ||
+        p < 0.0 ||
+        p > 1.0 ||
+        t >= -stdlib_base_ln(p)
+    ) {
+        return 0.0 / 0.0; // NaN
+    }
+
+    // Compute the MGF value:
+    double exp_t = stdlib_base_exp(t);
+    double numerator = (1.0 - p) * exp_t;
+    double denominator = 1.0 - (p * exp_t);
+    double ratio = numerator / denominator;
+
+    return stdlib_base_pow(ratio, r);
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/test/test.native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/test/test.native.js
@@ -23,6 +23,12 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var isNumber = require( '@stdlib/assert/is-number' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var randu = require( '@stdlib/random/base/randu' );
+var ln = require( '@stdlib/math/base/special/ln' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
 
 
 // VARIABLES //
@@ -41,63 +47,73 @@ tape( 'main export is a function', opts, function test( t ) {
 	t.end();
 });
 
-tape( 'the function returns NaN if provided a NaN input for `t`', opts, function test( t ) {
-	var y = mgf( NaN, 2.0, 0.5 );
-	t.strictEqual( typeof y, 'number', 'returns a number' );
-	t.ok( isNaN( y ), 'returns NaN' );
+tape( 'if provided `NaN` for any parameter, the function returns `NaN`', function test( t ) {
+	var y = mgf( NaN, 10, 0.5 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+	y = mgf( 0.0, NaN, 0.5 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+	y = mgf( 0.0, 10, NaN );
+	t.equal( isnan( y ), true, 'returns NaN' );
 	t.end();
 });
 
-tape( 'the function returns NaN if provided a NaN input for `r`', opts, function test( t ) {
-	var y = mgf( 0.1, NaN, 0.5 );
-	t.strictEqual( typeof y, 'number', 'returns a number' );
-	t.ok( isNaN( y ), 'returns NaN' );
-	t.end();
-});
+tape( 'if provided a `r` which is not a positive number, the function returns `NaN`', opts, function test( t ) {
+	var y;
 
-tape( 'the function returns NaN if provided a NaN input for `p`', opts, function test( t ) {
-	var y = mgf( 0.1, 2.0, NaN );
-	t.strictEqual( typeof y, 'number', 'returns a number' );
-	t.ok( isNaN( y ), 'returns NaN' );
-	t.end();
-});
+	y = mgf( 2.0, -2.0, 0.5 );
+	t.equal( isnan( y ), true, 'returns NaN' );
 
-tape( 'the function evaluates the MGF for valid inputs', opts, function test( t ) {
-	var y = mgf( 0.0, 1.0, 0.9 );
-	t.strictEqual( y, 1.0, 'returns 1 when t is 0' );
+	y = mgf( 2.0, -1.0, 0.5 );
+	t.equal( isnan( y ), true, 'returns NaN' );
 
-	y = mgf( 0.05, 20.0, 0.8 );
-	t.ok( Math.abs( y - 267.839 ) < 1e-3, 'returns ~267.839' );
+	y = mgf( 0.0, 0.0, 0.5 );
+	t.equal( isnan( y ), true, 'returns NaN' );
 
-	y = mgf( 0.1, 20.0, 0.1 );
-	t.ok( Math.abs( y - 9.347 ) < 1e-3, 'returns ~9.347' );
-
-	y = mgf( 0.5, 10.0, 0.4 );
-	t.ok( Math.abs( y - 42822.023 ) < 1e-3, 'returns ~42822.023' );
+	y = mgf( 0.0, NINF, 0.5 );
+	t.equal( isnan( y ), true, 'returns NaN' );
 
 	t.end();
 });
 
-tape( 'the function returns NaN if `p` is outside the interval [0,1]', opts, function test( t ) {
-	var y = mgf( 0.1, 2.0, -0.5 );
-	t.strictEqual( typeof y, 'number', 'returns a number' );
-	t.ok( isNaN( y ), 'returns NaN' );
+tape( 'if provided a success probability `p` outside of `[0,1]`, the function returns `NaN`', opts, function test( t ) {
+	var y;
 
-	y = mgf( 0.1, 2.0, 1.5 );
-	t.strictEqual( typeof y, 'number', 'returns a number' );
-	t.ok( isNaN( y ), 'returns NaN' );
+	y = mgf( 2.0, 20, -1.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = mgf( 0.0, 20, 1.5 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = mgf( 2.0, 20, NINF );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = mgf( 2.0, 20, PINF );
+	t.equal( isnan( y ), true, 'returns NaN' );
 
 	t.end();
 });
 
-tape( 'the function returns NaN if `r` is less than or equal to 0', opts, function test( t ) {
-	var y = mgf( 0.1, -2.0, 0.5 );
-	t.strictEqual( typeof y, 'number', 'returns a number' );
-	t.ok( isNaN( y ), 'returns NaN' );
+tape( 'if provided `t >= -ln( p )`, the function returns `NaN`', opts, function test( t ) {
+	var y = mgf( 0.7, 10.0, 0.5 ); // -ln( p ) = ~0.693
+	t.equal( isnan( y ), true, 'returns NaN' );
+	y = mgf( 1.7, 10.0, 0.2 ); // -ln( p ) = ~1.609
+	t.equal( isnan( y ), true, 'returns NaN' );
+	t.end();
+});
 
-	y = mgf( 0.1, 0.0, 0.5 );
-	t.strictEqual( typeof y, 'number', 'returns a number' );
-	t.ok( isNaN( y ), 'returns NaN' );
+tape( 'the function evaluates the mgf', opts, function test( t ) {
+	var i;
+	var r;
+	var p;
+	var x;
+	var y;
 
+	for ( i = 0; i < 100; i++ ) {
+		r = randu() * 20.0;
+		p = randu();
+		x = ln( p ) - randu();
+		y = mgf( x, r, p );
+		t.strictEqual( !isnan( y ) && isNumber( y ), true, 'returns a number' );
+	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/test/test.native.js
@@ -20,8 +20,8 @@
 
 // MODULES //
 
-var tape = require( 'tape' );
 var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -36,68 +36,68 @@ var opts = {
 // TESTS //
 
 tape( 'main export is a function', opts, function test( t ) {
-    t.ok( true, __filename );
-    t.strictEqual( typeof mgf, 'function', 'main export is a function' );
-    t.end();
+	t.ok( true, __filename );
+	t.strictEqual( typeof mgf, 'function', 'main export is a function' );
+	t.end();
 });
 
 tape( 'the function returns NaN if provided a NaN input for `t`', opts, function test( t ) {
-    var y = mgf( NaN, 2.0, 0.5 );
-    t.strictEqual( typeof y, 'number', 'returns a number' );
-    t.ok( isNaN( y ), 'returns NaN' );
-    t.end();
+	var y = mgf( NaN, 2.0, 0.5 );
+	t.strictEqual( typeof y, 'number', 'returns a number' );
+	t.ok( isNaN( y ), 'returns NaN' );
+	t.end();
 });
 
 tape( 'the function returns NaN if provided a NaN input for `r`', opts, function test( t ) {
-    var y = mgf( 0.1, NaN, 0.5 );
-    t.strictEqual( typeof y, 'number', 'returns a number' );
-    t.ok( isNaN( y ), 'returns NaN' );
-    t.end();
+	var y = mgf( 0.1, NaN, 0.5 );
+	t.strictEqual( typeof y, 'number', 'returns a number' );
+	t.ok( isNaN( y ), 'returns NaN' );
+	t.end();
 });
 
 tape( 'the function returns NaN if provided a NaN input for `p`', opts, function test( t ) {
-    var y = mgf( 0.1, 2.0, NaN );
-    t.strictEqual( typeof y, 'number', 'returns a number' );
-    t.ok( isNaN( y ), 'returns NaN' );
-    t.end();
+	var y = mgf( 0.1, 2.0, NaN );
+	t.strictEqual( typeof y, 'number', 'returns a number' );
+	t.ok( isNaN( y ), 'returns NaN' );
+	t.end();
 });
 
 tape( 'the function evaluates the MGF for valid inputs', opts, function test( t ) {
-    var y = mgf( 0.0, 1.0, 0.9 );
-    t.strictEqual( y, 1.0, 'returns 1 when t is 0' );
+	var y = mgf( 0.0, 1.0, 0.9 );
+	t.strictEqual( y, 1.0, 'returns 1 when t is 0' );
 
-    y = mgf( 0.05, 20.0, 0.8 );
-    t.ok( Math.abs( y - 267.839 ) < 1e-3, 'returns ~267.839' );
+	y = mgf( 0.05, 20.0, 0.8 );
+	t.ok( Math.abs( y - 267.839 ) < 1e-3, 'returns ~267.839' );
 
-    y = mgf( 0.1, 20.0, 0.1 );
-    t.ok( Math.abs( y - 9.347 ) < 1e-3, 'returns ~9.347' );
+	y = mgf( 0.1, 20.0, 0.1 );
+	t.ok( Math.abs( y - 9.347 ) < 1e-3, 'returns ~9.347' );
 
-    y = mgf( 0.5, 10.0, 0.4 );
-    t.ok( Math.abs( y - 42822.023 ) < 1e-3, 'returns ~42822.023' );
+	y = mgf( 0.5, 10.0, 0.4 );
+	t.ok( Math.abs( y - 42822.023 ) < 1e-3, 'returns ~42822.023' );
 
-    t.end();
+	t.end();
 });
 
 tape( 'the function returns NaN if `p` is outside the interval [0,1]', opts, function test( t ) {
-    var y = mgf( 0.1, 2.0, -0.5 );
-    t.strictEqual( typeof y, 'number', 'returns a number' );
-    t.ok( isNaN( y ), 'returns NaN' );
+	var y = mgf( 0.1, 2.0, -0.5 );
+	t.strictEqual( typeof y, 'number', 'returns a number' );
+	t.ok( isNaN( y ), 'returns NaN' );
 
-    y = mgf( 0.1, 2.0, 1.5 );
-    t.strictEqual( typeof y, 'number', 'returns a number' );
-    t.ok( isNaN( y ), 'returns NaN' );
+	y = mgf( 0.1, 2.0, 1.5 );
+	t.strictEqual( typeof y, 'number', 'returns a number' );
+	t.ok( isNaN( y ), 'returns NaN' );
 
-    t.end();
+	t.end();
 });
 
 tape( 'the function returns NaN if `r` is less than or equal to 0', opts, function test( t ) {
-    var y = mgf( 0.1, -2.0, 0.5 );
-    t.strictEqual( typeof y, 'number', 'returns a number' );
-    t.ok( isNaN( y ), 'returns NaN' );
+	var y = mgf( 0.1, -2.0, 0.5 );
+	t.strictEqual( typeof y, 'number', 'returns a number' );
+	t.ok( isNaN( y ), 'returns NaN' );
 
-    y = mgf( 0.1, 0.0, 0.5 );
-    t.strictEqual( typeof y, 'number', 'returns a number' );
-    t.ok( isNaN( y ), 'returns NaN' );
+	y = mgf( 0.1, 0.0, 0.5 );
+	t.strictEqual( typeof y, 'number', 'returns a number' );
+	t.ok( isNaN( y ), 'returns NaN' );
 
-    t.end();
+	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/mgf/test/test.native.js
@@ -1,0 +1,103 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var resolve = require( 'path' ).resolve;
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var mgf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( mgf instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+    t.ok( true, __filename );
+    t.strictEqual( typeof mgf, 'function', 'main export is a function' );
+    t.end();
+});
+
+tape( 'the function returns NaN if provided a NaN input for `t`', opts, function test( t ) {
+    var y = mgf( NaN, 2.0, 0.5 );
+    t.strictEqual( typeof y, 'number', 'returns a number' );
+    t.ok( isNaN( y ), 'returns NaN' );
+    t.end();
+});
+
+tape( 'the function returns NaN if provided a NaN input for `r`', opts, function test( t ) {
+    var y = mgf( 0.1, NaN, 0.5 );
+    t.strictEqual( typeof y, 'number', 'returns a number' );
+    t.ok( isNaN( y ), 'returns NaN' );
+    t.end();
+});
+
+tape( 'the function returns NaN if provided a NaN input for `p`', opts, function test( t ) {
+    var y = mgf( 0.1, 2.0, NaN );
+    t.strictEqual( typeof y, 'number', 'returns a number' );
+    t.ok( isNaN( y ), 'returns NaN' );
+    t.end();
+});
+
+tape( 'the function evaluates the MGF for valid inputs', opts, function test( t ) {
+    var y = mgf( 0.0, 1.0, 0.9 );
+    t.strictEqual( y, 1.0, 'returns 1 when t is 0' );
+
+    y = mgf( 0.05, 20.0, 0.8 );
+    t.ok( Math.abs( y - 267.839 ) < 1e-3, 'returns ~267.839' );
+
+    y = mgf( 0.1, 20.0, 0.1 );
+    t.ok( Math.abs( y - 9.347 ) < 1e-3, 'returns ~9.347' );
+
+    y = mgf( 0.5, 10.0, 0.4 );
+    t.ok( Math.abs( y - 42822.023 ) < 1e-3, 'returns ~42822.023' );
+
+    t.end();
+});
+
+tape( 'the function returns NaN if `p` is outside the interval [0,1]', opts, function test( t ) {
+    var y = mgf( 0.1, 2.0, -0.5 );
+    t.strictEqual( typeof y, 'number', 'returns a number' );
+    t.ok( isNaN( y ), 'returns NaN' );
+
+    y = mgf( 0.1, 2.0, 1.5 );
+    t.strictEqual( typeof y, 'number', 'returns a number' );
+    t.ok( isNaN( y ), 'returns NaN' );
+
+    t.end();
+});
+
+tape( 'the function returns NaN if `r` is less than or equal to 0', opts, function test( t ) {
+    var y = mgf( 0.1, -2.0, 0.5 );
+    t.strictEqual( typeof y, 'number', 'returns a number' );
+    t.ok( isNaN( y ), 'returns NaN' );
+
+    y = mgf( 0.1, 0.0, 0.5 );
+    t.strictEqual( typeof y, 'number', 'returns a number' );
+    t.ok( isNaN( y ), 'returns NaN' );
+
+    t.end();
+});


### PR DESCRIPTION
### Resolves  
https://github.com/stdlib-js/stdlib/issues/3764  

---

### Description  

#### Purpose of this pull request  
This pull request:  
- Adds a C implementation of the negative binomial mgf.  
- Includes benchmarks for the C implementation.  
- Provides examples demonstrating the usage of the negative binomial mgf in C.  

---

### Related Issues  

#### Does this pull request have any related issues?  
This pull request:  
- Resolves [Issue #3764](https://github.com/stdlib-js/stdlib/issues/3764).  

---

### Questions  

#### Any questions for reviewers of this pull request?  
No.  

---

### Other Information  

#### Any other relevant information?  
No.  

---

### Checklist  

Please ensure the following tasks are completed before submitting this pull request:  
- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).  

---  
**@stdlib-js/reviewers**  