### PR TITLE
bench: refactor random number generation in `stats/base/dists/degenerate`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/cdf/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var cdf = require( './../lib' );
@@ -30,16 +31,23 @@ var cdf = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var mu;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	mu = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -100.0, 0.0 );
+		mu[ i ] = uniform( -50.0, 50.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*100.0 ) - 100;
-		mu = ( randu()*100.0 ) - 50.0;
-		y = cdf( x, mu );
+		y = cdf( x[ i % len ], mu[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -54,6 +62,7 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var mycdf;
+	var len;
 	var mu;
 	var x;
 	var y;
@@ -61,11 +70,15 @@ bench( pkg+':factory', function benchmark( b ) {
 
 	mu = 40.0;
 	mycdf = cdf.factory( mu );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*100.0 );
-		y = mycdf( x );
+		y = mycdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/ctor/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var Degenerate = require( './../lib' );
@@ -32,13 +33,19 @@ var Degenerate = require( './../lib' );
 
 bench( pkg+'::instantiation', function benchmark( b ) {
 	var dist;
+	var len;
 	var mu;
 	var i;
 
+	len = 100;
+	mu = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		mu[ i ] = uniform( 0.0, 10.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		mu = randu() * 10.0;
-		dist = new Degenerate( mu );
+		dist = new Degenerate( mu[ i % len ] );
 		if ( !( dist instanceof Degenerate ) ) {
 			b.fail( 'should return a distribution instance' );
 		}
@@ -77,18 +84,23 @@ bench( pkg+'::get:mu', function benchmark( b ) {
 
 bench( pkg+'::set:mu', function benchmark( b ) {
 	var dist;
+	var len;
 	var mu;
 	var y;
 	var i;
 
 	mu = 2.0;
 	dist = new Degenerate( mu );
+	len = 100;
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = randu();
-		dist.mu = y;
-		if ( dist.mu !== y ) {
+		dist.mu = y[ i % len ];
+		if ( dist.mu !== y[ i % len ] ) {
 			b.fail( 'should return set value' );
 		}
 	}
@@ -102,16 +114,23 @@ bench( pkg+'::set:mu', function benchmark( b ) {
 
 bench( pkg+':entropy', function benchmark( b ) {
 	var dist;
+	var len;
 	var mu;
+	var x;
 	var y;
 	var i;
 
 	mu = 2.0;
 	dist = new Degenerate( mu );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.mu = randu();
+		dist.mu = x[ i % len ];
 		y = dist.entropy;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -127,16 +146,23 @@ bench( pkg+':entropy', function benchmark( b ) {
 
 bench( pkg+':mode', function benchmark( b ) {
 	var dist;
+	var len;
 	var mu;
+	var x;
 	var y;
 	var i;
 
 	mu = 2.0;
 	dist = new Degenerate( mu );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.mu = randu();
+		dist.mu = x[ i % len ];
 		y = dist.mode;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -152,16 +178,23 @@ bench( pkg+':mode', function benchmark( b ) {
 
 bench( pkg+':mean', function benchmark( b ) {
 	var dist;
+	var len;
 	var mu;
+	var x;
 	var y;
 	var i;
 
 	mu = 2.0;
 	dist = new Degenerate( mu );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.mu = randu();
+		dist.mu = x[ i % len ];
 		y = dist.mean;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -177,16 +210,23 @@ bench( pkg+':mean', function benchmark( b ) {
 
 bench( pkg+':median', function benchmark( b ) {
 	var dist;
+	var len;
 	var mu;
+	var x;
 	var y;
 	var i;
 
 	mu = 2.0;
 	dist = new Degenerate( mu );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.mu = randu();
+		dist.mu = x[ i % len ];
 		y = dist.median;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -202,16 +242,23 @@ bench( pkg+':median', function benchmark( b ) {
 
 bench( pkg+':stdev', function benchmark( b ) {
 	var dist;
+	var len;
 	var mu;
+	var x;
 	var y;
 	var i;
 
 	mu = 2.0;
 	dist = new Degenerate( mu );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.mu = randu();
+		dist.mu = x[ i % len ];
 		y = dist.stdev;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -227,16 +274,23 @@ bench( pkg+':stdev', function benchmark( b ) {
 
 bench( pkg+':variance', function benchmark( b ) {
 	var dist;
+	var len;
 	var mu;
+	var x;
 	var y;
 	var i;
 
 	mu = 2.0;
 	dist = new Degenerate( mu );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.mu = randu();
+		dist.mu = x[ i % len ];
 		y = dist.variance;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -252,6 +306,7 @@ bench( pkg+':variance', function benchmark( b ) {
 
 bench( pkg+':cdf', function benchmark( b ) {
 	var dist;
+	var len;
 	var mu;
 	var x;
 	var y;
@@ -259,11 +314,15 @@ bench( pkg+':cdf', function benchmark( b ) {
 
 	mu = 2.0;
 	dist = new Degenerate( mu );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 6.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu() * 6.0;
-		y = dist.cdf( x );
+		y = dist.cdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -278,6 +337,7 @@ bench( pkg+':cdf', function benchmark( b ) {
 
 bench( pkg+':logcdf', function benchmark( b ) {
 	var dist;
+	var len;
 	var mu;
 	var x;
 	var y;
@@ -285,11 +345,15 @@ bench( pkg+':logcdf', function benchmark( b ) {
 
 	mu = 2.0;
 	dist = new Degenerate( mu );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 6.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu() * 6.0;
-		y = dist.logcdf( x );
+		y = dist.logcdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -304,6 +368,7 @@ bench( pkg+':logcdf', function benchmark( b ) {
 
 bench( pkg+':logpdf', function benchmark( b ) {
 	var dist;
+	var len;
 	var mu;
 	var x;
 	var y;
@@ -311,11 +376,15 @@ bench( pkg+':logpdf', function benchmark( b ) {
 
 	mu = 2.0;
 	dist = new Degenerate( mu );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 6.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu() * 6.0;
-		y = dist.logpdf( x );
+		y = dist.logpdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -330,6 +399,7 @@ bench( pkg+':logpdf', function benchmark( b ) {
 
 bench( pkg+':logpmf', function benchmark( b ) {
 	var dist;
+	var len;
 	var mu;
 	var x;
 	var y;
@@ -337,11 +407,15 @@ bench( pkg+':logpmf', function benchmark( b ) {
 
 	mu = 2.0;
 	dist = new Degenerate( mu );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 6.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu() * 6.0;
-		y = dist.logpmf( x );
+		y = dist.logpmf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -356,6 +430,7 @@ bench( pkg+':logpmf', function benchmark( b ) {
 
 bench( pkg+':mgf', function benchmark( b ) {
 	var dist;
+	var len;
 	var mu;
 	var x;
 	var y;
@@ -363,11 +438,15 @@ bench( pkg+':mgf', function benchmark( b ) {
 
 	mu = 2.0;
 	dist = new Degenerate( mu );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu() * 10.0;
-		y = dist.mgf( x );
+		y = dist.mgf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -382,6 +461,7 @@ bench( pkg+':mgf', function benchmark( b ) {
 
 bench( pkg+':pdf', function benchmark( b ) {
 	var dist;
+	var len;
 	var mu;
 	var x;
 	var y;
@@ -389,11 +469,15 @@ bench( pkg+':pdf', function benchmark( b ) {
 
 	mu = 2.0;
 	dist = new Degenerate( mu );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 6.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu() * 6.0;
-		y = dist.pdf( x );
+		y = dist.pdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -408,6 +492,7 @@ bench( pkg+':pdf', function benchmark( b ) {
 
 bench( pkg+':pmf', function benchmark( b ) {
 	var dist;
+	var len;
 	var mu;
 	var x;
 	var y;
@@ -415,11 +500,15 @@ bench( pkg+':pmf', function benchmark( b ) {
 
 	mu = 2.0;
 	dist = new Degenerate( mu );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 0, 8 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = round( randu() * 8.0 );
-		y = dist.pmf( x );
+		y = dist.pmf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -434,6 +523,7 @@ bench( pkg+':pmf', function benchmark( b ) {
 
 bench( pkg+':quantile', function benchmark( b ) {
 	var dist;
+	var len;
 	var mu;
 	var x;
 	var y;
@@ -441,11 +531,15 @@ bench( pkg+':quantile', function benchmark( b ) {
 
 	mu = 2.0;
 	dist = new Degenerate( mu );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.quantile( x );
+		y = dist.quantile( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/entropy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/entropy/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var entropy = require( './../lib' );
@@ -30,14 +31,20 @@ var entropy = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var mu;
 	var y;
 	var i;
 
+	len = 100;
+	mu = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		mu[ i ] = uniform( -50.0, 50.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		mu = ( randu()*100.0 ) - 50.0;
-		y = entropy( mu );
+		y = entropy( mu[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logcdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logcdf/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var logcdf = require( './../lib' );
@@ -30,16 +31,23 @@ var logcdf = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var mu;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	mu = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -100.0, 0.0 );
+		mu[ i ] = uniform( -50.0, 50.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*100.0 ) - 100;
-		mu = ( randu()*100.0 ) - 50.0;
-		y = logcdf( x, mu );
+		y = logcdf( x[ i % len ], mu[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -54,6 +62,7 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var mylogcdf;
+	var len;
 	var mu;
 	var x;
 	var y;
@@ -61,11 +70,15 @@ bench( pkg+':factory', function benchmark( b ) {
 
 	mu = 40.0;
 	mylogcdf = logcdf.factory( mu );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*100.0 );
-		y = mylogcdf( x );
+		y = mylogcdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpdf/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
@@ -41,8 +41,8 @@ bench( pkg, function benchmark( b ) {
 	x = new Float64Array( len );
 	mu = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu() * 100.0 ) - 100.0;
-		mu[ i ] = ( randu() * 100.0 ) - 50.0;
+		x[ i ] = uniform( -100.0, 0.0 );
+		mu[ i ] = uniform( -50.0, 50.0 );
 	}
 
 	b.tic();
@@ -62,6 +62,7 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var mylogpdf;
+	var len;
 	var mu;
 	var x;
 	var y;
@@ -69,11 +70,15 @@ bench( pkg+':factory', function benchmark( b ) {
 
 	mu = 40.0;
 	mylogpdf = logpdf.factory( mu );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*100.0 );
-		y = mylogpdf( x );
+		y = mylogpdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpdf/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -50,8 +50,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	x = new Float64Array( len );
 	mu = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu() * 100.0 ) - 100.0;
-		mu[ i ] = ( randu() * 100.0 ) - 50.0;
+		x[ i ] = uniform( -100.0, 0.0 );
+		mu[ i ] = uniform( -50.0, 50.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/benchmark/benchmark.js
@@ -22,8 +22,8 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
 var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var logpmf = require( './../lib' );
@@ -42,7 +42,7 @@ bench( pkg, function benchmark( b ) {
 	x = new Float64Array( len );
 	mu = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ceil( uniform( -100.0, 0.0 ) );
+		x[ i ] = discreteUniform( -100, 0 );
 		mu[ i ] = uniform( -50.0, 50.0 );
 	}
 
@@ -74,7 +74,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	len = 100;
 	x = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ceil( uniform( -100.0, 0.0 ) );
+		x[ i ] = discreteUniform( -100, 0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/logpmf/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var uniform = require( '@stdlib/random/base/uniform' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -51,7 +51,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	x = new Float64Array( len );
 	mu = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ceil( uniform( -100.0, 0.0 ) );
+		x[ i ] = discreteUniform( -100, 0 );
 		mu[ i ] = uniform( -50.0, 50.0 );
 	}
 

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/mean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/mean/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var mean = require( './../lib' );
@@ -39,7 +39,7 @@ bench( pkg, function benchmark( b ) {
 	len = 100;
 	mu = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = ( randu() * 100.0 ) - 50.0;
+		mu[ i ] = uniform( -50.0, 50.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/mean/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/mean/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -48,7 +48,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	len = 100;
 	mu = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = ( randu() * 100.0 ) - 50.0;
+		mu[ i ] = uniform( -50.0, 50.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/median/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/median/benchmark/benchmark.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var Float64Array = require( '@stdlib/array/float64' );
 var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
@@ -30,14 +31,20 @@ var median = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var mu;
 	var y;
 	var i;
 
+	len = 100;
+	mu = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		mu[ i ] = uniform( -50.0, 50.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		mu = uniform( -50.0, 50.0 );
-		y = median( mu );
+		y = median( mu[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/mode/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/mode/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var mode = require( './../lib' );
@@ -30,14 +31,20 @@ var mode = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var mu;
 	var y;
 	var i;
 
+	len = 100;
+	mu = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		mu[ i ] = uniform( -50.0, 50.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		mu = ( randu()*100.0 ) - 50.0;
-		y = mode( mu );
+		y = mode( mu[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/mode/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/mode/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -48,7 +48,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	len = 100;
 	mu = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = ( randu() * 40.0 ) - 20.0;
+		mu[ i ] = uniform( -20.0, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/pdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/pdf/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
 var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
@@ -31,16 +31,23 @@ var pdf = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var mu;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	mu = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -100.0, 0.0 );
+		mu[ i ] = uniform( -50.0, 50.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = uniform( -100.0, 0.0 );
-		mu = uniform( -50.0, 50.0 );
-		y = pdf( x, mu );
+		y = pdf( x[ i % len ], mu[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -55,6 +62,7 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var mypdf;
+	var len;
 	var mu;
 	var x;
 	var y;
@@ -62,11 +70,15 @@ bench( pkg+':factory', function benchmark( b ) {
 
 	mu = 40.0;
 	mypdf = pdf.factory( mu );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*100.0 );
-		y = mypdf( x );
+		y = mypdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/pmf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/pmf/benchmark/benchmark.js
@@ -21,9 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
 var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var pmf = require( './../lib' );
@@ -32,16 +32,23 @@ var pmf = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var mu;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	mu = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( -100, 0 );
+		mu[ i ] = uniform( -50.0, 50.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ceil( uniform( -100.0, 0.0 ) );
-		mu = uniform( -50.0, 50.0 );
-		y = pmf( x, mu );
+		y = pmf( x[ i % len ], mu[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -56,6 +63,7 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var mypmf;
+	var len;
 	var mu;
 	var x;
 	var y;
@@ -63,11 +71,15 @@ bench( pkg+':factory', function benchmark( b ) {
 
 	mu = 40.0;
 	mypmf = pmf.factory( mu );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 0, 100 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ceil( randu()*100.0 );
-		y = mypmf( x );
+		y = mypmf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/pmf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/pmf/benchmark/benchmark.native.js
@@ -23,8 +23,8 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
 var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -51,7 +51,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	x = new Float64Array( len );
 	mu = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ceil( uniform( -100.0, 0.0 ) );
+		x[ i ] = discreteUniform( -100, 0 );
 		mu[ i ] = uniform( -50.0, 50.0 );
 	}
 

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/quantile/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
 var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
@@ -31,16 +31,23 @@ var quantile = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var mu;
 	var p;
 	var y;
 	var i;
 
+	len = 100;
+	p = new Float64Array( len );
+	mu = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		p[ i ] = uniform( 0.0, 1.0 );
+		mu[ i ] = uniform( -50.0, 50.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		mu = uniform( -50.0, 50.0 );
-		y = quantile( p, mu );
+		y = quantile( p[ i % len ], mu[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -55,6 +62,7 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var myQuantile;
+	var len;
 	var mu;
 	var p;
 	var y;
@@ -62,11 +70,15 @@ bench( pkg+':factory', function benchmark( b ) {
 
 	mu = 40.0;
 	myQuantile = quantile.factory( mu );
+	len = 100;
+	p = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		p[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		y = myQuantile( p );
+		y = myQuantile( p[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/quantile/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/quantile/benchmark/benchmark.native.js
@@ -23,7 +23,6 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
 var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -51,7 +50,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	p = new Float64Array( len );
 	mu = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		p[ i ] = randu();
+		p[ i ] = uniform( 0.0, 1.0 );
 		mu[ i ] = uniform( -50.0, 50.0 );
 	}
 

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/stdev/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/stdev/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var stdev = require( './../lib' );
@@ -30,14 +31,20 @@ var stdev = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var mu;
 	var y;
 	var i;
 
+	len = 100;
+	mu = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		mu[ i ] = uniform( -50.0, 50.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		mu = ( randu()*100.0 ) - 50.0;
-		y = stdev( mu );
+		y = stdev( mu[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/stdev/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/stdev/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -48,7 +48,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	len = 100;
 	mu = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = ( randu() * 40.0 ) - 20.0;
+		mu[ i ] = uniform( -50.0, 50.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/variance/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/variance/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var variance = require( './../lib' );
@@ -39,7 +39,7 @@ bench( pkg, function benchmark( b ) {
 	len = 100;
 	mu = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = ( randu() * 100.0 ) - 50.0;
+		mu[ i ] = uniform( -50.0, 50.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/variance/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/variance/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform	= require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 
@@ -48,7 +48,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	len = 100;
 	mu = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = ( randu() * 100.0 ) - 50.0;
+		mu[ i ] = uniform( -50.0, 50.0 );
 	}
 
 	b.tic();


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

- Refactors random number generation in JS benchmarks for `stats/base/dists/degenerate`.
- Replaces `randu()` with `uniform()` for cleaner and more consistent code.
- Moves the random number generation outside the benchmarking loops.

## Related Issues

> Does this pull request have any related issues?

This pull request:

- resolves none

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md