### PR TITLE
bench: refactor random number generation in `stats/base/dists/binomial`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/cdf/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var cdf = require( './../lib' );
@@ -31,18 +32,26 @@ var cdf = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var n;
 	var p;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	n = new Float64Array( len );
+	p = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 100.0 );
+		n[ i ] = discreteUniform( 1, 100 );
+		p[ i ] = uniform( 0.0, 1.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu() * 100.0;
-		n = ceil( randu()*100.0 );
-		p = randu();
-		y = cdf( x, n, p );
+		y = cdf( x[ i % len ], n[ i % len ], p[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -57,6 +66,7 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var mycdf;
+	var len;
 	var n;
 	var p;
 	var x;
@@ -66,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	n = 80;
 	p = 0.4;
 	mycdf = cdf.factory( n, p );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 80.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu() * 80.0;
-		y = mycdf( x );
+		y = mycdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/ctor/benchmark/benchmark.js
@@ -21,9 +21,10 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
 var Binomial = require( './../lib' );
@@ -33,15 +34,22 @@ var Binomial = require( './../lib' );
 
 bench( pkg+'::instantiation', function benchmark( b ) {
 	var dist;
+	var len;
 	var n;
 	var p;
 	var i;
 
+	len = 100;
+	n = new Float64Array( len );
+	p = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		n[ i ] = discreteUniform( 1, 50 );
+		p[ i ] = uniform( EPS, 1.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		n = ceil( ( randu() * 50.0 ) + EPS );
-		p = randu() + EPS;
-		dist = new Binomial( n, p );
+		dist = new Binomial( n[ i % len ], p[ i % len ] );
 		if ( !( dist instanceof Binomial ) ) {
 			b.fail( 'should return a distribution instance' );
 		}
@@ -82,6 +90,7 @@ bench( pkg+'::get:n', function benchmark( b ) {
 
 bench( pkg+'::set:n', function benchmark( b ) {
 	var dist;
+	var len;
 	var n;
 	var p;
 	var y;
@@ -90,12 +99,16 @@ bench( pkg+'::set:n', function benchmark( b ) {
 	n = 40;
 	p = 0.6;
 	dist = new Binomial( n, p );
+	len = 100;
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = discreteUniform( 1, 50 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = ceil( ( randu() * 50.0 ) + EPS );
-		dist.n = y;
-		if ( dist.n !== y ) {
+		dist.n = y[ i % len ];
+		if ( dist.n !== y[ i % len ] ) {
 			b.fail( 'should return set value' );
 		}
 	}
@@ -135,6 +148,7 @@ bench( pkg+'::get:p', function benchmark( b ) {
 
 bench( pkg+'::set:p', function benchmark( b ) {
 	var dist;
+	var len;
 	var n;
 	var p;
 	var y;
@@ -143,12 +157,16 @@ bench( pkg+'::set:p', function benchmark( b ) {
 	n = 40;
 	p = 0.6;
 	dist = new Binomial( n, p );
+	len = 100;
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = uniform( EPS, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = randu() + EPS;
-		dist.p = y;
-		if ( dist.p !== y ) {
+		dist.p = y[ i % len ];
+		if ( dist.p !== y[ i % len ] ) {
 			b.fail( 'should return set value' );
 		}
 	}
@@ -162,6 +180,8 @@ bench( pkg+'::set:p', function benchmark( b ) {
 
 bench( pkg+':kurtosis', function benchmark( b ) {
 	var dist;
+	var len;
+	var x;
 	var n;
 	var p;
 	var y;
@@ -170,10 +190,15 @@ bench( pkg+':kurtosis', function benchmark( b ) {
 	n = 40;
 	p = 0.6;
 	dist = new Binomial( n, p );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 1, 100 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.n = ceil( ( 100.0*randu() ) + EPS );
+		dist.n = x[ i % len ];
 		y = dist.kurtosis;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -189,6 +214,8 @@ bench( pkg+':kurtosis', function benchmark( b ) {
 
 bench( pkg+':mean', function benchmark( b ) {
 	var dist;
+	var len;
+	var x;
 	var n;
 	var p;
 	var y;
@@ -197,10 +224,15 @@ bench( pkg+':mean', function benchmark( b ) {
 	n = 40;
 	p = 0.6;
 	dist = new Binomial( n, p );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 1, 100 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.n = ceil( ( 100.0*randu() ) + EPS );
+		dist.n = x[ i % len ];
 		y = dist.mean;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -216,6 +248,8 @@ bench( pkg+':mean', function benchmark( b ) {
 
 bench( pkg+':mode', function benchmark( b ) {
 	var dist;
+	var len;
+	var x;
 	var n;
 	var p;
 	var y;
@@ -224,10 +258,15 @@ bench( pkg+':mode', function benchmark( b ) {
 	n = 40;
 	p = 0.6;
 	dist = new Binomial( n, p );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 1, 100 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.n = ceil( ( 100.0*randu() ) + EPS );
+		dist.n = x[ i % len ];
 		y = dist.mode;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -243,6 +282,8 @@ bench( pkg+':mode', function benchmark( b ) {
 
 bench( pkg+':skewness', function benchmark( b ) {
 	var dist;
+	var len;
+	var x;
 	var n;
 	var p;
 	var y;
@@ -251,10 +292,15 @@ bench( pkg+':skewness', function benchmark( b ) {
 	n = 40;
 	p = 0.6;
 	dist = new Binomial( n, p );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 1, 100 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.n = ceil( ( 100.0*randu() ) + EPS );
+		dist.n = x[ i % len ];
 		y = dist.skewness;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -270,6 +316,8 @@ bench( pkg+':skewness', function benchmark( b ) {
 
 bench( pkg+':stdev', function benchmark( b ) {
 	var dist;
+	var len;
+	var x;
 	var n;
 	var p;
 	var y;
@@ -278,10 +326,15 @@ bench( pkg+':stdev', function benchmark( b ) {
 	n = 40;
 	p = 0.6;
 	dist = new Binomial( n, p );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 1, 100 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.n = ceil( ( 100.0*randu() ) + EPS );
+		dist.n = x[ i % len ];
 		y = dist.stdev;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -297,6 +350,8 @@ bench( pkg+':stdev', function benchmark( b ) {
 
 bench( pkg+':variance', function benchmark( b ) {
 	var dist;
+	var len;
+	var x;
 	var n;
 	var p;
 	var y;
@@ -305,10 +360,15 @@ bench( pkg+':variance', function benchmark( b ) {
 	n = 40;
 	p = 0.6;
 	dist = new Binomial( n, p );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 1, 100 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.n = ceil( ( 100.0*randu() ) + EPS );
+		dist.n = x[ i % len ];
 		y = dist.variance;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -324,6 +384,7 @@ bench( pkg+':variance', function benchmark( b ) {
 
 bench( pkg+':cdf', function benchmark( b ) {
 	var dist;
+	var len;
 	var n;
 	var p;
 	var x;
@@ -333,11 +394,15 @@ bench( pkg+':cdf', function benchmark( b ) {
 	n = 40;
 	p = 0.6;
 	dist = new Binomial( n, p );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.cdf( x );
+		y = dist.cdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -352,6 +417,7 @@ bench( pkg+':cdf', function benchmark( b ) {
 
 bench( pkg+':logpmf', function benchmark( b ) {
 	var dist;
+	var len;
 	var n;
 	var p;
 	var x;
@@ -361,11 +427,15 @@ bench( pkg+':logpmf', function benchmark( b ) {
 	n = 40;
 	p = 0.6;
 	dist = new Binomial( n, p );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 0, n );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ceil( randu() * n );
-		y = dist.logpmf( x );
+		y = dist.logpmf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -380,6 +450,7 @@ bench( pkg+':logpmf', function benchmark( b ) {
 
 bench( pkg+':mgf', function benchmark( b ) {
 	var dist;
+	var len;
 	var n;
 	var p;
 	var x;
@@ -389,11 +460,15 @@ bench( pkg+':mgf', function benchmark( b ) {
 	n = 40;
 	p = 0.6;
 	dist = new Binomial( n, p );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.mgf( x );
+		y = dist.mgf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -408,6 +483,7 @@ bench( pkg+':mgf', function benchmark( b ) {
 
 bench( pkg+':pmf', function benchmark( b ) {
 	var dist;
+	var len;
 	var n;
 	var p;
 	var x;
@@ -417,11 +493,15 @@ bench( pkg+':pmf', function benchmark( b ) {
 	n = 40;
 	p = 0.6;
 	dist = new Binomial( n, p );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 0, n );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ceil( randu() * n );
-		y = dist.pmf( x );
+		y = dist.pmf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -436,6 +516,7 @@ bench( pkg+':pmf', function benchmark( b ) {
 
 bench( pkg+':quantile', function benchmark( b ) {
 	var dist;
+	var len;
 	var n;
 	var p;
 	var x;
@@ -445,11 +526,15 @@ bench( pkg+':quantile', function benchmark( b ) {
 	n = 40;
 	p = 0.6;
 	dist = new Binomial( n, p );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.quantile( x );
+		y = dist.quantile( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/entropy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/entropy/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var entropy = require( './../lib' );
@@ -31,16 +32,23 @@ var entropy = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var n;
 	var p;
 	var y;
 	var i;
 
+	len = 1000;
+	n = new Float64Array( len );
+	p = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		n[ i ] = discreteUniform( 1, 100 );
+		p[ i ] = uniform( 0.0, 1.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		n = ceil( randu()*100.0 );
-		p = randu();
-		y = entropy( n, p );
+		y = entropy( n[ i % len ], p[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/kurtosis/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/kurtosis/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var kurtosis = require( './../lib' );
@@ -31,16 +32,23 @@ var kurtosis = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var n;
 	var p;
 	var y;
 	var i;
 
+	len = 100;
+	n = new Float64Array( len );
+	p = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		n[ i ] = discreteUniform( 1, 100 );
+		p[ i ] = uniform( 0.0, 1.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		n = ceil( randu()*100.0 );
-		p = randu();
-		y = kurtosis( n, p );
+		y = kurtosis( n[ i % len ], p[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/logpmf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/logpmf/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var logpmf = require( './../lib' );
@@ -31,18 +32,26 @@ var logpmf = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var n;
 	var p;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	n = new Float64Array( len );
+	p = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 0, 50 );
+		n[ i ] = discreteUniform( 1, 100 );
+		p[ i ] = uniform( 0.0, 1.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ceil( randu()*50.0 );
-		n = ceil( randu()*100.0 );
-		p = randu();
-		y = logpmf( x, n, p );
+		y = logpmf( x[ i % len ], n[ i % len ], p[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -57,6 +66,7 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var mypmf;
+	var len;
 	var n;
 	var p;
 	var x;
@@ -66,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	n = 80;
 	p = 0.4;
 	mypmf = logpmf.factory( n, p );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 0, 80 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ceil( randu()*80.0 );
-		y = mypmf( x );
+		y = mypmf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/mean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/mean/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var mean = require( './../lib' );
@@ -31,16 +32,23 @@ var mean = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var n;
 	var p;
 	var y;
 	var i;
 
+	len = 100;
+	n = new Float64Array( len );
+	p = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		n[ i ] = discreteUniform( 1, 100 );
+		p[ i ] = uniform( 0.0, 1.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		n = ceil( randu()*100.0 );
-		p = randu();
-		y = mean( n, p );
+		y = mean( n[ i % len ], p[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/median/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/median/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var median = require( './../lib' );
@@ -31,16 +32,23 @@ var median = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var n;
 	var p;
 	var y;
 	var i;
 
+	len = 100;
+	n = new Float64Array( len );
+	p = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		n[ i ] = discreteUniform( 1, 100 );
+		p[ i ] = uniform( 0.0, 1.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		n = ceil( randu()*100.0 );
-		p = randu();
-		y = median( n, p );
+		y = median( n[ i % len ], p[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/mgf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/mgf/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var mgf = require( './../lib' );
@@ -31,18 +32,26 @@ var mgf = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var n;
 	var p;
 	var t;
 	var y;
 	var i;
 
+	len = 100;
+	t = new Float64Array( len );
+	n = new Float64Array( len );
+	p = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		t[ i ] = uniform( 0.0, 5.0 );
+		n[ i ] = discreteUniform( 1, 100 );
+		p[ i ] = uniform( 0.0, 1.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		t = randu()*5.0;
-		n = ceil( randu()*100.0 );
-		p = randu();
-		y = mgf( t, n, p );
+		y = mgf( t[ i % len ], n[ i % len ], p[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -57,6 +66,7 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var mymgf;
+	var len;
 	var n;
 	var p;
 	var t;
@@ -66,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	n = 80;
 	p = 0.4;
 	mymgf = mgf.factory( n, p );
+	len = 100;
+	t = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		t[ i ] = uniform( 0.0, 5.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		t = ( randu()*5.0 );
-		y = mymgf( t );
+		y = mymgf( t[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/mode/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/mode/benchmark/benchmark.js
@@ -21,10 +21,10 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
 var Int32Array = require( '@stdlib/array/int32' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var mode = require( './../lib' );
@@ -43,13 +43,13 @@ bench( pkg, function benchmark( b ) {
 	n = new Int32Array( len );
 	p = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		n[ i ] = ceil( randu() * 100.0 );
-		p[ i ] = randu();
+		n[ i ] = discreteUniform( 1, 100 );
+		p[ i ] = uniform( 0.0, 1.0 );
 	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = mode( n[ i%len ], p[ i%len ] );
+		y = mode( n[ i % len ], p[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/mode/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/mode/benchmark/benchmark.native.js
@@ -25,8 +25,8 @@ var bench = require( '@stdlib/bench' );
 var Int32Array = require( '@stdlib/array/int32' );
 var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 
@@ -52,8 +52,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	n = new Int32Array( len );
 	p = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		n[ i ] = ceil( randu() * 100.0 );
-		p[ i ] = randu();
+		n[ i ] = discreteUniform( 1, 100 );
+		p[ i ] = uniform( 0.0, 1.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/pmf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/pmf/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var pmf = require( './../lib' );
@@ -31,18 +32,26 @@ var pmf = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var n;
 	var p;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	n = new Float64Array( len );
+	p = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 0, 50 );
+		n[ i ] = discreteUniform( 1, 100 );
+		p[ i ] = uniform( 0.0, 1.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ceil( randu()*50.0 );
-		n = ceil( randu()*100.0 );
-		p = randu();
-		y = pmf( x, n, p );
+		y = pmf( x[ i % len ], n[ i % len ], p[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -57,6 +66,7 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var mypmf;
+	var len;
 	var n;
 	var p;
 	var x;
@@ -66,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	n = 80;
 	p = 0.4;
 	mypmf = pmf.factory( n, p );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 0, 80 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ceil( randu()*80.0 );
-		y = mypmf( x );
+		y = mypmf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/quantile/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var quantile = require( './../lib' );
@@ -31,18 +32,26 @@ var quantile = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var n;
 	var p;
 	var r;
 	var y;
 	var i;
 
+	len = 100;
+	r = new Float64Array( len );
+	n = new Float64Array( len );
+	p = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		r[ i ] = uniform( 0.0, 1.0 );
+		n[ i ] = discreteUniform( 1, 100 );
+		p[ i ] = uniform( 0.0, 1.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		r = randu();
-		n = ceil( randu()*100.0 );
-		p = randu();
-		y = quantile( r, n, p );
+		y = quantile( r[ i % len ], n[ i % len ], p[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -57,6 +66,7 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var myQuantile;
+	var len;
 	var n;
 	var p;
 	var r;
@@ -66,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	n = 80;
 	p = 0.4;
 	myQuantile = quantile.factory( n, p );
+	len = 100;
+	r = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		r[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		r = randu();
-		y = myQuantile( r );
+		y = myQuantile( r[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/skewness/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/skewness/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var skewness = require( './../lib' );
@@ -31,16 +32,23 @@ var skewness = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var n;
 	var p;
 	var y;
 	var i;
 
+	len = 100;
+	n = new Float64Array( len );
+	p = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		n[ i ] = discreteUniform( 1, 100 );
+		p[ i ] = uniform( 0.0, 1.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		n = ceil( randu()*100.0 );
-		p = randu();
-		y = skewness( n, p );
+		y = skewness( n[ i % len ], p[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/stdev/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/stdev/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var stdev = require( './../lib' );
@@ -31,16 +32,23 @@ var stdev = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var n;
 	var p;
 	var y;
 	var i;
 
+	len = 100;
+	n = new Float64Array( len );
+	p = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		n[ i ] = discreteUniform( 1, 100 );
+		p[ i ] = uniform( 0.0, 1.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		n = ceil( randu()*100.0 );
-		p = randu();
-		y = stdev( n, p );
+		y = stdev( n[ i % len ], p[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/variance/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/variance/benchmark/benchmark.js
@@ -21,10 +21,10 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
 var Int32Array = require( '@stdlib/array/int32' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var variance = require( './../lib' );
@@ -43,13 +43,13 @@ bench( pkg, function benchmark( b ) {
 	n = new Int32Array( len );
 	p = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		n[ i ] = ceil( randu() * 100.0 );
-		p[ i ] = randu();
+		n[ i ] = discreteUniform( 1, 100 );
+		p[ i ] = uniform( 0.0, 1.0 );
 	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = variance( n[ i%len ], p[ i%len ] );
+		y = variance( n[ i % len ], p[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/variance/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/variance/benchmark/benchmark.native.js
@@ -25,8 +25,8 @@ var bench = require( '@stdlib/bench' );
 var Int32Array = require( '@stdlib/array/int32' );
 var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 
@@ -52,8 +52,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	n = new Int32Array( len );
 	p = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		n[ i ] = ceil( randu() * 100.0 );
-		p[ i ] = randu();
+		n[ i ] = discreteUniform( 1, 100 );
+		p[ i ] = uniform( 0.0, 1.0 );
 	}
 
 	b.tic();


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

- Refactors random number generation in JS benchmarks for `stats/base/dists/binomial`.
- Replaces `randu()` with `uniform()` for cleaner and more consistent code.
- Moves the random number generation outside the benchmarking loops.

## Related Issues

> Does this pull request have any related issues?

This pull request:

- resolves none

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md