### PR TITLE
fix: use stdlib dependencies instead of math.h in `stats/base/dcuminabs`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dcuminabs/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dcuminabs/src/main.c
@@ -69,7 +69,7 @@ void API_SUFFIX(stdlib_strided_dcuminabs_ndarray)( const CBLAS_INT N, const doub
 	if ( !stdlib_base_is_nan( min ) ) {
 		for (; i < N; i++ ) {
 			ix += strideX;
-			v = fabs( X[ ix ] );
+			v = stdlib_base_abs( X[ ix ] );
 			if ( stdlib_base_is_nan( v ) ) {
 				min = v;
 				break;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   uses `stdlib_base_abs` instead of `fabs` from `<math.h>` in `stats/base/dcuminabs`

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
