### PR TITLE
fix: wrap void function call in `API_SUFFIX`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dcumax/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dcumax/src/addon.c
@@ -20,6 +20,7 @@
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/argv_strided_float64array.h"
 #include <node_api.h>
 
@@ -37,7 +38,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideY, argv, 4 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, Y, N, strideY, argv, 3 );
-	stdlib_strided_dcumax( N, X, strideX, Y, strideY );
+	API_SUFFIX(stdlib_strided_dcumax)( N, X, strideX, Y, strideY );
 	return NULL;
 }
 
@@ -57,7 +58,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, offsetY, argv, 6 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, Y, N, strideY, argv, 4 );
-	stdlib_strided_dcumax_ndarray( N, X, strideX, offsetX, Y, strideY, offsetY );
+	API_SUFFIX(stdlib_strided_dcumax_ndarray)( N, X, strideX, offsetX, Y, strideY, offsetY );
 	return NULL;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dcumaxabs/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dcumaxabs/src/addon.c
@@ -20,6 +20,7 @@
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/argv_strided_float64array.h"
 #include <node_api.h>
 
@@ -37,7 +38,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideY, argv, 4 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, Y, N, strideY, argv, 3 );
-	stdlib_strided_dcumaxabs( N, X, strideX, Y, strideY );
+	API_SUFFIX(stdlib_strided_dcumaxabs)( N, X, strideX, Y, strideY );
 	return NULL;
 }
 
@@ -57,7 +58,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, offsetY, argv, 6 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, Y, N, strideY, argv, 4 );
-	stdlib_strided_dcumaxabs_ndarray( N, X, strideX, offsetX, Y, strideY, offsetY );
+	API_SUFFIX(stdlib_strided_dcumaxabs_ndarray)( N, X, strideX, offsetX, Y, strideY, offsetY );
 	return NULL;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dcumin/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dcumin/src/addon.c
@@ -20,6 +20,7 @@
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/argv_strided_float64array.h"
 #include <node_api.h>
 
@@ -37,7 +38,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideY, argv, 4 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, Y, N, strideY, argv, 3 );
-	stdlib_strided_dcumin( N, X, strideX, Y, strideY );
+	API_SUFFIX(stdlib_strided_dcumin)( N, X, strideX, Y, strideY );
 	return NULL;
 }
 
@@ -57,7 +58,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, offsetY, argv, 6 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, Y, N, strideY, argv, 4 );
-	stdlib_strided_dcumin_ndarray( N, X, strideX, offsetX, Y, strideY, offsetY );
+	API_SUFFIX(stdlib_strided_dcumin_ndarray)( N, X, strideX, offsetX, Y, strideY, offsetY );
 	return NULL;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dcuminabs/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dcuminabs/src/addon.c
@@ -19,6 +19,7 @@
 #include "stdlib/stats/base/dcuminabs.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/argv_int64.h"
 #include "stdlib/napi/argv_strided_float64array.h"
 #include <node_api.h>
@@ -37,7 +38,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideY, argv, 4 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, Y, N, strideY, argv, 3 );
-	stdlib_strided_dcuminabs( N, X, strideX, Y, strideY );
+	API_SUFFIX(stdlib_strided_dcuminabs)( N, X, strideX, Y, strideY );
 	return NULL;
 }
 
@@ -52,12 +53,12 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV( env, info, argv, argc, 7 );
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
-    STDLIB_NAPI_ARGV_INT64( env, strideY, argv, 5 );
+	STDLIB_NAPI_ARGV_INT64( env, strideY, argv, 5 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
-    STDLIB_NAPI_ARGV_INT64( env, offsetY, argv, 6 );
+	STDLIB_NAPI_ARGV_INT64( env, offsetY, argv, 6 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, Y, N, strideY, argv, 4 );
-	stdlib_strided_dcuminabs_ndarray( N, X, strideX, offsetX, Y, strideY, offsetY );
+	API_SUFFIX(stdlib_strided_dcuminabs_ndarray)( N, X, strideX, offsetX, Y, strideY, offsetY );
 	return NULL;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/scumax/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/scumax/src/addon.c
@@ -20,6 +20,7 @@
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/argv_strided_float32array.h"
 #include <node_api.h>
 
@@ -37,7 +38,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideY, argv, 4 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, Y, N, strideY, argv, 3 );
-	stdlib_strided_scumax( N, X, strideX, Y, strideY );
+	API_SUFFIX(stdlib_strided_scumax)( N, X, strideX, Y, strideY );
 	return NULL;
 }
 
@@ -57,7 +58,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, offsetY, argv, 6 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, Y, N, strideY, argv, 4 );
-	stdlib_strided_scumax_ndarray( N, X, strideX, offsetX, Y, strideY, offsetY );
+	API_SUFFIX(stdlib_strided_scumax_ndarray)( N, X, strideX, offsetX, Y, strideY, offsetY );
 	return NULL;
 }
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   wraps void function call in `API_SUFFIX` in packages related to cumulative maximum/minimum

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
