### PR TITLE
bench: refactor random number generation in `stats/base/dists/betaprime`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,16 +34,24 @@ var cdf = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var alpha;
 	var beta;
+	var len;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	alpha = new Float64Array( len );
+	beta = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 2.0 );
+		alpha[ i ] = uniform( EPS, 100.0 );
+		beta[ i ] = uniform( EPS, 100.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*2.0 ) + EPS;
-		alpha = ( randu()*100.0 ) + EPS;
-		beta = ( randu()*100.0 ) + EPS;
-		y = cdf( x, alpha, beta );
+		y = cdf( x[i % len], alpha[i % len], beta[i % len] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -59,6 +68,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mycdf;
 	var alpha;
 	var beta;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -66,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	alpha = 100.56789;
 	beta = 55.54321;
 	mycdf = cdf.factory( alpha, beta );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 2.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*2.0 ) + EPS;
-		y = mycdf( x );
+		y = mycdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/ctor/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -34,13 +35,20 @@ bench( pkg+'::instantiation', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
 	var i;
+
+	len = 100;
+	alpha = new Float64Array( len );
+	beta = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		alpha[ i ] = uniform( EPS, 10.0 );
+		beta[ i ] = uniform( EPS, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		alpha = ( randu() * 10.0 ) + EPS;
-		beta = ( randu() * 10.0 ) + EPS;
-		dist = new BetaPrime( alpha, beta );
+		dist = new BetaPrime( alpha[ i % len ], beta[ i % len ] );
 		if ( !( dist instanceof BetaPrime ) ) {
 			b.fail( 'should return a distribution instance' );
 		}
@@ -83,18 +91,23 @@ bench( pkg+'::set:alpha', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
 	var y;
 	var i;
 
 	alpha = 100.56789;
 	beta = 55.54321;
 	dist = new BetaPrime( alpha, beta );
+	len = 100;
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = ( 100.0*randu() ) + EPS;
-		dist.alpha = y;
-		if ( dist.alpha !== y ) {
+		dist.alpha = y[ i % len ];
+		if ( dist.alpha !== y[ i % len ] ) {
 			b.fail( 'should return set value' );
 		}
 	}
@@ -136,18 +149,23 @@ bench( pkg+'::set:beta', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
 	var y;
 	var i;
 
 	alpha = 100.56789;
 	beta = 55.54321;
 	dist = new BetaPrime( alpha, beta );
+	len = 100;
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = ( 100.0*randu() ) + EPS;
-		dist.beta = y;
-		if ( dist.beta !== y ) {
+		dist.beta = y[ i % len ];
+		if ( dist.beta !== y[ i % len ] ) {
 			b.fail( 'should return set value' );
 		}
 	}
@@ -163,16 +181,23 @@ bench( pkg+':kurtosis', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 
 	alpha = 100.56789;
 	beta = 55.54321;
 	dist = new BetaPrime( alpha, beta );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.alpha = ( 100.0*randu() ) + EPS;
+		dist.alpha = x[ i % len ];
 		y = dist.kurtosis;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -190,16 +215,23 @@ bench( pkg+':mean', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 
 	alpha = 100.56789;
 	beta = 55.54321;
 	dist = new BetaPrime( alpha, beta );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.alpha = ( 100.0*randu() ) + EPS;
+		dist.alpha = x[ i % len ];
 		y = dist.mean;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -217,16 +249,23 @@ bench( pkg+':mode', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 
 	alpha = 100.56789;
 	beta = 55.54321;
 	dist = new BetaPrime( alpha, beta );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 1.0 + EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.alpha = ( 100.0*randu() ) + 1.0 + EPS;
+		dist.alpha = x[ i % len ];
 		y = dist.mode;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -244,16 +283,23 @@ bench( pkg+':skewness', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 
 	alpha = 100.56789;
 	beta = 55.54321;
 	dist = new BetaPrime( alpha, beta );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.alpha = ( 100.0*randu() ) + EPS;
+		dist.alpha = x[ i % len ];
 		y = dist.skewness;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -271,16 +317,23 @@ bench( pkg+':stdev', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 
 	alpha = 100.56789;
 	beta = 55.54321;
 	dist = new BetaPrime( alpha, beta );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.alpha = ( 100.0*randu() ) + EPS;
+		dist.alpha = x[ i % len ];
 		y = dist.stdev;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -298,6 +351,7 @@ bench( pkg+':cdf', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -305,11 +359,15 @@ bench( pkg+':cdf', function benchmark( b ) {
 	alpha = 100.56789;
 	beta = 55.54321;
 	dist = new BetaPrime( alpha, beta );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.cdf( x );
+		y = dist.cdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -326,6 +384,7 @@ bench( pkg+':logpdf', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -333,11 +392,15 @@ bench( pkg+':logpdf', function benchmark( b ) {
 	alpha = 100.56789;
 	beta = 55.54321;
 	dist = new BetaPrime( alpha, beta );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.logpdf( x );
+		y = dist.logpdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -354,6 +417,7 @@ bench( pkg+':pdf', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -361,11 +425,15 @@ bench( pkg+':pdf', function benchmark( b ) {
 	alpha = 100.56789;
 	beta = 55.54321;
 	dist = new BetaPrime( alpha, beta );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.pdf( x );
+		y = dist.pdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -382,6 +450,7 @@ bench( pkg+':quantile', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -389,11 +458,15 @@ bench( pkg+':quantile', function benchmark( b ) {
 	alpha = 100.56789;
 	beta = 55.54321;
 	dist = new BetaPrime( alpha, beta );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.quantile( x );
+		y = dist.quantile( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/kurtosis/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/kurtosis/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	alpha = new Float64Array( len );
 	beta = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = ( randu() * 20.0 ) + EPS;
-		beta[ i ] = ( randu() * 20.0 ) + 4.0 + EPS;
+		alpha[ i ] = uniform( EPS, 20.0 );
+		beta[ i ] = uniform( 4.0 + EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/kurtosis/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/kurtosis/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -51,8 +51,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	alpha = new Float64Array( len );
 	beta = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = ( randu() * 20.0 ) + EPS;
-		beta[ i ] = ( randu() * 20.0 ) + 4.0 + EPS;
+		alpha[ i ] = uniform( EPS, 20.0 );
+		beta[ i ] = uniform( 4.0 + EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/logcdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/logcdf/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,16 +34,24 @@ var logcdf = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var alpha;
 	var beta;
+	var len;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	alpha = new Float64Array( len );
+	beta = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 2.0 );
+		alpha[ i ] = uniform( EPS, 100.0 );
+		beta[ i ] = uniform( EPS, 100.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*2.0 ) + EPS;
-		alpha = ( randu()*100.0 ) + EPS;
-		beta = ( randu()*100.0 ) + EPS;
-		y = logcdf( x, alpha, beta );
+		y = logcdf( x[ i % len ], alpha[ i % len ], beta[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -59,6 +68,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mylogcdf;
 	var alpha;
 	var beta;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -66,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	alpha = 100.56789;
 	beta = 55.54321;
 	mylogcdf = logcdf.factory( alpha, beta );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 2.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*2.0 ) + EPS;
-		y = mylogcdf( x );
+		y = mylogcdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,16 +34,24 @@ var logpdf = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var alpha;
 	var beta;
+	var len;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	alpha = new Float64Array( len );
+	beta = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 2.0 );
+		alpha[ i ] = uniform( EPS, 100.0 );
+		beta[ i ] = uniform( EPS, 100.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*2.0 ) + EPS;
-		alpha = ( randu()*100.0 ) + EPS;
-		beta = ( randu()*100.0 ) + EPS;
-		y = logpdf( x, alpha, beta );
+		y = logpdf( x[ i % len ], alpha[ i % len ], beta[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -59,6 +68,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mylogpdf;
 	var alpha;
 	var beta;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -66,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	alpha = 100.56789;
 	beta = 55.54321;
 	mylogpdf = logpdf.factory( alpha, beta );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 2.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*2.0 ) + EPS;
-		y = mylogpdf( x );
+		y = mylogpdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/mean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/mean/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,14 +34,21 @@ var mean = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var alpha;
 	var beta;
+	var len;
 	var y;
 	var i;
 
+	len = 100;
+	alpha = new Float64Array( len );
+	beta = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		alpha[ i ] = uniform( EPS, 10.0 );
+		beta[ i ] = uniform( 1.0 + EPS, 10.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		alpha = ( randu()*10.0 ) + EPS;
-		beta = ( randu()*10.0 ) + 1.0 + EPS;
-		y = mean( alpha, beta );
+		y = mean( alpha[ i % len ], beta[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/mode/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/mode/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform	= require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,14 +34,21 @@ var mode = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var alpha;
 	var beta;
+	var len;
 	var y;
 	var i;
 
+	len = 100;
+	alpha = new Float64Array( len );
+	beta = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		alpha[ i ] = uniform( EPS, 10.0 );
+		beta[ i ] = uniform( EPS, 10.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		alpha = ( randu()*10.0 ) + EPS;
-		beta = ( randu()*10.0 ) + EPS;
-		y = mode( alpha, beta );
+		y = mode( alpha[ i % len ], beta[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/pdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/pdf/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,16 +34,24 @@ var pdf = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var alpha;
 	var beta;
+	var len;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	alpha = new Float64Array( len );
+	beta = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 2.0 );
+		alpha[ i ] = uniform( EPS, 100.0 );
+		beta[ i ] = uniform( EPS, 100.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*2.0 ) + EPS;
-		alpha = ( randu()*100.0 ) + EPS;
-		beta = ( randu()*100.0 ) + EPS;
-		y = pdf( x, alpha, beta );
+		y = pdf( x[ i % len ], alpha[ i % len ], beta[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -59,6 +68,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mypdf;
 	var alpha;
 	var beta;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -66,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	alpha = 100.56789;
 	beta = 55.54321;
 	mypdf = pdf.factory( alpha, beta );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 2.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*2.0 ) + EPS;
-		y = mypdf( x );
+		y = mypdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/quantile/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,16 +34,24 @@ var quantile = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var alpha;
 	var beta;
+	var len;
 	var p;
 	var y;
 	var i;
 
+	len = 100;
+	p = new Float64Array( len );
+	alpha = new Float64Array( len );
+	beta = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		p[ i ] = uniform( 0.0, 1.0 );
+		alpha[ i ] = uniform( EPS, 100.0 );
+		beta[ i ] = uniform( EPS, 100.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		alpha = ( randu()*100.0 ) + EPS;
-		beta = ( randu()*100.0 ) + EPS;
-		y = quantile( p, alpha, beta );
+		y = quantile( p[ i % len ], alpha[ i % len ], beta[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -59,6 +68,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	var myQuantile;
 	var alpha;
 	var beta;
+	var len;
 	var p;
 	var y;
 	var i;
@@ -66,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	alpha = 100.56789;
 	beta = 55.54321;
 	myQuantile = quantile.factory( alpha, beta );
+	len = 100;
+	p = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		p[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		y = myQuantile( p );
+		y = myQuantile( p[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/skewness/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/skewness/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	alpha = new Float64Array( len );
 	beta = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = ( randu() * 20.0 ) + EPS;
-		beta[ i ] = ( randu() * 20.0 ) + 3.0 + EPS;
+		alpha[ i ] = uniform( EPS, 20.0 );
+		beta[ i ] = uniform( 3.0 + EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/skewness/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/skewness/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -51,8 +51,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	alpha = new Float64Array( len );
 	beta = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = ( randu() * 20.0 ) + EPS;
-		beta[ i ] = ( randu() * 20.0 ) + 3.0 + EPS;
+		alpha[ i ] = uniform( EPS, 20.0 );
+		beta[ i ] = uniform( 3.0 + EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/stdev/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/stdev/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	alpha = new Float64Array( len );
 	beta = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = ( randu() * 20.0 ) + EPS;
-		beta[ i ] = ( randu() * 20.0 ) + 2.0 + EPS;
+		alpha[ i ] = uniform( EPS, 20.0 );
+		beta[ i ] = uniform( 2.0 + EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/stdev/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/stdev/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -51,8 +51,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	alpha = new Float64Array( len );
 	beta = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = ( randu() * 20.0 ) + EPS;
-		beta[ i ] = ( randu() * 20.0 ) + 2.0 + EPS;
+		alpha[ i ] = uniform( EPS, 20.0 );
+		beta[ i ] = uniform( 2.0 + EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/variance/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/variance/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	alpha = new Float64Array( len );
 	beta = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = ( randu() * 20.0 ) + EPS;
-		beta[ i ] = ( randu() * 20.0 ) + 2.0 + EPS;
+		alpha[ i ] = uniform( EPS, 20.0 );
+		beta[ i ] = uniform( 2.0 + EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/variance/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/variance/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -51,8 +51,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	alpha = new Float64Array( len );
 	beta = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = ( randu() * 20.0 ) + EPS;
-		beta[ i ] = ( randu() * 20.0 ) + 2.0 + EPS;
+		alpha[ i ] = uniform( EPS, 20.0 );
+		beta[ i ] = uniform( 2.0 + EPS, 20.0 );
 	}
 
 	b.tic();


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

- Refactors random number generation in JS benchmarks for `stats/base/dists/betaprime`.
- Replaces `randu()` with `uniform()` for cleaner and more consistent code.
- Moves the random number generation outside the benchmarking loops.

## Related Issues

> Does this pull request have any related issues?

This pull request:

- resolves none

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md