### PR TITLE
bench: refactor random number generation in `stats/base/dists/arcsine`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/ctor/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
 var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -33,15 +33,22 @@ var Arcsine = require( './../lib' );
 
 bench( pkg+'::instantiation', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var i;
 
+	len = 100;
+	a = new Float64Array( len );
+	b = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		a[ i ] = uniform( EPS, 10.0 );
+		b[ i ] = uniform( a[ i ] + EPS, a[ i ] + 10.0 + EPS );
+	}
+
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		a = uniform( EPS, 10.0 );
-		b = uniform( a + EPS, a + 10.0 + EPS );
-		dist = new Arcsine( a, b );
+		dist = new Arcsine( a[ i % len ], b[ i % len ] );
 		if ( !( dist instanceof Arcsine ) ) {
 			bm.fail( 'should return a distribution instance' );
 		}
@@ -82,6 +89,7 @@ bench( pkg+'::get:a', function benchmark( bm ) {
 
 bench( pkg+'::set:a', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var y;
@@ -90,12 +98,16 @@ bench( pkg+'::set:a', function benchmark( bm ) {
 	a = 20.0;
 	b = 120.0;
 	dist = new Arcsine( a, b );
+	len = 100;
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = uniform( EPS, 100.0 + EPS );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		y = uniform( EPS, 100.0 + EPS );
-		dist.a = y;
-		if ( dist.a !== y ) {
+		dist.a = y[ i % len ];
+		if ( dist.a !== y[ i % len ] ) {
 			bm.fail( 'should return set value' );
 		}
 	}
@@ -135,6 +147,7 @@ bench( pkg+'::get:b', function benchmark( bm ) {
 
 bench( pkg+'::set:b', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var y;
@@ -143,12 +156,16 @@ bench( pkg+'::set:b', function benchmark( bm ) {
 	a = 20.0;
 	b = 40.0;
 	dist = new Arcsine( a, b );
+	len = 100;
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = uniform( a + EPS, a + 100.0 + EPS );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		y = uniform( a + EPS, a + 100.0 + EPS );
-		dist.b = y;
-		if ( dist.b !== y ) {
+		dist.b = y[ i % len ];
+		if ( dist.b !== y[ i % len ] ) {
 			bm.fail( 'should return set value' );
 		}
 	}
@@ -162,6 +179,8 @@ bench( pkg+'::set:b', function benchmark( bm ) {
 
 bench( pkg+':entropy', function benchmark( bm ) {
 	var dist;
+	var len;
+	var x;
 	var a;
 	var b;
 	var y;
@@ -170,10 +189,15 @@ bench( pkg+':entropy', function benchmark( bm ) {
 	a = 20.0;
 	b = 140.0;
 	dist = new Arcsine( a, b );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 + EPS );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = uniform( EPS, 100.0 + EPS );
+		dist.a = x[ i % len ];
 		y = dist.entropy;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -189,6 +213,8 @@ bench( pkg+':entropy', function benchmark( bm ) {
 
 bench( pkg+':kurtosis', function benchmark( bm ) {
 	var dist;
+	var len;
+	var x;
 	var a;
 	var b;
 	var y;
@@ -197,10 +223,15 @@ bench( pkg+':kurtosis', function benchmark( bm ) {
 	a = 20.0;
 	b = 140.0;
 	dist = new Arcsine( a, b );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 + EPS );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = uniform( EPS, 100.0 + EPS );
+		dist.a = x[ i % len ];
 		y = dist.kurtosis;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -216,6 +247,8 @@ bench( pkg+':kurtosis', function benchmark( bm ) {
 
 bench( pkg+':mean', function benchmark( bm ) {
 	var dist;
+	var len;
+	var x;
 	var a;
 	var b;
 	var y;
@@ -224,10 +257,15 @@ bench( pkg+':mean', function benchmark( bm ) {
 	a = 20.0;
 	b = 140.0;
 	dist = new Arcsine( a, b );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 + EPS );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = uniform( EPS, 100.0 + EPS );
+		dist.a = x[ i % len ];
 		y = dist.mean;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -243,6 +281,8 @@ bench( pkg+':mean', function benchmark( bm ) {
 
 bench( pkg+':median', function benchmark( bm ) {
 	var dist;
+	var len;
+	var x;
 	var a;
 	var b;
 	var y;
@@ -251,10 +291,15 @@ bench( pkg+':median', function benchmark( bm ) {
 	a = 20.0;
 	b = 140.0;
 	dist = new Arcsine( a, b );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 + EPS );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = uniform( EPS, 100.0 + EPS );
+		dist.a = x[ i % len ];
 		y = dist.median;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -270,6 +315,8 @@ bench( pkg+':median', function benchmark( bm ) {
 
 bench( pkg+':mode', function benchmark( bm ) {
 	var dist;
+	var len;
+	var x;
 	var a;
 	var b;
 	var y;
@@ -278,10 +325,15 @@ bench( pkg+':mode', function benchmark( bm ) {
 	a = 20.0;
 	b = 140.0;
 	dist = new Arcsine( a, b );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 1.0 + EPS, 101.0 + EPS );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = uniform( 1.0 + EPS, 101.0 + EPS );
+		dist.a = x[ i % len ];
 		y = dist.mode;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -297,6 +349,8 @@ bench( pkg+':mode', function benchmark( bm ) {
 
 bench( pkg+':skewness', function benchmark( bm ) {
 	var dist;
+	var len;
+	var x;
 	var a;
 	var b;
 	var y;
@@ -305,10 +359,15 @@ bench( pkg+':skewness', function benchmark( bm ) {
 	a = 20.0;
 	b = 140.0;
 	dist = new Arcsine( a, b );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 + EPS );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = uniform( EPS, 100.0 + EPS );
+		dist.a = x[ i % len ];
 		y = dist.skewness;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -324,6 +383,8 @@ bench( pkg+':skewness', function benchmark( bm ) {
 
 bench( pkg+':stdev', function benchmark( bm ) {
 	var dist;
+	var len;
+	var x;
 	var a;
 	var b;
 	var y;
@@ -332,10 +393,15 @@ bench( pkg+':stdev', function benchmark( bm ) {
 	a = 20.0;
 	b = 140.0;
 	dist = new Arcsine( a, b );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 + EPS );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = uniform( EPS, 100.0 + EPS );
+		dist.a = x[ i % len ];
 		y = dist.stdev;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -351,6 +417,8 @@ bench( pkg+':stdev', function benchmark( bm ) {
 
 bench( pkg+':variance', function benchmark( bm ) {
 	var dist;
+	var len;
+	var x;
 	var a;
 	var b;
 	var y;
@@ -359,10 +427,15 @@ bench( pkg+':variance', function benchmark( bm ) {
 	a = 20.0;
 	b = 140.0;
 	dist = new Arcsine( a, b );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 + EPS );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = uniform( EPS, 100.0 + EPS );
+		dist.a = x[ i % len ];
 		y = dist.variance;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -378,6 +451,7 @@ bench( pkg+':variance', function benchmark( bm ) {
 
 bench( pkg+':cdf', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var x;
@@ -387,11 +461,15 @@ bench( pkg+':cdf', function benchmark( bm ) {
 	a = 20.0;
 	b = 40.0;
 	dist = new Arcsine( a, b );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = randu();
-		y = dist.cdf( x );
+		y = dist.cdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
 		}
@@ -406,6 +484,7 @@ bench( pkg+':cdf', function benchmark( bm ) {
 
 bench( pkg+':logpdf', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var x;
@@ -415,11 +494,15 @@ bench( pkg+':logpdf', function benchmark( bm ) {
 	a = 20.0;
 	b = 40.0;
 	dist = new Arcsine( a, b );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = randu();
-		y = dist.logpdf( x );
+		y = dist.logpdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
 		}
@@ -434,6 +517,7 @@ bench( pkg+':logpdf', function benchmark( bm ) {
 
 bench( pkg+':pdf', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var x;
@@ -443,11 +527,15 @@ bench( pkg+':pdf', function benchmark( bm ) {
 	a = 20.0;
 	b = 40.0;
 	dist = new Arcsine( a, b );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = randu();
-		y = dist.pdf( x );
+		y = dist.pdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
 		}
@@ -462,6 +550,7 @@ bench( pkg+':pdf', function benchmark( bm ) {
 
 bench( pkg+':quantile', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var x;
@@ -471,11 +560,15 @@ bench( pkg+':quantile', function benchmark( bm ) {
 	a = 20.0;
 	b = 40.0;
 	dist = new Arcsine( a, b );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( a, b );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = randu();
-		y = dist.quantile( x );
+		y = dist.quantile( x[ i % len ] );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/ctor/benchmark/benchmark.js
@@ -563,7 +563,7 @@ bench( pkg+':quantile', function benchmark( bm ) {
 	len = 100;
 	x = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( a, b );
+		x[ i ] = uniform( 0.0, 1.0 );
 	}
 
 	bm.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/logcdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/logcdf/benchmark/benchmark.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var Float64Array = require( '@stdlib/array/float64' );
 var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
@@ -32,16 +33,24 @@ var logcdf = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var min;
 	var max;
+	var len;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	min = new Float64Array( len );
+	max = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -10.0, 10.0 );
+		min[ i ] = uniform( -20.0, 0.0 );
+		max[ i ] = uniform( min[ i ], min[ i ] + 40.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = uniform( -10.0, 10.0 );
-		min = uniform( -20.0, 0.0 );
-		max = uniform( min, min + 40.0 );
-		y = logcdf( x, min, max );
+		y = logcdf( x[ i % len ], min[ i % len ], max[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -58,6 +67,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mylogcdf;
 	var min;
 	var max;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -65,11 +75,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	min = -1.5;
 	max = 1.5;
 	mylogcdf = logcdf.factory( min, max );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -2.0, 0.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = uniform( -2.0, 0.0 );
-		y = mylogcdf( x );
+		y = mylogcdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/logpdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/logpdf/benchmark/benchmark.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var Float64Array = require( '@stdlib/array/float64' );
 var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
@@ -32,16 +33,24 @@ var logpdf = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var min;
 	var max;
+	var len;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	min = new Float64Array( len );
+	max = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -10.0, 10.0 );
+		min[ i ] = uniform( -20.0, 0.0 );
+		max[ i ] = uniform( min[ i ], min[ i ] + 40.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = uniform( -10.0, 10.0 );
-		min = uniform( -20.0, 0.0 );
-		max = uniform( min, min + 40.0 );
-		y = logpdf( x, min, max );
+		y = logpdf( x[ i % len ], min[ i % len ], max[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -58,6 +67,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mylogpdf;
 	var min;
 	var max;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -65,11 +75,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	min = -1.5;
 	max = 1.5;
 	mylogpdf = logpdf.factory( min, max );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -2.0, 0.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = uniform( -2.0, 0.0 );
-		y = mylogpdf( x );
+		y = mylogpdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/mean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/mean/benchmark/benchmark.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var Float64Array = require( '@stdlib/array/float64' );
 var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
@@ -32,14 +33,21 @@ var mean = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var min;
 	var max;
+	var len;
 	var y;
 	var i;
 
+	len = 100;
+	min = new Float64Array( len );
+	max = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ], min[ i ] + 10.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		min = uniform( 0.0, 10.0 );
-		max = uniform( min, min + 10.0 );
-		y = mean( min, max );
+		y = mean( min[ i % len ], max[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/median/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/median/benchmark/benchmark.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var Float64Array = require( '@stdlib/array/float64' );
 var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
@@ -32,14 +33,21 @@ var median = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var min;
 	var max;
+	var len;
 	var y;
 	var i;
 
+	len = 100;
+	min = new Float64Array( len );
+	max = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ], min[ i ] + 10.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		min = uniform( 0.0, 10.0 );
-		max = uniform( min, min + 10.0 );
-		y = median( min, max );
+		y = median( min[ i % len ], max[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/mode/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/mode/benchmark/benchmark.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var Float64Array = require( '@stdlib/array/float64' );
 var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
@@ -32,14 +33,21 @@ var mode = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var min;
 	var max;
+	var len;
 	var y;
 	var i;
 
+	len = 100;
+	min = new Float64Array( len );
+	max = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ], min[ i ] + 10.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		min = uniform( 0.0, 10.0 );
-		max = uniform( min, min + 10.0 );
-		y = mode( min, max );
+		y = mode( min[ i % len ], max[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/mode/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/mode/benchmark/benchmark.native.js
@@ -23,7 +23,6 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
 var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -51,7 +50,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = ( randu()*10.0 );
+		min[ i ] = uniform( 0.0, 10.0 );
 		max[ i ] = uniform( min[ i ], min[ i ] + 10.0 );
 	}
 

--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/pdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/pdf/benchmark/benchmark.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var Float64Array = require( '@stdlib/array/float64' );
 var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
@@ -32,16 +33,24 @@ var pdf = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var min;
 	var max;
+	var len;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	min = new Float64Array( len );
+	max = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -10.0, 10.0 );
+		min[ i ] = uniform( -20.0, 0.0 );
+		max[ i ] = uniform( min[ i ], min[ i ] + 40.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = uniform( -10.0, 10.0 );
-		min = uniform( -20.0, 0.0 );
-		max = uniform( min, min + 40.0 );
-		y = pdf( x, min, max );
+		y = pdf( x[ i % len ], min[ i % len ], max[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -58,6 +67,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mypdf;
 	var min;
 	var max;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -65,11 +75,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	min = -1.5;
 	max = 1.5;
 	mypdf = pdf.factory( min, max );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -2.0, 0.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = uniform( -2.0, 0.0 );
-		y = mypdf( x );
+		y = mypdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/quantile/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
 var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
@@ -33,16 +33,24 @@ var quantile = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var min;
 	var max;
+	var len;
 	var p;
 	var y;
 	var i;
 
+	len = 100;
+	p = new Float64Array( len );
+	min = new Float64Array( len );
+	max = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		p[ i ] = uniform( 0.0, 1.0 );
+		min[ i ] = uniform( -20.0, 0.0 );
+		max[ i ] = uniform( min[ i ], min[ i ] + 40.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		min = uniform( -20.0, 0.0 );
-		max = uniform( min, min + 40.0 );
-		y = quantile( p, min, max );
+		y = quantile( p[ i % len ], min[ i % len ], max[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -59,6 +67,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	var myquantile;
 	var min;
 	var max;
+	var len;
 	var p;
 	var y;
 	var i;
@@ -66,11 +75,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	min = -1.5;
 	max = 1.5;
 	myquantile = quantile.factory( min, max );
+	len = 100;
+	p = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		p[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		y = myquantile( p );
+		y = myquantile( p[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/skewness/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/skewness/benchmark/benchmark.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var Float64Array = require( '@stdlib/array/float64' );
 var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
@@ -32,14 +33,21 @@ var skewness = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var min;
 	var max;
+	var len;
 	var y;
 	var i;
 
+	len = 100;
+	min = new Float64Array( len );
+	max = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ], min[ i ] + 10.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		min = uniform( 0.0, 10.0 );
-		max = uniform( min, min + 10.0 );
-		y = skewness( min, max );
+		y = skewness( min[ i % len ], max[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/skewness/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/skewness/benchmark/benchmark.native.js
@@ -23,7 +23,6 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
 var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -51,7 +50,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = ( randu()*10.0 );
+		min[ i ] = uniform( 0.0, 10.0 );
 		max[ i ] = uniform( min[ i ], min[ i ] + 10.0 );
 	}
 

--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/stdev/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/stdev/benchmark/benchmark.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var Float64Array = require( '@stdlib/array/float64' );
 var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
@@ -32,14 +33,21 @@ var stdev = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var min;
 	var max;
+	var len;
 	var y;
 	var i;
 
+	len = 100;
+	min = new Float64Array( len );
+	max = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ], min[ i ] + 10.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		min = uniform( 0.0, 10.0 );
-		max = uniform( min, min + 10.0 );
-		y = stdev( min, max );
+		y = stdev( min[ i % len ], max[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/stdev/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/stdev/benchmark/benchmark.native.js
@@ -23,7 +23,6 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
 var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -51,7 +50,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = ( randu()*10.0 );
+		min[ i ] = uniform( 0.0, 10.0 );
 		max[ i ] = uniform( min[ i ], min[ i ] + 10.0 );
 	}
 


### PR DESCRIPTION
Resolves none.

Extends: #4744

## Description

> What is the purpose of this pull request?

This pull request:

- Refactors random number generation in JS benchmarks for `stats/base/dists/arcsine`.
- Replaces `randu()` with `uniform()` for cleaner and more consistent code.
- Moves the random number generation outside the benchmarking loops.

## Related Issues

> Does this pull request have any related issues?

This pull request:

- resolves none

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
