### PR TITLE
bench: refactor random number generation in `stats/base/dists/chisquare`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/cdf/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var cdf = require( './../lib' );
@@ -31,16 +32,23 @@ var cdf = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var k;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	k = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 100.0 );
+		k[ i ] = discreteUniform( 1, 100 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu() * 100.0;
-		k = ceil( randu()*100.0 );
-		y = cdf( x, k );
+		y = cdf( x[ i % len ], k[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -55,6 +63,7 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var mycdf;
+	var len;
 	var k;
 	var x;
 	var y;
@@ -62,11 +71,15 @@ bench( pkg+':factory', function benchmark( b ) {
 
 	k = 10.0;
 	mycdf = cdf.factory( k );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu() * 100.0;
-		y = mycdf( x );
+		y = mycdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/ctor/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,13 +33,19 @@ var ChiSquare = require( './../lib' );
 
 bench( pkg+'::instantiation', function benchmark( b ) {
 	var dist;
+	var len;
 	var i;
 	var k;
 
+	len = 100;
+	k = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		k[ i ] = uniform( EPS, 10.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		k = ( randu() * 10.0 ) + EPS;
-		dist = new ChiSquare( k );
+		dist = new ChiSquare( k[ i % len ] );
 		if ( !( dist instanceof ChiSquare ) ) {
 			b.fail( 'should return a distribution instance' );
 		}
@@ -77,18 +84,23 @@ bench( pkg+'::get:k', function benchmark( b ) {
 
 bench( pkg+'::set:k', function benchmark( b ) {
 	var dist;
+	var len;
 	var y;
 	var i;
 	var k;
 
 	k = 5.54;
 	dist = new ChiSquare( k );
+	len = 100;
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = uniform( EPS, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = ( 10.0*randu() ) + EPS;
-		dist.k = y;
-		if ( dist.k !== y ) {
+		dist.k = y[ i % len ];
+		if ( dist.k !== y[ i % len ] ) {
 			b.fail( 'should return set value' );
 		}
 	}
@@ -102,16 +114,23 @@ bench( pkg+'::set:k', function benchmark( b ) {
 
 bench( pkg+':entropy', function benchmark( b ) {
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 	var k;
 
 	k = 5.54;
 	dist = new ChiSquare( k );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = ( 10.0*randu() ) + EPS;
+		dist.k = x[ i % len ];
 		y = dist.entropy;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -127,16 +146,23 @@ bench( pkg+':entropy', function benchmark( b ) {
 
 bench( pkg+':kurtosis', function benchmark( b ) {
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 	var k;
 
 	k = 5.54;
 	dist = new ChiSquare( k );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 1.0 + EPS, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = ( 10.0*randu() ) + 1.0 + EPS;
+		dist.k = x[ i % len ];
 		y = dist.kurtosis;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -152,16 +178,23 @@ bench( pkg+':kurtosis', function benchmark( b ) {
 
 bench( pkg+':mean', function benchmark( b ) {
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 	var k;
 
 	k = 5.54;
 	dist = new ChiSquare( k );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = ( 10.0*randu() ) + EPS;
+		dist.k = x[ i % len ];
 		y = dist.mean;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -177,16 +210,23 @@ bench( pkg+':mean', function benchmark( b ) {
 
 bench( pkg+':mode', function benchmark( b ) {
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 	var k;
 
 	k = 5.54;
 	dist = new ChiSquare( k );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 1.0 + EPS, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = ( 10.0*randu() ) + 1.0 + EPS;
+		dist.k = x[ i % len ];
 		y = dist.mode;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -202,16 +242,23 @@ bench( pkg+':mode', function benchmark( b ) {
 
 bench( pkg+':skewness', function benchmark( b ) {
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 	var k;
 
 	k = 5.54;
 	dist = new ChiSquare( k );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 1.0 + EPS, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = ( 10.0*randu() ) + 1.0 + EPS;
+		dist.k = x[ i % len ];
 		y = dist.skewness;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -227,16 +274,23 @@ bench( pkg+':skewness', function benchmark( b ) {
 
 bench( pkg+':stdev', function benchmark( b ) {
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 	var k;
 
 	k = 5.54;
 	dist = new ChiSquare( k );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 1.0 + EPS, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = ( 10.0*randu() ) + 1.0 + EPS;
+		dist.k = x[ i % len ];
 		y = dist.stdev;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -252,16 +306,23 @@ bench( pkg+':stdev', function benchmark( b ) {
 
 bench( pkg+':variance', function benchmark( b ) {
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 	var k;
 
 	k = 5.54;
 	dist = new ChiSquare( k );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 1.0 + EPS, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = ( 10.0*randu() ) + 1.0 + EPS;
+		dist.k = x[ i % len ];
 		y = dist.variance;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -277,6 +338,7 @@ bench( pkg+':variance', function benchmark( b ) {
 
 bench( pkg+':cdf', function benchmark( b ) {
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -284,11 +346,15 @@ bench( pkg+':cdf', function benchmark( b ) {
 
 	k = 5.54;
 	dist = new ChiSquare( k );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.cdf( x );
+		y = dist.cdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -303,6 +369,7 @@ bench( pkg+':cdf', function benchmark( b ) {
 
 bench( pkg+':mgf', function benchmark( b ) {
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -310,11 +377,15 @@ bench( pkg+':mgf', function benchmark( b ) {
 
 	k = 5.54;
 	dist = new ChiSquare( k );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 0.5 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu() * 0.5;
-		y = dist.mgf( x );
+		y = dist.mgf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -329,6 +400,7 @@ bench( pkg+':mgf', function benchmark( b ) {
 
 bench( pkg+':pdf', function benchmark( b ) {
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -336,11 +408,15 @@ bench( pkg+':pdf', function benchmark( b ) {
 
 	k = 5.54;
 	dist = new ChiSquare( k );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.pdf( x );
+		y = dist.pdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -355,6 +431,7 @@ bench( pkg+':pdf', function benchmark( b ) {
 
 bench( pkg+':quantile', function benchmark( b ) {
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -362,11 +439,15 @@ bench( pkg+':quantile', function benchmark( b ) {
 
 	k = 5.54;
 	dist = new ChiSquare( k );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.quantile( x );
+		y = dist.quantile( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/entropy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/entropy/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -40,7 +40,7 @@ bench( pkg, function benchmark( b ) {
 	len = 100;
 	k = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		k[ i ] = ( randu() * 20.0 ) + EPS;
+		k[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/entropy/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/entropy/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var EPS = require( '@stdlib/constants/float64/eps' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -49,7 +49,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	len = 100;
 	k = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		k[ i ] = ( randu() * 20.0 ) + EPS;
+		k[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/kurtosis/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/kurtosis/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -31,14 +32,20 @@ var kurtosis = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var k;
 	var y;
 	var i;
 
+	len = 100;
+	k = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		k[ i ] = uniform( EPS, 20.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		k = ( randu()*20.0 ) + EPS;
-		y = kurtosis( k );
+		y = kurtosis( k[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/logpdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/logpdf/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var logpdf = require( './../lib' );
@@ -31,16 +32,23 @@ var logpdf = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var k;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	k = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 100.0 );
+		k[ i ] = discreteUniform( 1, 100 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu() * 100.0;
-		k = ceil( randu()*100.0 );
-		y = logpdf( x, k );
+		y = logpdf( x[ i % len ], k[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -55,6 +63,7 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var mylogpdf;
+	var len;
 	var k;
 	var x;
 	var y;
@@ -62,11 +71,15 @@ bench( pkg+':factory', function benchmark( b ) {
 
 	k = 10.0;
 	mylogpdf = logpdf.factory( k );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu() * 100.0;
-		y = mylogpdf( x );
+		y = mylogpdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/mean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/mean/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -40,7 +40,7 @@ bench( pkg, function benchmark( b ) {
 	len = 100;
 	k = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		k[ i ] = ( randu() * 20.0 ) + EPS;
+		k[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/mean/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/mean/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var EPS = require( '@stdlib/constants/float64/eps' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -49,7 +49,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	len = 100;
 	k = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		k[ i ] = ( randu() * 20.0 ) + EPS;
+		k[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/median/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/median/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -31,14 +32,20 @@ var median = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var k;
 	var y;
 	var i;
 
+	len = 100;
+	k = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		k[ i ] = uniform( 1.0 + EPS, 20.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		k = ( randu()*20.0 ) + 1.0 + EPS;
-		y = median( k );
+		y = median( k[ i % len ]);
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/mgf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/mgf/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var mgf = require( './../lib' );
@@ -31,16 +32,23 @@ var mgf = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var k;
 	var t;
 	var y;
 	var i;
 
+	len = 100;
+	t = new Float64Array( len );
+	k = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		t[ i ] = uniform( 0.0, 0.5 );
+		k[ i ] = discreteUniform( 1, 100 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		t = randu() * 0.5;
-		k = ceil( randu()*100.0 );
-		y = mgf( t, k );
+		y = mgf( t[ i % len ], k[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -55,6 +63,7 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var mymgf;
+	var len;
 	var k;
 	var t;
 	var y;
@@ -62,11 +71,15 @@ bench( pkg+':factory', function benchmark( b ) {
 
 	k = 10.0;
 	mymgf = mgf.factory( k );
+	len = 100;
+	t = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		t[ i ] = uniform( 0.0, 0.5 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		t = randu() * 0.5;
-		y = mymgf( t );
+		y = mymgf( t[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/mgf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/mgf/benchmark/benchmark.native.js
@@ -23,7 +23,8 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -50,8 +51,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	t = new Float64Array( len );
 	k = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		t[ i ] = ( randu() * 0.8 ) - 0.4;
-		k[ i ] = ( randu() * 10.0 ) + 0.1;
+		t[ i ] = uniform( 0.0, 0.5 );
+		k[ i ] = discreteUniform( 1, 100 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/mode/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/mode/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -40,7 +40,7 @@ bench( pkg, function benchmark( b ) {
 	len = 100;
 	k = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		k[ i ] = ( randu() * 20.0 ) + EPS;
+		k[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/mode/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/mode/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var EPS = require( '@stdlib/constants/float64/eps' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -49,7 +49,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	len = 100;
 	k = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		k[ i ] = ( randu() * 20.0 ) + EPS;
+		k[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/pdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/pdf/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var pdf = require( './../lib' );
@@ -31,16 +32,23 @@ var pdf = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var k;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	k = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 100.0 );
+		k[ i ] = discreteUniform( 1, 100 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu() * 100.0;
-		k = ceil( randu()*100.0 );
-		y = pdf( x, k );
+		y = pdf( x[ i % len ], k[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -55,6 +63,7 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var mypdf;
+	var len;
 	var k;
 	var x;
 	var y;
@@ -62,11 +71,15 @@ bench( pkg+':factory', function benchmark( b ) {
 
 	k = 10.0;
 	mypdf = pdf.factory( k );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu() * 100.0;
-		y = mypdf( x );
+		y = mypdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/quantile/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var quantile = require( './../lib' );
@@ -31,16 +32,23 @@ var quantile = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var k;
 	var p;
 	var y;
 	var i;
 
+	len = 100;
+	p = new Float64Array( len );
+	k = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		p[ i ] = uniform( 0.0, 1.0 );
+		k[ i ] = discreteUniform( 1, 30 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		k = ceil( randu()*30.0 );
-		y = quantile( p, k );
+		y = quantile( p[ i % len ], k[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -55,6 +63,7 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var myquantile;
+	var len;
 	var k;
 	var p;
 	var y;
@@ -62,11 +71,15 @@ bench( pkg+':factory', function benchmark( b ) {
 
 	k = 10.0;
 	myquantile = quantile.factory( k );
+	len = 100;
+	p = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		p[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		y = myquantile( p );
+		y = myquantile( p[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/skewness/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/skewness/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -40,7 +40,7 @@ bench( pkg, function benchmark( b ) {
 	len = 100;
 	k = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		k[ i ] = ( randu() * 20.0 ) + EPS;
+		k[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/skewness/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/skewness/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var EPS = require( '@stdlib/constants/float64/eps' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -49,7 +49,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	len = 100;
 	k = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		k[ i ] = ( randu() * 20.0 ) + EPS;
+		k[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/stdev/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/stdev/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -40,7 +40,7 @@ bench( pkg, function benchmark( b ) {
 	len = 100;
 	k = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		k[ i ] = ( randu() * 20.0 ) + EPS;
+		k[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/stdev/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/stdev/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -49,7 +49,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	len = 100;
 	k = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		k[ i ] = ( randu() * 20.0 ) + EPS;
+		k[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/variance/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/variance/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform	= require( '@stdlib/random/base/uniform' );
 var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -40,7 +40,7 @@ bench( pkg, function benchmark( b ) {
 	len = 100;
 	k = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		k[ i ] = ( randu() * 20.0 ) + EPS;
+		k[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/variance/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/variance/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -49,7 +49,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	len = 100;
 	k = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		k[ i ] = ( randu() * 20.0 ) + EPS;
+		k[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

- Refactors random number generation in JS benchmarks for `stats/base/dists/chisquare`.
- Replaces `randu()` with `uniform()` for cleaner and more consistent code.
- Moves the random number generation outside the benchmarking loops.

## Related Issues

> Does this pull request have any related issues?

This pull request:

- resolves none

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md