### PR TITLE
refactor: update `math/base/special/hypotf` to follow latest project conventions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/hypotf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/hypotf/README.md
@@ -86,19 +86,16 @@ h = hypotf( 5.0, NaN );
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var hypotf = require( '@stdlib/math/base/special/hypotf' );
 
-var len;
-var x;
-var y;
-var h;
+var len = 100;
+var opts = {
+    'dtype': 'float32'
+};
+var x = discreteUniform( len, -50, 50, opts );
+var y = discreteUniform( len, -50, 50, opts );
+
 var i;
-
-len = 100;
-x = discreteUniform( len, -50, 50 );
-y = discreteUniform( len, -50, 50 );
-
-for ( i = 0; i < 100; i++ ) {
-    h = hypotf( x[ i ], y[ i ] );
-    console.log( 'h(%d,%d) = %d', x[ i ], y[ i ], h );
+for ( i = 0; i < len; i++ ) {
+    console.log( 'h(%d,%d) = %d', x[ i ], y[ i ], hypotf( x[ i ], y[ i ] ) );
 }
 ```
 

--- a/lib/node_modules/@stdlib/math/base/special/hypotf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/hypotf/README.md
@@ -83,20 +83,22 @@ h = hypotf( 5.0, NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var hypotf = require( '@stdlib/math/base/special/hypotf' );
 
+var len;
 var x;
 var y;
 var h;
 var i;
 
+len = 100;
+x = discreteUniform( len, -50, 50 );
+y = discreteUniform( len, -50, 50 );
+
 for ( i = 0; i < 100; i++ ) {
-    x = round( randu()*100.0 ) - 50.0;
-    y = round( randu()*100.0 ) - 50.0;
-    h = hypotf( x, y );
-    console.log( 'h(%d,%d) = %d', x, y, h );
+    h = hypotf( x[ i ], y[ i ] );
+    console.log( 'h(%d,%d) = %d', x[ i ], y[ i ], h );
 }
 ```
 

--- a/lib/node_modules/@stdlib/math/base/special/hypotf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/hypotf/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pkg = require( './../package.json' ).name;
 var hypotf = require( './../lib' );
@@ -37,16 +37,24 @@ var opts = {
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var opts;
+	var len;
 	var x;
 	var y;
 	var z;
 	var i;
 
+	opts = {
+		'dtype': 'float32'
+	};
+
+	len = 100;
+	x = uniform( len, -50, 50, opts );
+	y = uniform( len, -50, 50, opts );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*100.0 ) - 50.0;
-		y = ( randu()*100.0 ) - 50.0;
-		z = hypotf( x, y );
+		z = hypotf( x[ i % len ], y[ i % len ] );
 		if ( isnanf( z ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -60,16 +68,24 @@ bench( pkg, function benchmark( b ) {
 });
 
 bench( pkg+'::built-in', opts, function benchmark( b ) {
+	var opts;
+	var len;
 	var x;
 	var y;
 	var z;
 	var i;
 
+	opts = {
+		'dtype': 'float32'
+	};
+
+	len = 100;
+	x = uniform( len, -50, 50, opts );
+	y = uniform( len, -50, 50, opts );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*100.0 ) - 50.0;
-		y = ( randu()*100.0 ) - 50.0;
-		z = Math.hypot( x, y ); // eslint-disable-line stdlib/no-builtin-math
+		z = Math.hypot( x[ i % len ], y[ i % len ] ); // eslint-disable-line stdlib/no-builtin-math
 		if ( isnanf( z ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/hypotf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/hypotf/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -39,16 +39,24 @@ var opts = {
 // MAIN //
 
 bench( pkg+'::native', opts, function benchmark( b ) {
+	var opts;
+	var len;
 	var x;
 	var y;
 	var z;
 	var i;
 
+	opts = {
+		'dtype': 'float32'
+	};
+
+	len = 100;
+	x = uniform( len, -50, 50, opts );
+	y = uniform( len, -50, 50, opts );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*100.0 ) - 50.0;
-		y = ( randu()*100.0 ) - 50.0;
-		z = hypotf( x, y );
+		z = hypotf( x[ i % len ], y[ i % len ] );
 		if ( isnanf( z ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/hypotf/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/hypotf/benchmark/c/native/benchmark.c
@@ -92,16 +92,19 @@ static float rand_float( void ) {
 static double benchmark( void ) {
 	double elapsed;
 	double t;
-	float x;
-	float y;
+	float x[ 100 ];
+	float y[ 100 ];
 	float z;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 100.0f * rand_float() ) - 50.0f;
+		y[ i ] = ( 100.0f * rand_float() ) - 50.0f;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 100.0f*rand_float() ) - 50.0f;
-		y = ( 100.0f*rand_float() ) - 50.0f;
-		z = stdlib_base_hypotf( x, y );
+		z = stdlib_base_hypotf( x[ i % 100 ], y[ i % 100 ] );
 		if ( z != z ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/hypotf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/hypotf/examples/index.js
@@ -18,18 +18,20 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var hypotf = require( './../lib' );
 
+var len;
 var x;
 var y;
 var h;
 var i;
 
+len = 100;
+x = discreteUniform( len, -50, 50 );
+y = discreteUniform( len, -50, 50 );
+
 for ( i = 0; i < 100; i++ ) {
-	x = round( randu()*100.0 ) - 50.0;
-	y = round( randu()*100.0 ) - 50.0;
-	h = hypotf( x, y );
-	console.log( 'h(%d,%d) = %d', x, y, h );
+	h = hypotf( x[ i ], y[ i ] );
+	console.log( 'h(%d,%d) = %d', x[ i ], y[ i ], h );
 }

--- a/lib/node_modules/@stdlib/math/base/special/hypotf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/hypotf/examples/index.js
@@ -23,7 +23,7 @@ var hypotf = require( './../lib' );
 
 var len = 100;
 var opts = {
-    'dtype': 'float32'
+	'dtype': 'float32'
 };
 var x = discreteUniform( len, -50, 50, opts );
 var y = discreteUniform( len, -50, 50, opts );

--- a/lib/node_modules/@stdlib/math/base/special/hypotf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/hypotf/examples/index.js
@@ -21,17 +21,14 @@
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var hypotf = require( './../lib' );
 
-var len;
-var x;
-var y;
-var h;
+var len = 100;
+var opts = {
+    'dtype': 'float32'
+};
+var x = discreteUniform( len, -50, 50, opts );
+var y = discreteUniform( len, -50, 50, opts );
+
 var i;
-
-len = 100;
-x = discreteUniform( len, -50, 50 );
-y = discreteUniform( len, -50, 50 );
-
-for ( i = 0; i < 100; i++ ) {
-	h = hypotf( x[ i ], y[ i ] );
-	console.log( 'h(%d,%d) = %d', x[ i ], y[ i ], h );
+for ( i = 0; i < len; i++ ) {
+	console.log( 'h(%d,%d) = %d', x[ i ], y[ i ], hypotf( x[ i ], y[ i ] ) );
 }

--- a/lib/node_modules/@stdlib/math/base/special/hypotf/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/hypotf/manifest.json
@@ -1,87 +1,87 @@
 {
-	"options": {
-		"task": "build"
-	},
-	"fields": [
-		{
-			"field": "src",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "include",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "libraries",
-			"resolve": false,
-			"relative": false
-		},
-		{
-			"field": "libpath",
-			"resolve": true,
-			"relative": false
-		}
-	],
-	"confs": [
-		{
-			"task": "build",
-			"src": [
-				"./src/main.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [
-				"-lm"
-			],
-			"libpath": [],
-			"dependencies": [
-				"@stdlib/math/base/napi/binary",
-				"@stdlib/math/base/assert/is-nanf",
-				"@stdlib/math/base/assert/is-infinitef",
-				"@stdlib/math/base/special/sqrtf",
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [
+        "-lm"
+      ],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/napi/binary",
+        "@stdlib/math/base/assert/is-nanf",
+        "@stdlib/math/base/assert/is-infinitef",
+        "@stdlib/math/base/special/sqrtf",
         "@stdlib/constants/float32/pinf"
-			]
-		},
-		{
-			"task": "benchmark",
-			"src": [
-				"./src/main.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [
-				"-lm"
-			],
-			"libpath": [],
-			"dependencies": [
-				"@stdlib/math/base/assert/is-nanf",
-				"@stdlib/math/base/assert/is-infinitef",
-				"@stdlib/math/base/special/sqrtf",
+      ]
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [
+        "-lm"
+      ],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nanf",
+        "@stdlib/math/base/assert/is-infinitef",
+        "@stdlib/math/base/special/sqrtf",
         "@stdlib/constants/float32/pinf"
-			]
-		},
-		{
-			"task": "examples",
-			"src": [
-				"./src/main.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [
-				"-lm"
-			],
-			"libpath": [],
-			"dependencies": [
-				"@stdlib/math/base/assert/is-nanf",
-				"@stdlib/math/base/assert/is-infinitef",
-				"@stdlib/math/base/special/sqrtf",
+      ]
+    },
+    {
+      "task": "examples",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [
+        "-lm"
+      ],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/assert/is-nanf",
+        "@stdlib/math/base/assert/is-infinitef",
+        "@stdlib/math/base/special/sqrtf",
         "@stdlib/constants/float32/pinf"
-			]
-		}
-	]
+      ]
+    }
+  ]
 }

--- a/lib/node_modules/@stdlib/math/base/special/hypotf/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/hypotf/manifest.json
@@ -28,7 +28,7 @@
 		{
 			"task": "build",
 			"src": [
-				"./src/hypotf.c"
+				"./src/main.c"
 			],
 			"include": [
 				"./include"
@@ -41,13 +41,14 @@
 				"@stdlib/math/base/napi/binary",
 				"@stdlib/math/base/assert/is-nanf",
 				"@stdlib/math/base/assert/is-infinitef",
-				"@stdlib/math/base/special/sqrtf"
+				"@stdlib/math/base/special/sqrtf",
+        "@stdlib/constants/float32/pinf"
 			]
 		},
 		{
 			"task": "benchmark",
 			"src": [
-				"./src/hypotf.c"
+				"./src/main.c"
 			],
 			"include": [
 				"./include"
@@ -59,13 +60,14 @@
 			"dependencies": [
 				"@stdlib/math/base/assert/is-nanf",
 				"@stdlib/math/base/assert/is-infinitef",
-				"@stdlib/math/base/special/sqrtf"
+				"@stdlib/math/base/special/sqrtf",
+        "@stdlib/constants/float32/pinf"
 			]
 		},
 		{
 			"task": "examples",
 			"src": [
-				"./src/hypotf.c"
+				"./src/main.c"
 			],
 			"include": [
 				"./include"
@@ -77,7 +79,8 @@
 			"dependencies": [
 				"@stdlib/math/base/assert/is-nanf",
 				"@stdlib/math/base/assert/is-infinitef",
-				"@stdlib/math/base/special/sqrtf"
+				"@stdlib/math/base/special/sqrtf",
+        "@stdlib/constants/float32/pinf"
 			]
 		}
 	]

--- a/lib/node_modules/@stdlib/math/base/special/hypotf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/hypotf/src/main.c
@@ -41,7 +41,7 @@ float stdlib_base_hypotf( const float x, const float y ) {
 		return 0.0f / 0.0f; // NaN
 	}
 	if ( stdlib_base_is_infinitef( x ) || stdlib_base_is_infinitef( y ) ) {
-		return INFINITY;
+		return STDLIB_CONSTANT_FLOAT32_PINF;
 	}
 	a = x;
 	b = y;
@@ -60,5 +60,5 @@ float stdlib_base_hypotf( const float x, const float y ) {
 		return 0.0f;
 	}
 	b /= a;
-	return a * stdlib_base_sqrtf( 1.0f + (b*b) );
+	return a * stdlib_base_sqrtf( 1.0f + ( b * b ) );
 }

--- a/lib/node_modules/@stdlib/math/base/special/hypotf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/hypotf/src/main.c
@@ -20,7 +20,7 @@
 #include "stdlib/math/base/assert/is_nanf.h"
 #include "stdlib/math/base/assert/is_infinitef.h"
 #include "stdlib/math/base/special/sqrtf.h"
-#include <math.h>
+#include "stdlib/constants/float32/pinf.h"
 
 /**
 * Computes the hypotenuse avoiding overflow and underflow (single-precision).

--- a/lib/node_modules/@stdlib/math/base/special/hypotf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/hypotf/test/test.js
@@ -26,7 +26,7 @@ var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
 var EPS = require( '@stdlib/constants/float32/eps' );
 var absf = require( '@stdlib/math/base/special/absf' );
-var sqrt = require( '@stdlib/math/base/special/sqrt' );
+var sqrtf = require( '@stdlib/math/base/special/sqrtf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
@@ -50,28 +50,28 @@ tape( 'the function returns `+infinity` if either argument is `+-infinity`', fun
 	var h;
 
 	h = hypotf( PINF, 3.14 );
-	t.strictEqual( h, PINF, 'returns +infinity' );
+	t.strictEqual( h, PINF, 'returns expected value' );
 
 	h = hypotf( 3.14, PINF );
-	t.strictEqual( h, PINF, 'returns +infinity' );
+	t.strictEqual( h, PINF, 'returns expected value' );
 
 	h = hypotf( NINF, 3.14 );
-	t.strictEqual( h, PINF, 'returns +infinity' );
+	t.strictEqual( h, PINF, 'returns expected value' );
 
 	h = hypotf( 3.14, NINF );
-	t.strictEqual( h, PINF, 'returns +infinity' );
+	t.strictEqual( h, PINF, 'returns expected value' );
 
 	h = hypotf( PINF, PINF );
-	t.strictEqual( h, PINF, 'returns +infinity' );
+	t.strictEqual( h, PINF, 'returns expected value' );
 
 	h = hypotf( NINF, PINF );
-	t.strictEqual( h, PINF, 'returns +infinity' );
+	t.strictEqual( h, PINF, 'returns expected value' );
 
 	h = hypotf( PINF, NINF );
-	t.strictEqual( h, PINF, 'returns +infinity' );
+	t.strictEqual( h, PINF, 'returns expected value' );
 
 	h = hypotf( NINF, NINF );
-	t.strictEqual( h, PINF, 'returns +infinity' );
+	t.strictEqual( h, PINF, 'returns expected value' );
 
 	t.end();
 });
@@ -80,13 +80,13 @@ tape( 'the function returns `NaN` if either argument is `NaN`', function test( t
 	var h;
 
 	h = hypotf( NaN, 3.14 );
-	t.strictEqual( isnanf( h ), true, 'returns NaN' );
+	t.strictEqual( isnanf( h ), true, 'returns expected value' );
 
 	h = hypotf( 3.14, NaN );
-	t.strictEqual( isnanf( h ), true, 'returns NaN' );
+	t.strictEqual( isnanf( h ), true, 'returns expected value' );
 
 	h = hypotf( NaN, NaN );
-	t.strictEqual( isnanf( h ), true, 'returns NaN' );
+	t.strictEqual( isnanf( h ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -95,16 +95,16 @@ tape( 'the function returns `+0` if both arguments are `+-0`', function test( t 
 	var h;
 
 	h = hypotf( +0.0, +0.0 );
-	t.strictEqual( isPositiveZerof( h ), true, 'returns +0' );
+	t.strictEqual( isPositiveZerof( h ), true, 'returns expected value' );
 
 	h = hypotf( -0.0, +0.0 );
-	t.strictEqual( isPositiveZerof( h ), true, 'returns +0' );
+	t.strictEqual( isPositiveZerof( h ), true, 'returns expected value' );
 
 	h = hypotf( +0.0, -0.0 );
-	t.strictEqual( isPositiveZerof( h ), true, 'returns +0' );
+	t.strictEqual( isPositiveZerof( h ), true, 'returns expected value' );
 
 	h = hypotf( -0.0, -0.0 );
-	t.strictEqual( isPositiveZerof( h ), true, 'returns +0' );
+	t.strictEqual( isPositiveZerof( h ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -139,13 +139,13 @@ tape( 'the function computes the hypotenuse (canonical inputs)', function test( 
 	var h;
 
 	h = hypotf( 3.0, 4.0 );
-	t.strictEqual( h, 5.0, 'returns 5.0' );
+	t.strictEqual( h, 5.0, 'returns expected value' );
 
 	h = hypotf( 6.0, 8.0 );
-	t.strictEqual( h, 10.0, 'returns 10.0' );
+	t.strictEqual( h, 10.0, 'returns expected value' );
 
 	h = hypotf( 5.0, 12.0 );
-	t.strictEqual( h, 13.0, 'returns 13.0' );
+	t.strictEqual( h, 13.0, 'returns expected value' );
 
 	t.end();
 });
@@ -153,7 +153,7 @@ tape( 'the function computes the hypotenuse (canonical inputs)', function test( 
 tape( 'the function avoids overflow', function test( t ) {
 	var h;
 
-	h = float64ToFloat32( sqrt( float64ToFloat32( float64ToFloat32( pow( 1.0e38, 2 ) ) + float64ToFloat32( pow( 1.0e38, 2 ) ) ) ) ); // eslint-disable-line max-len
+	h = sqrtf( float64ToFloat32( float64ToFloat32( pow( 1.0e38, 2 ) ) + float64ToFloat32( pow( 1.0e38, 2 ) ) ) ); // eslint-disable-line max-len
 	t.strictEqual( h, PINF, 'returns +infinity' );
 
 	h = hypotf( 1.0e38, 1.0e38 );
@@ -165,7 +165,7 @@ tape( 'the function avoids overflow', function test( t ) {
 tape( 'the function avoids underflow', function test( t ) {
 	var h;
 
-	h = float64ToFloat32( sqrt( float64ToFloat32( float64ToFloat32( pow( 1.0e-45, 2 ) ) + float64ToFloat32( pow( 1.0e-45, 2 ) ) ) ) ); // eslint-disable-line max-len
+	h = sqrtf( float64ToFloat32( float64ToFloat32( pow( 1.0e-45, 2 ) ) + float64ToFloat32( pow( 1.0e-45, 2 ) ) ) ); // eslint-disable-line max-len
 	t.strictEqual( h, 0.0, 'returns 0' );
 
 	h = hypotf( 1.0e-45, 1.0e-45 );

--- a/lib/node_modules/@stdlib/math/base/special/hypotf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/hypotf/test/test.native.js
@@ -27,7 +27,7 @@ var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
 var EPS = require( '@stdlib/constants/float32/eps' );
 var absf = require( '@stdlib/math/base/special/absf' );
-var sqrt = require( '@stdlib/math/base/special/sqrt' );
+var sqrtf = require( '@stdlib/math/base/special/sqrtf' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
@@ -59,28 +59,28 @@ tape( 'the function returns `+infinity` if either argument is `+-infinity`', opt
 	var h;
 
 	h = hypotf( PINF, 3.14 );
-	t.strictEqual( h, PINF, 'returns +infinity' );
+	t.strictEqual( h, PINF, 'returns expected value' );
 
 	h = hypotf( 3.14, PINF );
-	t.strictEqual( h, PINF, 'returns +infinity' );
+	t.strictEqual( h, PINF, 'returns expected value' );
 
 	h = hypotf( NINF, 3.14 );
-	t.strictEqual( h, PINF, 'returns +infinity' );
+	t.strictEqual( h, PINF, 'returns expected value' );
 
 	h = hypotf( 3.14, NINF );
-	t.strictEqual( h, PINF, 'returns +infinity' );
+	t.strictEqual( h, PINF, 'returns expected value' );
 
 	h = hypotf( PINF, PINF );
-	t.strictEqual( h, PINF, 'returns +infinity' );
+	t.strictEqual( h, PINF, 'returns expected value' );
 
 	h = hypotf( NINF, PINF );
-	t.strictEqual( h, PINF, 'returns +infinity' );
+	t.strictEqual( h, PINF, 'returns expected value' );
 
 	h = hypotf( PINF, NINF );
-	t.strictEqual( h, PINF, 'returns +infinity' );
+	t.strictEqual( h, PINF, 'returns expected value' );
 
 	h = hypotf( NINF, NINF );
-	t.strictEqual( h, PINF, 'returns +infinity' );
+	t.strictEqual( h, PINF, 'returns expected value' );
 
 	t.end();
 });
@@ -89,13 +89,13 @@ tape( 'the function returns `NaN` if either argument is `NaN`', opts, function t
 	var h;
 
 	h = hypotf( NaN, 3.14 );
-	t.strictEqual( isnanf( h ), true, 'returns NaN' );
+	t.strictEqual( isnanf( h ), true, 'returns expected value' );
 
 	h = hypotf( 3.14, NaN );
-	t.strictEqual( isnanf( h ), true, 'returns NaN' );
+	t.strictEqual( isnanf( h ), true, 'returns expected value' );
 
 	h = hypotf( NaN, NaN );
-	t.strictEqual( isnanf( h ), true, 'returns NaN' );
+	t.strictEqual( isnanf( h ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -104,16 +104,16 @@ tape( 'the function returns `+0` if both arguments are `+-0`', opts, function te
 	var h;
 
 	h = hypotf( +0.0, +0.0 );
-	t.strictEqual( isPositiveZerof( h ), true, 'returns +0' );
+	t.strictEqual( isPositiveZerof( h ), true, 'returns expected value' );
 
 	h = hypotf( -0.0, +0.0 );
-	t.strictEqual( isPositiveZerof( h ), true, 'returns +0' );
+	t.strictEqual( isPositiveZerof( h ), true, 'returns expected value' );
 
 	h = hypotf( +0.0, -0.0 );
-	t.strictEqual( isPositiveZerof( h ), true, 'returns +0' );
+	t.strictEqual( isPositiveZerof( h ), true, 'returns expected value' );
 
 	h = hypotf( -0.0, -0.0 );
-	t.strictEqual( isPositiveZerof( h ), true, 'returns +0' );
+	t.strictEqual( isPositiveZerof( h ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -137,7 +137,7 @@ tape( 'the function computes the hypotenuse', opts, function test( t ) {
 			t.ok( true, 'x: '+x[i]+'. y: '+y[i]+'. h: '+h+'. Expected: '+expected[i]+'.' );
 		} else {
 			delta = absf( h - expected[ i ] );
-			tol = 1.4 * EPS * absf( expected[ i ] );
+			tol = 2.0 * EPS * absf( expected[ i ] );
 			t.strictEqual( delta <= tol, true, 'within tolerance. x: '+x[i]+'. y: '+y[i]+'. h: '+h+'. Expected: '+expected[i]+'. Delta: '+delta+'. Tol: '+tol+'.' );
 		}
 	}
@@ -148,13 +148,13 @@ tape( 'the function computes the hypotenuse (canonical inputs)', opts, function 
 	var h;
 
 	h = hypotf( 3.0, 4.0 );
-	t.strictEqual( h, 5.0, 'returns 5.0' );
+	t.strictEqual( h, 5.0, 'returns expected value' );
 
 	h = hypotf( 6.0, 8.0 );
-	t.strictEqual( h, 10.0, 'returns 10.0' );
+	t.strictEqual( h, 10.0, 'returns expected value' );
 
 	h = hypotf( 5.0, 12.0 );
-	t.strictEqual( h, 13.0, 'returns 13.0' );
+	t.strictEqual( h, 13.0, 'returns expected value' );
 
 	t.end();
 });
@@ -162,7 +162,7 @@ tape( 'the function computes the hypotenuse (canonical inputs)', opts, function 
 tape( 'the function avoids overflow', opts, function test( t ) {
 	var h;
 
-	h = float64ToFloat32( sqrt( float64ToFloat32( float64ToFloat32( pow( 1.0e38, 2 ) ) + float64ToFloat32( pow( 1.0e38, 2 ) ) ) ) ); // eslint-disable-line max-len
+	h = sqrtf( float64ToFloat32( float64ToFloat32( pow( 1.0e38, 2 ) ) + float64ToFloat32( pow( 1.0e38, 2 ) ) ) ); // eslint-disable-line max-len
 	t.strictEqual( h, PINF, 'returns +infinity' );
 
 	h = hypotf( 1.0e38, 1.0e38 );
@@ -174,7 +174,7 @@ tape( 'the function avoids overflow', opts, function test( t ) {
 tape( 'the function avoids underflow', opts, function test( t ) {
 	var h;
 
-	h = float64ToFloat32( sqrt( float64ToFloat32( float64ToFloat32( pow( 1.0e-45, 2 ) ) + float64ToFloat32( pow( 1.0e-45, 2 ) ) ) ) ); // eslint-disable-line max-len
+	h = sqrtf( float64ToFloat32( float64ToFloat32( pow( 1.0e-45, 2 ) ) + float64ToFloat32( pow( 1.0e-45, 2 ) ) ) ); // eslint-disable-line max-len
 	t.strictEqual( h, 0.0, 'returns 0' );
 
 	h = hypotf( 1.0e-45, 1.0e-45 );


### PR DESCRIPTION
Resolves None.

## Description

- refactored main.c to use stdlib api instead of math.h for  `math/base/special/hypotf` 
- updated benchmark calculations
- updated js examples
- updated test file
- updated readme

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

 - [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)


* * *

@stdlib-js/reviewers 

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
