### PR TITLE
bench: refactor random number generation in `stats/base/dists/cosine`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/cdf/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -44,9 +44,9 @@ bench( pkg, function benchmark( b ) {
 	mu = new Float64Array( len );
 	s = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu()*100.0 ) - 50.0;
-		mu[ i ] = ( randu()*20.0 ) - 10.0;
-		s[ i ] = ( randu()*5.0 ) + EPS;
+		x[ i ] = uniform( -50.0, 50.0 );
+		mu[ i ] = uniform( -10.0, 10.0 );
+		s[ i ] = uniform( EPS, 5.0 );
 	}
 
 	b.tic();
@@ -66,6 +66,7 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var mycdf;
+	var len;
 	var mu;
 	var s;
 	var x;
@@ -75,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	mu = 10.0;
 	s = 4.0;
 	mycdf = cdf.factory( mu, s );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 50.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*50.0 );
-		y = mycdf( x );
+		y = mycdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/cdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/cdf/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -53,9 +53,9 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	mu = new Float64Array( len );
 	s = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu()*100.0 ) - 50.0;
-		mu[ i ] = ( randu()*20.0 ) - 10.0;
-		s[ i ] = ( randu()*5.0 ) + EPS;
+		x[ i ] = uniform( -50.0, 50.0 );
+		mu[ i ] = uniform( -10.0, 10.0 );
+		s[ i ] = uniform( EPS, 5.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/ctor/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,15 +33,22 @@ var Cosine = require( './../lib' );
 
 bench( pkg+'::instantiation', function benchmark( bm ) {
 	var dist;
+	var len;
 	var mu;
 	var s;
 	var i;
 
+	len = 100;
+	mu = new Float64Array( len );
+	s = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		mu[ i ] = uniform( EPS, 10.0 );
+		s[ i ] = uniform( EPS, 10.0 );
+	}
+
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		mu = ( randu() * 10.0 ) + EPS;
-		s = ( randu() * 10.0 ) + EPS;
-		dist = new Cosine( mu, s );
+		dist = new Cosine( mu[ i % len ], s[ i % len ] );
 		if ( !( dist instanceof Cosine ) ) {
 			bm.fail( 'should return a distribution instance' );
 		}
@@ -81,6 +89,7 @@ bench( pkg+'::get:mu', function benchmark( bm ) {
 
 bench( pkg+'::set:mu', function benchmark( bm ) {
 	var dist;
+	var len;
 	var mu;
 	var s;
 	var y;
@@ -89,12 +98,16 @@ bench( pkg+'::set:mu', function benchmark( bm ) {
 	mu = 2.0;
 	s = 3.0;
 	dist = new Cosine( mu, s );
+	len = 100;
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = uniform( EPS, 100.0 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		y = ( 100.0*randu() ) + EPS;
-		dist.mu = y;
-		if ( dist.mu !== y ) {
+		dist.mu = y[ i % len ];
+		if ( dist.mu !== y[ i % len ] ) {
 			bm.fail( 'should return set value' );
 		}
 	}
@@ -134,6 +147,7 @@ bench( pkg+'::get:s', function benchmark( bm ) {
 
 bench( pkg+'::set:s', function benchmark( bm ) {
 	var dist;
+	var len;
 	var mu;
 	var s;
 	var y;
@@ -142,12 +156,16 @@ bench( pkg+'::set:s', function benchmark( bm ) {
 	mu = 2.0;
 	s = 3.0;
 	dist = new Cosine( mu, s );
+	len = 100;
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = uniform( EPS, 100.0 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		y = ( 100.0*randu() ) + EPS;
-		dist.s = y;
-		if ( dist.s !== y ) {
+		dist.s = y[ i % len ];
+		if ( dist.s !== y[ i % len ] ) {
 			bm.fail( 'should return set value' );
 		}
 	}
@@ -161,7 +179,9 @@ bench( pkg+'::set:s', function benchmark( bm ) {
 
 bench( pkg+':kurtosis', function benchmark( bm ) {
 	var dist;
+	var len;
 	var mu;
+	var x;
 	var s;
 	var y;
 	var i;
@@ -169,10 +189,15 @@ bench( pkg+':kurtosis', function benchmark( bm ) {
 	mu = 2.0;
 	s = 3.0;
 	dist = new Cosine( mu, s );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.mu = ( 100.0*randu() ) + EPS;
+		dist.mu = x[ i % len ];
 		y = dist.kurtosis;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -188,7 +213,9 @@ bench( pkg+':kurtosis', function benchmark( bm ) {
 
 bench( pkg+':mean', function benchmark( bm ) {
 	var dist;
+	var len;
 	var mu;
+	var x;
 	var s;
 	var y;
 	var i;
@@ -196,10 +223,15 @@ bench( pkg+':mean', function benchmark( bm ) {
 	mu = 2.0;
 	s = 3.0;
 	dist = new Cosine( mu, s );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.mu = ( 100.0*randu() ) + EPS;
+		dist.mu = x[ i % len ];
 		y = dist.mean;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -215,7 +247,9 @@ bench( pkg+':mean', function benchmark( bm ) {
 
 bench( pkg+':median', function benchmark( bm ) {
 	var dist;
+	var len;
 	var mu;
+	var x;
 	var s;
 	var y;
 	var i;
@@ -223,10 +257,15 @@ bench( pkg+':median', function benchmark( bm ) {
 	mu = 2.0;
 	s = 3.0;
 	dist = new Cosine( mu, s );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.mu = ( 100.0*randu() ) + EPS;
+		dist.mu = x[ i % len ];
 		y = dist.median;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -242,7 +281,9 @@ bench( pkg+':median', function benchmark( bm ) {
 
 bench( pkg+':mode', function benchmark( bm ) {
 	var dist;
+	var len;
 	var mu;
+	var x;
 	var s;
 	var y;
 	var i;
@@ -250,10 +291,15 @@ bench( pkg+':mode', function benchmark( bm ) {
 	mu = 2.0;
 	s = 3.0;
 	dist = new Cosine( mu, s );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 1.0 + EPS, 100.0 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.mu = ( 100.0*randu() ) + 1.0 + EPS;
+		dist.mu = x[ i % len ];
 		y = dist.mode;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -269,7 +315,9 @@ bench( pkg+':mode', function benchmark( bm ) {
 
 bench( pkg+':skewness', function benchmark( bm ) {
 	var dist;
+	var len;
 	var mu;
+	var x;
 	var s;
 	var y;
 	var i;
@@ -277,10 +325,15 @@ bench( pkg+':skewness', function benchmark( bm ) {
 	mu = 2.0;
 	s = 3.0;
 	dist = new Cosine( mu, s );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.mu = ( 100.0*randu() ) + EPS;
+		dist.mu = x[ i % len ];
 		y = dist.skewness;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -296,7 +349,9 @@ bench( pkg+':skewness', function benchmark( bm ) {
 
 bench( pkg+':stdev', function benchmark( bm ) {
 	var dist;
+	var len;
 	var mu;
+	var x;
 	var s;
 	var y;
 	var i;
@@ -304,10 +359,15 @@ bench( pkg+':stdev', function benchmark( bm ) {
 	mu = 2.0;
 	s = 3.0;
 	dist = new Cosine( mu, s );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.mu = ( 100.0*randu() ) + EPS;
+		dist.mu = x[ i % len ];
 		y = dist.stdev;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -323,7 +383,9 @@ bench( pkg+':stdev', function benchmark( bm ) {
 
 bench( pkg+':variance', function benchmark( bm ) {
 	var dist;
+	var len;
 	var mu;
+	var x;
 	var s;
 	var y;
 	var i;
@@ -331,10 +393,15 @@ bench( pkg+':variance', function benchmark( bm ) {
 	mu = 2.0;
 	s = 3.0;
 	dist = new Cosine( mu, s );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.mu = ( 100.0*randu() ) + EPS;
+		dist.mu = x[ i % len ];
 		y = dist.variance;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -350,6 +417,7 @@ bench( pkg+':variance', function benchmark( bm ) {
 
 bench( pkg+':cdf', function benchmark( bm ) {
 	var dist;
+	var len;
 	var mu;
 	var s;
 	var x;
@@ -359,11 +427,15 @@ bench( pkg+':cdf', function benchmark( bm ) {
 	mu = 2.0;
 	s = 3.0;
 	dist = new Cosine( mu, s );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -3.0, 3.0 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = ( randu()*6.0 ) - 3.0;
-		y = dist.cdf( x );
+		y = dist.cdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
 		}
@@ -378,6 +450,7 @@ bench( pkg+':cdf', function benchmark( bm ) {
 
 bench( pkg+':logpdf', function benchmark( bm ) {
 	var dist;
+	var len;
 	var mu;
 	var s;
 	var x;
@@ -387,11 +460,15 @@ bench( pkg+':logpdf', function benchmark( bm ) {
 	mu = 1.0;
 	s = 2.0;
 	dist = new Cosine( mu, s );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -3.0, 3.0 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = ( randu()*6.0 ) - 3.0;
-		y = dist.logpdf( x );
+		y = dist.logpdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
 		}
@@ -406,6 +483,7 @@ bench( pkg+':logpdf', function benchmark( bm ) {
 
 bench( pkg+':mgf', function benchmark( bm ) {
 	var dist;
+	var len;
 	var mu;
 	var s;
 	var x;
@@ -415,11 +493,15 @@ bench( pkg+':mgf', function benchmark( bm ) {
 	mu = 2.0;
 	s = 0.2;
 	dist = new Cosine( mu, s );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = randu();
-		y = dist.mgf( x );
+		y = dist.mgf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
 		}
@@ -434,6 +516,7 @@ bench( pkg+':mgf', function benchmark( bm ) {
 
 bench( pkg+':pdf', function benchmark( bm ) {
 	var dist;
+	var len;
 	var mu;
 	var s;
 	var x;
@@ -443,11 +526,15 @@ bench( pkg+':pdf', function benchmark( bm ) {
 	mu = 2.0;
 	s = 3.0;
 	dist = new Cosine( mu, s );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -3.0, 3.0 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = ( randu()*6.0 ) - 3.0;
-		y = dist.pdf( x );
+		y = dist.pdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
 		}
@@ -462,6 +549,7 @@ bench( pkg+':pdf', function benchmark( bm ) {
 
 bench( pkg+':quantile', function benchmark( bm ) {
 	var dist;
+	var len;
 	var mu;
 	var s;
 	var x;
@@ -471,11 +559,15 @@ bench( pkg+':quantile', function benchmark( bm ) {
 	mu = 2.0;
 	s = 3.0;
 	dist = new Cosine( mu, s );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = randu();
-		y = dist.quantile( x );
+		y = dist.quantile( x[ i % len ] );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/kurtosis/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/kurtosis/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	mu = new Float64Array( len );
 	s = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = ( randu()*100.0 ) - 50.0;
-		s[ i ] = ( randu()*20.0 ) + EPS;
+		mu[ i ] = uniform( -50.0, 50.0 );
+		s[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/kurtosis/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/kurtosis/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -51,8 +51,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	mu = new Float64Array( len );
 	s = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = ( randu()*100.0 ) - 50.0;
-		s[ i ] = ( randu()*20.0 ) + EPS;
+		mu[ i ] = uniform( -50.0, 50.0 );
+		s[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/logcdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/logcdf/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform	= require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -44,9 +44,9 @@ bench( pkg, function benchmark( b ) {
 	mu = new Float64Array( len );
 	s = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu()*100.0 ) - 50.0;
-		mu[ i ] = ( randu()*20.0 ) - 10.0;
-		s[ i ] = ( randu()*5.0 ) + EPS;
+		x[ i ] = uniform( -50.0, 50.0 );
+		mu[ i ] = uniform( -10.0, 10.0 );
+		s[ i ] = uniform( EPS, 5.0 );
 	}
 
 	b.tic();
@@ -66,6 +66,7 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var mylogcdf;
+	var len;
 	var mu;
 	var s;
 	var x;
@@ -75,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	mu = 10.0;
 	s = 4.0;
 	mylogcdf = logcdf.factory( mu, s );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 50.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*50.0 );
-		y = mylogcdf( x );
+		y = mylogcdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/logcdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/logcdf/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -53,9 +53,9 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	mu = new Float64Array( len );
 	s = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu()*100.0 ) - 50.0;
-		mu[ i ] = ( randu()*20.0 ) - 10.0;
-		s[ i ] = ( randu()*5.0 ) + EPS;
+		x[ i ] = uniform( -50.0, 50.0 );
+		mu[ i ] = uniform( -10.0, 10.0 );
+		s[ i ] = uniform( EPS, 5.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/logpdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/logpdf/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -44,9 +44,9 @@ bench( pkg, function benchmark( b ) {
 	mu = new Float64Array( len );
 	s = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu()*100.0 ) - 50.0;
-		mu[ i ] = ( randu()*20.0 ) - 10.0;
-		s[ i ] = ( randu()*5.0 ) + EPS;
+		x[ i ] = uniform( -50.0, 50.0 );
+		mu[ i ] = uniform( -10.0, 10.0 );
+		s[ i ] = uniform( EPS, 5.0 );
 	}
 
 	b.tic();
@@ -66,6 +66,7 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var mylogpdf;
+	var len;
 	var mu;
 	var s;
 	var x;
@@ -75,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	mu = 10.0;
 	s = 4.0;
 	mylogpdf = logpdf.factory( mu, s );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 50.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu() * 50.0;
-		y = mylogpdf( x );
+		y = mylogpdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/logpdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/logpdf/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -53,9 +53,9 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	mu = new Float64Array( len );
 	s = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu()*100.0 ) - 50.0;
-		mu[ i ] = ( randu()*20.0 ) - 10.0;
-		s[ i ] = ( randu()*5.0 ) + EPS;
+		x[ i ] = uniform( -50.0, 50.0 );
+		mu[ i ] = uniform( -10.0, 10.0 );
+		s[ i ] = uniform( EPS, 5.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/mean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/mean/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -31,16 +32,23 @@ var mean = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var mu;
 	var s;
 	var y;
 	var i;
 
+	len = 100;
+	mu = new Float64Array( len );
+	s = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		mu[ i ] = uniform( -50.0, 50.0 );
+		s[ i ] = uniform( EPS, 20.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		mu = ( randu()*100.0 ) - 50.0;
-		s = ( randu()*20.0 ) + EPS;
-		y = mean( mu, s );
+		y = mean( mu[ i % len ], s[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/median/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/median/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	mu = new Float64Array( len );
 	s = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = ( randu()*100.0 ) - 50.0;
-		s[ i ] = ( randu()*20.0 ) + EPS;
+		mu[ i ] = uniform( -50.0, 50.0 );
+		s[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/median/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/median/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -51,8 +51,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	mu = new Float64Array( len );
 	s = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = ( randu()*100.0 ) - 50.0;
-		s[ i ] = ( randu()*20.0 ) + EPS;
+		mu[ i ] = uniform( -50.0, 50.0 );
+		s[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/mgf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/mgf/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -44,9 +44,9 @@ bench( pkg, function benchmark( b ) {
 	mu = new Float64Array( len );
 	s = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		t[ i ] = ( randu()*10.0 ) + EPS;
-		mu[ i ] = ( randu()*20.0 ) - 10.0;
-		s[ i ] = ( randu()*5.0 ) + EPS;
+		t[ i ] = uniform( EPS, 10.0 );
+		mu[ i ] = uniform( -10.0, 10.0 );
+		s[ i ] = uniform( EPS, 5.0 );
 	}
 
 	b.tic();
@@ -66,6 +66,7 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var myMGF;
+	var len;
 	var mu;
 	var s;
 	var t;
@@ -75,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	mu = 10.0;
 	s = 4.0;
 	myMGF = mgf.factory( mu, s );
+	len = 100;
+	t = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		t[ i ] = uniform( EPS, 5.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		t = ( randu()*5.0 ) + EPS;
-		y = myMGF( t );
+		y = myMGF( t[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/mgf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/mgf/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -53,9 +53,9 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	mu = new Float64Array( len );
 	s = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		t[ i ] = ( randu()*10.0 ) + EPS;
-		mu[ i ] = ( randu()*20.0 ) - 10.0;
-		s[ i ] = ( randu()*5.0 ) + EPS;
+		t[ i ] = uniform( EPS, 10.0 );
+		mu[ i ] = uniform( -10.0, 10.0 );
+		s[ i ] = uniform( EPS, 5.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/mode/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/mode/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	mu = new Float64Array( len );
 	s = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = ( randu()*100.0 ) - 50.0;
-		s[ i ] = ( randu()*20.0 ) + EPS;
+		mu[ i ] = uniform( -50.0, 50.0 );
+		s[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/mode/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/mode/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -51,8 +51,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	mu = new Float64Array( len );
 	s = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = ( randu()*100.0 ) - 50.0;
-		s[ i ] = ( randu()*20.0 ) + EPS;
+		mu[ i ] = uniform( -50.0, 50.0 );
+		s[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/pdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/pdf/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -44,9 +44,9 @@ bench( pkg, function benchmark( b ) {
 	mu = new Float64Array( len );
 	s = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu()*100.0 ) - 50.0;
-		mu[ i ] = ( randu()*20.0 ) - 10.0;
-		s[ i ] = ( randu()*5.0 ) + EPS;
+		x[ i ] = uniform( -50.0, 50.0 );
+		mu[ i ] = uniform( -10.0, 10.0 );
+		s[ i ] = uniform( EPS, 5.0 );
 	}
 
 	b.tic();
@@ -66,6 +66,7 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var mypdf;
+	var len;
 	var mu;
 	var s;
 	var x;
@@ -75,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	mu = 10.0;
 	s = 4.0;
 	mypdf = pdf.factory( mu, s );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 50.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu() * 50.0;
-		y = mypdf( x );
+		y = mypdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/pdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/pdf/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -53,9 +53,9 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	mu = new Float64Array( len );
 	s = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu()*100.0 ) - 50.0;
-		mu[ i ] = ( randu()*20.0 ) - 10.0;
-		s[ i ] = ( randu()*5.0 ) + EPS;
+		x[ i ] = uniform( -50.0, 50.0 );
+		mu[ i ] = uniform( -10.0, 10.0 );
+		s[ i ] = uniform( EPS, 5.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/quantile/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -31,18 +32,26 @@ var quantile = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var mu;
 	var s;
 	var p;
 	var y;
 	var i;
 
+	len = 100;
+	p = new Float64Array( len );
+	mu = new Float64Array( len );
+	s = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		p[ i ] = uniform( 0.0, 1.0 );
+		mu[ i ] = uniform( -10.0, 10.0 );
+		s[ i ] = uniform( EPS, 5.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		mu = ( randu()*20.0 ) - 10.0;
-		s = ( randu()*5.0 ) + EPS;
-		y = quantile( p, mu, s );
+		y = quantile( p[ i % len ], mu[ i % len ], s[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -57,6 +66,7 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var myquantile;
+	var len;
 	var mu;
 	var s;
 	var p;
@@ -66,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	mu = 10.0;
 	s = 4.0;
 	myquantile = quantile.factory( mu, s );
+	len = 100;
+	p = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		p[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		y = myquantile( p );
+		y = myquantile( p[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/skewness/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/skewness/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	mu = new Float64Array( len );
 	s = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = ( randu()*100.0 ) - 50.0;
-		s[ i ] = ( randu()*20.0 ) + EPS;
+		mu[ i ] = uniform( -50.0, 50.0 );
+		s[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/skewness/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/skewness/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -51,8 +51,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	mu = new Float64Array( len );
 	s = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = ( randu()*100.0 ) - 50.0;
-		s[ i ] = ( randu()*20.0 ) + EPS;
+		mu[ i ] = uniform( -50.0, 50.0 );
+		s[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/stdev/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/stdev/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	mu = new Float64Array( len );
 	s = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = ( randu()*100.0 ) - 50.0;
-		s[ i ] = ( randu()*20.0 ) + EPS;
+		mu[ i ] = uniform( -50.0, 50.0 );
+		s[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/stdev/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/stdev/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -51,8 +51,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	mu = new Float64Array( len );
 	s = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = ( randu()*100.0 ) - 50.0;
-		s[ i ] = ( randu()*20.0 ) + EPS;
+		mu[ i ] = uniform( -50.0, 50.0 );
+		s[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/variance/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/variance/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -31,16 +32,23 @@ var variance = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var mu;
 	var s;
 	var y;
 	var i;
 
+	len = 100;
+	mu = new Float64Array( len );
+	s = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		mu[ i ] = uniform( -50.0, 50.0 );
+		s[ i ] = uniform( EPS, 20.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		mu = ( randu()*100.0 ) - 50.0;
-		s = ( randu()*20.0 ) + EPS;
-		y = variance( mu, s );
+		y = variance( mu[ i % len ], s[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

- Refactors random number generation in JS benchmarks for `stats/base/dists/cosine`.
- Replaces `randu()` with `uniform()` for cleaner and more consistent code.
- Moves the random number generation outside the benchmarking loops.

## Related Issues

> Does this pull request have any related issues?

This pull request:

- resolves none

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md