### PR TITLE
fix: wrap function calls in `API_SUFFIX` in native addons

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dmax/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dmax/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/dmax.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dmax( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dmax)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dmax_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dmax_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dmaxabs/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dmaxabs/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/dmaxabs.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dmaxabs( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dmaxabs)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dmaxabs_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dmaxabs_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dmaxabssorted/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dmaxabssorted/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/dmaxabssorted.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dmaxabssorted( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dmaxabssorted)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dmaxabssorted_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dmaxabssorted_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dmaxsorted/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dmaxsorted/src/addon.c
@@ -36,7 +36,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dmaxsorted( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dmaxsorted)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +53,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dmaxsorted_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dmaxsorted_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dmaxsorted/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dmaxsorted/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/dmaxsorted.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"

--- a/lib/node_modules/@stdlib/stats/base/dmediansorted/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dmediansorted/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/dmediansorted.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dmediansorted( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dmediansorted)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dmediansorted_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dmediansorted_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dmidrange/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dmidrange/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/dmidrange.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dmidrange( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dmidrange)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dmidrange_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dmidrange_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dmin/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dmin/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/dmin.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dmin( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dmin)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dmin_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dmin_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dminabs/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dminabs/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/dminabs.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dminabs( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dminabs)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dminabs_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dminabs_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dminsorted/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dminsorted/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/dminsorted.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dminsorted( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dminsorted)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dminsorted_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dminsorted_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dmskmax/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dmskmax/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/dmskmax.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -39,7 +40,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideMask, argv, 4 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
 	STDLIB_NAPI_ARGV_STRIDED_UINT8ARRAY( env, Mask, N, strideMask, argv, 3 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dmskmax( N, X, strideX, Mask, strideMask ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dmskmax)( N, X, strideX, Mask, strideMask ), v );
 	return v;
 }
 
@@ -59,7 +60,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, offsetMask, argv, 6 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
 	STDLIB_NAPI_ARGV_STRIDED_UINT8ARRAY( env, Mask, N, strideMask, argv, 4 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dmskmax_ndarray( N, X, strideX, offsetX, Mask, strideMask, offsetMask ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dmskmax_ndarray)( N, X, strideX, offsetX, Mask, strideMask, offsetMask ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dmskmin/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dmskmin/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/dmskmin.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -39,7 +40,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideMask, argv, 4 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
 	STDLIB_NAPI_ARGV_STRIDED_UINT8ARRAY( env, Mask, N, strideMask, argv, 3 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dmskmin( N, X, strideX, Mask, strideMask ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dmskmin)( N, X, strideX, Mask, strideMask ), v );
 	return v;
 }
 
@@ -59,7 +60,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, offsetMask, argv, 6 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
 	STDLIB_NAPI_ARGV_STRIDED_UINT8ARRAY( env, Mask, N, strideMask, argv, 4 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dmskmin_ndarray( N, X, strideX, offsetX, Mask, strideMask, offsetMask ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dmskmin_ndarray)( N, X, strideX, offsetX, Mask, strideMask, offsetMask ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dmskrange/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dmskrange/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/dmskrange.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -39,7 +40,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideMask, argv, 4 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
 	STDLIB_NAPI_ARGV_STRIDED_UINT8ARRAY( env, Mask, N, strideMask, argv, 3 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dmskrange( N, X, strideX, Mask, strideMask ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dmskrange)( N, X, strideX, Mask, strideMask ), v );
 	return v;
 }
 
@@ -59,7 +60,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, offsetMask, argv, 6 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
 	STDLIB_NAPI_ARGV_STRIDED_UINT8ARRAY( env, Mask, N, strideMask, argv, 4 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dmskrange_ndarray( N, X, strideX, offsetX, Mask, strideMask, offsetMask ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dmskrange_ndarray)( N, X, strideX, offsetX, Mask, strideMask, offsetMask ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dnanmax/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dnanmax/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/dnanmax.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dnanmax( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dnanmax)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dnanmax_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dnanmax_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dnanmaxabs/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dnanmaxabs/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/dnanmaxabs.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dnanmaxabs( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dnanmaxabs)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dnanmaxabs_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dnanmaxabs_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dnanmeanwd/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dnanmeanwd/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/dnanmeanwd.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -35,7 +36,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dnanmeanwd( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dnanmeanwd)( N, X, strideX ), v );
 	return v;
 }
 
@@ -52,7 +53,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dnanmeanwd_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dnanmeanwd_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dnanmin/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dnanmin/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/dnanmin.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dnanmin( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dnanmin)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dnanmin_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dnanmin_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dnanminabs/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dnanminabs/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/dnanminabs.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dnanminabs( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dnanminabs)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dnanminabs_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dnanminabs_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dnanrange/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dnanrange/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/dnanrange.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dnanrange( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dnanrange)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dnanrange_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dnanrange_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/drange/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/drange/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/drange.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_drange( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_drange)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_drange_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_drange_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dstdevch/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dstdevch/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/dstdevch.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -38,7 +39,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_DOUBLE( env, correction, argv, 1 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 2 )
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dstdevch( N, correction, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dstdevch)( N, correction, X, strideX ), v );
 	return v;
 }
 
@@ -56,7 +57,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 4 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dstdevch_ndarray( N, correction, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dstdevch_ndarray)( N, correction, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dvariancech/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dvariancech/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/dvariancech.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -38,7 +39,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_DOUBLE( env, correction, argv, 1 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 2 )
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dvariancech( N, correction, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dvariancech)( N, correction, X, strideX ), v );
 	return v;
 }
 
@@ -56,7 +57,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 4 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dvariancech_ndarray( N, correction, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dvariancech_ndarray)( N, correction, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dvariancetk/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dvariancetk/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/dvariancetk.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -38,7 +39,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_DOUBLE( env, correction, argv, 1 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 2 )
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dvariancetk( N, correction, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dvariancetk)( N, correction, X, strideX ), v );
 	return v;
 }
 
@@ -56,7 +57,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 4 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dvariancetk_ndarray( N, correction, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dvariancetk_ndarray)( N, correction, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dvariancewd/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dvariancewd/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/dvariancewd.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -38,7 +39,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_DOUBLE( env, correction, argv, 1 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 2 )
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dvariancewd( N, correction, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dvariancewd)( N, correction, X, strideX ), v );
 	return v;
 }
 
@@ -56,7 +57,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 4 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dvariancewd_ndarray( N, correction, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dvariancewd_ndarray)( N, correction, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dvarianceyc/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dvarianceyc/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/dvarianceyc.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -38,7 +39,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_DOUBLE( env, correction, argv, 1 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 2 )
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dvarianceyc( N, correction, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dvarianceyc)( N, correction, X, strideX ), v );
 	return v;
 }
 
@@ -56,7 +57,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 4 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dvarianceyc_ndarray( N, correction, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dvarianceyc_ndarray)( N, correction, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/dvarmtk/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/dvarmtk/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/dvarmtk.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -39,7 +40,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_DOUBLE( env, correction, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 4 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 3 )
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dvarmtk( N, mean, correction, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dvarmtk)( N, mean, correction, X, strideX ), v );
 	return v;
 }
 
@@ -58,7 +59,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 4 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT64ARRAY( env, X, N, strideX, argv, 3 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 5 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, stdlib_strided_dvarmtk_ndarray( N, mean, correction, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, API_SUFFIX(stdlib_strided_dvarmtk_ndarray)( N, mean, correction, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/smax/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/smax/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/smax.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_smax( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_smax)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_smax_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_smax_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/smaxabs/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/smaxabs/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/smaxabs.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_smaxabs( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_smaxabs)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_smaxabs_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_smaxabs_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/smaxabssorted/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/smaxabssorted/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/smaxabssorted.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_smaxabssorted( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_smaxabssorted)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_smaxabssorted_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_smaxabssorted_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/smaxsorted/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/smaxsorted/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/smaxsorted.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_smaxsorted( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_smaxsorted)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_smaxsorted_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_smaxsorted_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/smeanwd/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/smeanwd/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/smeanwd.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_smeanwd( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_smeanwd)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_smeanwd_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_smeanwd_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/smediansorted/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/smediansorted/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/smediansorted.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_smediansorted( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_smediansorted)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_smediansorted_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_smediansorted_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/smidrange/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/smidrange/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/smidrange.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_smidrange( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_smidrange)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_smidrange_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_smidrange_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/smin/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/smin/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/smin.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_smin( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_smin)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_smin_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_smin_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/sminabs/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/sminabs/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/sminabs.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_sminabs( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_sminabs)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_sminabs_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_sminabs_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/sminsorted/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/sminsorted/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/sminsorted.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_sminsorted( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_sminsorted)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_sminsorted_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_sminsorted_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/smskmax/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/smskmax/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/smskmax.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -39,7 +40,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideMask, argv, 4 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
 	STDLIB_NAPI_ARGV_STRIDED_UINT8ARRAY( env, Mask, N, strideMask, argv, 3 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_smskmax( N, X, strideX, Mask, strideMask ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_smskmax)( N, X, strideX, Mask, strideMask ), v );
 	return v;
 }
 
@@ -59,7 +60,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, offsetMask, argv, 6 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
 	STDLIB_NAPI_ARGV_STRIDED_UINT8ARRAY( env, Mask, N, strideMask, argv, 4 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_smskmax_ndarray( N, X, strideX, offsetX, Mask, strideMask, offsetMask ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_smskmax_ndarray)( N, X, strideX, offsetX, Mask, strideMask, offsetMask ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/smskmin/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/smskmin/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/smskmin.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -39,7 +40,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideMask, argv, 4 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
 	STDLIB_NAPI_ARGV_STRIDED_UINT8ARRAY( env, Mask, N, strideMask, argv, 3 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_smskmin( N, X, strideX, Mask, strideMask ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_smskmin)( N, X, strideX, Mask, strideMask ), v );
 	return v;
 }
 
@@ -59,7 +60,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, offsetMask, argv, 6 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
 	STDLIB_NAPI_ARGV_STRIDED_UINT8ARRAY( env, Mask, N, strideMask, argv, 4 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_smskmin_ndarray( N, X, strideX, offsetX, Mask, strideMask, offsetMask ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_smskmin_ndarray)( N, X, strideX, offsetX, Mask, strideMask, offsetMask ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/smskrange/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/smskrange/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/smskrange.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -39,7 +40,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideMask, argv, 4 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
 	STDLIB_NAPI_ARGV_STRIDED_UINT8ARRAY( env, Mask, N, strideMask, argv, 3 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_smskrange( N, X, strideX, Mask, strideMask ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_smskrange)( N, X, strideX, Mask, strideMask ), v );
 	return v;
 }
 
@@ -59,7 +60,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, offsetMask, argv, 6 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
 	STDLIB_NAPI_ARGV_STRIDED_UINT8ARRAY( env, Mask, N, strideMask, argv, 4 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_smskrange_ndarray( N, X, strideX, offsetX, Mask, strideMask, offsetMask ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_smskrange_ndarray)( N, X, strideX, offsetX, Mask, strideMask, offsetMask ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/snanmax/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/snanmax/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/snanmax.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_snanmax( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_snanmax)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_snanmax_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_snanmax_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/snanmaxabs/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/snanmaxabs/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/snanmaxabs.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_snanmaxabs( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_snanmaxabs)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_snanmaxabs_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_snanmaxabs_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/snanmin/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/snanmin/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/snanmin.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_snanmin( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_snanmin)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_snanmin_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_snanmin_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/snanminabs/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/snanminabs/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/snanminabs.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_snanminabs( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_snanminabs)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_snanminabs_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_snanminabs_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/snanrange/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/snanrange/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/snanrange.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_snanrange( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_snanrange)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_snanrange_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_snanrange_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/srange/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/srange/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/srange.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -36,7 +37,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, N, argv, 0 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_srange( N, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_srange)( N, X, strideX ), v );
 	return v;
 }
 
@@ -53,7 +54,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 1 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_srange_ndarray( N, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_srange_ndarray)( N, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/svariancech/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/svariancech/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/svariancech.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -38,7 +39,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_FLOAT( env, correction, argv, 1 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 2 )
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_svariancech( N, correction, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_svariancech)( N, correction, X, strideX ), v );
 	return v;
 }
 
@@ -56,7 +57,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 4 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_svariancech_ndarray( N, correction, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_svariancech_ndarray)( N, correction, X, strideX, offsetX ), v );
 	return v;
 }
 

--- a/lib/node_modules/@stdlib/stats/base/svariancetk/src/addon.c
+++ b/lib/node_modules/@stdlib/stats/base/svariancetk/src/addon.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/svariancetk.h"
+#include "stdlib/blas/base/shared.h"
 #include "stdlib/napi/export.h"
 #include "stdlib/napi/argv.h"
 #include "stdlib/napi/argv_int64.h"
@@ -38,7 +39,7 @@ static napi_value addon( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_FLOAT( env, correction, argv, 1 );
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 2 )
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_svariancetk( N, correction, X, strideX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_svariancetk)( N, correction, X, strideX ), v );
 	return v;
 }
 
@@ -56,7 +57,7 @@ static napi_value addon_method( napi_env env, napi_callback_info info ) {
 	STDLIB_NAPI_ARGV_INT64( env, strideX, argv, 3 );
 	STDLIB_NAPI_ARGV_STRIDED_FLOAT32ARRAY( env, X, N, strideX, argv, 2 );
 	STDLIB_NAPI_ARGV_INT64( env, offsetX, argv, 4 );
-	STDLIB_NAPI_CREATE_DOUBLE( env, (double)stdlib_strided_svariancetk_ndarray( N, correction, X, strideX, offsetX ), v );
+	STDLIB_NAPI_CREATE_DOUBLE( env, (double)API_SUFFIX(stdlib_strided_svariancetk_ndarray)( N, correction, X, strideX, offsetX ), v );
 	return v;
 }
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-  wraps function calls in native addons in `API_SUFFIX` for all functions with ndarray interfaces

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
