### PR TITLE
refactor: update `math/base/assert/is-integerf` to follow latest project conventions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/assert/is-integerf/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/assert/is-integerf/benchmark/c/native/benchmark.c
@@ -93,14 +93,17 @@ static float rand_float( void ) {
 static double benchmark( void ) {
 	double elapsed;
 	double t;
-	float x;
+	float x[ 100 ];
 	bool b;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( rand_float() * 1000.0f ) - 500.0f;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( rand_float() * 1000.0f ) - 500.0f;
-		b = stdlib_base_is_integerf( x );
+		b = stdlib_base_is_integerf( x[ i%100 ] );
 		if ( b != true && b != false ) {
 			printf( "should return either true or false\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/assert/is-integerf/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/assert/is-integerf/manifest.json
@@ -1,5 +1,7 @@
 {
-  "options": {},
+  "options": {
+    "task": "build"
+  },
   "fields": [
     {
       "field": "src",
@@ -24,6 +26,43 @@
   ],
   "confs": [
     {
+      "task": "build",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [
+        "-lm"
+      ],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/floorf",
+        "@stdlib/napi/export",
+        "@stdlib/napi/argv",
+        "@stdlib/napi/argv-double",
+        "@stdlib/napi/create-int32"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [
+        "-lm"
+      ],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/floorf"
+      ]
+    },
+    {
+      "task": "examples",
       "src": [
         "./src/main.c"
       ],

--- a/lib/node_modules/@stdlib/math/base/assert/is-integerf/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/assert/is-integerf/src/addon.c
@@ -17,9 +17,12 @@
 */
 
 #include "stdlib/math/base/assert/is_integerf.h"
+#include "stdlib/napi/argv.h"
+#include "stdlib/napi/argv_double.h"
+#include "stdlib/napi/create_int32.h"
+#include "stdlib/napi/export.h"
 #include <node_api.h>
 #include <stdint.h>
-#include <assert.h>
 
 /**
 * Receives JavaScript callback invocation data.
@@ -29,60 +32,10 @@
 * @return       Node-API value
 */
 static napi_value addon( napi_env env, napi_callback_info info ) {
-	napi_status status;
-
-	// Get callback arguments:
-	size_t argc = 1;
-	napi_value argv[ 1 ];
-	status = napi_get_cb_info( env, info, &argc, argv, NULL, NULL );
-	assert( status == napi_ok );
-
-	// Check whether we were provided the correct number of arguments:
-	if ( argc < 1 ) {
-		status = napi_throw_error( env, NULL, "invalid invocation. Insufficient arguments." );
-		assert( status == napi_ok );
-		return NULL;
-	}
-	if ( argc > 1 ) {
-		status = napi_throw_error( env, NULL, "invalid invocation. Too many arguments." );
-		assert( status == napi_ok );
-		return NULL;
-	}
-
-	napi_valuetype vtype0;
-	status = napi_typeof( env, argv[ 0 ], &vtype0 );
-	assert( status == napi_ok );
-	if ( vtype0 != napi_number ) {
-		status = napi_throw_type_error( env, NULL, "invalid argument. First argument must be a number." );
-		assert( status == napi_ok );
-		return NULL;
-	}
-
-	double x;
-	status = napi_get_value_double( env, argv[ 0 ], &x );
-	assert( status == napi_ok );
-
-	bool result = stdlib_base_is_integerf( (float)x );
-
-	napi_value v;
-	status = napi_create_int32( env, (int32_t)result, &v );
-	assert( status == napi_ok );
-
-	return v;
+	STDLIB_NAPI_ARGV( env, info, argv, argc, 1 );
+	STDLIB_NAPI_ARGV_DOUBLE( env, x, argv, 0 );
+	STDLIB_NAPI_CREATE_INT32( env, (int32_t)stdlib_base_is_integerf( (float)x ), out );
+	return out;
 }
 
-/**
-* Initializes a Node-API module.
-*
-* @param env      environment under which the function is invoked
-* @param exports  exports object
-* @return         main export
-*/
-static napi_value init( napi_env env, napi_value exports ) {
-	napi_value fcn;
-	napi_status status = napi_create_function( env, "exports", NAPI_AUTO_LENGTH, addon, NULL, &fcn );
-	assert( status == napi_ok );
-	return fcn;
-}
-
-NAPI_MODULE( NODE_GYP_MODULE_NAME, init )
+STDLIB_NAPI_MODULE_EXPORT_FCN( addon )


### PR DESCRIPTION
Resolves None.

## Description

- refactoring addon.c to follow latest project conventions for  `math/base/assert/is-integerf` 
- updating benchmark calculations

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

 - [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)


* * *

@stdlib-js/reviewers 

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
