### PR TITLE
feat: add C implementation for `stats/base/dists/frechet/variance`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/README.md
@@ -237,7 +237,7 @@ int main( void ) {
    double s;
    double m;
    double y;
-   int i; 
+   int i;
 
     for ( i = 0; i < 10; i++ ) {
        alpha = random_uniform( 0.0, 20.0 ) + STDLIB_CONSTANT_FLOAT64_EPS;

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/README.md
@@ -158,11 +158,104 @@ for ( i = 0; i < 10; i++ ) {
 
 <!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 
-<section class="references">
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
 
 </section>
 
-<!-- /.references -->
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/stats/base/dists/frechet/variance.h"
+```
+
+#### stdlib_base_dists_frechet_variance( alpha, s, m )
+
+Returns the variance for a Fréchet distribution with shape `alpha`, scale `s`, and location `m`.
+
+```c
+double y = stdlib_base_frechet_variance( 5.0, 2.0, 0.0 );
+// returns ~0.535
+```
+
+The function accepts the following arguments:
+
+-   **alpha**: `[in] double` shape parameter.
+-   **s**: `[in] double` scale parameter.
+-   **m**: `[in] double` location parameter.
+
+```c
+double stdlib_base_dists_frechet_variance( const double alpha, const double s, const double m );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/stats/base/dists/frechet/variance.h"
+#include "stdlib/constants/float64/eps.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+static double random_uniform( const double min, const double max ) {
+    double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+    return min + ( v*(max-min) );
+}
+
+int main( void ) {
+   double alpha;
+   double s;
+   double m;
+   double y;
+   int i; 
+
+    for ( i = 0; i < 10; i++ ) {
+       alpha = random_uniform( 0.0, 20.0 ) + STDLIB_CONSTANT_FLOAT64_EPS;
+       s = random_uniform( 0.0, 20.0 ) + STDLIB_CONSTANT_FLOAT64_EPS;
+       m = random_uniform( 0.0, 20.0 ) - 40.0;
+       y = stdlib_base_dists_frechet_variance( alpha, s, m );
+       printf( "α: %.4lf, s: %.4lf, m: %.4lf, Var(X;α,s,m): %.4lf\n", alpha, s, m, y );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
 
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/benchmark/benchmark.native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -20,22 +20,31 @@
 
 // MODULES //
 
+var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
 var Float64Array = require( '@stdlib/array/float64' );
+var randu = require( '@stdlib/random/base/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
-var variance = require( './../lib' );
+
+
+// VARIABLES //
+
+var variance = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( variance instanceof Error )
+};
 
 
 // MAIN //
 
-bench( pkg, function benchmark( b ) {
+bench( pkg+'::native', opts, function benchmark( b ) {
 	var alpha;
 	var len;
-	var m;
 	var s;
+	var m;
 	var y;
 	var i;
 
@@ -48,7 +57,6 @@ bench( pkg, function benchmark( b ) {
 		s[ i ] = ( randu()*20.0 ) + EPS;
 		m[ i ] = ( randu()*20.0 ) - 40.0;
 	}
-
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
 		y = variance( alpha[ i % len ], s[ i % len ], m[ i % len ] );

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/benchmark/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2025 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/benchmark/c/benchmark.c
@@ -109,7 +109,7 @@ static double benchmark( void ) {
 
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		 y = stdlib_base_dists_frechet_variance( alpha[ i%100 ], s[ i%100 ], m[ i%100 ] );
+		y = stdlib_base_dists_frechet_variance( alpha[ i%100 ], s[ i%100 ], m[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/benchmark/c/benchmark.c
@@ -1,0 +1,143 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/frechet/variance.h"
+#include "stdlib/constants/float64/eps.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "frechet-variance"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+static void print_version( void ) {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+static void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+static void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+static double tic( void ) {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [min,max).
+*
+* @param min    minimum value (inclusive)
+* @param max    maximum value (exclusive)
+* @return       random number
+*/
+static double random_uniform( const double min, const double max ) {
+	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+	return min + ( v*(max-min) );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+static double benchmark( void ) {
+	double elapsed;
+	double alpha[ 100 ];
+	double s[ 100 ];
+	double m[ 100 ];
+	double y;
+	double t;
+	int i;
+
+	for ( i = 0; i < 100; i++ ) {
+		alpha[ i ] = random_uniform( 0.0, 20.0 ) + STDLIB_CONSTANT_FLOAT64_EPS;
+		s[ i ] = random_uniform( 0.0, 20.0 ) + STDLIB_CONSTANT_FLOAT64_EPS;
+		m[ i ] = random_uniform( 0.0, 20.0 ) - 40.0;
+	}
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		 y = stdlib_base_dists_frechet_variance( alpha[ i%100 ], s[ i%100 ], m[ i%100 ] );
+		if ( y != y ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( y != y ) {
+		printf( "should not return NaN\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/binding.gyp
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2025 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2025 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/examples/c/example.c
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/frechet/variance.h"
+#include "stdlib/constants/float64/eps.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+static double random_uniform( const double min, const double max ) {
+	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+	return min + ( v*(max-min) );
+}
+
+int main( void ) {
+	double alpha;
+	double s;
+	double m;
+	double y;
+	int i;
+
+	for ( i = 0; i < 10; i++ ) {
+		alpha = random_uniform( 0.0, 20.0 ) + STDLIB_CONSTANT_FLOAT64_EPS;
+		s = random_uniform( 0.0, 20.0 ) + STDLIB_CONSTANT_FLOAT64_EPS;
+		m = random_uniform( 0.0, 20.0 ) - 40.0;
+		y = stdlib_base_dists_frechet_variance( alpha, s, m );
+		printf( "α: %.4lf, s: %.4lf, m: %.4lf, Var(X;α,s,m): %.4lf\n", alpha, s, m, y );
+	}
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/include.gypi
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2025 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/include/stdlib/stats/base/dists/frechet/variance.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/include/stdlib/stats/base/dists/frechet/variance.h
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_STATS_BASE_DISTS_FRECHET_VARIANCE_H
+#define STDLIB_STATS_BASE_DISTS_FRECHET_VARIANCE_H
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Returns the variance for a Fréchet distribution with shape `alpha`, scale `s`, and location `m`.
+*/
+double stdlib_base_dists_frechet_variance( const double alpha, const double s, const double m );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_STATS_BASE_DISTS_FRECHET_VARIANCE_H

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/lib/native.js
@@ -1,0 +1,68 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Returns the variance for a Fréchet distribution with shape `alpha`, scale `s`, and location `m`.
+*
+* @private
+* @param {PositiveNumber} alpha - shape parameter
+* @param {PositiveNumber} s - scale parameter
+* @param {number} m - location parameter
+* @returns {number} variance
+*
+* @example
+* var y = variance( 5.0, 2.0, 0.0 );
+* // returns ~0.535
+*
+* @example
+* var y = variance( 5.0, 2.0, -5.0 );
+* // returns ~0.535
+*
+* @example
+* var y = variance( 1.0, 1.0, 0.0 );
+* // returns Infinity
+*
+* @example
+* var y = variance( NaN, 1.0, 0.0 );
+* // returns NaN
+*
+* @example
+* var y = variance( 1.0, NaN, 0.0 );
+* // returns NaN
+*
+* @example
+* var y = variance( 1.0, 1.0, NaN );
+* // returns NaN
+*/
+function variance( alpha, s, m ) {
+	return addon( alpha, s, m );
+}
+
+
+// EXPORTS //
+
+module.exports = variance;

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/manifest.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/manifest.json
@@ -1,0 +1,84 @@
+{
+  "options": {
+    "task": "build",
+    "wasm": false
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/napi/ternary",
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/special/gamma",
+        "@stdlib/constants/float64/pinf"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/special/gamma",
+        "@stdlib/constants/float64/pinf",
+        "@stdlib/constants/float64/eps"
+      ]
+    },
+    {
+      "task": "examples",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/special/gamma",
+        "@stdlib/constants/float64/pinf",
+        "@stdlib/constants/float64/eps"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/package.json
@@ -14,11 +14,14 @@
     }
   ],
   "main": "./lib",
+  "gypfile": true,
   "directories": {
     "benchmark": "./benchmark",
     "doc": "./docs",
     "example": "./examples",
+    "include": "./include",
     "lib": "./lib",
+    "src": "./src",
     "test": "./test"
   },
   "types": "./docs/types",

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/src/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2025 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/src/addon.c
@@ -1,0 +1,23 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/frechet/variance.h"
+#include "stdlib/math/base/napi/ternary.h"
+
+// cppcheck-suppress shadowFunction
+STDLIB_MATH_BASE_NAPI_MODULE_DDD_D( stdlib_base_dists_frechet_variance )

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/src/main.c
@@ -35,7 +35,7 @@
 */
 double stdlib_base_dists_frechet_variance( const double alpha, const double s, const double m ) {
 	double g1;
-    double g2;
+	double g2;
 	if (
 		stdlib_base_is_nan( alpha ) ||
 		stdlib_base_is_nan( s ) ||
@@ -46,9 +46,9 @@ double stdlib_base_dists_frechet_variance( const double alpha, const double s, c
 		return 0.0/0.0; // NaN
 	}
 	if ( alpha <= 2.0 ) {
-        return STDLIB_CONSTANT_FLOAT64_PINF;
-    }
+		return STDLIB_CONSTANT_FLOAT64_PINF;
+	}
 	g1 = stdlib_base_gamma( 1.0 - (1.0/alpha) );
-    g2 = stdlib_base_gamma( 1.0 - (2.0/alpha) );
+	g2 = stdlib_base_gamma( 1.0 - (2.0/alpha) );
 	return (s * s) * (g2 - (g1 * g1));
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/src/main.c
@@ -1,0 +1,54 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/frechet/variance.h"
+#include "stdlib/math/base/assert/is_nan.h"
+#include "stdlib/math/base/special/gamma.h"
+#include "stdlib/constants/float64/pinf.h"
+
+/**
+* Returns the variance for a Fréchet distribution with shape `alpha`, scale `s`, and location `m`.
+*
+* @param alpha    shape parameter
+* @param s        scale parameter
+* @param m        location parameter
+* @return         variance
+*
+* @example
+* double y = stdlib_base_frechet_variance( 5.0, 2.0, 0.0 );
+* // returns ~0.535
+*/
+double stdlib_base_dists_frechet_variance( const double alpha, const double s, const double m ) {
+	double g1;
+    double g2;
+	if (
+		stdlib_base_is_nan( alpha ) ||
+		stdlib_base_is_nan( s ) ||
+		stdlib_base_is_nan( m ) ||
+		alpha <= 0.0 ||
+		s <= 0.0
+	) {
+		return 0.0/0.0; // NaN
+	}
+	if ( alpha <= 2.0 ) {
+        return STDLIB_CONSTANT_FLOAT64_PINF;
+    }
+	g1 = stdlib_base_gamma( 1.0 - (1.0/alpha) );
+    g2 = stdlib_base_gamma( 1.0 - (2.0/alpha) );
+	return (s * s) * (g2 - (g1 * g1));
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/variance/test/test.native.js
@@ -1,0 +1,137 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var abs = require( '@stdlib/math/base/special/abs' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+var EPS = require( '@stdlib/constants/float64/eps' );
+
+
+// FIXTURES //
+
+var data = require( './fixtures/julia/data.json' );
+
+
+// VARIABLES //
+
+var variance = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( variance instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof variance, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'if provided `NaN` for any parameter, the function returns `NaN`', function test( t ) {
+	var y = variance( NaN, 1.0, 0.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+	y = variance( 1.0, NaN, 0.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+	y = variance( 1.0, 1.0, NaN );
+	t.equal( isnan( y ), true, 'returns NaN' );
+	t.end();
+});
+
+tape( 'if provided a nonpositive `alpha`, the function returns `NaN`', opts, function test( t ) {
+	var y;
+
+	y = variance( 0.0, 2.0, 0.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = variance( -1.0, 2.0, 0.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = variance( -1.0, 2.0, 0.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = variance( NINF, 2.0, 0.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = variance( NINF, PINF, 0.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = variance( NINF, NaN, 2.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	t.end();
+});
+
+tape( 'if provided a nonpositive `s`, the function returns `NaN`', opts, function test( t ) {
+	var y;
+
+	y = variance( 2.0, 0.0, 0.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = variance( 2.0, -1.0, 0.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = variance( 2.0, -1.0, 0.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = variance( 1.0, NINF, 0.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = variance( PINF, NINF, 0.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = variance( NaN, NINF, 2.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	t.end();
+});
+
+tape( 'the function returns the variance of a Fréchet distribution', opts, function test( t ) {
+	var expected;
+	var alpha;
+	var delta;
+	var tol;
+	var s;
+	var y;
+	var i;
+
+	expected = data.expected;
+	alpha = data.alpha;
+	s = data.s;
+	for ( i = 0; i < alpha.length; i++ ) {
+		y = variance( alpha[i], s[i], 0.0 );
+		if ( expected[i] !== null ) {
+			if ( y === expected[i] ) {
+				t.equal( y, expected[i], 'alpha:'+alpha[i]+', s: '+s[i]+', m: 0, y: '+y+', expected: '+expected[i] );
+			} else {
+				delta = abs( y - expected[ i ] );
+				tol = 45.0 * EPS * abs( expected[ i ] );
+				t.ok( delta <= tol, 'within tolerance. alpha: '+alpha[i]+'. s: '+s[i]+'. m: 0. y: '+y+'. E: '+expected[ i ]+'. Δ: '+delta+'. tol: '+tol+'.' );
+			}
+		}
+	}
+	t.end();
+});


### PR DESCRIPTION

Resolves #3616

## Description

> What is the purpose of this pull request?

This pull request:

-   adds C implementation for @stdlib/stats/base/dists/frechet/variance along with relevant tests, benchmarks and examples.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves [[RFC]: Add C implementation for @stdlib/stats/base/dists/frechet/variance #3616](https://github.com/stdlib-js/stdlib/issues/3616)

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
