### PR TITLE
feat(stats): add C implementation for `stats/base/dists/degenerate/logpmf`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/README.md
@@ -160,6 +160,7 @@ double stdlib_base_dists_degenerate_logpmf( const double x, const double mu );
 ### Examples
 
 ```c
+#include "stdlib/math/base/special/round.h"
 #include "stdlib/stats/base/dists/degenerate/logpmf.h"
 #include <stdlib.h>
 #include <stdio.h>
@@ -170,17 +171,17 @@ static double random_uniform( const double min, const double max ) {
 }
 
 int main( void ) {
-    double x;
-    double mu;
     double result;
+    double mu;
+    double x;
     int i;
 
     for ( i = 0; i < 10; i++ ) {
-        x = random_uniform( -10.0, 10.0 );
-        mu = random_uniform( -20.0, 20.0 );
+        x = stdlib_base_round( random_uniform( 0.0, 5.0 ) );
+        mu = stdlib_base_round( random_uniform( 0.0, 5.0 ) );
         result = stdlib_base_dists_degenerate_logpmf( x, mu );
 
-        printf( "x: %lf, mu: %lf, logPMF: %lf \n", x, mu, result );
+        printf( "x: %lf, µ: %lf, ln(P(X=x;µ)): %lf \n", x, mu, result );
     }
 
     return 0;

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/README.md
@@ -125,7 +125,7 @@ for ( i = 0; i < 100; i++ ) {
 
 #### stdlib_base_dists_degenerate_logpmf( x, mu )
 
-Evaluates the natural logarithm of the probability mass function (logPMF) for a degenerate distribution centered at `mu`.
+Evaluate the natural logarithm of the [probability mass function][pmf] (PMF) for a [degenerate distribution][degenerate-distribution].
 
 ```c
 double out = stdlib_base_dists_degenerate_logpmf( 2.0, 3.0 );

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/README.md
@@ -97,6 +97,104 @@ for ( i = 0; i < 100; i++ ) {
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/stats/base/dists/degenerate/logpmf.h"
+```
+
+#### stdlib_base_dists_degenerate_logpmf( x, mu )
+
+Evaluates the natural logarithm of the probability mass function (logPMF) for a degenerate distribution centered at `mu`.
+
+```c
+double out = stdlib_base_dists_degenerate_logpmf( 2.0, 3.0 );
+// returns -INFINITY
+```
+
+The function accepts the following arguments:
+
+-   **x**: `[in] double` input value.
+-   **mu**: `[in] double` constant value of the distribution.
+
+```c
+double stdlib_base_dists_degenerate_logpmf( const double x, const double mu );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/stats/base/dists/degenerate/logpmf.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+static double random_uniform( const double min, const double max ) {
+    double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+    return min + ( v * ( max - min ) );
+}
+
+int main( void ) {
+    double x;
+    double mu;
+    double result;
+    int i;
+
+    for ( i = 0; i < 10; i++ ) {
+        x = random_uniform( -10.0, 10.0 );
+        mu = random_uniform( -20.0, 20.0 );
+        result = stdlib_base_dists_degenerate_logpmf( x, mu );
+
+        printf( "x: %lf, mu: %lf, logPMF: %lf \n", x, mu, result );
+    }
+
+    return 0;
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/README.md
@@ -180,11 +180,8 @@ int main( void ) {
         x = stdlib_base_round( random_uniform( 0.0, 5.0 ) );
         mu = stdlib_base_round( random_uniform( 0.0, 5.0 ) );
         result = stdlib_base_dists_degenerate_logpmf( x, mu );
-
         printf( "x: %lf, µ: %lf, ln(P(X=x;µ)): %lf \n", x, mu, result );
     }
-
-    return 0;
 }
 ```
 

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/README.md
@@ -129,7 +129,7 @@ Evaluate the natural logarithm of the [probability mass function][pmf] (PMF) for
 
 ```c
 double out = stdlib_base_dists_degenerate_logpmf( 2.0, 3.0 );
-// returns -INFINITY
+// returns -Infinity
 ```
 
 The function accepts the following arguments:

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/README.md
@@ -160,8 +160,8 @@ double stdlib_base_dists_degenerate_logpmf( const double x, const double mu );
 ### Examples
 
 ```c
-#include "stdlib/math/base/special/round.h"
 #include "stdlib/stats/base/dists/degenerate/logpmf.h"
+#include "stdlib/math/base/special/round.h"
 #include <stdlib.h>
 #include <stdio.h>
 

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/benchmark/benchmark.js
@@ -21,8 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var Float64Array = require( '@stdlib/array/float64' );
 var ceil = require( '@stdlib/math/base/special/ceil' );
-var randu = require( '@stdlib/random/base/randu' );
 var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
@@ -32,16 +32,23 @@ var logpmf = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var mu;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	mu = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = ceil( uniform( -100.0, 0.0 ) );
+		mu[ i ] = uniform( -50.0, 50.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ceil( uniform( -100.0, 0.0 ) );
-		mu = uniform( -50.0, 50.0 );
-		y = logpmf( x, mu );
+		y = logpmf( x[ i % len ], mu[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -56,6 +63,7 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var mypmf;
+	var len;
 	var mu;
 	var x;
 	var y;
@@ -63,11 +71,15 @@ bench( pkg+':factory', function benchmark( b ) {
 
 	mu = 40.0;
 	mypmf = logpmf.factory( mu );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = ceil( uniform( -100.0, 0.0 ) );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ceil( randu()*100.0 );
-		y = mypmf( x );
+		y = mypmf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/benchmark/benchmark.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var ceil = require( '@stdlib/math/base/special/ceil' );
 var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var logpmf = require( './../lib' );
@@ -38,8 +39,8 @@ bench( pkg, function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ceil( ( randu()*100.0 ) - 100.0 );
-		mu = ( randu()*100.0 ) - 50.0;
+		x = ceil( uniform( -100.0, 0.0 ) );
+		mu = uniform( -50.0, 50.0 );
 		y = logpmf( x, mu );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/benchmark/benchmark.native.js
@@ -41,8 +41,8 @@ var opts = {
 
 bench( pkg+'::native', opts, function benchmark( b ) {
 	var len;
-	var x;
 	var mu;
+	var x;
 	var y;
 	var i;
 

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/benchmark/benchmark.native.js
@@ -1,0 +1,70 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var Float64Array = require( '@stdlib/array/float64' );
+var randu = require( '@stdlib/random/base/randu' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var logpmf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( logpmf instanceof Error )
+};
+
+
+// MAIN //
+
+bench( pkg+'::native', opts, function benchmark( b ) {
+	var len;
+	var x;
+	var mu;
+	var y;
+	var i;
+
+	len = 100;
+	x = new Float64Array( len );
+	mu = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = ( randu() * 20.0 ) - 10.0;
+		mu[ i ] = ( randu() * 40.0 ) - 20.0;
+	}
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		y = logpmf( x[ i % len ], mu[ i % len ] );
+		if ( isnan( y ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnan( y ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/benchmark/benchmark.native.js
@@ -23,7 +23,8 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var ceil = require( '@stdlib/math/base/special/ceil' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -50,8 +51,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	x = new Float64Array( len );
 	mu = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu() * 20.0 ) - 10.0;
-		mu[ i ] = ( randu() * 40.0 ) - 20.0;
+		x[ i ] = ceil( uniform( -100.0, 0.0 ) );
+		mu[ i ] = uniform( -50.0, 50.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/benchmark/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2025 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/benchmark/c/benchmark.c
@@ -93,7 +93,7 @@ int main( void ) {
 	double elapsed;
 	int i;
 
-  	// Seed the random number generator:
+	// Seed the random number generator:
 	srand( time( NULL ) );
 
 	print_version();

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/benchmark/c/benchmark.c
@@ -16,12 +16,12 @@
 * limitations under the License.
 */
 
-#include <sys/time.h>
 #include "stdlib/stats/base/dists/degenerate/logpmf.h"
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
+#include <sys/time.h>
 
 #define NAME "degenerate-logpmf"
 #define ITERATIONS 1000000

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/benchmark/c/benchmark.c
@@ -16,12 +16,12 @@
 * limitations under the License.
 */
 
-#include "stdlib/stats/base/dists/degenerate/logpmf.h"
-#include <stdlib.h>
-#include <stdio.h>
-#include <math.h>
-#include <time.h>
 #include <sys/time.h>
+#include "stdlib/stats/base/dists/degenerate/logpmf.h"
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
 
 #define NAME "degenerate-logpmf"
 #define ITERATIONS 1000000
@@ -52,12 +52,12 @@ static void print_results( double elapsed ) {
 static double tic( void ) {
 	struct timeval now;
 	gettimeofday( &now, NULL );
-	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+	return (double)now.tv_sec + (double)now.tv_usec / 1.0e6;
 }
 
 static double random_uniform( const double min, const double max ) {
 	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
-	return min + ( v*(max-min) );
+	return min + ( v * ( max - min ) );
 }
 
 static double benchmark( void ) {
@@ -75,7 +75,7 @@ static double benchmark( void ) {
 
 	start = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		y = stdlib_base_dists_degenerate_logpmf( x[ i%100 ], mu[ i%100 ] );
+		y = stdlib_base_dists_degenerate_logpmf( x[ i % 100 ], mu[ i % 100 ] );
 		if ( isnan( y ) ) { // Check for NaN
 			printf( "should not return NaN\n" );
 			break;
@@ -93,7 +93,7 @@ int main( void ) {
 	double elapsed;
 	int i;
 
-	// Seed the random number generator:
+  	// Seed the random number generator:
 	srand( time( NULL ) );
 
 	print_version();
@@ -101,7 +101,7 @@ int main( void ) {
 		printf( "# c::%s\n", NAME );
 		elapsed = benchmark();
 		print_results( elapsed );
-		printf( "ok %d benchmark finished\n", i+1 );
+		printf( "ok %d benchmark finished\n", i + 1 );
 	}
 	print_summary( REPEATS, REPEATS );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/benchmark/c/benchmark.c
@@ -1,0 +1,107 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/degenerate/logpmf.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "degenerate-logpmf"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+static void print_version( void ) {
+	printf( "TAP version 13\n" );
+}
+
+static void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+static void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+static double tic( void ) {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+static double random_uniform( const double min, const double max ) {
+	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+	return min + ( v*(max-min) );
+}
+
+static double benchmark( void ) {
+	double elapsed;
+	double x[ 100 ];
+	double mu[ 100 ];
+	double y;
+	double start;
+	int i;
+
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = random_uniform( -10.0, 10.0 );
+		mu[ i ] = random_uniform( -20.0, 20.0 );
+	}
+
+	start = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		y = stdlib_base_dists_degenerate_logpmf( x[ i%100 ], mu[ i%100 ] );
+		if ( isnan( y ) ) { // Check for NaN
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - start;
+
+	if ( isnan( y ) ) {
+		printf( "should not return NaN\n" );
+	}
+	return elapsed;
+}
+
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/benchmark/c/benchmark.c
@@ -17,9 +17,10 @@
 */
 
 #include "stdlib/stats/base/dists/degenerate/logpmf.h"
-#include <math.h>
-#include <stdio.h>
+#include "stdlib/math/base/special/ceil.h"
 #include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
 #include <time.h>
 #include <sys/time.h>
 
@@ -27,10 +28,19 @@
 #define ITERATIONS 1000000
 #define REPEATS 3
 
+/**
+* Prints the TAP version.
+*/
 static void print_version( void ) {
 	printf( "TAP version 13\n" );
 }
 
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
 static void print_summary( int total, int passing ) {
 	printf( "#\n" );
 	printf( "1..%d\n", total ); // TAP plan
@@ -40,6 +50,11 @@ static void print_summary( int total, int passing ) {
 	printf( "# ok\n" );
 }
 
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
 static void print_results( double elapsed ) {
 	double rate = (double)ITERATIONS / elapsed;
 	printf( "  ---\n" );
@@ -49,34 +64,51 @@ static void print_results( double elapsed ) {
 	printf( "  ...\n" );
 }
 
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
 static double tic( void ) {
 	struct timeval now;
 	gettimeofday( &now, NULL );
-	return (double)now.tv_sec + (double)now.tv_usec / 1.0e6;
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
 }
 
+/**
+* Generates a random number on the interval [min,max).
+*
+* @param min    minimum value (inclusive)
+* @param max    maximum value (exclusive)
+* @return       random number
+*/
 static double random_uniform( const double min, const double max ) {
 	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
-	return min + ( v * ( max - min ) );
+	return min + ( v*(max-min) );
 }
 
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
 static double benchmark( void ) {
-	double elapsed;
-	double x[ 100 ];
 	double mu[ 100 ];
-	double y;
+	double x[ 100 ];
+	double elapsed;
 	double start;
+	double y;
 	int i;
 
 	for ( i = 0; i < 100; i++ ) {
-		x[ i ] = random_uniform( -10.0, 10.0 );
-		mu[ i ] = random_uniform( -20.0, 20.0 );
+		x[ i ] = stdlib_base_ceil( random_uniform( -100.0, 0.0 ) );
+		mu[ i ] = random_uniform( -50.0, 50.0 );
 	}
 
 	start = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
 		y = stdlib_base_dists_degenerate_logpmf( x[ i % 100 ], mu[ i % 100 ] );
-		if ( isnan( y ) ) { // Check for NaN
+		if ( isnan( y ) ) {
 			printf( "should not return NaN\n" );
 			break;
 		}
@@ -89,11 +121,14 @@ static double benchmark( void ) {
 	return elapsed;
 }
 
+/**
+* Main execution sequence.
+*/
 int main( void ) {
 	double elapsed;
 	int i;
 
-	// Seed the random number generator:
+	// Use the current time to seed the random number generator:
 	srand( time( NULL ) );
 
 	print_version();

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/binding.gyp
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/binding.gyp
@@ -19,131 +19,152 @@
 # [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
 # [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
 {
-    # List of files to include in this file:
-    "includes": [
-        "./include.gypi",
-    ],
-    # Define variables to be used throughout the configuration for all targets:
-    "variables": {
-        # Target name should match the add-on export name:
-        "addon_target_name%": "addon",
-        # Set variables based on the host OS:
-        "conditions": [
-            [
-                'OS=="win"',
-                {
-                    # Define the object file suffix:
-                    "obj": "obj",
-                },
-                {
-                    # Define the object file suffix:
-                    "obj": "o",
-                },
-            ],  # end condition (OS=="win")
-        ],  # end conditions
-    },  # end variables
-    # Define compile targets:
-    "targets": [
-        # Target to generate an add-on:
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
         {
-            # The target name should match the add-on export name:
-            "target_name": "<(addon_target_name)",
-            # Define dependencies:
-            "dependencies": [],
-            # Define directories which contain relevant include headers:
-            "include_dirs": [
-                # Local include directory:
-                "<@(include_dirs)",
-            ],
-            # List of source files:
-            "sources": [
-                "<@(src_files)",
-                "src/addon.c",
-            ],
-            # Settings which should be applied when a target's object files are used as linker input:
-            "link_settings": {
-                # Define libraries:
-                "libraries": [
-                    "<@(libraries)",
-                ],
-                # Define library directories:
-                "library_dirs": [
-                    "<@(library_dirs)",
-                ],
-            },
-            # C/C++ compiler flags:
-            "cflags": [
-                # Enable commonly used warning options:
-                "-Wall",
-                # Aggressive optimization:
-                "-O3",
-            ],
-            # C specific compiler flags:
-            "cflags_c": [
-                # Specify the C standard to which a program is expected to conform:
-                "-std=c99",
-            ],
-            # C++ specific compiler flags:
-            "cflags_cpp": [
-                # Specify the C++ standard to which a program is expected to conform:
-                "-std=c++11",
-            ],
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
             # Linker flags:
-            "ldflags": [],
-            # Apply conditions based on the host OS:
-            "conditions": [
-                [
-                    'OS=="mac"',
-                    {
-                        # Linker flags:
-                        "ldflags": [
-                            "-undefined dynamic_lookup",
-                            "-Wl,-no-pie",
-                            "-Wl,-search_paths_first",
-                        ],
-                    },
-                ],  # end condition (OS=="mac")
-                [
-                    'OS!="win"',
-                    {
-                        # C/C++ flags:
-                        "cflags": [
-                            # Generate platform-independent code:
-                            "-fPIC",
-                        ],
-                    },
-                ],  # end condition (OS!="win")
-            ],  # end conditions
-        },  # end target <(addon_target_name)
-        # Target to copy a generated add-on to a standard location:
-        {
-            "target_name": "copy_addon",
-            # Declare that the output of this target is not linked:
-            "type": "none",
-            # Define dependencies:
-            "dependencies": [
-                # Require that the add-on be generated before building this target:
-                "<(addon_target_name)",
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
             ],
-            # Define a list of actions:
-            "actions": [
-                {
-                    "action_name": "copy_addon",
-                    "message": "Copying addon...",
-                    # Explicitly list the inputs in the command-line invocation below:
-                    "inputs": [],
-                    # Declare the expected outputs:
-                    "outputs": [
-                        "<(addon_output_dir)/<(addon_target_name).node",
-                    ],
-                    # Define the command-line invocation:
-                    "action": [
-                        "cp",
-                        "<(PRODUCT_DIR)/<(addon_target_name).node",
-                        "<(addon_output_dir)/<(addon_target_name).node",
-                    ],
-                },
-            ],  # end actions
-        },  # end target copy_addon
-    ],  # end targets
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/binding.gyp
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/binding.gyp
@@ -1,0 +1,149 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2025 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+    # List of files to include in this file:
+    "includes": [
+        "./include.gypi",
+    ],
+    # Define variables to be used throughout the configuration for all targets:
+    "variables": {
+        # Target name should match the add-on export name:
+        "addon_target_name%": "addon",
+        # Set variables based on the host OS:
+        "conditions": [
+            [
+                'OS=="win"',
+                {
+                    # Define the object file suffix:
+                    "obj": "obj",
+                },
+                {
+                    # Define the object file suffix:
+                    "obj": "o",
+                },
+            ],  # end condition (OS=="win")
+        ],  # end conditions
+    },  # end variables
+    # Define compile targets:
+    "targets": [
+        # Target to generate an add-on:
+        {
+            # The target name should match the add-on export name:
+            "target_name": "<(addon_target_name)",
+            # Define dependencies:
+            "dependencies": [],
+            # Define directories which contain relevant include headers:
+            "include_dirs": [
+                # Local include directory:
+                "<@(include_dirs)",
+            ],
+            # List of source files:
+            "sources": [
+                "<@(src_files)",
+                "src/addon.c",
+            ],
+            # Settings which should be applied when a target's object files are used as linker input:
+            "link_settings": {
+                # Define libraries:
+                "libraries": [
+                    "<@(libraries)",
+                ],
+                # Define library directories:
+                "library_dirs": [
+                    "<@(library_dirs)",
+                ],
+            },
+            # C/C++ compiler flags:
+            "cflags": [
+                # Enable commonly used warning options:
+                "-Wall",
+                # Aggressive optimization:
+                "-O3",
+            ],
+            # C specific compiler flags:
+            "cflags_c": [
+                # Specify the C standard to which a program is expected to conform:
+                "-std=c99",
+            ],
+            # C++ specific compiler flags:
+            "cflags_cpp": [
+                # Specify the C++ standard to which a program is expected to conform:
+                "-std=c++11",
+            ],
+            # Linker flags:
+            "ldflags": [],
+            # Apply conditions based on the host OS:
+            "conditions": [
+                [
+                    'OS=="mac"',
+                    {
+                        # Linker flags:
+                        "ldflags": [
+                            "-undefined dynamic_lookup",
+                            "-Wl,-no-pie",
+                            "-Wl,-search_paths_first",
+                        ],
+                    },
+                ],  # end condition (OS=="mac")
+                [
+                    'OS!="win"',
+                    {
+                        # C/C++ flags:
+                        "cflags": [
+                            # Generate platform-independent code:
+                            "-fPIC",
+                        ],
+                    },
+                ],  # end condition (OS!="win")
+            ],  # end conditions
+        },  # end target <(addon_target_name)
+        # Target to copy a generated add-on to a standard location:
+        {
+            "target_name": "copy_addon",
+            # Declare that the output of this target is not linked:
+            "type": "none",
+            # Define dependencies:
+            "dependencies": [
+                # Require that the add-on be generated before building this target:
+                "<(addon_target_name)",
+            ],
+            # Define a list of actions:
+            "actions": [
+                {
+                    "action_name": "copy_addon",
+                    "message": "Copying addon...",
+                    # Explicitly list the inputs in the command-line invocation below:
+                    "inputs": [],
+                    # Declare the expected outputs:
+                    "outputs": [
+                        "<(addon_output_dir)/<(addon_target_name).node",
+                    ],
+                    # Define the command-line invocation:
+                    "action": [
+                        "cp",
+                        "<(PRODUCT_DIR)/<(addon_target_name).node",
+                        "<(addon_output_dir)/<(addon_target_name).node",
+                    ],
+                },
+            ],  # end actions
+        },  # end target copy_addon
+    ],  # end targets
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2025 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/examples/c/example.c
@@ -16,28 +16,29 @@
 * limitations under the License.
 */
 
+#include "stdlib/math/base/special/round.h"
 #include "stdlib/stats/base/dists/degenerate/logpmf.h"
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 static double random_uniform( const double min, const double max ) {
-    double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
-    return min + ( v * ( max - min ) );
+	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+	return min + ( v * ( max - min ) );
 }
 
 int main( void ) {
-    double x;
-    double mu;
-    double result;
-    int i;
+	double result;
+	double mu;
+	double x;
+	int i;
 
-    for ( i = 0; i < 10; i++ ) {
-        x = random_uniform( -10.0, 10.0 );
-        mu = random_uniform( -20.0, 20.0 );
-        result = stdlib_base_dists_degenerate_logpmf( x, mu );
+	for ( i = 0; i < 10; i++ ) {
+		x = stdlib_base_round( random_uniform( 0.0, 5.0 ) );
+		mu = stdlib_base_round( random_uniform( 0.0, 5.0 ) );
+		result = stdlib_base_dists_degenerate_logpmf( x, mu );
 
-        printf( "x: %lf, mu: %lf, logPMF: %lf \n", x, mu, result );
-    }
+		printf( "x: %lf, µ: %lf, ln(P(X=x;µ)): %lf \n", x, mu, result );
+	}
 
-    return 0;
+	return 0;
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/examples/c/example.c
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/degenerate/logpmf.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+static double random_uniform( const double min, const double max ) {
+    double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
+    return min + ( v * ( max - min ) );
+}
+
+int main( void ) {
+    double x;
+    double mu;
+    double result;
+    int i;
+
+    for ( i = 0; i < 10; i++ ) {
+        x = random_uniform( -10.0, 10.0 );
+        mu = random_uniform( -20.0, 20.0 );
+        result = stdlib_base_dists_degenerate_logpmf( x, mu );
+
+        printf( "x: %lf, mu: %lf, logPMF: %lf \n", x, mu, result );
+    }
+
+    return 0;
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/examples/c/example.c
@@ -36,9 +36,6 @@ int main( void ) {
 		x = stdlib_base_round( random_uniform( 0.0, 5.0 ) );
 		mu = stdlib_base_round( random_uniform( 0.0, 5.0 ) );
 		result = stdlib_base_dists_degenerate_logpmf( x, mu );
-
 		printf( "x: %lf, µ: %lf, ln(P(X=x;µ)): %lf \n", x, mu, result );
 	}
-
-	return 0;
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/examples/c/example.c
@@ -16,8 +16,8 @@
 * limitations under the License.
 */
 
-#include "stdlib/math/base/special/round.h"
 #include "stdlib/stats/base/dists/degenerate/logpmf.h"
+#include "stdlib/math/base/special/round.h"
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/include.gypi
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/include.gypi
@@ -1,0 +1,48 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2025 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+    # Define variables to be used throughout the configuration for all targets:
+    "variables": {
+        # Source directory:
+        "src_dir": "./src",
+        # Include directories:
+        "include_dirs": [
+            "<!@(node -e \"var arr = require('@stdlib/utils/library-manifest')('./manifest.json',{},{'basedir':process.cwd(),'paths':'posix'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }\")",
+        ],
+        # Add-on destination directory:
+        "addon_output_dir": "./src",
+        # Source files:
+        "src_files": [
+            "<(src_dir)/addon.c",
+            "<!@(node -e \"var arr = require('@stdlib/utils/library-manifest')('./manifest.json',{},{'basedir':process.cwd(),'paths':'posix'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }\")",
+        ],
+        # Library dependencies:
+        "libraries": [
+            "<!@(node -e \"var arr = require('@stdlib/utils/library-manifest')('./manifest.json',{},{'basedir':process.cwd(),'paths':'posix'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }\")",
+        ],
+        # Library directories:
+        "library_dirs": [
+            "<!@(node -e \"var arr = require('@stdlib/utils/library-manifest')('./manifest.json',{},{'basedir':process.cwd(),'paths':'posix'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }\")",
+        ],
+    },  # end variables
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/include.gypi
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/include.gypi
@@ -21,28 +21,33 @@
 # [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
 # [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
 {
-    # Define variables to be used throughout the configuration for all targets:
-    "variables": {
-        # Source directory:
-        "src_dir": "./src",
-        # Include directories:
-        "include_dirs": [
-            "<!@(node -e \"var arr = require('@stdlib/utils/library-manifest')('./manifest.json',{},{'basedir':process.cwd(),'paths':'posix'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }\")",
-        ],
-        # Add-on destination directory:
-        "addon_output_dir": "./src",
-        # Source files:
-        "src_files": [
-            "<(src_dir)/addon.c",
-            "<!@(node -e \"var arr = require('@stdlib/utils/library-manifest')('./manifest.json',{},{'basedir':process.cwd(),'paths':'posix'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }\")",
-        ],
-        # Library dependencies:
-        "libraries": [
-            "<!@(node -e \"var arr = require('@stdlib/utils/library-manifest')('./manifest.json',{},{'basedir':process.cwd(),'paths':'posix'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }\")",
-        ],
-        # Library directories:
-        "library_dirs": [
-            "<!@(node -e \"var arr = require('@stdlib/utils/library-manifest')('./manifest.json',{},{'basedir':process.cwd(),'paths':'posix'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }\")",
-        ],
-    },  # end variables
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/include/stdlib/stats/base/dists/degenerate/logpmf.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/include/stdlib/stats/base/dists/degenerate/logpmf.h
@@ -1,0 +1,42 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_STATS_BASE_DISTS_DEGENERATE_LOGPMF_H
+#define STDLIB_STATS_BASE_DISTS_DEGENERATE_LOGPMF_H
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Evaluates the natural logarithm of the probability mass function (logPMF) for a degenerate distribution centered at `mu`.
+*
+* @param x    input value
+* @param mu   constant value of the distribution
+* @return     natural logarithm of the probability mass function
+*/
+double stdlib_base_dists_degenerate_logpmf( const double x, const double mu );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_STATS_BASE_DISTS_DEGENERATE_LOGPMF_H

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/include/stdlib/stats/base/dists/degenerate/logpmf.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/include/stdlib/stats/base/dists/degenerate/logpmf.h
@@ -27,11 +27,7 @@ extern "C" {
 #endif
 
 /**
-* Evaluates the natural logarithm of the probability mass function (logPMF) for a degenerate distribution centered at `mu`.
-*
-* @param x    input value
-* @param mu   constant value of the distribution
-* @return     natural logarithm of the probability mass function
+* Evaluates the natural logarithm of the probability mass function (PMF) for a degenerate distribution centered at `mu`.
 */
 double stdlib_base_dists_degenerate_logpmf( const double x, const double mu );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/lib/native.js
@@ -1,0 +1,59 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Evaluates the natural logarithm of the probability mass function (logPMF) for a degenerate distribution centered at `mu`.
+*
+* @private
+* @param {number} x - input value
+* @param {number} mu - constant value of the distribution
+* @returns {number} natural logarithm of the probability mass function
+*
+* @example
+* var y = logpmf( 3.0, 3.0 );
+* // returns 0.0
+*
+* @example
+* var y = logpmf( 2.0, 3.0 );
+* // returns -Infinity
+*
+* @example
+* var y = logpmf( NaN, 2.0 );
+* // returns NaN
+*
+* @example
+* var y = logpmf( 3.0, NaN );
+* // returns NaN
+*/
+function logpmf( x, mu ) {
+	return addon( x, mu );
+}
+
+
+// EXPORTS //
+
+module.exports = logpmf;

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/lib/native.js
@@ -34,19 +34,19 @@ var addon = require( './../src/addon.node' );
 * @returns {number} logarithm of probability mass function
 *
 * @example
-* var y = logpmf( 3.0, 3.0 );
-* // returns 0.0
-*
-* @example
 * var y = logpmf( 2.0, 3.0 );
 * // returns -Infinity
 *
 * @example
-* var y = logpmf( NaN, 2.0 );
+* var y = logpmf( 3.0, 3.0 );
+* // returns 0.0
+*
+* @example
+* var y = logpmf( NaN, 0.0 );
 * // returns NaN
 *
 * @example
-* var y = logpmf( 3.0, NaN );
+* var y = logpmf( 0.0, NaN );
 * // returns NaN
 */
 function logpmf( x, mu ) {

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/lib/native.js
@@ -26,12 +26,12 @@ var addon = require( './../src/addon.node' );
 // MAIN //
 
 /**
-* Evaluates the natural logarithm of the probability mass function (logPMF) for a degenerate distribution centered at `mu`.
+* Evaluates the natural logarithm of the probability mass function (PMF) for a degenerate distribution centered at `mu`.
 *
 * @private
 * @param {number} x - input value
 * @param {number} mu - constant value of the distribution
-* @returns {number} natural logarithm of the probability mass function
+* @returns {number} logarithm of probability mass function
 *
 * @example
 * var y = logpmf( 3.0, 3.0 );

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/manifest.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/manifest.json
@@ -1,0 +1,79 @@
+{
+  "options": {
+    "task": "build",
+    "wasm": false
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/napi/binary",
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/ninf"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/ninf"
+      ]
+    },
+    {
+      "task": "examples",
+      "wasm": false,
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/constants/float64/ninf"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/manifest.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/manifest.json
@@ -72,7 +72,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/math/base/special/round"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/manifest.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/manifest.json
@@ -56,7 +56,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/assert/is-nan",
-        "@stdlib/constants/float64/ninf"
+        "@stdlib/constants/float64/ninf",
+        "@stdlib/math/base/special/ceil"
       ]
     },
     {

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/package.json
@@ -14,10 +14,13 @@
     }
   ],
   "main": "./lib",
+  "gypfile": true,
   "directories": {
     "benchmark": "./benchmark",
     "doc": "./docs",
+    "include": "./include",
     "example": "./examples",
+    "src": "./src",
     "lib": "./lib",
     "test": "./test"
   },

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/package.json
@@ -18,10 +18,10 @@
   "directories": {
     "benchmark": "./benchmark",
     "doc": "./docs",
-    "include": "./include",
     "example": "./examples",
-    "src": "./src",
+    "include": "./include",
     "lib": "./lib",
+    "src": "./src",
     "test": "./test"
   },
   "types": "./docs/types",

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/src/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2025 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/src/addon.c
@@ -1,0 +1,23 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/napi/binary.h"
+#include "stdlib/stats/base/dists/degenerate/logpmf.h"
+
+// cppcheck-suppress shadowFunction
+STDLIB_MATH_BASE_NAPI_MODULE_DD_D( stdlib_base_dists_degenerate_logpmf )

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/src/addon.c
@@ -16,8 +16,8 @@
 * limitations under the License.
 */
 
-#include "stdlib/math/base/napi/binary.h"
 #include "stdlib/stats/base/dists/degenerate/logpmf.h"
+#include "stdlib/math/base/napi/binary.h"
 
 // cppcheck-suppress shadowFunction
 STDLIB_MATH_BASE_NAPI_MODULE_DD_D( stdlib_base_dists_degenerate_logpmf )

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/src/main.c
@@ -16,8 +16,8 @@
 * limitations under the License.
 */
 
-#include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/constants/float64/ninf.h"
+#include "stdlib/math/base/assert/is_nan.h"
 
 /**
 * Evaluates the natural logarithm of the probability mass function (logPMF) for a degenerate distribution centered at `mu`.
@@ -29,22 +29,10 @@
 * @example
 * double y = stdlib_base_dists_degenerate_logpmf( 2.0, 3.0 );
 * // returns -Infinity
-*
-* @example
-* double y = stdlib_base_dists_degenerate_logpmf( 3.0, 3.0 );
-* // returns 0.0
-*
-* @example
-* double y = stdlib_base_dists_degenerate_logpmf( NAN, 0.0 );
-* // returns NaN
-*
-* @example
-* double y = stdlib_base_dists_degenerate_logpmf( 0.0, NAN );
-* // returns NaN
 */
 double stdlib_base_dists_degenerate_logpmf( const double x, const double mu ) {
-    if ( stdlib_base_is_nan( x ) || stdlib_base_is_nan( mu ) ) {
-        return 0.0 / 0.0; // NaN
-    }
-    return ( x == mu ) ? 0.0 : STDLIB_CONSTANT_FLOAT64_NINF;
+	if ( stdlib_base_is_nan( x ) || stdlib_base_is_nan( mu ) ) {
+		return 0.0 / 0.0; // NaN
+	}
+	return ( x == mu ) ? 0.0 : STDLIB_CONSTANT_FLOAT64_NINF;
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/src/main.c
@@ -20,11 +20,11 @@
 #include "stdlib/math/base/assert/is_nan.h"
 
 /**
-* Evaluates the natural logarithm of the probability mass function (logPMF) for a degenerate distribution centered at `mu`.
+* Evaluates the natural logarithm of the probability mass function (PMF) for a degenerate distribution centered at `mu`.
 *
 * @param x    input value
 * @param mu   constant value of the distribution
-* @return     natural logarithm of the probability mass function, or NaN if input is invalid
+* @return     logarithm of probability mass function
 *
 * @example
 * double y = stdlib_base_dists_degenerate_logpmf( 2.0, 3.0 );

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/src/main.c
@@ -1,0 +1,50 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/assert/is_nan.h"
+#include "stdlib/constants/float64/ninf.h"
+
+/**
+* Evaluates the natural logarithm of the probability mass function (logPMF) for a degenerate distribution centered at `mu`.
+*
+* @param x    input value
+* @param mu   constant value of the distribution
+* @return     natural logarithm of the probability mass function, or NaN if input is invalid
+*
+* @example
+* double y = stdlib_base_dists_degenerate_logpmf( 2.0, 3.0 );
+* // returns -Infinity
+*
+* @example
+* double y = stdlib_base_dists_degenerate_logpmf( 3.0, 3.0 );
+* // returns 0.0
+*
+* @example
+* double y = stdlib_base_dists_degenerate_logpmf( NAN, 0.0 );
+* // returns NaN
+*
+* @example
+* double y = stdlib_base_dists_degenerate_logpmf( 0.0, NAN );
+* // returns NaN
+*/
+double stdlib_base_dists_degenerate_logpmf( const double x, const double mu ) {
+    if ( stdlib_base_is_nan( x ) || stdlib_base_is_nan( mu ) ) {
+        return 0.0 / 0.0; // NaN
+    }
+    return ( x == mu ) ? 0.0 : STDLIB_CONSTANT_FLOAT64_NINF;
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/src/main.c
@@ -16,9 +16,9 @@
 * limitations under the License.
 */
 
+#include "stdlib/stats/base/dists/degenerate/logpmf.h"
 #include "stdlib/constants/float64/ninf.h"
 #include "stdlib/math/base/assert/is_nan.h"
-#include "stdlib/stats/base/dists/degenerate/logpmf.h"
 
 /**
 * Evaluates the natural logarithm of the probability mass function (PMF) for a degenerate distribution centered at `mu`.

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/src/main.c
@@ -17,8 +17,8 @@
 */
 
 #include "stdlib/stats/base/dists/degenerate/logpmf.h"
-#include "stdlib/constants/float64/ninf.h"
 #include "stdlib/math/base/assert/is_nan.h"
+#include "stdlib/constants/float64/ninf.h"
 
 /**
 * Evaluates the natural logarithm of the probability mass function (PMF) for a degenerate distribution centered at `mu`.

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/src/main.c
@@ -18,6 +18,7 @@
 
 #include "stdlib/constants/float64/ninf.h"
 #include "stdlib/math/base/assert/is_nan.h"
+#include "stdlib/stats/base/dists/degenerate/logpmf.h"
 
 /**
 * Evaluates the natural logarithm of the probability mass function (PMF) for a degenerate distribution centered at `mu`.

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/test/test.native.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/test/test.native.js
@@ -1,0 +1,86 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+
+
+// VARIABLES //
+
+var logpmf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( logpmf instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof logpmf, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'if provided `NaN` for any parameter, the function returns `NaN`', opts, function test( t ) {
+	var y;
+
+	y = logpmf( NaN, 0.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = logpmf( 0.0, NaN );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = logpmf( NaN, NaN );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	t.end();
+});
+
+tape( 'the function returns `0.0` if provided `x` equal to `mu`', opts, function test( t ) {
+	var y;
+
+	y = logpmf( 2.0, 2.0 );
+	t.equal( y, 0.0, 'returns 0.0' );
+
+	y = logpmf( 0.0, 0.0 );
+	t.equal( y, 0.0, 'returns 0.0' );
+
+	y = logpmf( -3.0, -3.0 );
+	t.equal( y, 0.0, 'returns 0.0' );
+
+	t.end();
+});
+
+tape( 'the function returns `-Infinity` if provided `x` not equal to `mu`', opts, function test( t ) {
+	var y;
+
+	y = logpmf( 2.0, 3.0 );
+	t.equal( y, NINF, 'returns -Infinity' );
+
+	y = logpmf( 4.0, 3.0 );
+	t.equal( y, NINF, 'returns -Infinity' );
+
+	t.end();
+});


### PR DESCRIPTION
### Resolves  
https://github.com/stdlib-js/stdlib/issues/3539  

---

### Description  

#### Purpose of this pull request  
This pull request:  
- Adds a C implementation of the degenerate logpmf.  
- Includes benchmarks for the C implementation.  
- Provides examples demonstrating the usage of the degenerate logpmf in C.  

---

### Related Issues  

#### Does this pull request have any related issues?  
This pull request:  
- Resolves [Issue #3539](https://github.com/stdlib-js/stdlib/issues/3539).  

---

### Questions  

#### Any questions for reviewers of this pull request?  
No.  

---

### Other Information  

#### Any other relevant information?  
No.  

---

### Checklist  

Please ensure the following tasks are completed before submitting this pull request:  
- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).  

---  
**@stdlib-js/reviewers**  