### PR TITLE
feat: add `lapack/base/zlacpy`

### DIFF
--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/README.md
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2024 The Stdlib Authors.
+Copyright (c) 2025 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/README.md
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/README.md
@@ -1,0 +1,260 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2024 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# zlacpy
+
+> Copy all or part of a matrix `A` to another matrix `B`.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var zlacpy = require( '@stdlib/lapack/base/zlacpy' );
+```
+
+#### zlacpy( order, uplo, M, N, A, LDA, B, LDB )
+
+Copies all or part of a matrix `A` to another matrix `B`.
+
+```javascript
+var Complex128Array = require( '@stdlib/array/complex128' );
+
+var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+var B = new Complex128Array( 4 );
+
+zlacpy( 'row-major', 'all', 2, 2, A, 2, B, 2 );
+// B => <Complex128Array>[ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ]
+```
+
+The function has the following parameters:
+
+-   **order**: storage layout.
+-   **uplo**: specifies whether to copy the upper or lower triangular/trapezoidal part of a matrix `A`.
+-   **M**: number of rows in `A`.
+-   **N**: number of columns in `A`.
+-   **A**: input [`Complex128Array`][@stdlib/array/complex128].
+-   **LDA**: stride of the first dimension of `A` (a.k.a., leading dimension of the matrix `A`).
+-   **B**: output [`Complex128Array`][@stdlib/array/complex128].
+-   **LDB**: stride of the first dimension of `B` (a.k.a., leading dimension of the matrix `B`).
+
+Note that indexing is relative to the first index. To introduce an offset, use [`typed array`][mdn-typed-array] views.
+
+<!-- eslint-disable stdlib/capitalized-comments -->
+
+```javascript
+var Complex128Array = require( '@stdlib/array/complex128' );
+
+// Initial arrays...
+var A0 = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+var B0 = new Complex128Array( 5 );
+
+// Create offset views...
+var A1 = new Complex128Array( A0.buffer, A0.BYTES_PER_ELEMENT*1 ); // start at 2nd element
+var B1 = new Complex128Array( B0.buffer, B0.BYTES_PER_ELEMENT*1 ); // start at 2nd element
+
+zlacpy( 'row-major', 'all', 2, 2, A1, 2, B1, 2 );
+// B0 => <Complex128Array>[ 0.0, 2.0, 3.0, 4.0, 5.0 ]
+```
+
+#### zlacpy.ndarray( uplo, M, N, A, sa1, sa2, oa, B, sb1, sb2, ob )
+
+Copies all or part of a matrix `A` to another matrix `B` using alternative indexing semantics.
+
+```javascript
+var Complex128Array = require( '@stdlib/array/complex128' );
+
+var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+var B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0 ] );
+
+zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, 2, 1, 0 );
+// B => <Complex128Array>[ 1.0, 2.0, 3.0, 4.0 ]
+```
+
+The function has the following parameters:
+
+-   **uplo**: specifies whether to copy the upper or lower triangular/trapezoidal part of a matrix `A`.
+-   **M**: number of rows in `A`.
+-   **N**: number of columns in `A`.
+-   **A**: input [`Complex128Array`][@stdlib/array/complex128].
+-   **sa1**: stride of the first dimension of `A`.
+-   **sa2**: stride of the second dimension of `A`.
+-   **oa**: starting index for `A`.
+-   **B**: output [`Complex128Array`][@stdlib/array/complex128].
+-   **sb1**: stride of the first dimension of `B`.
+-   **sb2**: stride of the second dimension of `B`.
+-   **ob**: starting index for `B`.
+
+While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying buffer, the offset parameters support indexing semantics based on starting indices. For example,
+
+```javascript
+var Complex128Array = require( '@stdlib/array/complex128' );
+
+var A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0 ] );
+var B = new Complex128Array( [ 0.0, 0.0, 11.0, 312.0, 53.0, 412.0 ] );
+
+zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
+// B => <Complex128Array>[ 0.0, 0.0, 1.0, 2.0, 3.0, 4.0 ]
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   `zlacpy()` corresponds to the [LAPACK][lapack] routine [`zlacpy`][lapack-zlacpy].
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var ndarray2array = require( '@stdlib/ndarray/base/to-array' );
+var uniform = require( '@stdlib/random/array/discrete-uniform' );
+var numel = require( '@stdlib/ndarray/base/numel' );
+var shape2strides = require( '@stdlib/ndarray/base/shape2strides' );
+var zlacpy = require( '@stdlib/lapack/base/zlacpy' );
+
+var shape = [ 5, 8 ];
+var order = 'row-major';
+var strides = shape2strides( shape, order );
+
+var N = numel( shape );
+
+var A = uniform( N, -10, 10, {
+    'dtype': 'complex128'
+});
+console.log( ndarray2array( A, shape, strides, 0, order ) );
+
+var B = uniform( N, -10, 10, {
+    'dtype': 'complex128'
+});
+console.log( ndarray2array( B, shape, strides, 0, order ) );
+
+zlacpy( order, 'all', shape[ 0 ], shape[ 1 ], A, strides[ 0 ], B, strides[ 0 ] );
+console.log( ndarray2array( B, shape, strides, 0, order ) );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+TODO
+```
+
+#### TODO
+
+TODO.
+
+```c
+TODO
+```
+
+TODO
+
+```c
+TODO
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+TODO
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[lapack]: https://www.netlib.org/lapack/explore-html/
+
+[lapack-zlacpy]: https://netlib.org/lapack/explore-html/d0/d9e/group__lacpy_ga243f0a47458b9a525136a69146c10192.html#ga243f0a47458b9a525136a69146c10192
+
+[@stdlib/array/complex128]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/complex128
+
+[mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/README.md
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/README.md
@@ -36,12 +36,15 @@ Copies all or part of a matrix `A` to another matrix `B`.
 
 ```javascript
 var Complex128Array = require( '@stdlib/array/complex128' );
+var reinterpret = require( '@stdlib/strided/base/reinterpret-complex128' );
 
 var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 var B = new Complex128Array( 4 );
 
 zlacpy( 'row-major', 'all', 2, 2, A, 2, B, 2 );
-// B => <Complex128Array>
+
+var viewB = reinterpret( B, 0 );
+// returns <Float64Array>[ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ]
 ```
 
 The function has the following parameters:
@@ -61,6 +64,7 @@ Note that indexing is relative to the first index. To introduce an offset, use [
 
 ```javascript
 var Complex128Array = require( '@stdlib/array/complex128' );
+var reinterpret = require( '@stdlib/strided/base/reinterpret-complex128' );
 
 // Initial arrays...
 var A0 = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ] );
@@ -71,7 +75,9 @@ var A1 = new Complex128Array( A0.buffer, A0.BYTES_PER_ELEMENT*1 ); // start at 2
 var B1 = new Complex128Array( B0.buffer, B0.BYTES_PER_ELEMENT*1 ); // start at 2nd element
 
 zlacpy( 'row-major', 'all', 2, 2, A1, 2, B1, 2 );
-// B0 => <Complex128Array>
+
+var viewB = reinterpret( B0, 0 );
+// returns <Float64Array>[ 0.0, 0.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ]
 ```
 
 #### zlacpy.ndarray( uplo, M, N, A, sa1, sa2, oa, B, sb1, sb2, ob )
@@ -80,12 +86,15 @@ Copies all or part of a matrix `A` to another matrix `B` using alternative index
 
 ```javascript
 var Complex128Array = require( '@stdlib/array/complex128' );
+var reinterpret = require( '@stdlib/strided/base/reinterpret-complex128' );
 
 var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-var B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+var B = new Complex128Array( 4 );
 
 zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, 2, 1, 0 );
-// B => <Complex128Array>
+
+var viewB = reinterpret( B, 0 );
+// returns <Float64Array>[ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ]
 ```
 
 The function has the following parameters:
@@ -108,12 +117,15 @@ While [`typed array`][mdn-typed-array] views mandate a view offset based on the 
 
 ```javascript
 var Complex128Array = require( '@stdlib/array/complex128' );
+var reinterpret = require( '@stdlib/strided/base/reinterpret-complex128' );
 
-var A = new Complex128Array( [ 0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-var B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 11.0, 312.0, 53.0, 412.0, 24.0, 58.0, 85.0, 74.0 ] );
+var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ] );
+var B = new Complex128Array( 6 );
 
 zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
-// B => <Complex128Array>
+
+var viewB = reinterpret( B, 0 );
+// returns <Float64Array>[ 0.0, 0.0, 0.0, 0.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ]
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/README.md
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/README.md
@@ -41,7 +41,7 @@ var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 var B = new Complex128Array( 4 );
 
 zlacpy( 'row-major', 'all', 2, 2, A, 2, B, 2 );
-// B => <Complex128Array>[ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ]
+// B => <Complex128Array>
 ```
 
 The function has the following parameters:
@@ -63,7 +63,7 @@ Note that indexing is relative to the first index. To introduce an offset, use [
 var Complex128Array = require( '@stdlib/array/complex128' );
 
 // Initial arrays...
-var A0 = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+var A0 = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ] );
 var B0 = new Complex128Array( 5 );
 
 // Create offset views...
@@ -71,7 +71,7 @@ var A1 = new Complex128Array( A0.buffer, A0.BYTES_PER_ELEMENT*1 ); // start at 2
 var B1 = new Complex128Array( B0.buffer, B0.BYTES_PER_ELEMENT*1 ); // start at 2nd element
 
 zlacpy( 'row-major', 'all', 2, 2, A1, 2, B1, 2 );
-// B0 => <Complex128Array>[ 0.0, 2.0, 3.0, 4.0, 5.0 ]
+// B0 => <Complex128Array>
 ```
 
 #### zlacpy.ndarray( uplo, M, N, A, sa1, sa2, oa, B, sb1, sb2, ob )
@@ -81,11 +81,11 @@ Copies all or part of a matrix `A` to another matrix `B` using alternative index
 ```javascript
 var Complex128Array = require( '@stdlib/array/complex128' );
 
-var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
-var B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0 ] );
+var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+var B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
 
 zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, 2, 1, 0 );
-// B => <Complex128Array>[ 1.0, 2.0, 3.0, 4.0 ]
+// B => <Complex128Array>
 ```
 
 The function has the following parameters:
@@ -107,11 +107,11 @@ While [`typed array`][mdn-typed-array] views mandate a view offset based on the 
 ```javascript
 var Complex128Array = require( '@stdlib/array/complex128' );
 
-var A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0 ] );
-var B = new Complex128Array( [ 0.0, 0.0, 11.0, 312.0, 53.0, 412.0 ] );
+var A = new Complex128Array( [ 0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+var B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 11.0, 312.0, 53.0, 412.0, 24.0, 58.0, 85.0, 74.0 ] );
 
 zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
-// B => <Complex128Array>[ 0.0, 0.0, 1.0, 2.0, 3.0, 4.0 ]
+// B => <Complex128Array>
 ```
 
 </section>
@@ -135,6 +135,7 @@ zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
+var Complex128Array = require( '@stdlib/array/complex128' );
 var ndarray2array = require( '@stdlib/ndarray/base/to-array' );
 var uniform = require( '@stdlib/random/array/discrete-uniform' );
 var numel = require( '@stdlib/ndarray/base/numel' );
@@ -147,14 +148,14 @@ var strides = shape2strides( shape, order );
 
 var N = numel( shape );
 
-var A = uniform( N, -10, 10, {
-    'dtype': 'complex128'
-});
+var A = new Complex128Array( uniform( 2*N, -10, 10, {
+    'dtype': 'generic'
+}));
 console.log( ndarray2array( A, shape, strides, 0, order ) );
 
-var B = uniform( N, -10, 10, {
-    'dtype': 'complex128'
-});
+var B = new Complex128Array( uniform( 2*N, -10, 10, {
+    'dtype': 'generic'
+}));
 console.log( ndarray2array( B, shape, strides, 0, order ) );
 
 zlacpy( order, 'all', shape[ 0 ], shape[ 1 ], A, strides[ 0 ], B, strides[ 0 ] );

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/README.md
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/README.md
@@ -57,7 +57,7 @@ The function has the following parameters:
 
 Note that indexing is relative to the first index. To introduce an offset, use [`typed array`][mdn-typed-array] views.
 
-<!-- eslint-disable stdlib/capitalized-comments -->
+<!-- eslint-disable stdlib/capitalized-comments, max-len -->
 
 ```javascript
 var Complex128Array = require( '@stdlib/array/complex128' );
@@ -103,6 +103,8 @@ The function has the following parameters:
 -   **ob**: starting index for `B`.
 
 While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying buffer, the offset parameters support indexing semantics based on starting indices. For example,
+
+<!-- eslint-disable max-len -->
 
 ```javascript
 var Complex128Array = require( '@stdlib/array/complex128' );

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/benchmark/benchmark.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/benchmark/benchmark.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var Complex128Array = require( '@stdlib/array/complex128' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
@@ -44,11 +45,11 @@ function createBenchmark( N ) {
 	var B;
 
 	opts = {
-		'dtype': 'complex128'
+		'dtype': 'float64'
 	};
 
-	A = uniform( N*N, -10.0, 10.0, opts );
-	B = uniform( N*N, -10.0, 10.0, opts );
+	A = new Complex128Array( uniform( 2*N*N, -10.0, 10.0, opts ) );
+	B = new Complex128Array( uniform( 2*N*N, -10.0, 10.0, opts ) );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/benchmark/benchmark.js
@@ -1,0 +1,105 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var floor = require( '@stdlib/math/base/special/floor' );
+var pkg = require( './../package.json' ).name;
+var zlacpy = require( './../lib/zlacpy.js' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} N - number of elements along each dimension
+* @returns {Function} benchmark function
+*/
+function createBenchmark( N ) {
+	var opts;
+	var A;
+	var B;
+
+	opts = {
+		'dtype': 'complex128'
+	};
+
+	A = uniform( N*N, -10.0, 10.0, opts );
+	B = uniform( N*N, -10.0, 10.0, opts );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var z;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			z = zlacpy( 'column-major', 'all', N, N, A, N, B, N );
+			if ( isnan( z[ i%z.length ] ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnan( z[ i%z.length ] ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var min;
+	var max;
+	var N;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		N = floor( pow( pow( 10, i ), 1.0/2.0 ) );
+		f = createBenchmark( N );
+		bench( pkg+':order=column-major,size='+(N*N), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/benchmark/benchmark.ndarray.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/benchmark/benchmark.ndarray.js
@@ -1,0 +1,105 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var floor = require( '@stdlib/math/base/special/floor' );
+var pkg = require( './../package.json' ).name;
+var dlacpy = require( './../lib/ndarray.js' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} N - number of elements along each dimension
+* @returns {Function} benchmark function
+*/
+function createBenchmark( N ) {
+	var opts;
+	var A;
+	var B;
+
+	opts = {
+		'dtype': 'complex128'
+	};
+
+	A = uniform( N*N, -10.0, 10.0, opts );
+	B = uniform( N*N, -10.0, 10.0, opts );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var z;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			z = dlacpy( 'all', N, N, A, 1, N, 0, B, 1, N, 0 );
+			if ( isnan( z[ i%z.length ] ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnan( z[ i%z.length ] ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var min;
+	var max;
+	var N;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		N = floor( pow( pow( 10, i ), 1.0/2.0 ) );
+		f = createBenchmark( N );
+		bench( pkg+':ndarray:order=column-major,size='+(N*N), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/benchmark/benchmark.ndarray.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var Complex128Array = require( '@stdlib/array/complex128' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
@@ -44,11 +45,11 @@ function createBenchmark( N ) {
 	var B;
 
 	opts = {
-		'dtype': 'complex128'
+		'dtype': 'float64'
 	};
 
-	A = uniform( N*N, -10.0, 10.0, opts );
-	B = uniform( N*N, -10.0, 10.0, opts );
+	A = new Complex128Array( uniform( 2*N*N, -10.0, 10.0, opts ) );
+	B = new Complex128Array( uniform( 2*N*N, -10.0, 10.0, opts ) );
 	return benchmark;
 
 	/**

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/benchmark/benchmark.ndarray.js
@@ -27,7 +27,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var floor = require( '@stdlib/math/base/special/floor' );
 var pkg = require( './../package.json' ).name;
-var dlacpy = require( './../lib/ndarray.js' );
+var zlacpy = require( './../lib/ndarray.js' );
 
 
 // FUNCTIONS //
@@ -64,7 +64,7 @@ function createBenchmark( N ) {
 
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
-			z = dlacpy( 'all', N, N, A, 1, N, 0, B, 1, N, 0 );
+			z = zlacpy( 'all', N, N, A, 1, N, 0, B, 1, N, 0 );
 			if ( isnan( z[ i%z.length ] ) ) {
 				b.fail( 'should not return NaN' );
 			}

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/docs/repl.txt
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/docs/repl.txt
@@ -1,0 +1,108 @@
+
+{{alias}}( order, uplo, M, N, A, LDA, B, LDB )
+    Copies all or part of a matrix `A` to another matrix `B`.
+
+    Indexing is relative to the first index. To introduce an offset, use typed
+    array views.
+
+    Parameters
+    ----------
+    order: string
+        Row-major (C-style) or column-major (Fortran-style) order. Must be
+        either 'row-major' or 'column-major'.
+
+    uplo: string
+        Specifies whether to copy the upper or lower triangular/trapezoidal part
+        of a matrix `A`.
+
+    M: integer
+        Number of rows in `A`.
+
+    N: integer
+        Number of columns in `A`.
+
+    A: Float64Array
+        Input matrix `A`.
+
+    LDA: integer
+        Stride of the first dimension of `A` (a.k.a., leading dimension of the
+        matrix `A`).
+
+    B: Float64Array
+        Output matrix `B`.
+
+    LDB: integer
+        Stride of the first dimension of `B` (a.k.a., leading dimension of the
+        matrix `B`).
+
+    Returns
+    -------
+    B: Float64Array
+        Output matrix.
+
+    Examples
+    --------
+    > var A = new {{alias:@stdlib/array/float64}}( [ 1.0, 3.0, 0.0, 4.0 ] );
+    > var B = new {{alias:@stdlib/array/float64}}( [ 5.0, 7.0, 0.0, 8.0 ] );
+    > {{alias}}( 'row-major', 'all', 2, 2, A, 2, B, 2 )
+    <Float64Array>[ 1.0, 3.0, 0.0, 4.0 ]
+
+
+{{alias}}.ndarray( uplo, M, N, A, sa1, sa2, oa, B, sb1, sb2, ob )
+    Copies all or part of a matrix `A` to another matrix `B` using alternative
+    indexing semantics.
+
+    While typed array views mandate a view offset based on the underlying
+    buffer, the offset parameters support indexing semantics based on starting
+    indices.
+
+    Parameters
+    ----------
+    uplo: string
+        Specifies whether to copy the upper or lower triangular/trapezoidal part
+        of a matrix `A`.
+
+    M: integer
+        Number of rows in `A`.
+
+    N: integer
+        Number of columns in `A`.
+
+    A: Float64Array
+        Input matrix `A`.
+
+    sa1: integer
+        Stride of the first dimension of `A`.
+
+    sa2: integer
+        Stride of the second dimension of `A`.
+
+    oa: integer
+        Starting index for `A`.
+
+    B: Float64Array
+        Output matrix `B`.
+
+    sb1: integer
+        Stride of the first dimension of `B`.
+
+    sb2: integer
+        Stride of the second dimension of `B`.
+
+    ob: integer
+        Starting index for `B`.
+
+    Returns
+    -------
+    B: Float64Array
+        Output matrix.
+
+    Examples
+    --------
+    > var A = new {{alias:@stdlib/array/float64}}( [ 0.0, 1.0, 3.0, 0.0, 4.0 ] );
+    > var B = new {{alias:@stdlib/array/float64}}( [ 0.0, 0.0, 5.0, 7.0, 0.0, 8.0 ] );
+    > {{alias}}.ndarray( 'all', 2, 2, A, 2, 1, 1, B, 2, 1, 2 )
+    <Float64Array>[ 0.0, 0.0, 1.0, 3.0, 0.0, 4.0 ]
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/docs/repl.txt
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/docs/repl.txt
@@ -42,10 +42,16 @@
 
     Examples
     --------
-    > var A = new {{alias:@stdlib/array/complex128}}( [ 1.0, 3.0, 0.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-    > var B = new {{alias:@stdlib/array/complex128}}( [ 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0 ] );
-    > {{alias}}( 'row-major', 'all', 2, 2, A, 2, B, 2 )
-    <Complex128Array>
+    > var abuf = [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ];
+    > var bbuf = [ 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0 ];
+    > var A = new {{alias:@stdlib/array/complex128}}( abuf );
+    > var B = new {{alias:@stdlib/array/complex128}}( bbuf );
+    > {{alias}}( 'row-major', 'all', 2, 2, A, 2, B, 2 );
+    > var z = B.get( 0 );
+    > {{alias:@stdlib/complex/float64/real}}( z )
+    1.0
+    > {{alias:@stdlib/complex/float64/imag}}( z )
+    2.0
 
 
 {{alias}}.ndarray( uplo, M, N, A, sa1, sa2, oa, B, sb1, sb2, ob )
@@ -99,10 +105,16 @@
 
     Examples
     --------
-    > var A = new {{alias:@stdlib/array/complex128}}( [ 0.0, 1.0, 3.0, 0.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0 ] );
-    > var B = new {{alias:@stdlib/array/complex128}}( [ 0.0, 0.0, 5.0, 7.0, 0.0, 8.0 ] );
-    > {{alias}}.ndarray( 'all', 2, 2, A, 2, 1, 1, B, 2, 1, 2 )
-    <Complex128Array>
+    > var abuf = [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ];
+    > var bbuf = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
+    > var A = new {{alias:@stdlib/array/complex128}}( abuf );
+    > var B = new {{alias:@stdlib/array/complex128}}( bbuf );
+    > {{alias}}.ndarray( 'all', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
+    > var z = B.get( 2 );
+    > {{alias:@stdlib/complex/float64/real}}( z )
+    3.0
+    > {{alias:@stdlib/complex/float64/imag}}( z )
+    4.0
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/docs/repl.txt
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/docs/repl.txt
@@ -21,14 +21,14 @@
     N: integer
         Number of columns in `A`.
 
-    A: Float64Array
+    A: Complex128Array
         Input matrix `A`.
 
     LDA: integer
         Stride of the first dimension of `A` (a.k.a., leading dimension of the
         matrix `A`).
 
-    B: Float64Array
+    B: Complex128Array
         Output matrix `B`.
 
     LDB: integer
@@ -37,15 +37,15 @@
 
     Returns
     -------
-    B: Float64Array
+    B: Complex128Array
         Output matrix.
 
     Examples
     --------
-    > var A = new {{alias:@stdlib/array/float64}}( [ 1.0, 3.0, 0.0, 4.0 ] );
-    > var B = new {{alias:@stdlib/array/float64}}( [ 5.0, 7.0, 0.0, 8.0 ] );
+    > var A = new {{alias:@stdlib/array/complex128}}( [ 1.0, 3.0, 0.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+    > var B = new {{alias:@stdlib/array/complex128}}( [ 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0 ] );
     > {{alias}}( 'row-major', 'all', 2, 2, A, 2, B, 2 )
-    <Float64Array>[ 1.0, 3.0, 0.0, 4.0 ]
+    <Complex128Array>
 
 
 {{alias}}.ndarray( uplo, M, N, A, sa1, sa2, oa, B, sb1, sb2, ob )
@@ -68,7 +68,7 @@
     N: integer
         Number of columns in `A`.
 
-    A: Float64Array
+    A: Complex128Array
         Input matrix `A`.
 
     sa1: integer
@@ -80,7 +80,7 @@
     oa: integer
         Starting index for `A`.
 
-    B: Float64Array
+    B: Complex128Array
         Output matrix `B`.
 
     sb1: integer
@@ -94,15 +94,15 @@
 
     Returns
     -------
-    B: Float64Array
+    B: Complex128Array
         Output matrix.
 
     Examples
     --------
-    > var A = new {{alias:@stdlib/array/float64}}( [ 0.0, 1.0, 3.0, 0.0, 4.0 ] );
-    > var B = new {{alias:@stdlib/array/float64}}( [ 0.0, 0.0, 5.0, 7.0, 0.0, 8.0 ] );
+    > var A = new {{alias:@stdlib/array/complex128}}( [ 0.0, 1.0, 3.0, 0.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0 ] );
+    > var B = new {{alias:@stdlib/array/complex128}}( [ 0.0, 0.0, 5.0, 7.0, 0.0, 8.0 ] );
     > {{alias}}.ndarray( 'all', 2, 2, A, 2, 1, 1, B, 2, 1, 2 )
-    <Float64Array>[ 0.0, 0.0, 1.0, 3.0, 0.0, 4.0 ]
+    <Complex128Array>
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/docs/types/index.d.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/docs/types/index.d.ts
@@ -79,6 +79,8 @@ interface Routine {
 	*
 	* @example
 	* var Complex128Array = require( '@stdlib/array/complex128' );
+	* var real = require( '@stdlib/complex/float64/real' );
+	* var imag = require( '@stdlib/complex/float64/imag' );
 	*
 	* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 	* var B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0 ] );
@@ -112,6 +114,8 @@ interface Routine {
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
+* var real = require( '@stdlib/complex/float64/real' );
+* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
 * var B = new Complex128Array( 4 );
@@ -129,6 +133,8 @@ interface Routine {
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
+* var real = require( '@stdlib/complex/float64/real' );
+* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0 ] );

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/docs/types/index.d.ts
@@ -1,0 +1,117 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { Layout } from '@stdlib/types/blas';
+
+/**
+* Interface describing `zlacpy`.
+*/
+interface Routine {
+	/**
+	* Copies all or part of a matrix `A` to another matrix `B`.
+	*
+	* @param order - storage layout of `A` and `B`
+	* @param uplo - specifies whether to copy the upper or lower triangular/trapezoidal part of matrix `A`
+	* @param M - number of rows in matrix `A`
+	* @param N - number of columns in matrix `A`
+	* @param A - input matrix
+	* @param LDA - stride of the first dimension of `A` (a.k.a., leading dimension of the matrix `A`)
+	* @param B - output matrix
+	* @param LDB - stride of the first dimension of `B` (a.k.a., leading dimension of the matrix `B`)
+	* @returns `B`
+	*
+	* @example
+	* var Complex128Array = require( '@stdlib/array/complex128' );
+	*
+	* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	* var B = new Complex128Array( 4 );
+	*
+	* zlacpy( 'row-major', 'all', 2, 2, A, 2, B, 2 );
+	* // B => <Complex128Array>[ 1.0, 2.0, 3.0, 4.0 ]
+	*/
+	( order: Layout, uplo: string, M: number, N: number, A: Complex128Array, LDA: number, B: Complex128Array, LDB: number ): Complex128Array;
+
+	/**
+	* Copies all or part of a matrix `A` to another matrix `B` using alternative indexing semantics.
+	*
+	* @param uplo - specifies whether to copy the upper or lower triangular/trapezoidal part of matrix `A`
+	* @param M - number of rows in matrix `A`
+	* @param N - number of columns in matrix `A`
+	* @param A - input matrix
+	* @param strideA1 - stride of the first dimension of `A`
+	* @param strideA2 - stride of the second dimension of `A`
+	* @param offsetA - starting index for `A`
+	* @param B - output matrix
+	* @param strideB1 - stride of the first dimension of `B`
+	* @param strideB2 - stride of the second dimension of `B`
+	* @param offsetB - starting index for `B`
+	* @returns `B`
+	*
+	* @example
+	* var Complex128Array = require( '@stdlib/array/complex128' );
+	*
+	* var A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0 ] );
+	* var B = new Complex128Array( [ 0.0, 0.0, 11.0, 312.0, 53.0, 412.0 ] );
+	*
+	* zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
+	* // B => <Complex128Array>[ 0.0, 0.0, 1.0, 2.0, 3.0, 4.0 ]
+	*/
+	ndarray( uplo: string, M: number, N: number, A: Complex128Array, strideA1: number, strideA2: number, offsetA: number, B: Complex128Array, strideB1: number, strideB2: number, offsetB: number ): Complex128Array;
+}
+
+/**
+* Copies all or part of a matrix `A` to another matrix `B`.
+*
+* @param order - storage layout of `A` and `B`
+* @param uplo - specifies whether to copy the upper or lower triangular/trapezoidal part of matrix `A`
+* @param M - number of rows in matrix `A`
+* @param N - number of columns in matrix `A`
+* @param A - input matrix
+* @param LDA - stride of the first dimension of `A` (a.k.a., leading dimension of the matrix `A`)
+* @param B - output matrix
+* @param LDB - stride of the first dimension of `B` (a.k.a., leading dimension of the matrix `B`)
+* @returns `B`
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* zlacpy( 'row-major', 'all', 2, 2, A, 2, B, 2 );
+* // B => <Complex128Array>[ 1.0, 2.0, 3.0, 4.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( [ 0.0, 0.0, 11.0, 312.0, 53.0, 412.0 ] );
+*
+* zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
+* // B => <Complex128Array>[ 0.0, 0.0, 1.0, 2.0, 3.0, 4.0 ]
+*/
+declare var zlacpy: Routine;
+
+
+// EXPORTS //
+
+export = zlacpy;

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/docs/types/index.d.ts
@@ -82,8 +82,8 @@ interface Routine {
 	* var real = require( '@stdlib/complex/float64/real' );
 	* var imag = require( '@stdlib/complex/float64/imag' );
 	*
-	* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-	* var B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0 ] );
+	* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ] );
+	* var B = new Complex128Array( 12 );
 	*
 	* zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
 	*
@@ -91,10 +91,10 @@ interface Routine {
 	* // returns <Complex128>
 	*
 	* var v = real( z );
-	* // returns 1.0
+	* // returns 3.0
 	*
 	* v = imag( z );
-	* // returns 2.0
+	* // returns 4.0
 	*/
 	ndarray( uplo: string, M: number, N: number, A: Complex128Array, strideA1: number, strideA2: number, offsetA: number, B: Complex128Array, strideB1: number, strideB2: number, offsetB: number ): Complex128Array;
 }
@@ -136,8 +136,8 @@ interface Routine {
 * var real = require( '@stdlib/complex/float64/real' );
 * var imag = require( '@stdlib/complex/float64/imag' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ] );
+* var B = new Complex128Array( 12 );
 *
 * zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
 *
@@ -145,10 +145,10 @@ interface Routine {
 * // returns <Complex128>
 *
 * var v = real( z );
-* // returns 1.0
+* // returns 3.0
 *
 * v = imag( z );
-* // returns 2.0
+* // returns 4.0
 */
 declare var zlacpy: Routine;
 

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/docs/types/index.d.ts
@@ -21,7 +21,7 @@
 /// <reference types="@stdlib/types"/>
 
 import { Layout } from '@stdlib/types/blas';
-import Complex128Array from '@stdlib/array/complex128';
+import { Complex128Array } from '@stdlib/types/array';
 
 /**
 * Interface describing `zlacpy`.
@@ -42,12 +42,22 @@ interface Routine {
 	*
 	* @example
 	* var Complex128Array = require( '@stdlib/array/complex128' );
+	* var real = require( '@stdlib/complex/float64/real' );
+	* var imag = require( '@stdlib/complex/float64/imag' );
 	*
 	* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 	* var B = new Complex128Array( 4 );
 	*
 	* zlacpy( 'row-major', 'all', 2, 2, A, 2, B, 2 );
-	* // B => <Complex128Array>
+	*
+	* var z = B.get( 0 );
+	* // returns <Complex128>
+	*
+	* var v = real( z );
+	* // returns 1.0
+	*
+	* v = imag( z );
+	* // returns 2.0
 	*/
 	( order: Layout, uplo: string, M: number, N: number, A: Complex128Array, LDA: number, B: Complex128Array, LDB: number ): Complex128Array;
 
@@ -71,10 +81,18 @@ interface Routine {
 	* var Complex128Array = require( '@stdlib/array/complex128' );
 	*
 	* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 11.0, 312.0, 53.0, 412.0, 24.0, 58.0, 85.0, 74.0 ] );
+	* var B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0 ] );
 	*
 	* zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
-	* // B => <Complex128Array>
+	*
+	* var z = B.get( 2 );
+	* // returns <Complex128>
+	*
+	* var v = real( z );
+	* // returns 1.0
+	*
+	* v = imag( z );
+	* // returns 2.0
 	*/
 	ndarray( uplo: string, M: number, N: number, A: Complex128Array, strideA1: number, strideA2: number, offsetA: number, B: Complex128Array, strideB1: number, strideB2: number, offsetB: number ): Complex128Array;
 }
@@ -99,16 +117,32 @@ interface Routine {
 * var B = new Complex128Array( 4 );
 *
 * zlacpy( 'row-major', 'all', 2, 2, A, 2, B, 2 );
-* // B => <Complex128Array>
+*
+* var z = B.get( 0 );
+* // returns <Complex128>
+*
+* var v = real( z );
+* // returns 1.0
+*
+* v = imag( z );
+* // returns 2.0
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
 * var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 11.0, 312.0, 53.0, 412.0, 24.0, 58.0, 85.0, 74.0 ] );
+* var B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0 ] );
 *
 * zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
-* // B => <Complex128Array>
+*
+* var z = B.get( 2 );
+* // returns <Complex128>
+*
+* var v = real( z );
+* // returns 1.0
+*
+* v = imag( z );
+* // returns 2.0
 */
 declare var zlacpy: Routine;
 

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/docs/types/index.d.ts
@@ -21,6 +21,7 @@
 /// <reference types="@stdlib/types"/>
 
 import { Layout } from '@stdlib/types/blas';
+import Complex128Array from '@stdlib/array/complex128';
 
 /**
 * Interface describing `zlacpy`.
@@ -42,11 +43,11 @@ interface Routine {
 	* @example
 	* var Complex128Array = require( '@stdlib/array/complex128' );
 	*
-	* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 	* var B = new Complex128Array( 4 );
 	*
 	* zlacpy( 'row-major', 'all', 2, 2, A, 2, B, 2 );
-	* // B => <Complex128Array>[ 1.0, 2.0, 3.0, 4.0 ]
+	* // B => <Complex128Array>
 	*/
 	( order: Layout, uplo: string, M: number, N: number, A: Complex128Array, LDA: number, B: Complex128Array, LDB: number ): Complex128Array;
 
@@ -69,11 +70,11 @@ interface Routine {
 	* @example
 	* var Complex128Array = require( '@stdlib/array/complex128' );
 	*
-	* var A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0 ] );
-	* var B = new Complex128Array( [ 0.0, 0.0, 11.0, 312.0, 53.0, 412.0 ] );
+	* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 11.0, 312.0, 53.0, 412.0, 24.0, 58.0, 85.0, 74.0 ] );
 	*
 	* zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
-	* // B => <Complex128Array>[ 0.0, 0.0, 1.0, 2.0, 3.0, 4.0 ]
+	* // B => <Complex128Array>
 	*/
 	ndarray( uplo: string, M: number, N: number, A: Complex128Array, strideA1: number, strideA2: number, offsetA: number, B: Complex128Array, strideB1: number, strideB2: number, offsetB: number ): Complex128Array;
 }
@@ -98,16 +99,16 @@ interface Routine {
 * var B = new Complex128Array( 4 );
 *
 * zlacpy( 'row-major', 'all', 2, 2, A, 2, B, 2 );
-* // B => <Complex128Array>[ 1.0, 2.0, 3.0, 4.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0 ] );
-* var B = new Complex128Array( [ 0.0, 0.0, 11.0, 312.0, 53.0, 412.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 11.0, 312.0, 53.0, 412.0, 24.0, 58.0, 85.0, 74.0 ] );
 *
 * zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
-* // B => <Complex128Array>[ 0.0, 0.0, 1.0, 2.0, 3.0, 4.0 ]
+* // B => <Complex128Array>
 */
 declare var zlacpy: Routine;
 

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/docs/types/test.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/docs/types/test.ts
@@ -24,7 +24,7 @@ import Complex128Array = require( '@stdlib/array/complex128' );
 
 // The function returns a Complex128Array...
 {
-	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 	const B = new Complex128Array( 4 );
 
 	zlacpy( 'row-major', 'all', 2, 2, A, 2, B, 2 ); // $ExpectType Complex128Array
@@ -32,7 +32,7 @@ import Complex128Array = require( '@stdlib/array/complex128' );
 
 // The compiler throws an error if the function is provided a first argument which is not a string...
 {
-	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 	const B = new Complex128Array( 4 );
 
 	zlacpy( 5, 'all', 2, 2, A, 2, B, 2 ); // $ExpectError
@@ -47,7 +47,7 @@ import Complex128Array = require( '@stdlib/array/complex128' );
 
 // The compiler throws an error if the function is provided a second argument which is not a string...
 {
-	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 	const B = new Complex128Array( 4 );
 
 	zlacpy( 'row-major', 5, 2, 2, A, 2, B, 2 ); // $ExpectError
@@ -62,7 +62,7 @@ import Complex128Array = require( '@stdlib/array/complex128' );
 
 // The compiler throws an error if the function is provided a third argument which is not a number...
 {
-	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 	const B = new Complex128Array( 4 );
 
 	zlacpy( 'row-major', 'all', '5', 2, A, 2, B, 2 ); // $ExpectError
@@ -77,7 +77,7 @@ import Complex128Array = require( '@stdlib/array/complex128' );
 
 // The compiler throws an error if the function is provided a fourth argument which is not a number...
 {
-	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 	const B = new Complex128Array( 4 );
 
 	zlacpy( 'row-major', 'all', 2, '5', A, 2, B, 2 ); // $ExpectError
@@ -107,7 +107,7 @@ import Complex128Array = require( '@stdlib/array/complex128' );
 
 // The compiler throws an error if the function is provided a sixth argument which is not a number...
 {
-	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 	const B = new Complex128Array( 4 );
 
 	zlacpy( 'row-major', 'all', 2, 2, A, '5', B, 2 ); // $ExpectError
@@ -122,7 +122,7 @@ import Complex128Array = require( '@stdlib/array/complex128' );
 
 // The compiler throws an error if the function is provided a seventh argument which is not a Complex128Array...
 {
-	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 
 	zlacpy( 'row-major', 'all', 2, 2, A, 2, '5', 2 ); // $ExpectError
 	zlacpy( 'row-major', 'all', 2, 2, A, 2, 5, 2 ); // $ExpectError
@@ -137,7 +137,7 @@ import Complex128Array = require( '@stdlib/array/complex128' );
 
 // The compiler throws an error if the function is provided an eighth argument which is not a number...
 {
-	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 	const B = new Complex128Array( 4 );
 
 	zlacpy( 'row-major', 'all', 2, 2, A, 2, B, '5' ); // $ExpectError
@@ -152,7 +152,7 @@ import Complex128Array = require( '@stdlib/array/complex128' );
 
 // The compiler throws an error if the function is provided an unsupported number of arguments...
 {
-	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 	const B = new Complex128Array( 4 );
 
 	zlacpy(); // $ExpectError
@@ -168,7 +168,7 @@ import Complex128Array = require( '@stdlib/array/complex128' );
 
 // Attached to main export is an `ndarray` method which returns a Complex128Array...
 {
-	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 	const B = new Complex128Array( 4 );
 
 	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectType Complex128Array
@@ -176,7 +176,7 @@ import Complex128Array = require( '@stdlib/array/complex128' );
 
 // The compiler throws an error if the function is provided a first argument which is not a string...
 {
-	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 	const B = new Complex128Array( 4 );
 
 	zlacpy.ndarray( 5, 2, 2, A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
@@ -191,7 +191,7 @@ import Complex128Array = require( '@stdlib/array/complex128' );
 
 // The compiler throws an error if the function is provided a second argument which is not a number...
 {
-	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 	const B = new Complex128Array( 4 );
 
 	zlacpy.ndarray( 'all', '5', 2, A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
@@ -206,7 +206,7 @@ import Complex128Array = require( '@stdlib/array/complex128' );
 
 // The compiler throws an error if the function is provided a third argument which is not a number...
 {
-	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 	const B = new Complex128Array( 4 );
 
 	zlacpy.ndarray( 'all', 2, '5', A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
@@ -236,7 +236,7 @@ import Complex128Array = require( '@stdlib/array/complex128' );
 
 // The compiler throws an error if the function is provided a fifth argument which is not a number...
 {
-	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 	const B = new Complex128Array( 4 );
 
 	zlacpy.ndarray( 'all', 2, 2, A, '5', 1, 0, B, 2, 1, 0 ); // $ExpectError
@@ -251,7 +251,7 @@ import Complex128Array = require( '@stdlib/array/complex128' );
 
 // The compiler throws an error if the function is provided a sixth argument which is not a number...
 {
-	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 	const B = new Complex128Array( 4 );
 
 	zlacpy.ndarray( 'all', 2, 2, A, 2, '5', 0, B, 2, 1, 0 ); // $ExpectError
@@ -266,7 +266,7 @@ import Complex128Array = require( '@stdlib/array/complex128' );
 
 // The compiler throws an error if the function is provided a seventh argument which is not a number...
 {
-	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 	const B = new Complex128Array( 4 );
 
 	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, '5', B, 2, 1, 0 ); // $ExpectError
@@ -281,7 +281,7 @@ import Complex128Array = require( '@stdlib/array/complex128' );
 
 // The compiler throws an error if the function is provided an eighth argument which is not a Complex128Array...
 {
-	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 
 	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, '5', 2, 1, 0 ); // $ExpectError
 	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, 5, 2, 1, 0 ); // $ExpectError
@@ -296,7 +296,7 @@ import Complex128Array = require( '@stdlib/array/complex128' );
 
 // The compiler throws an error if the function is provided a ninth argument which is not a number...
 {
-	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 	const B = new Complex128Array( 4 );
 
 	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, '5', 1, 0 ); // $ExpectError
@@ -311,7 +311,7 @@ import Complex128Array = require( '@stdlib/array/complex128' );
 
 // The compiler throws an error if the function is provided a tenth argument which is not a number...
 {
-	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 	const B = new Complex128Array( 4 );
 
 	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, 2, '5', 0 ); // $ExpectError
@@ -326,7 +326,7 @@ import Complex128Array = require( '@stdlib/array/complex128' );
 
 // The compiler throws an error if the function is provided an eleventh argument which is not a number...
 {
-	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 	const B = new Complex128Array( 4 );
 
 	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, 2, 1, '5' ); // $ExpectError
@@ -341,7 +341,7 @@ import Complex128Array = require( '@stdlib/array/complex128' );
 
 // The compiler throws an error if the `ndarray` method is provided an unsupported number of arguments...
 {
-	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 	const B = new Complex128Array( 4 );
 
 	zlacpy.ndarray(); // $ExpectError

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/docs/types/test.ts
@@ -1,0 +1,359 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import zlacpy = require( './index' );
+import Complex128Array = require( '@stdlib/array/complex128' );
+
+
+// TESTS //
+
+// The function returns a Complex128Array...
+{
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const B = new Complex128Array( 4 );
+
+	zlacpy( 'row-major', 'all', 2, 2, A, 2, B, 2 ); // $ExpectType Complex128Array
+}
+
+// The compiler throws an error if the function is provided a first argument which is not a string...
+{
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const B = new Complex128Array( 4 );
+
+	zlacpy( 5, 'all', 2, 2, A, 2, B, 2 ); // $ExpectError
+	zlacpy( true, 'all', 2, 2, A, 2, B, 2 ); // $ExpectError
+	zlacpy( false, 'all', 2, 2, A, 2, B, 2 ); // $ExpectError
+	zlacpy( null, 'all', 2, 2, A, 2, B, 2 ); // $ExpectError
+	zlacpy( void 0, 'all', 2, 2, A, 2, B, 2 ); // $ExpectError
+	zlacpy( [], 'all', 2, 2, A, 2, B, 2 ); // $ExpectError
+	zlacpy( {}, 'all', 2, 2, A, 2, B, 2 ); // $ExpectError
+	zlacpy( ( x: number ): number => x, 'all', 2, 2, A, 2, B, 2 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument which is not a string...
+{
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const B = new Complex128Array( 4 );
+
+	zlacpy( 'row-major', 5, 2, 2, A, 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', true, 2, 2, A, 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', false, 2, 2, A, 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', null, 2, 2, A, 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', void 0, 2, 2, A, 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', [], 2, 2, A, 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', {}, 2, 2, A, 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', ( x: number ): number => x, 2, 2, A, 2, B, 2 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a third argument which is not a number...
+{
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const B = new Complex128Array( 4 );
+
+	zlacpy( 'row-major', 'all', '5', 2, A, 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', true, 2, A, 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', false, 2, A, 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', null, 2, A, 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', void 0, 2, A, 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', [], 2, A, 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', {}, 2, A, 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', ( x: number ): number => x, 2, A, 2, B, 2 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a fourth argument which is not a number...
+{
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const B = new Complex128Array( 4 );
+
+	zlacpy( 'row-major', 'all', 2, '5', A, 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, true, A, 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, false, A, 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, null, A, 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, void 0, A, 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, [], A, 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, {}, A, 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, ( x: number ): number => x, A, 2, B, 2 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a fifth argument which is not a Complex128Array...
+{
+	const B = new Complex128Array( 4 );
+
+	zlacpy( 'row-major', 'all', 2, 2, '5', 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, 5, 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, true, 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, false, 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, null, 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, void 0, 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, [], 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, {}, 2, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, ( x: number ): number => x, 2, B, 2 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a sixth argument which is not a number...
+{
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const B = new Complex128Array( 4 );
+
+	zlacpy( 'row-major', 'all', 2, 2, A, '5', B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, A, true, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, A, false, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, A, null, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, A, void 0, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, A, [], B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, A, {}, B, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, A, ( x: number ): number => x, B, 2 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a seventh argument which is not a Complex128Array...
+{
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+
+	zlacpy( 'row-major', 'all', 2, 2, A, 2, '5', 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, A, 2, 5, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, A, 2, true, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, A, 2, false, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, A, 2, null, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, A, 2, void 0, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, A, 2, [], 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, A, 2, {}, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, A, 2, ( x: number ): number => x, 2 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an eighth argument which is not a number...
+{
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const B = new Complex128Array( 4 );
+
+	zlacpy( 'row-major', 'all', 2, 2, A, 2, B, '5' ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, A, 2, B, true ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, A, 2, B, false ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, A, 2, B, null ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, A, 2, B, void 0 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, A, 2, B, [] ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, A, 2, B, {} ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, A, 2, B, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const B = new Complex128Array( 4 );
+
+	zlacpy(); // $ExpectError
+	zlacpy( 'row-major' ); // $ExpectError
+	zlacpy( 'row-major', 'all' ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, A ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, A, 2 ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, A, 2, B ); // $ExpectError
+	zlacpy( 'row-major', 'all', 2, 2, A, 2, B, 2, 10 ); // $ExpectError
+}
+
+// Attached to main export is an `ndarray` method which returns a Complex128Array...
+{
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const B = new Complex128Array( 4 );
+
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectType Complex128Array
+}
+
+// The compiler throws an error if the function is provided a first argument which is not a string...
+{
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const B = new Complex128Array( 4 );
+
+	zlacpy.ndarray( 5, 2, 2, A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( true, 2, 2, A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( false, 2, 2, A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( null, 2, 2, A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( void 0, 2, 2, A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( [], 2, 2, A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( {}, 2, 2, A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( ( x: number ): number => x, 2, 2, A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument which is not a number...
+{
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const B = new Complex128Array( 4 );
+
+	zlacpy.ndarray( 'all', '5', 2, A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', true, 2, A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', false, 2, A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', null, 2, A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', void 0, 2, A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', [], 2, A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', {}, 2, A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', ( x: number ): number => x, 2, A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a third argument which is not a number...
+{
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const B = new Complex128Array( 4 );
+
+	zlacpy.ndarray( 'all', 2, '5', A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, true, A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, false, A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, null, A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, void 0, A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, [], A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, {}, A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, ( x: number ): number => x, A, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a fourth argument which is not a Complex128Array...
+{
+	const B = new Complex128Array( 4 );
+
+	zlacpy.ndarray( 'all', 2, 2, '5', 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, 5, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, true, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, false, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, null, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, void 0, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, [], 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, {}, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, ( x: number ): number => x, 2, 1, 0, B, 2, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a fifth argument which is not a number...
+{
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const B = new Complex128Array( 4 );
+
+	zlacpy.ndarray( 'all', 2, 2, A, '5', 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, true, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, false, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, null, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, void 0, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, [], 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, {}, 1, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, ( x: number ): number => x, 1, 0, B, 2, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a sixth argument which is not a number...
+{
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const B = new Complex128Array( 4 );
+
+	zlacpy.ndarray( 'all', 2, 2, A, 2, '5', 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, true, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, false, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, null, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, void 0, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, [], 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, {}, 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, ( x: number ): number => x, 0, B, 2, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a seventh argument which is not a number...
+{
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const B = new Complex128Array( 4 );
+
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, '5', B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, true, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, false, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, null, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, void 0, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, [], B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, {}, B, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, ( x: number ): number => x, B, 2, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an eighth argument which is not a Complex128Array...
+{
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, '5', 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, 5, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, true, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, false, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, null, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, void 0, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, [], 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, {}, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, ( x: number ): number => x, 2, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a ninth argument which is not a number...
+{
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const B = new Complex128Array( 4 );
+
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, '5', 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, true, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, false, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, null, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, void 0, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, [], 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, {}, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, ( x: number ): number => x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a tenth argument which is not a number...
+{
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const B = new Complex128Array( 4 );
+
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, 2, '5', 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, 2, true, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, 2, false, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, 2, null, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, 2, void 0, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, 2, [], 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, 2, {}, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, 2, ( x: number ): number => x, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an eleventh argument which is not a number...
+{
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const B = new Complex128Array( 4 );
+
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, 2, 1, '5' ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, 2, 1, true ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, 2, 1, false ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, 2, 1, null ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, 2, 1, void 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, 2, 1, [] ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, 2, 1, {} ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, 2, 1, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the `ndarray` method is provided an unsupported number of arguments...
+{
+	const A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const B = new Complex128Array( 4 );
+
+	zlacpy.ndarray(); // $ExpectError
+	zlacpy.ndarray( 'all' ); // $ExpectError
+	zlacpy.ndarray( 'all', 2 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, 2 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, 2, 1 ); // $ExpectError
+	zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 0, B, 2, 1, 0, 10 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/docs/types/test.ts
@@ -16,8 +16,8 @@
 * limitations under the License.
 */
 
-import zlacpy = require( './index' );
 import Complex128Array = require( '@stdlib/array/complex128' );
+import zlacpy = require( './index' );
 
 
 // TESTS //

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/examples/index.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/examples/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/examples/index.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/examples/index.js
@@ -1,0 +1,44 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var ndarray2array = require( '@stdlib/ndarray/base/to-array' );
+var uniform = require( '@stdlib/random/array/discrete-uniform' );
+var numel = require( '@stdlib/ndarray/base/numel' );
+var shape2strides = require( '@stdlib/ndarray/base/shape2strides' );
+var dlacpy = require( './../lib' );
+
+var shape = [ 5, 8 ];
+var order = 'row-major';
+var strides = shape2strides( shape, order );
+
+var N = numel( shape );
+
+var A = uniform( N, -10, 10, {
+	'dtype': 'float64'
+});
+console.log( ndarray2array( A, shape, strides, 0, order ) );
+
+var B = uniform( N, -10, 10, {
+	'dtype': 'float64'
+});
+console.log( ndarray2array( B, shape, strides, 0, order ) );
+
+dlacpy( order, 'all', shape[ 0 ], shape[ 1 ], A, strides[ 0 ], B, strides[ 0 ] );
+console.log( ndarray2array( B, shape, strides, 0, order ) );

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/examples/index.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/examples/index.js
@@ -19,6 +19,7 @@
 'use strict';
 
 var ndarray2array = require( '@stdlib/ndarray/base/to-array' );
+var Complex128Array = require( '@stdlib/array/complex128' );
 var uniform = require( '@stdlib/random/array/discrete-uniform' );
 var numel = require( '@stdlib/ndarray/base/numel' );
 var shape2strides = require( '@stdlib/ndarray/base/shape2strides' );
@@ -30,14 +31,14 @@ var strides = shape2strides( shape, order );
 
 var N = numel( shape );
 
-var A = uniform( N, -10, 10, {
+var A = new Complex128Array( uniform( 2*N, -10, 10, {
 	'dtype': 'float64'
-});
+}));
 console.log( ndarray2array( A, shape, strides, 0, order ) );
 
-var B = uniform( N, -10, 10, {
+var B = new Complex128Array( uniform( 2*N, -10, 10, {
 	'dtype': 'float64'
-});
+}));
 console.log( ndarray2array( B, shape, strides, 0, order ) );
 
 dlacpy( order, 'all', shape[ 0 ], shape[ 1 ], A, strides[ 0 ], B, strides[ 0 ] );

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/base.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/base.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/base.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/base.js
@@ -48,74 +48,74 @@ var min = require( '@stdlib/math/base/special/fast/min' );
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * copyAll( 2, 2, A, 2, 1, 0, B, 2, 1, 0 );
-* // B => <Complex128Array>[ 1.0, 2.0, 3.0, 4.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * copyAll( 2, 2, A, 2, -1, 1, B, 2, 1, 0 );
-* // B => <Complex128Array>[ 2.0, 1.0, 4.0, 3.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * copyAll( 2, 2, A, -2, 1, 2, B, 2, 1, 0 );
-* // B => <Complex128Array>[ 3.0, 4.0, 1.0, 2.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * copyAll( 2, 2, A, -2, -1, 3, B, 2, 1, 0 );
-* // B => <Complex128Array>[ 4.0, 3.0, 2.0, 1.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * copyAll( 2, 2, A, 1, 2, 0, B, 2, 1, 0 );
-* // B => <Complex128Array>[ 1.0, 3.0, 2.0, 4.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * copyAll( 2, 2, A, -1, 2, 1, B, 2, 1, 0 );
-* // B => <Complex128Array>[ 2.0, 4.0, 1.0, 3.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * copyAll( 2, 2, A, 1, -2, 2, B, 2, 1, 0 );
-* // B => <Complex128Array>[ 3.0, 1.0, 4.0, 2.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * copyAll( 2, 2, A, -1, -2, 3, B, 2, 1, 0 );
-* // B => <Complex128Array>[ 4.0, 2.0, 3.0, 1.0 ]
+* // B => <Complex128Array>
 */
 function copyAll( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB ) {
 	var da0;
@@ -183,74 +183,74 @@ function copyAll( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, o
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * copyUpper( 2, 2, A, 2, 1, 0, B, 2, 1, 0 );
-* // B => <Complex128Array>[ 1.0, 2.0, 0.0, 4.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * copyUpper( 2, 2, A, 2, -1, 1, B, 2, 1, 0 );
-* // B => <Complex128Array>[ 2.0, 1.0, 0.0, 3.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * copyUpper( 2, 2, A, -2, 1, 2, B, 2, 1, 0 );
-* // B => <Complex128Array>[ 3.0, 4.0, 0.0, 2.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * copyUpper( 2, 2, A, -2, -1, 3, B, 2, 1, 0 );
-* // B => <Complex128Array>[ 4.0, 3.0, 0.0, 1.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * copyUpper( 2, 2, A, 1, 2, 0, B, 2, 1, 0 );
-* // B => <Complex128Array>[ 1.0, 3.0, 0.0, 4.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * copyUpper( 2, 2, A, -1, 2, 1, B, 2, 1, 0 );
-* // B => <Complex128Array>[ 2.0, 4.0, 0.0, 3.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * copyUpper( 2, 2, A, 1, -2, 2, B, 2, 1, 0 );
-* // B => <Complex128Array>[ 3.0, 1.0, 0.0, 2.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * copyUpper( 2, 2, A, -1, -2, 3, B, 2, 1, 0 );
-* // B => <Complex128Array>[ 4.0, 2.0, 0.0, 1.0 ]
+* // B => <Complex128Array>
 */
 function copyUpper( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB ) {
 	var ia;
@@ -299,74 +299,74 @@ function copyUpper( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2,
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * copyLower( 2, 2, A, 2, 1, 0, B, 2, 1, 0 );
-* // B => <Complex128Array>[ 1.0, 0.0, 3.0, 4.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * copyLower( 2, 2, A, 2, -1, 1, B, 2, 1, 0 );
-* // B => <Complex128Array>[ 2.0, 0.0, 4.0, 3.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * copyLower( 2, 2, A, -2, 1, 2, B, 2, 1, 0 );
-* // B => <Complex128Array>[ 3.0, 0.0, 1.0, 2.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * copyLower( 2, 2, A, -2, -1, 3, B, 2, 1, 0 );
-* // B => <Complex128Array>[ 4.0, 0.0, 2.0, 1.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * copyLower( 2, 2, A, 1, 2, 0, B, 2, 1, 0 );
-* // B => <Complex128Array>[ 1.0, 0.0, 2.0, 4.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * copyLower( 2, 2, A, -1, 2, 1, B, 2, 1, 0 );
-* // B => <Complex128Array>[ 2.0, 0.0, 1.0, 3.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * copyLower( 2, 2, A, 1, -2, 2, B, 2, 1, 0 );
-* // B => <Complex128Array>[ 3.0, 0.0, 4.0, 2.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * copyLower( 2, 2, A, -1, -2, 3, B, 2, 1, 0 );
-* // B => <Complex128Array>[ 4.0, 0.0, 3.0, 1.0 ]
+* // B => <Complex128Array>
 */
 function copyLower( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB ) {
 	var ia;
@@ -419,29 +419,29 @@ function copyLower( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2,
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * zlacpy( 'all', 2, 2, A, 2, 1, 0, B, 2, 1, 0 );
-* // B => <Complex128Array>[ 1.0, 2.0, 3.0, 4.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * zlacpy( 'upper', 2, 2, A, 2, 1, 0, B, 2, 1, 0 );
-* // B => <Complex128Array>[ 1.0, 2.0, 0.0, 4.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * zlacpy( 'lower', 2, 2, A, 2, 1, 0, B, 2, 1, 0 );
-* // B => <Complex128Array>[ 1.0, 0.0, 3.0, 4.0 ]
+* // B => <Complex128Array>
 */
 function zlacpy( uplo, M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB ) {
 	if ( uplo === 'upper' ) {

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/base.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/base.js
@@ -36,91 +36,89 @@ var min = require( '@stdlib/math/base/special/fast/min' );
 * @private
 * @param {NonNegativeInteger} M - number of rows in matrix `A`
 * @param {NonNegativeInteger} N - number of columns in matrix `A`
-* @param {Complex128Array} A - input matrix
+* @param {Float64Array} A - input matrix view
 * @param {integer} strideA1 - stride of the first dimension of `A`
 * @param {integer} strideA2 - stride of the second dimension of `A`
 * @param {NonNegativeInteger} offsetA - starting index for `A`
-* @param {Complex128Array} B - output matrix
+* @param {Float64Array} B - output matrix view
 * @param {integer} strideB1 - stride of the first dimension of `B`
 * @param {integer} strideB2 - stride of the second dimension of `B`
 * @param {NonNegativeInteger} offsetB - starting index for `B`
-* @returns {Complex128Array} `B`
+* @returns {Float64Array} `B`
 *
 * @example
-* var Complex128Array = require( '@stdlib/array/complex128' );
+* var Float64Array = require( '@stdlib/array/float64' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( 4 );
+* var A = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Float64Array( 8 );
 *
-* copyAll( 2, 2, A, 2, 1, 0, B, 2, 1, 0 );
-* // B => <Complex128Array>
-*
-* @example
-* var Complex128Array = require( '@stdlib/array/complex128' );
-*
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( 4 );
-*
-* copyAll( 2, 2, A, 2, -1, 1, B, 2, 1, 0 );
-* // B => <Complex128Array>
+* copyAll( 2, 2, A, 4, 2, 0, B, 4, 2, 0 );
+* // B => <Float64Array>[ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ]
 *
 * @example
-* var Complex128Array = require( '@stdlib/array/complex128' );
+* var Float64Array = require( '@stdlib/array/float64' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( 4 );
+* var A = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Float64Array( 8 );
 *
-* copyAll( 2, 2, A, -2, 1, 2, B, 2, 1, 0 );
-* // B => <Complex128Array>
-*
-* @example
-* var Complex128Array = require( '@stdlib/array/complex128' );
-*
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( 4 );
-*
-* copyAll( 2, 2, A, -2, -1, 3, B, 2, 1, 0 );
-* // B => <Complex128Array>
+* copyAll( 2, 2, A, 4, -2, 2, B, 4, 2, 0 );
+* // B => <Float64Array>[ 3.0, 4.0, 1.0, 2.0, 7.0, 8.0, 5.0, 6.0 ]
 *
 * @example
-* var Complex128Array = require( '@stdlib/array/complex128' );
+* var Float64Array = require( '@stdlib/array/float64' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( 4 );
+* var A = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Float64Array( 8 );
 *
-* copyAll( 2, 2, A, 1, 2, 0, B, 2, 1, 0 );
-* // B => <Complex128Array>
-*
-* @example
-* var Complex128Array = require( '@stdlib/array/complex128' );
-*
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( 4 );
-*
-* copyAll( 2, 2, A, -1, 2, 1, B, 2, 1, 0 );
-* // B => <Complex128Array>
+* copyAll( 2, 2, A, -4, 2, 4, B, 4, 2, 0 );
+* // B => <Float64Array>[ 5.0, 6.0, 7.0, 8.0, 1.0, 2.0, 3.0, 4.0 ]
 *
 * @example
-* var Complex128Array = require( '@stdlib/array/complex128' );
+* var Float64Array = require( '@stdlib/array/float64' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( 4 );
+* var A = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Float64Array( 8 );
 *
-* copyAll( 2, 2, A, 1, -2, 2, B, 2, 1, 0 );
-* // B => <Complex128Array>
+* copyAll( 2, 2, A, -4, -2, 6, B, 4, 2, 0 );
+* // B => <Float64Array>[ 7.0, 8.0, 5.0, 6.0, 3.0, 4.0, 1.0, 2.0 ]
 *
 * @example
-* var Complex128Array = require( '@stdlib/array/complex128' );
+* var Float64Array = require( '@stdlib/array/float64' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( 4 );
+* var A = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Float64Array( 8 );
 *
-* copyAll( 2, 2, A, -1, -2, 3, B, 2, 1, 0 );
-* // B => <Complex128Array>
+* copyAll( 2, 2, A, 2, 4, 0, B, 4, 2, 0 );
+* // B => <Float64Array>[ 1.0, 2.0, 5.0, 6.0, 3.0, 4.0, 7.0, 8.0 ]
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+*
+* var A = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Float64Array( 8 );
+*
+* copyAll( 2, 2, A, -2, 4, 2, B, 4, 2, 0 );
+* // B => <Float64Array>[ 3.0, 4.0, 7.0, 8.0, 1.0, 2.0, 5.0, 6.0 ]
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+*
+* var A = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Float64Array( 8 );
+*
+* copyAll( 2, 2, A, 2, -4, 4, B, 4, 2, 0 );
+* // B => <Float64Array>[ 5.0, 6.0, 1.0, 2.0, 7.0, 8.0, 3.0, 4.0 ]
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+*
+* var A = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Float64Array( 8 );
+*
+* copyAll( 2, 2, A, -2, -4, 6, B, 4, 2, 0 );
+* // B => <Float64Array>[ 7.0, 8.0, 3.0, 4.0, 5.0, 6.0, 1.0, 2.0 ]
 */
 function copyAll( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB ) {
-	var A64;
-	var B64;
 	var da0;
 	var da1;
 	var db0;
@@ -145,24 +143,20 @@ function copyAll( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, o
 	// Extract loop variables for purposes of loop interchange: dimensions and loop offset (pointer) increments...
 	S0 = sh[ 0 ];
 	S1 = sh[ 1 ];
-	da0 = (sa[ 0 ] ) * 2;
-	da1 = (sa[ 1 ] - ( S0*sa[0] ) ) * 2;
-	db0 = (sb[ 0 ] ) * 2;
-	db1 = (sb[ 1 ] - ( S0*sb[0] ) ) * 2;
+	da0 = sa[ 0 ];
+	da1 = sa[ 1 ] - ( S0*sa[0] );
+	db0 = sb[ 0 ];
+	db1 = sb[ 1 ] - ( S0*sb[0] );
 
 	// Set the pointers to the first indexed elements in the respective matrices...
-	ia = offsetA * 2;
-	ib = offsetB * 2;
-
-	// Reinterpret the input and output arrays as float64 arrays:
-	A64 = reinterpret( A, 0 );
-	B64 = reinterpret( B, 0 );
+	ia = offsetA;
+	ib = offsetB;
 
 	// Iterate over the matrix dimensions...
 	for ( i1 = 0; i1 < S1; i1++ ) {
 		for ( i0 = 0; i0 < S0; i0++ ) {
-			B64[ ib ] = A64[ ia ];
-			B64[ ib+1 ] = A64[ ia+1 ];
+			B[ ib ] = A[ ia ];
+			B[ ib+1 ] = A[ ia+1 ];
 			ia += da0;
 			ib += db0;
 		}
@@ -178,95 +172,89 @@ function copyAll( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, o
 * @private
 * @param {NonNegativeInteger} M - number of rows in matrix `A`
 * @param {NonNegativeInteger} N - number of columns in matrix `A`
-* @param {Complex128Array} A - input matrix
+* @param {Float64Array} A - input matrix view
 * @param {integer} strideA1 - stride of the first dimension of `A`
 * @param {integer} strideA2 - stride of the second dimension of `A`
 * @param {NonNegativeInteger} offsetA - starting index for `A`
-* @param {Complex128Array} B - output matrix
+* @param {Float64Array} B - output matrix view
 * @param {integer} strideB1 - stride of the first dimension of `B`
 * @param {integer} strideB2 - stride of the second dimension of `B`
 * @param {NonNegativeInteger} offsetB - starting index for `B`
-* @returns {Complex128Array} `B`
+* @returns {Float64Array} `B`
 *
 * @example
-* var Complex128Array = require( '@stdlib/array/complex128' );
+* var Float64Array = require( '@stdlib/array/float64' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( 4 );
+* var A = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Float64Array( 8 );
 *
-* copyUpper( 2, 2, A, 2, 1, 0, B, 2, 1, 0 );
-* // B => <Complex128Array>
-*
-* @example
-* var Complex128Array = require( '@stdlib/array/complex128' );
-*
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( 4 );
-*
-* copyUpper( 2, 2, A, 2, -1, 1, B, 2, 1, 0 );
-* // B => <Complex128Array>
+* copyUpper( 2, 2, A, 4, 2, 0, B, 4, 2, 0 );
+* // B => <Float64Array>[ 1.0, 2.0, 3.0, 4.0, 0.0, 0.0, 7.0, 8.0 ]
 *
 * @example
-* var Complex128Array = require( '@stdlib/array/complex128' );
+* var Float64Array = require( '@stdlib/array/float64' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( 4 );
+* var A = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Float64Array( 8 );
 *
-* copyUpper( 2, 2, A, -2, 1, 2, B, 2, 1, 0 );
-* // B => <Complex128Array>
-*
-* @example
-* var Complex128Array = require( '@stdlib/array/complex128' );
-*
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( 4 );
-*
-* copyUpper( 2, 2, A, -2, -1, 3, B, 2, 1, 0 );
-* // B => <Complex128Array>
+* copyUpper( 2, 2, A, 4, -2, 2, B, 4, 2, 0 );
+* // B => <Float64Array>[ 3.0, 4.0, 1.0, 2.0, 0.0, 0.0, 5.0, 6.0 ]
 *
 * @example
-* var Complex128Array = require( '@stdlib/array/complex128' );
+* var Float64Array = require( '@stdlib/array/float64' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( 4 );
+* var A = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Float64Array( 8 );
 *
-* copyUpper( 2, 2, A, 1, 2, 0, B, 2, 1, 0 );
-* // B => <Complex128Array>
-*
-* @example
-* var Complex128Array = require( '@stdlib/array/complex128' );
-*
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( 4 );
-*
-* copyUpper( 2, 2, A, -1, 2, 1, B, 2, 1, 0 );
-* // B => <Complex128Array>
+* copyUpper( 2, 2, A, -4, 2, 4, B, 4, 2, 0 );
+* // B => <Float64Array>[ 5.0, 6.0, 7.0, 8.0, 0.0, 0.0, 3.0, 4.0 ]
 *
 * @example
-* var Complex128Array = require( '@stdlib/array/complex128' );
+* var Float64Array = require( '@stdlib/array/float64' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( 4 );
+* var A = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Float64Array( 8 );
 *
-* copyUpper( 2, 2, A, 1, -2, 2, B, 2, 1, 0 );
-* // B => <Complex128Array>
+* copyUpper( 2, 2, A, -4, -2, 6, B, 4, 2, 0 );
+* // B => <Float64Array>[ 7.0, 8.0, 5.0, 6.0, 0.0, 0.0, 1.0, 2.0 ]
 *
 * @example
-* var Complex128Array = require( '@stdlib/array/complex128' );
+* var Float64Array = require( '@stdlib/array/float64' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( 4 );
+* var A = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Float64Array( 8 );
 *
-* copyUpper( 2, 2, A, -1, -2, 3, B, 2, 1, 0 );
-* // B => <Complex128Array>
+* copyUpper( 2, 2, A, 2, 4, 0, B, 4, 2, 0 );
+* // B => <Float64Array>[ 1.0, 2.0, 5.0, 6.0, 0.0, 0.0, 7.0, 8.0 ]
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+*
+* var A = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Float64Array( 8 );
+*
+* copyUpper( 2, 2, A, -2, 4, 2, B, 4, 2, 0 );
+* // B => <Float64Array>[ 3.0, 4.0, 7.0, 8.0, 0.0, 0.0, 5.0, 6.0 ]
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+*
+* var A = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Float64Array( 8 );
+*
+* copyUpper( 2, 2, A, 2, -4, 4, B, 4, 2, 0 );
+* // B => <Float64Array>[ 5.0, 6.0, 1.0, 2.0, 0.0, 0.0, 3.0, 4.0 ]
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+*
+* var A = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Float64Array( 8 );
+*
+* copyUpper( 2, 2, A, -2, -4, 6, B, 4, 2, 0 );
+* // B => <Float64Array>[ 7.0, 8.0, 3.0, 4.0, 0.0, 0.0, 1.0, 2.0 ]
 */
 function copyUpper( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB ) {
-	var A64;
-	var B64;
-	var da1;
-	var da2;
-	var db1;
-	var db2;
 	var ia;
 	var ib;
 	var i0;
@@ -274,32 +262,20 @@ function copyUpper( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2,
 	var ja;
 	var jb;
 
-	// Prepare strides with doubled byte offsets
-	da1 = strideA1 * 2;
-	da2 = strideA2 * 2;
-	db1 = strideB1 * 2;
-	db2 = strideB2 * 2;
-
-	// Reinterpret the input and output arrays as float64 arrays:
-	A64 = reinterpret( A, 0 );
-	B64 = reinterpret( B, 0 );
-
-	// Set the pointers to the first indexed elements in the respective matrices...
-	ia = offsetA * 2;
-	ib = offsetB * 2;
-
+	ia = offsetA;
+	ib = offsetB;
 	if ( isRowMajor( [ strideA1, strideA2 ] ) ) {
 		for ( i1 = 0; i1 < M; i1++ ) {
-			ja = ia+(i1*da2);
-			jb = ib+(i1*db2);
+			ja = ia + ( i1*strideA2 );
+			jb = ib + ( i1*strideB2 );
 			for ( i0 = i1; i0 < N; i0++ ) {
-				B64[ jb ] = A64[ ja ];
-				B64[ jb+1 ] = A64[ ja+1 ];
-				ja += da2;
-				jb += db2;
+				B[ jb ] = A[ ja ];
+				B[ jb+1 ] = A[ ja+1 ];
+				ja += strideA2;
+				jb += strideB2;
 			}
-			ia += da1;
-			ib += db1;
+			ia += strideA1;
+			ib += strideB1;
 		}
 		return B;
 	}
@@ -307,13 +283,13 @@ function copyUpper( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2,
 		jb = ib;
 		ja = ia;
 		for ( i0 = 0; i0 <= min( i1, M-1 ); i0++ ) {
-			B64[ jb ] = A64[ ja ];
-			B64[ jb+1 ] = A64[ ja+1 ];
-			ja += da1;
-			jb += db1;
+			B[ jb ] = A[ ja ];
+			B[ jb+1 ] = A[ ja+1 ];
+			ja += strideA1;
+			jb += strideB1;
 		}
-		ia += da2;
-		ib += db2;
+		ia += strideA2;
+		ib += strideB2;
 	}
 	return B;
 }
@@ -324,95 +300,89 @@ function copyUpper( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2,
 * @private
 * @param {NonNegativeInteger} M - number of rows in matrix `A`
 * @param {NonNegativeInteger} N - number of columns in matrix `A`
-* @param {Complex128Array} A - input matrix
+* @param {Float64Array} A - input matrix
 * @param {integer} strideA1 - stride of the first dimension of `A`
 * @param {integer} strideA2 - stride of the second dimension of `A`
 * @param {NonNegativeInteger} offsetA - starting index for `A`
-* @param {Complex128Array} B - output matrix
+* @param {Float64Array} B - output matrix
 * @param {integer} strideB1 - stride of the first dimension of `B`
 * @param {integer} strideB2 - stride of the second dimension of `B`
 * @param {NonNegativeInteger} offsetB - starting index for `B`
-* @returns {Complex128Array} `B`
+* @returns {Float64Array} `B`
 *
 * @example
-* var Complex128Array = require( '@stdlib/array/complex128' );
+* var Float64Array = require( '@stdlib/array/float64' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( 4 );
+* var A = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Float64Array( 8 );
 *
-* copyLower( 2, 2, A, 2, 1, 0, B, 2, 1, 0 );
-* // B => <Complex128Array>
-*
-* @example
-* var Complex128Array = require( '@stdlib/array/complex128' );
-*
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( 4 );
-*
-* copyLower( 2, 2, A, 2, -1, 1, B, 2, 1, 0 );
-* // B => <Complex128Array>
+* copyLower( 2, 2, A, 4, 2, 0, B, 4, 2, 0 );
+* // B => <Float64Array>[ 1.0, 2.0, 0.0, 0.0, 5.0, 6.0, 7.0, 8.0 ]
 *
 * @example
-* var Complex128Array = require( '@stdlib/array/complex128' );
+* var Float64Array = require( '@stdlib/array/float64' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( 4 );
+* var A = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Float64Array( 8 );
 *
-* copyLower( 2, 2, A, -2, 1, 2, B, 2, 1, 0 );
-* // B => <Complex128Array>
-*
-* @example
-* var Complex128Array = require( '@stdlib/array/complex128' );
-*
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( 4 );
-*
-* copyLower( 2, 2, A, -2, -1, 3, B, 2, 1, 0 );
-* // B => <Complex128Array>
+* copyLower( 2, 2, A, 4, -2, 2, B, 4, 2, 0 );
+* // B => <Float64Array>[ 3.0, 4.0, 0.0, 0.0, 7.0, 8.0, 5.0, 6.0 ]
 *
 * @example
-* var Complex128Array = require( '@stdlib/array/complex128' );
+* var Float64Array = require( '@stdlib/array/float64' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( 4 );
+* var A = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Float64Array( 8 );
 *
-* copyLower( 2, 2, A, 1, 2, 0, B, 2, 1, 0 );
-* // B => <Complex128Array>
-*
-* @example
-* var Complex128Array = require( '@stdlib/array/complex128' );
-*
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( 4 );
-*
-* copyLower( 2, 2, A, -1, 2, 1, B, 2, 1, 0 );
-* // B => <Complex128Array>
+* copyLower( 2, 2, A, -4, 2, 4, B, 4, 2, 0 );
+* // B => <Float64Array>[ 5.0, 6.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0 ]
 *
 * @example
-* var Complex128Array = require( '@stdlib/array/complex128' );
+* var Float64Array = require( '@stdlib/array/float64' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( 4 );
+* var A = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Float64Array( 8 );
 *
-* copyLower( 2, 2, A, 1, -2, 2, B, 2, 1, 0 );
-* // B => <Complex128Array>
+* copyLower( 2, 2, A, -4, -2, 6, B, 4, 2, 0 );
+* // B => <Float64Array>[ 7.0, 8.0, 0.0, 0.0, 3.0, 4.0, 1.0, 2.0 ]
 *
 * @example
-* var Complex128Array = require( '@stdlib/array/complex128' );
+* var Float64Array = require( '@stdlib/array/float64' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( 4 );
+* var A = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Float64Array( 8 );
 *
-* copyLower( 2, 2, A, -1, -2, 3, B, 2, 1, 0 );
-* // B => <Complex128Array>
+* copyLower( 2, 2, A, 2, 4, 0, B, 4, 2, 0 );
+* // B => <Float64Array>[ 1.0, 2.0, 0.0, 0.0, 3.0, 4.0, 7.0, 8.0 ]
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+*
+* var A = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Float64Array( 8 );
+*
+* copyLower( 2, 2, A, -2, 4, 2, B, 4, 2, 0 );
+* // B => <Float64Array>[ 3.0, 4.0, 0.0, 0.0, 1.0, 2.0, 5.0, 6.0 ]
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+*
+* var A = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Float64Array( 8 );
+*
+* copyLower( 2, 2, A, 2, -4, 4, B, 4, 2, 0 );
+* // B => <Float64Array>[ 5.0, 6.0, 0.0, 0.0, 7.0, 8.0, 3.0, 4.0 ]
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+*
+* var A = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Float64Array( 8 );
+*
+* copyLower( 2, 2, A, -2, -4, 6, B, 4, 2, 0 );
+* // B => <Float64Array>[ 7.0, 8.0, 0.0, 0.0, 5.0, 6.0, 1.0, 2.0 ]
 */
 function copyLower( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB ) {
-	var A64;
-	var B64;
-	var da1;
-	var da2;
-	var db1;
-	var db2;
 	var ia;
 	var ib;
 	var i0;
@@ -420,46 +390,34 @@ function copyLower( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2,
 	var ja;
 	var jb;
 
-	// Prepare strides with doubled byte offsets
-	da1 = strideA1 * 2;
-	da2 = strideA2 * 2;
-	db1 = strideB1 * 2;
-	db2 = strideB2 * 2;
-
-	// Reinterpret the input and output arrays as float64 arrays:
-	A64 = reinterpret( A, 0 );
-	B64 = reinterpret( B, 0 );
-
-	// Set the pointers to the first indexed elements in the respective matrices...
-	ia = offsetA * 2;
-	ib = offsetB * 2;
-
+	ia = offsetA;
+	ib = offsetB;
 	if ( isRowMajor( [ strideA1, strideA2 ] ) ) {
 		for ( i1 = 0; i1 < M; i1++ ) {
 			ja = ia;
 			jb = ib;
 			for ( i0 = 0; i0 <= min( i1, N-1 ); i0++ ) {
-				B64[ jb ] = A64[ ja ];
-				B64[ jb+1 ] = A64[ ja+1 ];
-				ja += da2;
-				jb += db2;
+				B[ jb ] = A[ ja ];
+				B[ jb+1 ] = A[ ja+1 ];
+				ja += strideA2;
+				jb += strideB2;
 			}
-			ia += da1;
-			ib += db1;
+			ia += strideA1;
+			ib += strideB1;
 		}
 		return B;
 	}
 	for ( i1 = 0; i1 < N; i1++ ) {
-		ja = ia+(i1*da1);
-		jb = ib+(i1*db1);
+		ja = ia + ( i1*strideA1 );
+		jb = ib + ( i1*strideB1 );
 		for ( i0 = i1; i0 < M; i0++ ) {
-			B64[ jb ] = A64[ ja ];
-			B64[ jb+1 ] = A64[ ja+1 ];
-			ja += da1;
-			jb += db1;
+			B[ jb ] = A[ ja ];
+			B[ jb+1 ] = A[ ja+1 ];
+			ja += strideA1;
+			jb += strideB1;
 		}
-		ia += da2;
-		ib += db2;
+		ia += strideA2;
+		ib += strideB2;
 	}
 	return B;
 }
@@ -486,15 +444,54 @@ function copyLower( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2,
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
+* var real = require( '@stdlib/complex/float64/real' );
+* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * zlacpy( 'all', 2, 2, A, 2, 1, 0, B, 2, 1, 0 );
-* // B => <Complex128Array>
+*
+* var z = B.get( 0 );
+* // returns <Complex128>
+*
+* var v = real( z );
+* // returns 1.0
+*
+* v = imag( z );
+* // returns 2.0
+*
+* z = B.get( 1 );
+* // returns <Complex128>
+*
+* v = real( z );
+* // returns 3.0
+*
+* v = imag( z );
+* // returns 4.0
+*
+* z = B.get( 2 );
+* // returns <Complex128>
+*
+* v = real( z );
+* // returns 5.0
+*
+* v = imag( z );
+* // returns 6.0
+*
+* z = B.get( 3 );
+* // returns <Complex128>
+*
+* v = real( z );
+* // returns 7.0
+*
+* v = imag( z );
+* // returns 8.0
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
+* var real = require( '@stdlib/complex/float64/real' );
+* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
@@ -502,23 +499,110 @@ function copyLower( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2,
 * zlacpy( 'upper', 2, 2, A, 2, 1, 0, B, 2, 1, 0 );
 * // B => <Complex128Array>
 *
+* var z = B.get( 0 );
+* // returns <Complex128>
+*
+* var v = real( z );
+* // returns 1.0
+*
+* v = imag( z );
+* // returns 2.0
+*
+* z = B.get( 1 );
+* // returns <Complex128>
+*
+* v = real( z );
+* // returns 3.0
+*
+* v = imag( z );
+* // returns 4.0
+*
+* z = B.get( 2 );
+* // returns <Complex128>
+*
+* v = real( z );
+* // returns 0.0
+*
+* v = imag( z );
+* // returns 0.0
+*
+* z = B.get( 3 );
+* // returns <Complex128>
+*
+* v = real( z );
+* // returns 7.0
+*
+* v = imag( z );
+* // returns 8.0
+*
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
+* var real = require( '@stdlib/complex/float64/real' );
+* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * zlacpy( 'lower', 2, 2, A, 2, 1, 0, B, 2, 1, 0 );
-* // B => <Complex128Array>
+*
+* var z = B.get( 0 );
+* // returns <Complex128>
+*
+* var v = real( z );
+* // returns 1.0
+*
+* v = imag( z );
+* // returns 2.0
+*
+* z = B.get( 1 );
+* // returns <Complex128>
+*
+* v = real( z );
+* // returns 0.0
+*
+* v = imag( z );
+* // returns 0.0
+*
+* z = B.get( 2 );
+* // returns <Complex128>
+*
+* v = real( z );
+* // returns 5.0
+*
+* v = imag( z );
+* // returns 6.0
+*
+* z = B.get( 3 );
+* // returns <Complex128>
+*
+* v = real( z );
+* // returns 7.0
+*
+* v = imag( z );
+* // returns 8.0
 */
 function zlacpy( uplo, M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB ) {
+	// Reinterpret the input and output arrays as real-valued arrays of interleaved real and imaginary components:
+	A = reinterpret( A, 0 );
+	B = reinterpret( B, 0 );
+
+	// Adjust the strides and offsets accordingly:
+	strideA1 *= 2;
+	strideA2 *= 2;
+	strideB1 *= 2;
+	strideB2 *= 2;
+
+	offsetA *= 2;
+	offsetB *= 2;
+
 	if ( uplo === 'upper' ) {
-		return copyUpper( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB );
+		copyUpper( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB );
+	} else if ( uplo === 'lower' ) {
+		copyLower( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB );
+	} else {
+		copyAll( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB );
 	}
-	if ( uplo === 'lower' ) {
-		return copyLower( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB );
-	}
-	return copyAll( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB );
+	return B;
 }
 
 

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/base.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/base.js
@@ -582,9 +582,12 @@ function copyLower( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2,
 * // returns 8.0
 */
 function zlacpy( uplo, M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB ) {
+	var viewA;
+	var viewB;
+
 	// Reinterpret the input and output arrays as real-valued arrays of interleaved real and imaginary components:
-	A = reinterpret( A, 0 );
-	B = reinterpret( B, 0 );
+	viewA = reinterpret( A, 0 );
+	viewB = reinterpret( B, 0 );
 
 	// Adjust the strides and offsets accordingly:
 	strideA1 *= 2;
@@ -596,11 +599,11 @@ function zlacpy( uplo, M, N, A, strideA1, strideA2, offsetA, B, strideB1, stride
 	offsetB *= 2;
 
 	if ( uplo === 'upper' ) {
-		copyUpper( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB );
+		copyUpper( M, N, viewA, strideA1, strideA2, offsetA, viewB, strideB1, strideB2, offsetB );
 	} else if ( uplo === 'lower' ) {
-		copyLower( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB );
+		copyLower( M, N, viewA, strideA1, strideA2, offsetA, viewB, strideB1, strideB2, offsetB );
 	} else {
-		copyAll( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB );
+		copyAll( M, N, viewA, strideA1, strideA2, offsetA, viewB, strideB1, strideB2, offsetB );
 	}
 	return B;
 }

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/base.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/base.js
@@ -22,6 +22,7 @@
 
 // MODULES //
 
+var reinterpret = require( '@stdlib/strided/base/reinterpret-complex128' );
 var isRowMajor = require( '@stdlib/ndarray/base/assert/is-row-major' );
 var loopOrder = require( '@stdlib/ndarray/base/unary-loop-interchange-order' );
 var min = require( '@stdlib/math/base/special/fast/min' );
@@ -118,6 +119,8 @@ var min = require( '@stdlib/math/base/special/fast/min' );
 * // B => <Complex128Array>
 */
 function copyAll( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB ) {
+	var A64;
+	var B64;
 	var da0;
 	var da1;
 	var db0;
@@ -142,19 +145,24 @@ function copyAll( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, o
 	// Extract loop variables for purposes of loop interchange: dimensions and loop offset (pointer) increments...
 	S0 = sh[ 0 ];
 	S1 = sh[ 1 ];
-	da0 = sa[ 0 ];
-	da1 = sa[ 1 ] - ( S0*sa[0] );
-	db0 = sb[ 0 ];
-	db1 = sb[ 1 ] - ( S0*sb[0] );
+	da0 = (sa[ 0 ] ) * 2;
+	da1 = (sa[ 1 ] - ( S0*sa[0] ) ) * 2;
+	db0 = (sb[ 0 ] ) * 2;
+	db1 = (sb[ 1 ] - ( S0*sb[0] ) ) * 2;
 
 	// Set the pointers to the first indexed elements in the respective matrices...
-	ia = offsetA;
-	ib = offsetB;
+	ia = offsetA * 2;
+	ib = offsetB * 2;
+
+	// Reinterpret the input and output arrays as float64 arrays:
+	A64 = reinterpret( A, 0 );
+	B64 = reinterpret( B, 0 );
 
 	// Iterate over the matrix dimensions...
 	for ( i1 = 0; i1 < S1; i1++ ) {
 		for ( i0 = 0; i0 < S0; i0++ ) {
-			B.set( A.get( ia ), ib );
+			B64[ ib ] = A64[ ia ];
+			B64[ ib+1 ] = A64[ ia+1 ];
 			ia += da0;
 			ib += db0;
 		}
@@ -253,29 +261,59 @@ function copyAll( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, o
 * // B => <Complex128Array>
 */
 function copyUpper( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB ) {
+	var A64;
+	var B64;
+	var da1;
+	var da2;
+	var db1;
+	var db2;
 	var ia;
 	var ib;
 	var i0;
 	var i1;
+	var ja;
+	var jb;
 
-	ia = offsetA;
-	ib = offsetB;
+	// Prepare strides with doubled byte offsets
+	da1 = strideA1 * 2;
+	da2 = strideA2 * 2;
+	db1 = strideB1 * 2;
+	db2 = strideB2 * 2;
+
+	// Reinterpret the input and output arrays as float64 arrays:
+	A64 = reinterpret( A, 0 );
+	B64 = reinterpret( B, 0 );
+
+	// Set the pointers to the first indexed elements in the respective matrices...
+	ia = offsetA * 2;
+	ib = offsetB * 2;
+
 	if ( isRowMajor( [ strideA1, strideA2 ] ) ) {
 		for ( i1 = 0; i1 < M; i1++ ) {
+			ja = ia+(i1*da2);
+			jb = ib+(i1*db2);
 			for ( i0 = i1; i0 < N; i0++ ) {
-				B.set( A.get( ia+(i0*strideA2) ), ib+(i0*strideB2) );
+				B64[ jb ] = A64[ ja ];
+				B64[ jb+1 ] = A64[ ja+1 ];
+				ja += da2;
+				jb += db2;
 			}
-			ia += strideA1;
-			ib += strideB1;
+			ia += da1;
+			ib += db1;
 		}
 		return B;
 	}
 	for ( i1 = 0; i1 < N; i1++ ) {
+		jb = ib;
+		ja = ia;
 		for ( i0 = 0; i0 <= min( i1, M-1 ); i0++ ) {
-			B.set( A.get( ia+(i0*strideA1) ), ib+(i0*strideB1) );
+			B64[ jb ] = A64[ ja ];
+			B64[ jb+1 ] = A64[ ja+1 ];
+			ja += da1;
+			jb += db1;
 		}
-		ia += strideA2;
-		ib += strideB2;
+		ia += da2;
+		ib += db2;
 	}
 	return B;
 }
@@ -369,29 +407,59 @@ function copyUpper( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2,
 * // B => <Complex128Array>
 */
 function copyLower( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB ) {
+	var A64;
+	var B64;
+	var da1;
+	var da2;
+	var db1;
+	var db2;
 	var ia;
 	var ib;
 	var i0;
 	var i1;
+	var ja;
+	var jb;
 
-	ia = offsetA;
-	ib = offsetB;
+	// Prepare strides with doubled byte offsets
+	da1 = strideA1 * 2;
+	da2 = strideA2 * 2;
+	db1 = strideB1 * 2;
+	db2 = strideB2 * 2;
+
+	// Reinterpret the input and output arrays as float64 arrays:
+	A64 = reinterpret( A, 0 );
+	B64 = reinterpret( B, 0 );
+
+	// Set the pointers to the first indexed elements in the respective matrices...
+	ia = offsetA * 2;
+	ib = offsetB * 2;
+
 	if ( isRowMajor( [ strideA1, strideA2 ] ) ) {
 		for ( i1 = 0; i1 < M; i1++ ) {
+			ja = ia;
+			jb = ib;
 			for ( i0 = 0; i0 <= min( i1, N-1 ); i0++ ) {
-				B.set( A.get( ia+(i0*strideA2) ), ib+(i0*strideB2) );
+				B64[ jb ] = A64[ ja ];
+				B64[ jb+1 ] = A64[ ja+1 ];
+				ja += da2;
+				jb += db2;
 			}
-			ia += strideA1;
-			ib += strideB1;
+			ia += da1;
+			ib += db1;
 		}
 		return B;
 	}
 	for ( i1 = 0; i1 < N; i1++ ) {
+		ja = ia+(i1*da1);
+		jb = ib+(i1*db1);
 		for ( i0 = i1; i0 < M; i0++ ) {
-			B.set( A.get( ia+(i0*strideA1) ), ib+(i0*strideB1) );
+			B64[ jb ] = A64[ ja ];
+			B64[ jb+1 ] = A64[ ja+1 ];
+			ja += da1;
+			jb += db1;
 		}
-		ia += strideA2;
-		ib += strideB2;
+		ia += da2;
+		ib += db2;
 	}
 	return B;
 }

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/base.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/base.js
@@ -1,0 +1,459 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* eslint-disable max-len, max-params */
+
+'use strict';
+
+// MODULES //
+
+var isRowMajor = require( '@stdlib/ndarray/base/assert/is-row-major' );
+var loopOrder = require( '@stdlib/ndarray/base/unary-loop-interchange-order' );
+var min = require( '@stdlib/math/base/special/fast/min' );
+
+
+// FUNCTIONS //
+
+/**
+* Copies all of a matrix `A` to another matrix `B`.
+*
+* @private
+* @param {NonNegativeInteger} M - number of rows in matrix `A`
+* @param {NonNegativeInteger} N - number of columns in matrix `A`
+* @param {Complex128Array} A - input matrix
+* @param {integer} strideA1 - stride of the first dimension of `A`
+* @param {integer} strideA2 - stride of the second dimension of `A`
+* @param {NonNegativeInteger} offsetA - starting index for `A`
+* @param {Complex128Array} B - output matrix
+* @param {integer} strideB1 - stride of the first dimension of `B`
+* @param {integer} strideB2 - stride of the second dimension of `B`
+* @param {NonNegativeInteger} offsetB - starting index for `B`
+* @returns {Complex128Array} `B`
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* copyAll( 2, 2, A, 2, 1, 0, B, 2, 1, 0 );
+* // B => <Complex128Array>[ 1.0, 2.0, 3.0, 4.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* copyAll( 2, 2, A, 2, -1, 1, B, 2, 1, 0 );
+* // B => <Complex128Array>[ 2.0, 1.0, 4.0, 3.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* copyAll( 2, 2, A, -2, 1, 2, B, 2, 1, 0 );
+* // B => <Complex128Array>[ 3.0, 4.0, 1.0, 2.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* copyAll( 2, 2, A, -2, -1, 3, B, 2, 1, 0 );
+* // B => <Complex128Array>[ 4.0, 3.0, 2.0, 1.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* copyAll( 2, 2, A, 1, 2, 0, B, 2, 1, 0 );
+* // B => <Complex128Array>[ 1.0, 3.0, 2.0, 4.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* copyAll( 2, 2, A, -1, 2, 1, B, 2, 1, 0 );
+* // B => <Complex128Array>[ 2.0, 4.0, 1.0, 3.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* copyAll( 2, 2, A, 1, -2, 2, B, 2, 1, 0 );
+* // B => <Complex128Array>[ 3.0, 1.0, 4.0, 2.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* copyAll( 2, 2, A, -1, -2, 3, B, 2, 1, 0 );
+* // B => <Complex128Array>[ 4.0, 2.0, 3.0, 1.0 ]
+*/
+function copyAll( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB ) {
+	var da0;
+	var da1;
+	var db0;
+	var db1;
+	var sh;
+	var S0;
+	var S1;
+	var sa;
+	var sb;
+	var ia;
+	var ib;
+	var i0;
+	var i1;
+	var o;
+
+	// Resolve the loop interchange order:
+	o = loopOrder( [ M, N ], [ strideA1, strideA2 ], [ strideB1, strideB2 ] );
+	sh = o.sh;
+	sa = o.sx;
+	sb = o.sy;
+
+	// Extract loop variables for purposes of loop interchange: dimensions and loop offset (pointer) increments...
+	S0 = sh[ 0 ];
+	S1 = sh[ 1 ];
+	da0 = sa[ 0 ];
+	da1 = sa[ 1 ] - ( S0*sa[0] );
+	db0 = sb[ 0 ];
+	db1 = sb[ 1 ] - ( S0*sb[0] );
+
+	// Set the pointers to the first indexed elements in the respective matrices...
+	ia = offsetA;
+	ib = offsetB;
+
+	// Iterate over the matrix dimensions...
+	for ( i1 = 0; i1 < S1; i1++ ) {
+		for ( i0 = 0; i0 < S0; i0++ ) {
+			B.set( A.get( ia ), ib );
+			ia += da0;
+			ib += db0;
+		}
+		ia += da1;
+		ib += db1;
+	}
+	return B;
+}
+
+/**
+* Copies the upper triangular/trapezoidal part of a matrix `A` to another matrix `B`.
+*
+* @private
+* @param {NonNegativeInteger} M - number of rows in matrix `A`
+* @param {NonNegativeInteger} N - number of columns in matrix `A`
+* @param {Complex128Array} A - input matrix
+* @param {integer} strideA1 - stride of the first dimension of `A`
+* @param {integer} strideA2 - stride of the second dimension of `A`
+* @param {NonNegativeInteger} offsetA - starting index for `A`
+* @param {Complex128Array} B - output matrix
+* @param {integer} strideB1 - stride of the first dimension of `B`
+* @param {integer} strideB2 - stride of the second dimension of `B`
+* @param {NonNegativeInteger} offsetB - starting index for `B`
+* @returns {Complex128Array} `B`
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* copyUpper( 2, 2, A, 2, 1, 0, B, 2, 1, 0 );
+* // B => <Complex128Array>[ 1.0, 2.0, 0.0, 4.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* copyUpper( 2, 2, A, 2, -1, 1, B, 2, 1, 0 );
+* // B => <Complex128Array>[ 2.0, 1.0, 0.0, 3.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* copyUpper( 2, 2, A, -2, 1, 2, B, 2, 1, 0 );
+* // B => <Complex128Array>[ 3.0, 4.0, 0.0, 2.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* copyUpper( 2, 2, A, -2, -1, 3, B, 2, 1, 0 );
+* // B => <Complex128Array>[ 4.0, 3.0, 0.0, 1.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* copyUpper( 2, 2, A, 1, 2, 0, B, 2, 1, 0 );
+* // B => <Complex128Array>[ 1.0, 3.0, 0.0, 4.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* copyUpper( 2, 2, A, -1, 2, 1, B, 2, 1, 0 );
+* // B => <Complex128Array>[ 2.0, 4.0, 0.0, 3.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* copyUpper( 2, 2, A, 1, -2, 2, B, 2, 1, 0 );
+* // B => <Complex128Array>[ 3.0, 1.0, 0.0, 2.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* copyUpper( 2, 2, A, -1, -2, 3, B, 2, 1, 0 );
+* // B => <Complex128Array>[ 4.0, 2.0, 0.0, 1.0 ]
+*/
+function copyUpper( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB ) {
+	var ia;
+	var ib;
+	var i0;
+	var i1;
+
+	ia = offsetA;
+	ib = offsetB;
+	if ( isRowMajor( [ strideA1, strideA2 ] ) ) {
+		for ( i1 = 0; i1 < M; i1++ ) {
+			for ( i0 = i1; i0 < N; i0++ ) {
+				B.set( A.get( ia+(i0*strideA2) ), ib+(i0*strideB2) );
+			}
+			ia += strideA1;
+			ib += strideB1;
+		}
+		return B;
+	}
+	for ( i1 = 0; i1 < N; i1++ ) {
+		for ( i0 = 0; i0 <= min( i1, M-1 ); i0++ ) {
+			B.set( A.get( ia+(i0*strideA1) ), ib+(i0*strideB1) );
+		}
+		ia += strideA2;
+		ib += strideB2;
+	}
+	return B;
+}
+
+/**
+* Copies the lower triangular/trapezoidal part of a matrix `A` to another matrix `B`.
+*
+* @private
+* @param {NonNegativeInteger} M - number of rows in matrix `A`
+* @param {NonNegativeInteger} N - number of columns in matrix `A`
+* @param {Complex128Array} A - input matrix
+* @param {integer} strideA1 - stride of the first dimension of `A`
+* @param {integer} strideA2 - stride of the second dimension of `A`
+* @param {NonNegativeInteger} offsetA - starting index for `A`
+* @param {Complex128Array} B - output matrix
+* @param {integer} strideB1 - stride of the first dimension of `B`
+* @param {integer} strideB2 - stride of the second dimension of `B`
+* @param {NonNegativeInteger} offsetB - starting index for `B`
+* @returns {Complex128Array} `B`
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* copyLower( 2, 2, A, 2, 1, 0, B, 2, 1, 0 );
+* // B => <Complex128Array>[ 1.0, 0.0, 3.0, 4.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* copyLower( 2, 2, A, 2, -1, 1, B, 2, 1, 0 );
+* // B => <Complex128Array>[ 2.0, 0.0, 4.0, 3.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* copyLower( 2, 2, A, -2, 1, 2, B, 2, 1, 0 );
+* // B => <Complex128Array>[ 3.0, 0.0, 1.0, 2.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* copyLower( 2, 2, A, -2, -1, 3, B, 2, 1, 0 );
+* // B => <Complex128Array>[ 4.0, 0.0, 2.0, 1.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* copyLower( 2, 2, A, 1, 2, 0, B, 2, 1, 0 );
+* // B => <Complex128Array>[ 1.0, 0.0, 2.0, 4.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* copyLower( 2, 2, A, -1, 2, 1, B, 2, 1, 0 );
+* // B => <Complex128Array>[ 2.0, 0.0, 1.0, 3.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* copyLower( 2, 2, A, 1, -2, 2, B, 2, 1, 0 );
+* // B => <Complex128Array>[ 3.0, 0.0, 4.0, 2.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* copyLower( 2, 2, A, -1, -2, 3, B, 2, 1, 0 );
+* // B => <Complex128Array>[ 4.0, 0.0, 3.0, 1.0 ]
+*/
+function copyLower( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB ) {
+	var ia;
+	var ib;
+	var i0;
+	var i1;
+
+	ia = offsetA;
+	ib = offsetB;
+	if ( isRowMajor( [ strideA1, strideA2 ] ) ) {
+		for ( i1 = 0; i1 < M; i1++ ) {
+			for ( i0 = 0; i0 <= min( i1, N-1 ); i0++ ) {
+				B.set( A.get( ia+(i0*strideA2) ), ib+(i0*strideB2) );
+			}
+			ia += strideA1;
+			ib += strideB1;
+		}
+		return B;
+	}
+	for ( i1 = 0; i1 < N; i1++ ) {
+		for ( i0 = i1; i0 < M; i0++ ) {
+			B.set( A.get( ia+(i0*strideA1) ), ib+(i0*strideB1) );
+		}
+		ia += strideA2;
+		ib += strideB2;
+	}
+	return B;
+}
+
+
+// MAIN //
+
+/**
+* Copies all or part of a matrix `A` to another matrix `B`.
+*
+* @private
+* @param {string} uplo - specifies whether to copy the upper or lower triangular/trapezoidal part of matrix `A`
+* @param {NonNegativeInteger} M - number of rows in matrix `A`
+* @param {NonNegativeInteger} N - number of columns in matrix `A`
+* @param {Complex128Array} A - input matrix
+* @param {integer} strideA1 - stride of the first dimension of `A`
+* @param {integer} strideA2 - stride of the second dimension of `A`
+* @param {NonNegativeInteger} offsetA - starting index for `A`
+* @param {Complex128Array} B - output matrix
+* @param {integer} strideB1 - stride of the first dimension of `B`
+* @param {integer} strideB2 - stride of the second dimension of `B`
+* @param {NonNegativeInteger} offsetB - starting index for `B`
+* @returns {Complex128Array} `B`
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* zlacpy( 'all', 2, 2, A, 2, 1, 0, B, 2, 1, 0 );
+* // B => <Complex128Array>[ 1.0, 2.0, 3.0, 4.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* zlacpy( 'upper', 2, 2, A, 2, 1, 0, B, 2, 1, 0 );
+* // B => <Complex128Array>[ 1.0, 2.0, 0.0, 4.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* zlacpy( 'lower', 2, 2, A, 2, 1, 0, B, 2, 1, 0 );
+* // B => <Complex128Array>[ 1.0, 0.0, 3.0, 4.0 ]
+*/
+function zlacpy( uplo, M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB ) {
+	if ( uplo === 'upper' ) {
+		return copyUpper( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB );
+	}
+	if ( uplo === 'lower' ) {
+		return copyLower( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB );
+	}
+	return copyAll( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB );
+}
+
+
+// EXPORTS //
+
+module.exports = zlacpy;

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/index.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/index.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/index.js
@@ -1,0 +1,70 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* LAPACK routine to copy all or part of a matrix `A` to another matrix `B`.
+*
+* @module @stdlib/lapack/base/zlacpy
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+* var zlacpy = require( '@stdlib/lapack/base/zlacpy' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* zlacpy( 'row-major', 'all', 2, 2, A, 2, B, 2 );
+* // B => <Complex128Array>[ 1.0, 2.0, 3.0, 4.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+* var zlacpy = require( '@stdlib/lapack/base/zlacpy' );
+*
+* var A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( [ 0.0, 0.0, 11.0, 312.0, 53.0, 412.0 ] );
+*
+* zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
+* // B => <Complex128Array>[ 0.0, 0.0, 1.0, 2.0, 3.0, 4.0 ]
+*/
+
+// MODULES //
+
+var join = require( 'path' ).join;
+var tryRequire = require( '@stdlib/utils/try-require' );
+var isError = require( '@stdlib/assert/is-error' );
+var main = require( './main.js' );
+
+
+// MAIN //
+
+var zlacpy;
+var tmp = tryRequire( join( __dirname, './native.js' ) );
+if ( isError( tmp ) ) {
+	zlacpy = main;
+} else {
+	zlacpy = tmp;
+}
+
+
+// EXPORTS //
+
+module.exports = zlacpy;
+
+// exports: { "ndarray": "zlacpy.ndarray" }

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/index.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/index.js
@@ -25,23 +25,43 @@
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
+* var real = require( '@stdlib/complex/float64/real' );
+* var imag = require( '@stdlib/complex/float64/imag' );
 * var zlacpy = require( '@stdlib/lapack/base/zlacpy' );
 *
 * var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * zlacpy( 'row-major', 'all', 2, 2, A, 2, B, 2 );
-* // B => <Complex128Array>
+*
+* var z = B.get( 0 );
+* // returns <Complex128>
+*
+* var v = real( z );
+* // returns 1.0
+*
+* v = imag( z );
+* // returns 2.0
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
+* var real = require( '@stdlib/complex/float64/real' );
+* var imag = require( '@stdlib/complex/float64/imag' );
 * var zlacpy = require( '@stdlib/lapack/base/zlacpy' );
 *
-* var A = new Complex128Array( [ 0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 11.0, 312.0, 53.0, 412.0, 24.0, 58.0, 85.0, 74.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ] );
+* var B = new Complex128Array( 12 );
 *
 * zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
-* // B => <Complex128Array>
+*
+* var z = B.get( 2 );
+* // returns <Complex128>
+*
+* var v = real( z );
+* // returns 3.0
+*
+* v = imag( z );
+* // returns 4.0
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/index.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/index.js
@@ -27,21 +27,21 @@
 * var Complex128Array = require( '@stdlib/array/complex128' );
 * var zlacpy = require( '@stdlib/lapack/base/zlacpy' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * zlacpy( 'row-major', 'all', 2, 2, A, 2, B, 2 );
-* // B => <Complex128Array>[ 1.0, 2.0, 3.0, 4.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 * var zlacpy = require( '@stdlib/lapack/base/zlacpy' );
 *
-* var A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0 ] );
-* var B = new Complex128Array( [ 0.0, 0.0, 11.0, 312.0, 53.0, 412.0 ] );
+* var A = new Complex128Array( [ 0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 11.0, 312.0, 53.0, 412.0, 24.0, 58.0, 85.0, 74.0 ] );
 *
 * zlacpy.ndarray( 'all', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
-* // B => <Complex128Array>[ 0.0, 0.0, 1.0, 2.0, 3.0, 4.0 ]
+* // B => <Complex128Array>
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/main.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/main.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/main.js
@@ -1,0 +1,35 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
+var zlacpy = require( './zlacpy.js' );
+var ndarray = require( './ndarray.js' );
+
+
+// MAIN //
+
+setReadOnly( zlacpy, 'ndarray', ndarray );
+
+
+// EXPORTS //
+
+module.exports = zlacpy;

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/ndarray.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/ndarray.js
@@ -44,29 +44,29 @@ var base = require( './base.js' );
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0 ] );
-* var B = new Complex128Array( [ 0.0, 0.0, 11.0, 312.0, 53.0, 412.0 ] );
+* var A = new Complex128Array( [ 0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 11.0, 312.0, 53.0, 412.0, 24.0, 58.0, 85.0, 74.0 ] );
 *
 * clacpy( 'all', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
-* // B => <Complex128Array>[ 0.0, 0.0, 1.0, 2.0, 3.0, 4.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0 ] );
-* var B = new Complex128Array( [ 0.0, 0.0, 11.0, 312.0, 53.0, 412.0 ] );
+* var A = new Complex128Array( [ 0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 11.0, 312.0, 53.0, 412.0, 24.0, 58.0, 85.0, 74.0 ] );
 *
 * clacpy( 'upper', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
-* // B => <Complex128Array>[ 0.0, 0.0, 1.0, 2.0, 53.0, 4.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0 ] );
-* var B = new Complex128Array( [ 0.0, 0.0, 11.0, 312.0, 53.0, 412.0 ] );
+* var A = new Complex128Array( [ 0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+* var B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 11.0, 312.0, 53.0, 412.0, 24.0, 58.0, 85.0, 74.0 ] );
 *
 * clacpy( 'lower', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
-* // B => <Complex128Array>[ 0.0, 0.0, 1.0, 312.0, 3.0, 4.0 ]
+* // B => <Complex128Array>
 */
 function clacpy( uplo, M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB ) { // eslint-disable-line max-len, max-params
 	return base( uplo, M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB ); // eslint-disable-line max-len

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/ndarray.js
@@ -1,0 +1,78 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var base = require( './base.js' );
+
+
+// MAIN //
+
+/**
+* Copies all or part of a matrix `A` to another matrix `B` using alternative indexing semantics.
+*
+* @param {string} uplo - specifies whether to copy the upper or lower triangular/trapezoidal part of matrix `A`
+* @param {NonNegativeInteger} M - number of rows in matrix `A`
+* @param {NonNegativeInteger} N - number of columns in matrix `A`
+* @param {Complex128Array} A - input matrix
+* @param {integer} strideA1 - stride of the first dimension of `A`
+* @param {integer} strideA2 - stride of the second dimension of `A`
+* @param {NonNegativeInteger} offsetA - starting index for `A`
+* @param {Complex128Array} B - output matrix
+* @param {integer} strideB1 - stride of the first dimension of `B`
+* @param {integer} strideB2 - stride of the second dimension of `B`
+* @param {NonNegativeInteger} offsetB - starting index for `B`
+* @returns {Complex128Array} `B`
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( [ 0.0, 0.0, 11.0, 312.0, 53.0, 412.0 ] );
+*
+* clacpy( 'all', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
+* // B => <Complex128Array>[ 0.0, 0.0, 1.0, 2.0, 3.0, 4.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( [ 0.0, 0.0, 11.0, 312.0, 53.0, 412.0 ] );
+*
+* clacpy( 'upper', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
+* // B => <Complex128Array>[ 0.0, 0.0, 1.0, 2.0, 53.0, 4.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( [ 0.0, 0.0, 11.0, 312.0, 53.0, 412.0 ] );
+*
+* clacpy( 'lower', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
+* // B => <Complex128Array>[ 0.0, 0.0, 1.0, 312.0, 3.0, 4.0 ]
+*/
+function clacpy( uplo, M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB ) { // eslint-disable-line max-len, max-params
+	return base( uplo, M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB ); // eslint-disable-line max-len
+}
+
+
+// EXPORTS //
+
+module.exports = clacpy;

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/ndarray.js
@@ -43,36 +43,84 @@ var base = require( './base.js' );
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
+* var real = require( '@stdlib/complex/float64/real' );
+* var imag = require( '@stdlib/complex/float64/imag' );
 *
-* var A = new Complex128Array( [ 0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 11.0, 312.0, 53.0, 412.0, 24.0, 58.0, 85.0, 74.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ] );
+* var B = new Complex128Array( 12 );
 *
-* clacpy( 'all', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
-* // B => <Complex128Array>
+* zlacpy( 'all', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
+*
+* var z = B.get( 2 );
+* // returns <Complex128>
+*
+* var v = real( z );
+* // returns 3.0
+*
+* v = imag( z );
+* // returns 4.0
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
+* var real = require( '@stdlib/complex/float64/real' );
+* var imag = require( '@stdlib/complex/float64/imag' );
 *
-* var A = new Complex128Array( [ 0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 11.0, 312.0, 53.0, 412.0, 24.0, 58.0, 85.0, 74.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ] );
+* var B = new Complex128Array( 12 );
 *
-* clacpy( 'upper', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
-* // B => <Complex128Array>
+* zlacpy( 'upper', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
+*
+* var z = B.get( 2 );
+* // returns <Complex128>
+*
+* var v = real( z );
+* // returns 3.0
+*
+* v = imag( z );
+* // returns 4.0
+*
+* z = B.get( 4 );
+* // returns <Complex128>
+*
+* v = real( z );
+* // returns 0.0
+*
+* v = imag( z );
+* // returns 0.0
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
+* var real = require( '@stdlib/complex/float64/real' );
+* var imag = require( '@stdlib/complex/float64/imag' );
 *
-* var A = new Complex128Array( [ 0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
-* var B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 11.0, 312.0, 53.0, 412.0, 24.0, 58.0, 85.0, 74.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ] );
+* var B = new Complex128Array( 12 );
 *
-* clacpy( 'lower', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
-* // B => <Complex128Array>
+* zlacpy( 'lower', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
+*
+* var z = B.get( 2 );
+* // returns <Complex128>
+*
+* var v = real( z );
+* // returns 3.0
+*
+* v = imag( z );
+* // returns 4.0
+*
+* z = B.get( 1 );
+* // returns <Complex128>
+*
+* v = real( z );
+* // returns 0.0
+*
+* v = imag( z );
+* // returns 0.0
 */
-function clacpy( uplo, M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB ) { // eslint-disable-line max-len, max-params
+function zlacpy( uplo, M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB ) { // eslint-disable-line max-len, max-params
 	return base( uplo, M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB ); // eslint-disable-line max-len
 }
 
 
 // EXPORTS //
 
-module.exports = clacpy;
+module.exports = zlacpy;

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/zlacpy.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/zlacpy.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/zlacpy.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/zlacpy.js
@@ -45,32 +45,80 @@ var base = require( './base.js' );
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
+* var real = require( '@stdlib/complex/float64/real' );
+* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
-* dlacpy( 'row-major', 'all', 2, 2, A, 2, B, 2 );
-* // B => <Complex128Array>
+* zlacpy( 'row-major', 'all', 2, 2, A, 2, B, 2 );
+*
+* var z = B.get( 0 );
+* // returns <Complex128>
+*
+* var v = real( z );
+* // returns 1.0
+*
+* v = imag( z );
+* // returns 2.0
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
+* var real = require( '@stdlib/complex/float64/real' );
+* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
-* dlacpy( 'row-major', 'upper', 2, 2, A, 2, B, 2 );
-* // B => <Complex128Array>
+* zlacpy( 'row-major', 'upper', 2, 2, A, 2, B, 2 );
+*
+* var z = B.get( 0 );
+* // returns <Complex128>
+*
+* var v = real( z );
+* // returns 1.0
+*
+* v = imag( z );
+* // returns 2.0
+*
+* z = B.get( 2 );
+* // returns <Complex128>
+*
+* v = real( z );
+* // returns 0.0
+*
+* v = imag( z );
+* // returns 0.0
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
+* var real = require( '@stdlib/complex/float64/real' );
+* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
-* dlacpy( 'row-major', 'lower', 2, 2, A, 2, B, 2 );
-* // B => <Complex128Array>
+* zlacpy( 'row-major', 'lower', 2, 2, A, 2, B, 2 );
+*
+* var z = B.get( 0 );
+* // returns <Complex128>
+*
+* var v = real( z );
+* // returns 1.0
+*
+* v = imag( z );
+* // returns 2.0
+*
+* z = B.get( 1 );
+* // returns <Complex128>
+*
+* v = real( z );
+* // returns 0.0
+*
+* v = imag( z );
+* // returns 0.0
 */
-function dlacpy( order, uplo, M, N, A, LDA, B, LDB ) {
+function zlacpy( order, uplo, M, N, A, LDA, B, LDB ) {
 	var sa1;
 	var sa2;
 	var sb1;
@@ -101,4 +149,4 @@ function dlacpy( order, uplo, M, N, A, LDA, B, LDB ) {
 
 // EXPORTS //
 
-module.exports = dlacpy;
+module.exports = zlacpy;

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/zlacpy.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/zlacpy.js
@@ -1,0 +1,104 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isLayout = require( '@stdlib/blas/base/assert/is-layout' );
+var format = require( '@stdlib/string/format' );
+var base = require( './base.js' );
+
+
+// MAIN //
+
+/**
+* Copies all or part of a matrix `A` to another matrix `B`.
+*
+* @param {string} order - storage layout of `A` and `B`
+* @param {string} uplo - specifies whether to copy the upper or lower triangular/trapezoidal part of matrix `A`
+* @param {NonNegativeInteger} M - number of rows in matrix `A`
+* @param {NonNegativeInteger} N - number of columns in matrix `A`
+* @param {Complex128Array} A - input matrix
+* @param {PositiveInteger} LDA - stride of the first dimension of `A` (a.k.a., leading dimension of the matrix `A`)
+* @param {Complex128Array} B - output matrix
+* @param {PositiveInteger} LDB - stride of the first dimension of `B` (a.k.a., leading dimension of the matrix `B`)
+* @throws {TypeError} first argument must be a valid order
+* @throws {RangeError} sixth argument must be greater than or equal to `N`
+* @throws {RangeError} eighth argument must be greater than or equal to `N`
+* @returns {Complex128Array} `B`
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* dlacpy( 'row-major', 'all', 2, 2, A, 2, B, 2 );
+* // B => <Complex128Array>[ 1.0, 2.0, 3.0, 4.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* dlacpy( 'row-major', 'upper', 2, 2, A, 2, B, 2 );
+* // B => <Complex128Array>[ 1.0, 2.0, 0.0, 4.0 ]
+*
+* @example
+* var Complex128Array = require( '@stdlib/array/complex128' );
+*
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var B = new Complex128Array( 4 );
+*
+* dlacpy( 'row-major', 'lower', 2, 2, A, 2, B, 2 );
+* // B => <Complex128Array>[ 1.0, 0.0, 3.0, 4.0 ]
+*/
+function dlacpy( order, uplo, M, N, A, LDA, B, LDB ) {
+	var sa1;
+	var sa2;
+	var sb1;
+	var sb2;
+	if ( !isLayout( order ) ) {
+		throw new TypeError( format( 'invalid argument. First argument must be a valid order. Value: `%s`.', order ) );
+	}
+	if ( order === 'column-major' ) {
+		sa1 = 1;
+		sa2 = LDA;
+		sb1 = 1;
+		sb2 = LDB;
+	} else { // order === 'row-major'
+		if ( LDA < N ) {
+			throw new RangeError( format( 'invalid argument. Sixth argument must be greater than or equal to %d. Value: `%d`.', N, LDA ) );
+		}
+		if ( LDB < N ) {
+			throw new RangeError( format( 'invalid argument. Eighth argument must be greater than or equal to %d. Value: `%d`.', N, LDB ) );
+		}
+		sa1 = LDA;
+		sa2 = 1;
+		sb1 = LDB;
+		sb2 = 1;
+	}
+	return base( uplo, M, N, A, sa1, sa2, 0, B, sb1, sb2, 0 );
+}
+
+
+// EXPORTS //
+
+module.exports = dlacpy;

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/zlacpy.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/lib/zlacpy.js
@@ -46,29 +46,29 @@ var base = require( './base.js' );
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * dlacpy( 'row-major', 'all', 2, 2, A, 2, B, 2 );
-* // B => <Complex128Array>[ 1.0, 2.0, 3.0, 4.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * dlacpy( 'row-major', 'upper', 2, 2, A, 2, B, 2 );
-* // B => <Complex128Array>[ 1.0, 2.0, 0.0, 4.0 ]
+* // B => <Complex128Array>
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 *
-* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex128Array( 4 );
 *
 * dlacpy( 'row-major', 'lower', 2, 2, A, 2, B, 2 );
-* // B => <Complex128Array>[ 1.0, 0.0, 3.0, 4.0 ]
+* // B => <Complex128Array>
 */
 function dlacpy( order, uplo, M, N, A, LDA, B, LDB ) {
 	var sa1;

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/package.json
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@stdlib/lapack/base/zlacpy",
+  "version": "0.0.0",
+  "description": "Copy all or part of a matrix A to another matrix B.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
+    "lapack",
+    "zlacpy",
+    "copy",
+    "linear",
+    "algebra",
+    "subroutines",
+    "array",
+    "ndarray",
+    "matrix",
+    "complex128",
+    "complex128array"
+  ]
+}

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/test/test.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/test/test.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/test/test.js
@@ -1,0 +1,82 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var proxyquire = require( 'proxyquire' );
+var IS_BROWSER = require( '@stdlib/assert/is-browser' );
+var zlacpy = require( './../lib' );
+
+
+// VARIABLES //
+
+var opts = {
+	'skip': IS_BROWSER
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof zlacpy, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'attached to the main export is a method providing an ndarray interface', function test( t ) {
+	t.strictEqual( typeof zlacpy.ndarray, 'function', 'method is a function' );
+	t.end();
+});
+
+tape( 'if a native implementation is available, the main export is the native implementation', opts, function test( t ) {
+	var zlacpy = proxyquire( './../lib', {
+		'@stdlib/utils/try-require': tryRequire
+	});
+
+	t.strictEqual( zlacpy, mock, 'returns expected value' );
+	t.end();
+
+	function tryRequire() {
+		return mock;
+	}
+
+	function mock() {
+		// Mock...
+	}
+});
+
+tape( 'if a native implementation is not available, the main export is a JavaScript implementation', opts, function test( t ) {
+	var zlacpy;
+	var main;
+
+	main = require( './../lib/zlacpy.js' );
+
+	zlacpy = proxyquire( './../lib', {
+		'@stdlib/utils/try-require': tryRequire
+	});
+
+	t.strictEqual( zlacpy, main, 'returns expected value' );
+	t.end();
+
+	function tryRequire() {
+		return new Error( 'Cannot find module' );
+	}
+});

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/test/test.ndarray.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/test/test.ndarray.js
@@ -1,0 +1,330 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* eslint-disable max-len */
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var ndarray = require( '@stdlib/ndarray/ctor' );
+var ndarray2array = require( '@stdlib/ndarray/to-array' );
+var isSameComplex128Array = require( '@stdlib/assert/is-same-complex128array' );
+var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
+var Complex128Array = require( '@stdlib/array/complex128' );
+var zlacpy = require( './../lib/ndarray.js' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof zlacpy, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 11', function test( t ) {
+	t.strictEqual( zlacpy.length, 11, 'returns expected value' );
+	t.end();
+});
+
+function prettyPrintNdarray(arr) {
+	var maxLengths = [];
+
+	function printRecursive(subArr, shape, idx, maxLengths) {
+		var lines = [];
+		var value;
+		var row;
+		var i;
+		if (shape.length === 1) {
+			row = '  ';
+			for (i = 0; i < shape[0]; i++) {
+				value = subArr.get(...idx, i).toString();
+				row += value.padEnd(maxLengths[idx.length], ' ') + '    ';
+			}
+			lines.push(row);
+		} else {
+			for (i = 0; i < shape[0]; i++) {
+				lines.push(printRecursive(subArr, shape.slice(1), idx.concat(i), maxLengths));
+			}
+		}
+		return lines.join('\n');
+	}
+
+	function calculateMaxLengths(arr, shape, idx, maxLengths) {
+		var value;
+		var i;
+		if (shape.length === 1) {
+			for (i = 0; i < shape[0]; i++) {
+				value = arr.get(...idx, i).toString();
+				maxLengths[idx.length] = Math.max(maxLengths[idx.length] || 0, value.length);
+			}
+		} else {
+			for (i = 0; i < shape[0]; i++) {
+				calculateMaxLengths(arr, shape.slice(1), idx.concat(i), maxLengths);
+			}
+		}
+	}
+
+	calculateMaxLengths(arr, arr.shape, [], maxLengths);
+	return printRecursive(arr, arr.shape, [], maxLengths);
+}
+
+tape( 'the function copies all of a matrix `A` to another matrix `B` (row-major)', function test( t ) {
+	var expected;
+	var out;
+	var An;
+	var Bn;
+	var En;
+	var A;
+	var B;
+
+	A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0 ] );
+	B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0 ] );
+
+	out = zlacpy( 'all', 2, 3, A, 3, 1, 1, B, 3, 1, 3 );
+
+	t.strictEqual( out, B, 'returns expected value' );
+	t.ok( isSameComplex128Array( out, expected ), 'returns expected value' );
+
+	A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0 ] );
+	B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 13.0, 14.0, 11.0, 12.0, 9.0, 10.0, 7.0, 8.0, 5.0, 6.0, 3.0, 4.0 ] );
+
+	out = zlacpy( 'all', 2, 3, A, -3, -1, 6, B, 3, 1, 3 );
+	t.strictEqual( out, B, 'returns expected value' );
+	t.ok( isSameComplex128Array( out, expected ), 'returns expected value' );
+
+	A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0 ] );
+	B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0 ] );
+
+	out = zlacpy( 'all', 3, 2, A, 2, 1, 1, B, 2, 1, 3 );
+	t.strictEqual( out, B, 'returns expected value' );
+	t.ok( isSameComplex128Array( out, expected ), 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function copies part of a matrix `A` to another matrix `B` (row-major, upper)', function test( t ) {
+	var expected;
+	var out;
+	var A;
+	var B;
+
+	A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0 ] );
+	B = new Complex128Array( 7 );
+	expected = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0 ] );
+
+	out = zlacpy( 'upper', 2, 3, A, 3, 1, 1, B, 3, 1, 3 );
+	console.log('\nA =\n' + prettyPrintNdarray(ndarray('float64', A, [ 2, 3 ], [ 3, 1 ], 0, 'row-major')));
+	console.log('\nB =\n' + prettyPrintNdarray(ndarray('float64', B, [ 3, 3 ], [ 3, 1 ], 0, 'row-major')));
+	console.log('\nE =\n' + prettyPrintNdarray(ndarray('float64', expected, [ 3, 3 ], [ 3, 1 ], 0, 'row-major')));
+
+	console.log(new Float64Array(B.buffer));
+
+	t.strictEqual( out, B, 'returns expected value' );
+	t.ok( isEqualArray( out, expected ), 'returns expected value' );
+	t.ok( isSameComplex128Array( out, expected ), 'returns expected value' );
+
+	return t.end();
+	A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+	B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 3.0, 2.0, 1.0, 0.0, 5.0, 4.0 ] );
+
+	out = zlacpy( 'upper', 2, 3, A, 3, -1, 3, B, 3, 1, 3 );
+	t.strictEqual( out, B, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+	B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 1.0, 2.0, 0.0, 4.0, 0.0, 0.0 ] );
+
+	out = zlacpy( 'upper', 3, 2, A, 2, 1, 1, B, 2, 1, 3 );
+	t.strictEqual( out, B, 'returns expected value' );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+if (false) {
+	tape( 'the function copies part of a matrix `A` to another matrix `B` (row-major, lower)', function test( t ) {
+		var expected;
+		var out;
+		var A;
+		var B;
+
+		A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+		B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+		expected = new Complex128Array( [ 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 4.0, 5.0, 0.0 ] );
+
+		out = zlacpy( 'lower', 2, 3, A, 3, 1, 1, B, 3, 1, 3 );
+		t.strictEqual( out, B, 'returns expected value' );
+		t.deepEqual( out, expected, 'returns expected value' );
+
+		A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+		B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+		expected = new Complex128Array( [ 0.0, 0.0, 0.0, 4.0, 0.0, 0.0, 1.0, 2.0, 0.0 ] );
+
+		out = zlacpy( 'lower', 2, 3, A, -3, 1, 4, B, 3, 1, 3 );
+		t.strictEqual( out, B, 'returns expected value' );
+		t.deepEqual( out, expected, 'returns expected value' );
+
+		A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+		B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+		expected = new Complex128Array( [ 0.0, 0.0, 0.0, 1.0, 0.0, 3.0, 4.0, 5.0, 6.0 ] );
+
+		out = zlacpy( 'lower', 3, 2, A, 2, 1, 1, B, 2, 1, 3 );
+		t.strictEqual( out, B, 'returns expected value' );
+		t.deepEqual( out, expected, 'returns expected value' );
+
+		t.end();
+	});
+
+	tape( 'the function copies all of a matrix `A` to another matrix `B` (column-major)', function test( t ) {
+		var expected;
+		var out;
+		var A;
+		var B;
+
+		A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+		B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+		expected = new Complex128Array( [ 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+
+		out = zlacpy( 'all', 2, 3, A, 1, 2, 1, B, 1, 2, 3 );
+		t.strictEqual( out, B, 'returns expected value' );
+		t.deepEqual( out, expected, 'returns expected value' );
+
+		A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+		B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+		expected = new Complex128Array( [ 0.0, 0.0, 0.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0 ] );
+
+		out = zlacpy( 'all', 2, 3, A, 1, 2, 1, B, -1, -2, 8 );
+		t.strictEqual( out, B, 'returns expected value' );
+		t.deepEqual( out, expected, 'returns expected value' );
+
+		A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+		B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+		expected = new Complex128Array( [ 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+
+		out = zlacpy( 'all', 3, 2, A, 1, 3, 1, B, 1, 3, 3 );
+		t.strictEqual( out, B, 'returns expected value' );
+		t.deepEqual( out, expected, 'returns expected value' );
+
+		t.end();
+	});
+
+	tape( 'the function copies part of a matrix `A` to another matrix `B` (column-major, upper)', function test( t ) {
+		var expected;
+		var out;
+		var A;
+		var B;
+
+		A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+		B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+		expected = new Complex128Array( [ 0.0, 0.0, 0.0, 1.0, 0.0, 3.0, 4.0, 5.0, 6.0 ] );
+
+		out = zlacpy( 'upper', 2, 3, A, 1, 2, 1, B, 1, 2, 3 );
+		t.strictEqual( out, B, 'returns expected value' );
+		t.deepEqual( out, expected, 'returns expected value' );
+
+		A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+		B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+		expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 1.0, 4.0, 3.0, 6.0, 5.0 ] );
+
+		out = zlacpy( 'upper', 2, 3, A, 1, 2, 1, B, -1, 2, 4 );
+		t.strictEqual( out, B, 'returns expected value' );
+		t.deepEqual( out, expected, 'returns expected value' );
+
+		A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+		B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+		expected = new Complex128Array( [ 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 4.0, 5.0, 0.0 ] );
+
+		out = zlacpy( 'upper', 3, 2, A, 1, 3, 1, B, 1, 3, 3 );
+		t.strictEqual( out, B, 'returns expected value' );
+		t.deepEqual( out, expected, 'returns expected value' );
+
+		t.end();
+	});
+
+	tape( 'the function copies part of a matrix `A` to another matrix `B` (column-major, lower)', function test( t ) {
+		var expected;
+		var out;
+		var A;
+		var B;
+
+		A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+		B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+		expected = new Complex128Array( [ 0.0, 0.0, 0.0, 1.0, 2.0, 0.0, 4.0, 0.0, 0.0 ] );
+
+		out = zlacpy( 'lower', 2, 3, A, 1, 2, 1, B, 1, 2, 3 );
+		t.strictEqual( out, B, 'returns expected value' );
+		t.deepEqual( out, expected, 'returns expected value' );
+
+		A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+		B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+		expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 4.0, 1.0, 2.0 ] );
+
+		out = zlacpy( 'lower', 2, 3, A, 1, 2, 1, B, 1, -2, 7 );
+		t.strictEqual( out, B, 'returns expected value' );
+		t.deepEqual( out, expected, 'returns expected value' );
+
+		A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+		B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+		expected = new Complex128Array( [ 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 0.0, 5.0, 6.0 ] );
+
+		out = zlacpy( 'lower', 3, 2, A, 1, 3, 1, B, 1, 3, 3 );
+		t.strictEqual( out, B, 'returns expected value' );
+		t.deepEqual( out, expected, 'returns expected value' );
+
+		t.end();
+	});
+
+	tape( 'the function copies all of a matrix `A` to another matrix `B` (column-major, lower, complex access patterns)', function test( t ) {
+		var out;
+		var A;
+		var B;
+
+		/* eslint-disable array-element-newline, no-multi-spaces */
+
+		A = new Complex128Array([
+			999, 999, 999, 999, 999, 999,
+			999,   1, 999,   2, 999,   3,
+			999,   0, 999,   4, 999,   5,
+			999,   0, 999,   0, 999,   6,
+			999, 999, 999, 999, 999, 999
+		]);
+		B = new Complex128Array([
+			999, 999, 999, 999, 999, 999,
+			999, 999, 999, 999, 999, 999,
+			999, 999, 999, 999, 999, 999,
+			999, 999, 999, 999, 999, 999,
+			999, 999, 999, 999, 999, 999
+		]);
+
+		/* eslint-enable array-element-newline, no-multi-spaces */
+
+		out = zlacpy( 'all', 3, 3, A, 2, 6, 7, B, 2, 6, 7 );
+		t.strictEqual( out, B, 'returns expected value' );
+		t.deepEqual( out, A, 'returns expected value' );
+
+		t.end();
+	});
+}

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/test/test.ndarray.js
@@ -82,25 +82,25 @@ tape( 'the function copies part of a matrix `A` to another matrix `B` (row-major
 
 	A = new Complex128Array( [ 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
 	B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
-	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
+	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 0.0, 0.0, 20.0, 21.0, 22.0, 23.0 ] );
 
-	out = zlacpy( 'all', 2, 3, A, 3, 1, 1, B, 3, 1, 3 );
+	out = zlacpy( 'upper', 2, 3, A, 3, 1, 1, B, 3, 1, 3 );
 	t.strictEqual( out, B, 'returns expected value' );
 	t.ok( isSameComplex128Array( out, expected ), 'returns expected value' );
 
 	A = new Complex128Array( [ 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
 	B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
-	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 22.0, 23.0, 20.0, 21.0, 18.0, 19.0, 16.0, 17.0, 14.0, 15.0, 12.0, 13.0 ] );
+	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 22.0, 23.0, 20.0, 21.0, 18.0, 19.0, 0.0, 0.0, 14.0, 15.0, 12.0, 13.0 ] );
 
-	out = zlacpy( 'all', 2, 3, A, -3, -1, 6, B, 3, 1, 3 );
+	out = zlacpy( 'upper', 2, 3, A, -3, -1, 6, B, 3, 1, 3 );
 	t.strictEqual( out, B, 'returns expected value' );
 	t.ok( isSameComplex128Array( out, expected ), 'returns expected value' );
 
 	A = new Complex128Array( [ 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
 	B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
-	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
+	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 12.0, 13.0, 14.0, 15.0, 0.0, 0.0, 18.0, 19.0, 0.0, 0.0, 0.0, 0.0 ] );
 
-	out = zlacpy( 'all', 3, 2, A, 2, 1, 1, B, 2, 1, 3 );
+	out = zlacpy( 'upper', 3, 2, A, 2, 1, 1, B, 2, 1, 3 );
 	t.strictEqual( out, B, 'returns expected value' );
 	t.ok(isSameComplex128Array(out, expected), 'returns expected value');
 

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/test/test.ndarray.js
@@ -23,10 +23,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var ndarray = require( '@stdlib/ndarray/ctor' );
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var isSameComplex128Array = require( '@stdlib/assert/is-same-complex128array' );
-var reinterpret128 = require( '@stdlib/strided/base/reinterpret-complex128' );
 var Complex128Array = require( '@stdlib/array/complex128' );
 var zlacpy = require( './../lib/ndarray.js' );
 
@@ -44,77 +41,31 @@ tape( 'the function has an arity of 11', function test( t ) {
 	t.end();
 });
 
-function prettyPrintNdarray(arr) {
-	var maxLengths = [];
-
-	function printRecursive(subArr, shape, idx, maxLengths) {
-		var lines = [];
-		var value;
-		var row;
-		var i;
-		if (shape.length === 1) {
-			row = '  ';
-			for (i = 0; i < shape[0]; i++) {
-				value = subArr.get(...idx, i).toString();
-				row += value.padEnd(maxLengths[idx.length], ' ') + '    ';
-			}
-			lines.push(row);
-		} else {
-			for (i = 0; i < shape[0]; i++) {
-				lines.push(printRecursive(subArr, shape.slice(1), idx.concat(i), maxLengths));
-			}
-		}
-		return lines.join('\n');
-	}
-
-	function calculateMaxLengths(arr, shape, idx, maxLengths) {
-		var value;
-		var i;
-		if (shape.length === 1) {
-			for (i = 0; i < shape[0]; i++) {
-				value = arr.get(...idx, i).toString();
-				maxLengths[idx.length] = Math.max(maxLengths[idx.length] || 0, value.length);
-			}
-		} else {
-			for (i = 0; i < shape[0]; i++) {
-				calculateMaxLengths(arr, shape.slice(1), idx.concat(i), maxLengths);
-			}
-		}
-	}
-
-	calculateMaxLengths(arr, arr.shape, [], maxLengths);
-	return printRecursive(arr, arr.shape, [], maxLengths);
-}
-
 tape( 'the function copies all of a matrix `A` to another matrix `B` (row-major)', function test( t ) {
 	var expected;
 	var out;
-	var An;
-	var Bn;
-	var En;
 	var A;
 	var B;
 
-	A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0 ] );
+	A = new Complex128Array( [ 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
 	B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
-	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0 ] );
+	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0] );
 
 	out = zlacpy( 'all', 2, 3, A, 3, 1, 1, B, 3, 1, 3 );
-
 	t.strictEqual( out, B, 'returns expected value' );
 	t.ok( isSameComplex128Array( out, expected ), 'returns expected value' );
 
-	A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0 ] );
+	A = new Complex128Array( [ 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
 	B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
-	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 13.0, 14.0, 11.0, 12.0, 9.0, 10.0, 7.0, 8.0, 5.0, 6.0, 3.0, 4.0 ] );
+	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 22.0, 23.0, 20.0, 21.0, 18.0, 19.0, 16.0, 17.0, 14.0, 15.0, 12.0, 13.0 ] );
 
 	out = zlacpy( 'all', 2, 3, A, -3, -1, 6, B, 3, 1, 3 );
 	t.strictEqual( out, B, 'returns expected value' );
 	t.ok( isSameComplex128Array( out, expected ), 'returns expected value' );
 
-	A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0 ] );
+	A = new Complex128Array( [ 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
 	B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
-	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0 ] );
+	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
 
 	out = zlacpy( 'all', 3, 2, A, 2, 1, 1, B, 2, 1, 3 );
 	t.strictEqual( out, B, 'returns expected value' );
@@ -129,202 +80,191 @@ tape( 'the function copies part of a matrix `A` to another matrix `B` (row-major
 	var A;
 	var B;
 
-	A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0 ] );
-	B = new Complex128Array( 7 );
-	expected = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0 ] );
+	A = new Complex128Array( [ 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
+	B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
 
-	out = zlacpy( 'upper', 2, 3, A, 3, 1, 1, B, 3, 1, 3 );
-	console.log('\nA =\n' + prettyPrintNdarray(ndarray('float64', A, [ 2, 3 ], [ 3, 1 ], 0, 'row-major')));
-	console.log('\nB =\n' + prettyPrintNdarray(ndarray('float64', B, [ 3, 3 ], [ 3, 1 ], 0, 'row-major')));
-	console.log('\nE =\n' + prettyPrintNdarray(ndarray('float64', expected, [ 3, 3 ], [ 3, 1 ], 0, 'row-major')));
-
-	console.log(new Float64Array(B.buffer));
-
+	out = zlacpy( 'all', 2, 3, A, 3, 1, 1, B, 3, 1, 3 );
 	t.strictEqual( out, B, 'returns expected value' );
-	t.ok( isEqualArray( out, expected ), 'returns expected value' );
 	t.ok( isSameComplex128Array( out, expected ), 'returns expected value' );
 
-	return t.end();
-	A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
-	B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
-	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 3.0, 2.0, 1.0, 0.0, 5.0, 4.0 ] );
+	A = new Complex128Array( [ 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
+	B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 22.0, 23.0, 20.0, 21.0, 18.0, 19.0, 16.0, 17.0, 14.0, 15.0, 12.0, 13.0 ] );
 
-	out = zlacpy( 'upper', 2, 3, A, 3, -1, 3, B, 3, 1, 3 );
+	out = zlacpy( 'all', 2, 3, A, -3, -1, 6, B, 3, 1, 3 );
 	t.strictEqual( out, B, 'returns expected value' );
-	t.deepEqual( out, expected, 'returns expected value' );
+	t.ok( isSameComplex128Array( out, expected ), 'returns expected value' );
 
-	A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
-	B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
-	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 1.0, 2.0, 0.0, 4.0, 0.0, 0.0 ] );
+	A = new Complex128Array( [ 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
+	B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
 
-	out = zlacpy( 'upper', 3, 2, A, 2, 1, 1, B, 2, 1, 3 );
+	out = zlacpy( 'all', 3, 2, A, 2, 1, 1, B, 2, 1, 3 );
 	t.strictEqual( out, B, 'returns expected value' );
-	t.deepEqual( out, expected, 'returns expected value' );
+	t.ok(isSameComplex128Array(out, expected), 'returns expected value');
 
 	t.end();
 });
 
-if (false) {
-	tape( 'the function copies part of a matrix `A` to another matrix `B` (row-major, lower)', function test( t ) {
-		var expected;
-		var out;
-		var A;
-		var B;
+tape( 'the function copies part of a matrix `A` to another matrix `B` (row-major, lower)', function test( t ) {
+	var expected;
+	var out;
+	var A;
+	var B;
 
-		A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
-		B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
-		expected = new Complex128Array( [ 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 4.0, 5.0, 0.0 ] );
+	A = new Complex128Array( [ 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
+	B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 12.0, 13.0, 0.0, 0.0, 0.0, 0.0, 18.0, 19.0, 20.0, 21.0, 0.0, 0.0 ] );
 
-		out = zlacpy( 'lower', 2, 3, A, 3, 1, 1, B, 3, 1, 3 );
-		t.strictEqual( out, B, 'returns expected value' );
-		t.deepEqual( out, expected, 'returns expected value' );
+	out = zlacpy( 'lower', 2, 3, A, 3, 1, 1, B, 3, 1, 3 );
+	t.strictEqual( out, B, 'returns expected value' );
+	t.ok(isSameComplex128Array(out, expected), 'returns expected value');
 
-		A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
-		B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
-		expected = new Complex128Array( [ 0.0, 0.0, 0.0, 4.0, 0.0, 0.0, 1.0, 2.0, 0.0 ] );
+	A = new Complex128Array( [ 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
+	B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 18.0, 19.0, 0.0, 0.0, 0.0, 0.0, 12.0, 13.0, 14.0, 15.0, 0.0, 0.0 ] );
 
-		out = zlacpy( 'lower', 2, 3, A, -3, 1, 4, B, 3, 1, 3 );
-		t.strictEqual( out, B, 'returns expected value' );
-		t.deepEqual( out, expected, 'returns expected value' );
+	out = zlacpy( 'lower', 2, 3, A, -3, 1, 4, B, 3, 1, 3 );
+	t.strictEqual( out, B, 'returns expected value' );
+	t.ok( isSameComplex128Array( out, expected ), 'returns expected value' );
 
-		A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
-		B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
-		expected = new Complex128Array( [ 0.0, 0.0, 0.0, 1.0, 0.0, 3.0, 4.0, 5.0, 6.0 ] );
+	A = new Complex128Array( [ 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
+	B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 12.0, 13.0, 0.0, 0.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
 
-		out = zlacpy( 'lower', 3, 2, A, 2, 1, 1, B, 2, 1, 3 );
-		t.strictEqual( out, B, 'returns expected value' );
-		t.deepEqual( out, expected, 'returns expected value' );
+	out = zlacpy( 'lower', 3, 2, A, 2, 1, 1, B, 2, 1, 3 );
+	t.strictEqual( out, B, 'returns expected value' );
+	t.ok( isSameComplex128Array( out, expected ), 'returns expected value' );
 
-		t.end();
-	});
+	t.end();
+});
+tape( 'the function copies all of a matrix `A` to another matrix `B` (column-major)', function test( t ) {
+	var expected;
+	var out;
+	var A;
+	var B;
 
-	tape( 'the function copies all of a matrix `A` to another matrix `B` (column-major)', function test( t ) {
-		var expected;
-		var out;
-		var A;
-		var B;
+	A = new Complex128Array( [ 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
+	B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
 
-		A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
-		B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
-		expected = new Complex128Array( [ 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+	out = zlacpy( 'all', 2, 3, A, 1, 2, 1, B, 1, 2, 3 );
+	t.strictEqual( out, B, 'returns expected value' );
+	t.ok( isSameComplex128Array( out, expected ), 'returns expected value' );
 
-		out = zlacpy( 'all', 2, 3, A, 1, 2, 1, B, 1, 2, 3 );
-		t.strictEqual( out, B, 'returns expected value' );
-		t.deepEqual( out, expected, 'returns expected value' );
+	A = new Complex128Array( [ 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
+	B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 22.0, 23.0, 20.0, 21.0, 18.0, 19.0, 16.0, 17.0, 14.0, 15.0, 12.0, 13.0 ] );
 
-		A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
-		B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
-		expected = new Complex128Array( [ 0.0, 0.0, 0.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0 ] );
+	out = zlacpy( 'all', 2, 3, A, 1, 2, 1, B, -1, -2, 8 );
+	t.strictEqual( out, B, 'returns expected value' );
+	t.ok( isSameComplex128Array( out, expected ), 'returns expected value' );
 
-		out = zlacpy( 'all', 2, 3, A, 1, 2, 1, B, -1, -2, 8 );
-		t.strictEqual( out, B, 'returns expected value' );
-		t.deepEqual( out, expected, 'returns expected value' );
+	A = new Complex128Array( [ 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
+	B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
 
-		A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
-		B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
-		expected = new Complex128Array( [ 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+	out = zlacpy( 'all', 3, 2, A, 1, 3, 1, B, 1, 3, 3 );
+	t.strictEqual( out, B, 'returns expected value' );
+	t.ok( isSameComplex128Array( out, expected ), 'returns expected value' );
 
-		out = zlacpy( 'all', 3, 2, A, 1, 3, 1, B, 1, 3, 3 );
-		t.strictEqual( out, B, 'returns expected value' );
-		t.deepEqual( out, expected, 'returns expected value' );
+	t.end();
+});
 
-		t.end();
-	});
+tape( 'the function copies part of a matrix `A` to another matrix `B` (column-major, upper)', function test( t ) {
+	var expected;
+	var out;
+	var A;
+	var B;
 
-	tape( 'the function copies part of a matrix `A` to another matrix `B` (column-major, upper)', function test( t ) {
-		var expected;
-		var out;
-		var A;
-		var B;
+	A = new Complex128Array( [ 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
+	B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 12.0, 13.0, 0.0, 0.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
 
-		A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
-		B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
-		expected = new Complex128Array( [ 0.0, 0.0, 0.0, 1.0, 0.0, 3.0, 4.0, 5.0, 6.0 ] );
+	out = zlacpy( 'upper', 2, 3, A, 1, 2, 1, B, 1, 2, 3 );
+	t.strictEqual( out, B, 'returns expected value' );
+	t.ok( isSameComplex128Array( out, expected ), 'returns expected value' );
 
-		out = zlacpy( 'upper', 2, 3, A, 1, 2, 1, B, 1, 2, 3 );
-		t.strictEqual( out, B, 'returns expected value' );
-		t.deepEqual( out, expected, 'returns expected value' );
+	A = new Complex128Array( [ 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
+	B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 12.0, 13.0, 18.0, 19.0, 16.0, 17.0, 22.0, 23.0, 20.0, 21.0 ] );
 
-		A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
-		B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
-		expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 1.0, 4.0, 3.0, 6.0, 5.0 ] );
+	out = zlacpy( 'upper', 2, 3, A, 1, 2, 1, B, -1, 2, 4 );
+	t.strictEqual( out, B, 'returns expected value' );
+	t.ok( isSameComplex128Array( out, expected ), 'returns expected value' );
 
-		out = zlacpy( 'upper', 2, 3, A, 1, 2, 1, B, -1, 2, 4 );
-		t.strictEqual( out, B, 'returns expected value' );
-		t.deepEqual( out, expected, 'returns expected value' );
+	A = new Complex128Array( [ 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
+	B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 12.0, 13.0, 0.0, 0.0, 0.0, 0.0, 18.0, 19.0, 20.0, 21.0, 0.0, 0.0 ] );
 
-		A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
-		B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
-		expected = new Complex128Array( [ 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 4.0, 5.0, 0.0 ] );
+	out = zlacpy( 'upper', 3, 2, A, 1, 3, 1, B, 1, 3, 3 );
+	t.strictEqual( out, B, 'returns expected value' );
+	t.ok( isSameComplex128Array( out, expected ), 'returns expected value' );
 
-		out = zlacpy( 'upper', 3, 2, A, 1, 3, 1, B, 1, 3, 3 );
-		t.strictEqual( out, B, 'returns expected value' );
-		t.deepEqual( out, expected, 'returns expected value' );
+	t.end();
+});
 
-		t.end();
-	});
+tape( 'the function copies part of a matrix `A` to another matrix `B` (column-major, lower)', function test( t ) {
+	var expected;
+	var out;
+	var A;
+	var B;
 
-	tape( 'the function copies part of a matrix `A` to another matrix `B` (column-major, lower)', function test( t ) {
-		var expected;
-		var out;
-		var A;
-		var B;
+	A = new Complex128Array( [ 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
+	B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 12.0, 13.0, 14.0, 15.0, 0.0, 0.0, 18.0, 19.0, 0.0, 0.0, 0.0, 0.0 ] );
 
-		A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
-		B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
-		expected = new Complex128Array( [ 0.0, 0.0, 0.0, 1.0, 2.0, 0.0, 4.0, 0.0, 0.0 ] );
+	out = zlacpy( 'lower', 2, 3, A, 1, 2, 1, B, 1, 2, 3 );
+	t.strictEqual( out, B, 'returns expected value' );
+	t.ok( isSameComplex128Array( out, expected ), 'returns expected value' );
 
-		out = zlacpy( 'lower', 2, 3, A, 1, 2, 1, B, 1, 2, 3 );
-		t.strictEqual( out, B, 'returns expected value' );
-		t.deepEqual( out, expected, 'returns expected value' );
+	A = new Complex128Array( [ 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
+	B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 18.0, 19.0, 12.0, 13.0, 14.0, 15.0 ] );
 
-		A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
-		B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
-		expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 4.0, 1.0, 2.0 ] );
+	out = zlacpy( 'lower', 2, 3, A, 1, 2, 1, B, 1, -2, 7 );
+	t.strictEqual( out, B, 'returns expected value' );
+	t.ok( isSameComplex128Array( out, expected ), 'returns expected value' );
 
-		out = zlacpy( 'lower', 2, 3, A, 1, 2, 1, B, 1, -2, 7 );
-		t.strictEqual( out, B, 'returns expected value' );
-		t.deepEqual( out, expected, 'returns expected value' );
+	A = new Complex128Array( [ 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0 ] );
+	B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
+	expected = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 0.0, 0.0, 20.0, 21.0, 22.0, 23.0 ] );
 
-		A = new Complex128Array( [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
-		B = new Complex128Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
-		expected = new Complex128Array( [ 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 0.0, 5.0, 6.0 ] );
+	out = zlacpy( 'lower', 3, 2, A, 1, 3, 1, B, 1, 3, 3 );
+	t.strictEqual( out, B, 'returns expected value' );
+	t.ok( isSameComplex128Array( out, expected ), 'returns expected value' );
 
-		out = zlacpy( 'lower', 3, 2, A, 1, 3, 1, B, 1, 3, 3 );
-		t.strictEqual( out, B, 'returns expected value' );
-		t.deepEqual( out, expected, 'returns expected value' );
+	t.end();
+});
 
-		t.end();
-	});
+tape( 'the function copies all of a matrix `A` to another matrix `B` (column-major, lower, complex access patterns)', function test( t ) {
+	var out;
+	var A;
+	var B;
 
-	tape( 'the function copies all of a matrix `A` to another matrix `B` (column-major, lower, complex access patterns)', function test( t ) {
-		var out;
-		var A;
-		var B;
+	/* eslint-disable array-element-newline, no-multi-spaces */
 
-		/* eslint-disable array-element-newline, no-multi-spaces */
+	A = new Complex128Array([
+		999, 999, 999, 999, 999, 999, 999, 999, 999, 999, 999, 999,
+		999, 999,   1,   2, 999, 999,   3,   4, 999, 999,   5,   6,
+		999, 999,   7,   8, 999, 999,   9,  10, 999, 999,  11,  12,
+		999, 999,  13,  14, 999, 999,  15,  16, 999, 999,  17,  18,
+		999, 999, 999, 999, 999, 999, 999, 999, 999, 999, 999, 999
+	]);
+	B = new Complex128Array([
+		999, 999, 999, 999, 999, 999, 999, 999, 999, 999, 999, 999,
+		999, 999, 999, 999, 999, 999, 999, 999, 999, 999, 999, 999,
+		999, 999, 999, 999, 999, 999, 999, 999, 999, 999, 999, 999,
+		999, 999, 999, 999, 999, 999, 999, 999, 999, 999, 999, 999,
+		999, 999, 999, 999, 999, 999, 999, 999, 999, 999, 999, 999
+	]);
 
-		A = new Complex128Array([
-			999, 999, 999, 999, 999, 999,
-			999,   1, 999,   2, 999,   3,
-			999,   0, 999,   4, 999,   5,
-			999,   0, 999,   0, 999,   6,
-			999, 999, 999, 999, 999, 999
-		]);
-		B = new Complex128Array([
-			999, 999, 999, 999, 999, 999,
-			999, 999, 999, 999, 999, 999,
-			999, 999, 999, 999, 999, 999,
-			999, 999, 999, 999, 999, 999,
-			999, 999, 999, 999, 999, 999
-		]);
+	/* eslint-enable array-element-newline, no-multi-spaces */
 
-		/* eslint-enable array-element-newline, no-multi-spaces */
+	out = zlacpy( 'all', 3, 3, A, 2, 6, 7, B, 2, 6, 7 );
+	t.strictEqual( out, B, 'returns expected value' );
+	t.ok( isSameComplex128Array( out, A ), 'returns expected value' );
 
-		out = zlacpy( 'all', 3, 3, A, 2, 6, 7, B, 2, 6, 7 );
-		t.strictEqual( out, B, 'returns expected value' );
-		t.deepEqual( out, A, 'returns expected value' );
-
-		t.end();
-	});
-}
+	t.end();
+});

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/test/test.zlacpy.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/test/test.zlacpy.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/test/test.zlacpy.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/test/test.zlacpy.js
@@ -132,7 +132,7 @@ tape( 'the function copies all of a matrix `A` to another matrix `B` (row-major)
 	N = 8;
 
 	opts = {
-		'dtype': 'generic'
+		'dtype': 'float64'
 	};
 
 	A = new Complex128Array( uniform( M*N*2, -10.0, 10.0, opts ) );
@@ -157,7 +157,7 @@ tape( 'the function copies a part of a matrix `A` to another matrix `B` (row-maj
 	N = 8;
 
 	opts = {
-		'dtype': 'generic'
+		'dtype': 'float64'
 	};
 
 	A = new Complex128Array( uniform( M*N*2, -10.0, 10.0, opts ) );
@@ -185,7 +185,7 @@ tape( 'the function copies a part of a matrix `A` to another matrix `B` (row-maj
 	N = 8;
 
 	opts = {
-		'dtype': 'generic'
+		'dtype': 'float64'
 	};
 
 	A = new Complex128Array( uniform( M*N*2, -10.0, 10.0, opts ) );
@@ -213,7 +213,7 @@ tape( 'the function copies all of a matrix `A` to another matrix `B` (column-maj
 	N = 8;
 
 	opts = {
-		'dtype': 'generic'
+		'dtype': 'float64'
 	};
 
 	A = new Complex128Array( uniform( M*N*2, -10.0, 10.0, opts ) );
@@ -238,7 +238,7 @@ tape( 'the function copies a part of a matrix `A` to another matrix `B` (column-
 	N = 8;
 
 	opts = {
-		'dtype': 'generic'
+		'dtype': 'float64'
 	};
 
 	A = new Complex128Array( uniform( M*N*2, -10.0, 10.0, opts ) );
@@ -266,7 +266,7 @@ tape( 'the function copies a part of a matrix `A` to another matrix `B` (column-
 	N = 8;
 
 	opts = {
-		'dtype': 'generic'
+		'dtype': 'float64'
 	};
 
 	A = new Complex128Array( uniform( M*N*2, -10.0, 10.0, opts ) );

--- a/lib/node_modules/@stdlib/lapack/base/zlacpy/test/test.zlacpy.js
+++ b/lib/node_modules/@stdlib/lapack/base/zlacpy/test/test.zlacpy.js
@@ -1,0 +1,283 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isSameComplex128Array = require( '@stdlib/assert/is-same-complex128array' );
+var Complex128Array = require( '@stdlib/array/complex128' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var zlacpy = require( './../lib/zlacpy.js' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof zlacpy, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function has an arity of 8', function test( t ) {
+	t.strictEqual( zlacpy.length, 8, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function throws an error if provided an invalid first argument', function test( t ) {
+	var values;
+	var A;
+	var B;
+	var i;
+
+	values = [
+		'foo',
+		'bar',
+		'beep',
+		'boop'
+	];
+
+	A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+	B = new Complex128Array( 4 );
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), TypeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			zlacpy( value, 'all', 2, 2, A, 2, B, 2 );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an invalid sixth argument (row-major)', function test( t ) {
+	var values;
+	var A;
+	var B;
+	var i;
+
+	values = [
+		0,
+		1
+	];
+
+	A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+	B = new Complex128Array( 4 );
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), RangeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			zlacpy( 'row-major', 'all', 2, 2, A, value, B, 2 );
+		};
+	}
+});
+
+tape( 'the function throws an error if provided an invalid eighth argument (row-major)', function test( t ) {
+	var values;
+	var A;
+	var B;
+	var i;
+
+	values = [
+		0,
+		1
+	];
+
+	A = new Complex128Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
+	B = new Complex128Array( 4 );
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[ i ] ), RangeError, 'throws an error when provided ' + values[ i ] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			zlacpy( 'row-major', 'all', 2, 2, A, 2, B, value );
+		};
+	}
+});
+
+tape( 'the function copies all of a matrix `A` to another matrix `B` (row-major)', function test( t ) {
+	var opts;
+	var out;
+	var A;
+	var B;
+	var M;
+	var N;
+
+	M = 5;
+	N = 8;
+
+	opts = {
+		'dtype': 'generic'
+	};
+
+	A = new Complex128Array( uniform( M*N*2, -10.0, 10.0, opts ) );
+	B = new Complex128Array( M*N );
+
+	out = zlacpy( 'row-major', 'all', M, N, A, N, B, N );
+	t.strictEqual( out, B, 'returns expected value' );
+	t.ok( isSameComplex128Array( out, A ), 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function copies a part of a matrix `A` to another matrix `B` (row-major, upper)', function test( t ) {
+	var opts;
+	var out;
+	var A;
+	var B;
+	var M;
+	var N;
+
+	M = 5;
+	N = 8;
+
+	opts = {
+		'dtype': 'generic'
+	};
+
+	A = new Complex128Array( uniform( M*N*2, -10.0, 10.0, opts ) );
+	B = new Complex128Array( M*N );
+
+	out = zlacpy( 'row-major', 'lower', M, N, A, N, B, N );
+	t.strictEqual( out, B, 'returns expected value' );
+
+	out = zlacpy( 'row-major', 'upper', M, N, A, N, B, N );
+	t.strictEqual( out, B, 'returns expected value' );
+	t.ok( isSameComplex128Array( out, A ), 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function copies a part of a matrix `A` to another matrix `B` (row-major, lower)', function test( t ) {
+	var opts;
+	var out;
+	var A;
+	var B;
+	var M;
+	var N;
+
+	M = 5;
+	N = 8;
+
+	opts = {
+		'dtype': 'generic'
+	};
+
+	A = new Complex128Array( uniform( M*N*2, -10.0, 10.0, opts ) );
+	B = new Complex128Array( M*N );
+
+	out = zlacpy( 'row-major', 'upper', M, N, A, N, B, N );
+	t.strictEqual( out, B, 'returns expected value' );
+
+	out = zlacpy( 'row-major', 'lower', M, N, A, N, B, N );
+	t.strictEqual( out, B, 'returns expected value' );
+	t.ok( isSameComplex128Array( out, A ), 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function copies all of a matrix `A` to another matrix `B` (column-major)', function test( t ) {
+	var opts;
+	var out;
+	var A;
+	var B;
+	var M;
+	var N;
+
+	M = 5;
+	N = 8;
+
+	opts = {
+		'dtype': 'generic'
+	};
+
+	A = new Complex128Array( uniform( M*N*2, -10.0, 10.0, opts ) );
+	B = new Complex128Array( M*N );
+
+	out = zlacpy( 'column-major', 'all', M, N, A, M, B, M );
+	t.strictEqual( out, B, 'returns expected value' );
+	t.ok( isSameComplex128Array( out, A ), 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function copies a part of a matrix `A` to another matrix `B` (column-major, upper)', function test( t ) {
+	var opts;
+	var out;
+	var A;
+	var B;
+	var M;
+	var N;
+
+	M = 5;
+	N = 8;
+
+	opts = {
+		'dtype': 'generic'
+	};
+
+	A = new Complex128Array( uniform( M*N*2, -10.0, 10.0, opts ) );
+	B = new Complex128Array( M*N );
+
+	out = zlacpy( 'column-major', 'lower', M, N, A, M, B, M );
+	t.strictEqual( out, B, 'returns expected value' );
+
+	out = zlacpy( 'column-major', 'upper', M, N, A, M, B, M );
+	t.strictEqual( out, B, 'returns expected value' );
+	t.ok( isSameComplex128Array( out, A ), 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function copies a part of a matrix `A` to another matrix `B` (column-major, lower)', function test( t ) {
+	var opts;
+	var out;
+	var A;
+	var B;
+	var M;
+	var N;
+
+	M = 5;
+	N = 8;
+
+	opts = {
+		'dtype': 'generic'
+	};
+
+	A = new Complex128Array( uniform( M*N*2, -10.0, 10.0, opts ) );
+	B = new Complex128Array( M*N );
+
+	out = zlacpy( 'column-major', 'upper', M, N, A, M, B, M );
+	t.strictEqual( out, B, 'returns expected value' );
+
+	out = zlacpy( 'column-major', 'lower', M, N, A, M, B, M );
+	t.strictEqual( out, B, 'returns expected value' );
+	t.ok( isSameComplex128Array( out, A ), 'returns expected value' );
+
+	t.end();
+});


### PR DESCRIPTION
Towards #2464

## Description

> What is the purpose of this pull request?

This pull request adds JS implementation for lapack/base/zlacpy.

## Related Issues

> Does this pull request have any related issues?

N/A

## Questions

- [ ] When printed, Complex128Array shows up as `<Complex128Array>`, unlike Float64Array which is printed as `<Float64Array>[ 1.0, 2.0, 3.0, 4.0 ]`. This makes the 40-or-so instances of repl text output in docs, readmes, code etc. mostly useless. Is there a better solution for this? I left them all just blank since that's technically correct for what's printed.
- [ ] What is the correct syntax for importing Complex128Array into the typescript annotations?
- [ ] TypeScript complains that Complex128Array should be a dependency of this module. Should it?
- [ ] Is there a better way to generate random data than this? `new Complex128Array( uniform( 2*N, -10, 10, { 'dtype': 'generic' }));`
- [ ] I commit and push with `--no-verify`. This is not ideal. Maybe there's a better pattern? I mostly did this because of line length limits. It's hard to fit nontrivial arrays of complex numbers onto one line, and I wasn't quite sure the rules for breaking them onto multiple lines and getting around line length linters.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
