### PR TITLE
fix: removes unused function from `reimann-zeta`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/riemann-zeta/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/riemann-zeta/src/main.c
@@ -575,26 +575,6 @@ static double series( const double s ) {
 }
 
 /**
-* Evaluates the Riemann zeta function for an odd positive integer.
-*
-* @param s    input value
-* @return     function value
-*
-* @example
-* double out = zeta( 3.0 );
-* // returns ~1.202
-*/
-static double zeta( const double s ) {
-	int32_t idx;
-
-	idx = ( s - 3 ) / 2;
-	if ( idx >= 56 ) {
-		return series( s );
-	}
-	return ODD_POSITIVE_INTEGERS[ idx ];
-}
-
-/**
 * Evaluates the Riemann zeta function.
 *
 * ## Method


### PR DESCRIPTION
## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

This PR removes unused `zeta` function from main.c file.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
