### PR TITLE
fix: add `math/base/speical/abs` in manifest.json of `blas/ext/base/dapxsumkbn`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsumkbn/manifest.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsumkbn/manifest.json
@@ -79,7 +79,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/blas/base/shared",
-        "@stdlib/strided/base/stride2offset"
+        "@stdlib/strided/base/stride2offset",
+        "@stdlib/math/base/special/abs"
       ]
     },
     {


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   fixes a bug in the building of C examples of `blas/ext/base/dapxsumkbn`

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
