### PR TITLE
bench: refactor random number generation in `stats/base/dists/discrete-uniform`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/cdf/benchmark/benchmark.js
@@ -22,8 +22,8 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var cdf = require( './../lib' );
@@ -44,9 +44,9 @@ bench( pkg, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu() * 20.0 ) - 10.0;
-		min[ i ] = round( randu()*10.0 );
-		max[ i ] = round( randu() * 10.0 ) + min[ i ];
+		x[ i ] = uniform( -10.0, 10.0 );
+		min[ i ] = discreteUniform( 0, 10 );
+		max[ i ] = discreteUniform( min[ i ], min[ i ] + 10 );
 	}
 
 	b.tic();
@@ -68,6 +68,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mycdf;
 	var min;
 	var max;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -75,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	min = -2;
 	max = 2;
 	mycdf = cdf.factory( min, max );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -2.0, 0.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*2.0 ) - 2.0;
-		y = mycdf( x );
+		y = mycdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/cdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/cdf/benchmark/benchmark.native.js
@@ -23,8 +23,8 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -53,9 +53,9 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu() * 20.0 ) - 10.0;
-		min[ i ] = round( randu()*10.0 );
-		max[ i ] = round( randu() * 10.0 ) + min[ i ];
+		x[ i ] = uniform( -10.0, 10.0 );
+		min[ i ] = discreteUniform( 0, 10 );
+		max[ i ] = discreteUniform( min[ i ], min[ i ] + 10 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/ctor/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var DiscreteUniform = require( './../lib' );
@@ -32,15 +33,22 @@ var DiscreteUniform = require( './../lib' );
 
 bench( pkg+'::instantiation', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var i;
 
+	len = 100;
+	a = new Float64Array( len );
+	b = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		a[ i ] = discreteUniform( 0, 10 );
+		b[ i ] = discreteUniform( a[ i ], a[ i ] + 10 );
+	}
+
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		a = round( randu() * 10.0 );
-		b = round( ( randu() * 10.0 ) + a );
-		dist = new DiscreteUniform( a, b );
+		dist = new DiscreteUniform( a[ i % len ], b[ i % len ] );
 		if ( !( dist instanceof DiscreteUniform ) ) {
 			bm.fail( 'should return a distribution instance' );
 		}
@@ -81,6 +89,7 @@ bench( pkg+'::get:a', function benchmark( bm ) {
 
 bench( pkg+'::set:a', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var y;
@@ -89,12 +98,16 @@ bench( pkg+'::set:a', function benchmark( bm ) {
 	a = 20;
 	b = 120;
 	dist = new DiscreteUniform( a, b );
+	len = 100;
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = discreteUniform( 0, 100 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		y = round( 100.0*randu() );
-		dist.a = y;
-		if ( dist.a !== y ) {
+		dist.a = y[ i % len ];
+		if ( dist.a !== y[ i % len ] ) {
 			bm.fail( 'should return set value' );
 		}
 	}
@@ -134,6 +147,7 @@ bench( pkg+'::get:b', function benchmark( bm ) {
 
 bench( pkg+'::set:b', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var y;
@@ -142,12 +156,16 @@ bench( pkg+'::set:b', function benchmark( bm ) {
 	a = 20;
 	b = 40;
 	dist = new DiscreteUniform( a, b );
+	len = 100;
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = discreteUniform( a, a + 100 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		y = round( ( 100.0*randu() ) + a );
-		dist.b = y;
-		if ( dist.b !== y ) {
+		dist.b = y[ i % len ];
+		if ( dist.b !== y[ i % len ] ) {
 			bm.fail( 'should return set value' );
 		}
 	}
@@ -161,6 +179,8 @@ bench( pkg+'::set:b', function benchmark( bm ) {
 
 bench( pkg+':entropy', function benchmark( bm ) {
 	var dist;
+	var len;
+	var x;
 	var a;
 	var b;
 	var y;
@@ -169,10 +189,15 @@ bench( pkg+':entropy', function benchmark( bm ) {
 	a = 20;
 	b = 140;
 	dist = new DiscreteUniform( a, b );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 0, 100 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = round( 100.0*randu() );
+		dist.a = x[ i % len ];
 		y = dist.entropy;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -188,6 +213,8 @@ bench( pkg+':entropy', function benchmark( bm ) {
 
 bench( pkg+':kurtosis', function benchmark( bm ) {
 	var dist;
+	var len;
+	var x;
 	var a;
 	var b;
 	var y;
@@ -196,10 +223,15 @@ bench( pkg+':kurtosis', function benchmark( bm ) {
 	a = 20;
 	b = 140;
 	dist = new DiscreteUniform( a, b );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 0, 100 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = round( 100.0*randu() );
+		dist.a = x[ i % len ];
 		y = dist.kurtosis;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -215,6 +247,8 @@ bench( pkg+':kurtosis', function benchmark( bm ) {
 
 bench( pkg+':mean', function benchmark( bm ) {
 	var dist;
+	var len;
+	var x;
 	var a;
 	var b;
 	var y;
@@ -223,10 +257,15 @@ bench( pkg+':mean', function benchmark( bm ) {
 	a = 20;
 	b = 140;
 	dist = new DiscreteUniform( a, b );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 0, 100 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = round( 100.0*randu() );
+		dist.a = x[ i % len ];
 		y = dist.mean;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -242,6 +281,8 @@ bench( pkg+':mean', function benchmark( bm ) {
 
 bench( pkg+':median', function benchmark( bm ) {
 	var dist;
+	var len;
+	var x;
 	var a;
 	var b;
 	var y;
@@ -250,10 +291,15 @@ bench( pkg+':median', function benchmark( bm ) {
 	a = 20;
 	b = 140;
 	dist = new DiscreteUniform( a, b );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 0, 100 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = round( randu()*100.0 );
+		dist.a = x[ i % len ];
 		y = dist.median;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -269,6 +315,8 @@ bench( pkg+':median', function benchmark( bm ) {
 
 bench( pkg+':skewness', function benchmark( bm ) {
 	var dist;
+	var len;
+	var x;
 	var a;
 	var b;
 	var y;
@@ -277,10 +325,15 @@ bench( pkg+':skewness', function benchmark( bm ) {
 	a = 20;
 	b = 140;
 	dist = new DiscreteUniform( a, b );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 0, 100 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = round( randu()*100.0 );
+		dist.a = x[ i % len ];
 		y = dist.skewness;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -296,6 +349,8 @@ bench( pkg+':skewness', function benchmark( bm ) {
 
 bench( pkg+':stdev', function benchmark( bm ) {
 	var dist;
+	var len;
+	var x;
 	var a;
 	var b;
 	var y;
@@ -304,10 +359,15 @@ bench( pkg+':stdev', function benchmark( bm ) {
 	a = 20;
 	b = 140;
 	dist = new DiscreteUniform( a, b );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 0, 100 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = round( randu()*100.0 );
+		dist.a = x[ i % len ];
 		y = dist.stdev;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -323,6 +383,8 @@ bench( pkg+':stdev', function benchmark( bm ) {
 
 bench( pkg+':variance', function benchmark( bm ) {
 	var dist;
+	var len;
+	var x;
 	var a;
 	var b;
 	var y;
@@ -331,10 +393,15 @@ bench( pkg+':variance', function benchmark( bm ) {
 	a = 20;
 	b = 140;
 	dist = new DiscreteUniform( a, b );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 0, 100 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = round( randu()*100.0 );
+		dist.a = x[ i % len ];
 		y = dist.variance;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -350,6 +417,7 @@ bench( pkg+':variance', function benchmark( bm ) {
 
 bench( pkg+':cdf', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var x;
@@ -359,11 +427,15 @@ bench( pkg+':cdf', function benchmark( bm ) {
 	a = 20;
 	b = 40;
 	dist = new DiscreteUniform( a, b );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 60.0 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = randu() * 60.0;
-		y = dist.cdf( x );
+		y = dist.cdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
 		}
@@ -378,6 +450,7 @@ bench( pkg+':cdf', function benchmark( bm ) {
 
 bench( pkg+':logcdf', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var x;
@@ -387,11 +460,15 @@ bench( pkg+':logcdf', function benchmark( bm ) {
 	a = 20;
 	b = 40;
 	dist = new DiscreteUniform( a, b );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 60.0 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = randu() * 60.0;
-		y = dist.logcdf( x );
+		y = dist.logcdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
 		}
@@ -406,6 +483,7 @@ bench( pkg+':logcdf', function benchmark( bm ) {
 
 bench( pkg+':logpmf', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var x;
@@ -415,11 +493,15 @@ bench( pkg+':logpmf', function benchmark( bm ) {
 	a = 20;
 	b = 40;
 	dist = new DiscreteUniform( a, b );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 0, 60 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = round( randu() * 60.0 );
-		y = dist.logpmf( x );
+		y = dist.logpmf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
 		}
@@ -434,6 +516,7 @@ bench( pkg+':logpmf', function benchmark( bm ) {
 
 bench( pkg+':mgf', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var x;
@@ -443,11 +526,15 @@ bench( pkg+':mgf', function benchmark( bm ) {
 	a = 20;
 	b = 40;
 	dist = new DiscreteUniform( a, b );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = randu();
-		y = dist.mgf( x );
+		y = dist.mgf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
 		}
@@ -462,6 +549,7 @@ bench( pkg+':mgf', function benchmark( bm ) {
 
 bench( pkg+':pmf', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var x;
@@ -471,11 +559,15 @@ bench( pkg+':pmf', function benchmark( bm ) {
 	a = 20;
 	b = 40;
 	dist = new DiscreteUniform( a, b );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 0, 60 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = round( randu() * 60.0 );
-		y = dist.pmf( x );
+		y = dist.pmf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
 		}
@@ -490,6 +582,7 @@ bench( pkg+':pmf', function benchmark( bm ) {
 
 bench( pkg+':quantile', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var x;
@@ -499,11 +592,15 @@ bench( pkg+':quantile', function benchmark( bm ) {
 	a = 20;
 	b = 40;
 	dist = new DiscreteUniform( a, b );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = randu();
-		y = dist.quantile( x );
+		y = dist.quantile( x[ i % len ] );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/entropy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/entropy/benchmark/benchmark.js
@@ -22,8 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var entropy = require( './../lib' );
@@ -42,8 +41,8 @@ bench( pkg, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = round( randu() * 10.0 );
-		max[ i ] = round( randu() * 10.0 ) + min[ i ];
+		min[ i ] = discreteUniform( 0, 10 );
+		max[ i ] = discreteUniform( min[ i ], min[ i ] + 10 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/entropy/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/entropy/benchmark/benchmark.native.js
@@ -23,8 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -51,8 +50,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = round( randu()*10.0 );
-		max[ i ] = round( randu() * 10.0 ) + min[ i ];
+		min[ i ] = discreteUniform( 0, 10 );
+		max[ i ] = discreteUniform( min[ i ], min[ i ] + 10 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/kurtosis/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/kurtosis/benchmark/benchmark.js
@@ -22,8 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var kurtosis = require( './../lib' );
@@ -42,8 +41,8 @@ bench( pkg, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = round( randu() * 10.0 );
-		max[ i ] = round( randu() * 10.0 ) + min[ i ];
+		min[ i ] = discreteUniform( 0, 10 );
+		max[ i ] = discreteUniform( min[ i ], min[ i ] + 10 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/kurtosis/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/kurtosis/benchmark/benchmark.native.js
@@ -23,8 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -51,8 +50,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = round( randu()*10.0 );
-		max[ i ] = round( randu() * 10.0 ) + min[ i ];
+		min[ i ] = discreteUniform( 0, 10 );
+		max[ i ] = discreteUniform( min[ i ], min[ i ] + 10 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/logcdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/logcdf/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var logcdf = require( './../lib' );
@@ -33,16 +34,24 @@ var logcdf = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var min;
 	var max;
+	var len;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	min = new Float64Array( len );
+	max = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -10.0, 10.0 );
+		min[ i ] = discreteUniform( -20, 0 );
+		max[ i ] = discreteUniform( min[ i ], min[ i ] + 40 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu() * 20.0 ) - 10.0;
-		min = round( ( randu() * 20.0 ) - 20.0 );
-		max = round( min + ( randu() * 40.0 ) );
-		y = logcdf( x, min, max );
+		y = logcdf( x[ i % len ], min[ i % len ], max[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -59,6 +68,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mylogcdf;
 	var min;
 	var max;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -66,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	min = -2;
 	max = 2;
 	mylogcdf = logcdf.factory( min, max );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -2.0, 0.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*2.0 ) - 2.0;
-		y = mylogcdf( x );
+		y = mylogcdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/logpmf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/logpmf/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var logpmf = require( './../lib' );
@@ -33,16 +34,24 @@ var logpmf = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var min;
 	var max;
+	var len;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	min = new Float64Array( len );
+	max = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -10.0, 10.0 );
+		min[ i ] = discreteUniform( -20, 0 );
+		max[ i ] = discreteUniform( min[ i ], min[ i ] + 40 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu() * 20.0 ) - 10.0;
-		min = round( ( randu() * 20.0 ) - 20.0 );
-		max = round( min + ( randu() * 40.0 ) );
-		y = logpmf( x, min, max );
+		y = logpmf( x[ i % len ], min[ i % len ], max[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -59,6 +68,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mylogpmf;
 	var min;
 	var max;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -66,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	min = -2;
 	max = 2;
 	mylogpmf = logpmf.factory( min, max );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -2.0, 0.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*2.0 ) - 2.0;
-		y = mylogpmf( x );
+		y = mylogpmf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mean/benchmark/benchmark.js
@@ -22,8 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var mean = require( './../lib' );
@@ -42,8 +41,8 @@ bench( pkg, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = round( randu() * 10.0 );
-		max[ i ] = round( randu() * 10.0 ) + min[ i ];
+		min[ i ] = discreteUniform( 0, 10 );
+		max[ i ] = discreteUniform( min[ i ], min[ i ] + 10 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mean/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mean/benchmark/benchmark.native.js
@@ -23,8 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -51,8 +50,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = round( randu() * 10.0 );
-		max[ i ] = round( randu() * 10.0 ) + min[ i ];
+		min[ i ] = discreteUniform( 0, 10 );
+		max[ i ] = discreteUniform( min[ i ], min[ i ] + 10 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/median/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/median/benchmark/benchmark.js
@@ -22,8 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var median = require( './../lib' );
@@ -42,8 +41,8 @@ bench( pkg, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = round( randu() * 10.0 );
-		max[ i ] = round( randu() * 10.0 ) + min[ i ];
+		min[ i ] = discreteUniform( 0, 10 );
+		max[ i ] = discreteUniform( min[ i ], min[ i ] + 10 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/median/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/median/benchmark/benchmark.native.js
@@ -23,8 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -51,8 +50,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = round( randu() * 10.0 );
-		max[ i ] = round( randu() * 10.0 ) + min[ i ];
+		min[ i ] = discreteUniform( 0, 10 );
+		max[ i ] = discreteUniform( min[ i ], min[ i ] + 10 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mgf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mgf/benchmark/benchmark.js
@@ -22,8 +22,8 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var mgf = require( './../lib' );
@@ -44,9 +44,9 @@ bench( pkg, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		t[ i ] = ( randu()*4.0 ) - 2.0;
-		min[ i ] = round( randu()*10.0 );
-		max[ i ] = round( randu() * 10.0 ) + min[ i ];
+		t[ i ] = uniform( -2.0, 2.0 );
+		min[ i ] = discreteUniform( 0, 10 );
+		max[ i ] = discreteUniform( min[ i ], min[ i ] + 10 );
 	}
 
 	b.tic();
@@ -68,6 +68,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mymgf;
 	var min;
 	var max;
+	var len;
 	var t;
 	var y;
 	var i;
@@ -75,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	min = -2;
 	max = 2;
 	mymgf = mgf.factory( min, max );
+	len = 100;
+	t = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		t[ i ] = uniform( -2.0, 0.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		t = ( randu()*2.0 ) - 2.0;
-		y = mymgf( t );
+		y = mymgf( t[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mgf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/mgf/benchmark/benchmark.native.js
@@ -23,8 +23,8 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -53,9 +53,9 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		t[ i ] = ( randu()*4.0 ) - 2.0;
-		min[ i ] = round( randu()*10.0 );
-		max[ i ] = round( randu() * 10.0 ) + min[ i ];
+		t[ i ] = uniform( -2.0, 2.0 );
+		min[ i ] = discreteUniform( 0, 10 );
+		max[ i ] = discreteUniform( min[ i ], min[ i ] + 10 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/pmf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/pmf/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var pmf = require( './../lib' );
@@ -33,16 +34,24 @@ var pmf = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var min;
 	var max;
+	var len;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	min = new Float64Array( len );
+	max = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -10.0, 10.0 );
+		min[ i ] = discreteUniform( -20, 0 );
+		max[ i ] = discreteUniform( min[ i ], min[ i ] + 40 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu() * 20.0 ) - 10.0;
-		min = round( ( randu() * 20.0 ) - 20.0 );
-		max = round( min + ( randu() * 40.0 ) );
-		y = pmf( x, min, max );
+		y = pmf( x[ i % len ], min[ i % len ], max[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -59,6 +68,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mypmf;
 	var min;
 	var max;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -66,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	min = -2;
 	max = 2;
 	mypmf = pmf.factory( min, max );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -2.0, 0.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*2.0 ) - 2.0;
-		y = mypmf( x );
+		y = mypmf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/quantile/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var quantile = require( './../lib' );
@@ -33,16 +34,24 @@ var quantile = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var min;
 	var max;
+	var len;
 	var p;
 	var y;
 	var i;
 
+	len = 100;
+	p = new Float64Array( len );
+	min = new Float64Array( len );
+	max = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		p[ i ] = uniform( 0.0, 1.0 );
+		min[ i ] = discreteUniform( -20, 0 );
+		max[ i ] = discreteUniform( min[ i ], min[ i ] + 40 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		min = round( ( randu() * 20.0 ) - 20.0 );
-		max = round( min + ( randu() * 40.0 ) );
-		y = quantile( p, min, max );
+		y = quantile( p[ i % len ], min[ i % len ], max[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -59,6 +68,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	var myquantile;
 	var min;
 	var max;
+	var len;
 	var p;
 	var y;
 	var i;
@@ -66,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	min = -2;
 	max = 2;
 	myquantile = quantile.factory( min, max );
+	len = 100;
+	p = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		p[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		y = myquantile( p );
+		y = myquantile( p[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/skewness/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/skewness/benchmark/benchmark.js
@@ -22,8 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var skewness = require( './../lib' );
@@ -42,8 +41,8 @@ bench( pkg, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = round( randu() * 10.0 );
-		max[ i ] = round( randu() * 10.0 ) + min[ i ];
+		min[ i ] = discreteUniform( 0, 10 );
+		max[ i ] = discreteUniform( min[ i ], min[ i ] + 10 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/skewness/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/skewness/benchmark/benchmark.native.js
@@ -23,8 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -51,8 +50,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = round( randu()*10.0 );
-		max[ i ] = round( randu() * 10.0 ) + min[ i ];
+		min[ i ] = discreteUniform( 0, 10 );
+		max[ i ] = discreteUniform( min[ i ], min[ i ] + 10 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/stdev/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/stdev/benchmark/benchmark.js
@@ -22,8 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var stdev = require( './../lib' );
@@ -42,8 +41,8 @@ bench( pkg, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = round( randu() * 10.0 );
-		max[ i ] = round( randu() * 10.0 ) + min[ i ];
+		min[ i ] = discreteUniform( 0, 10 );
+		max[ i ] = discreteUniform( min[ i ], min[ i ] + 10 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/stdev/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/stdev/benchmark/benchmark.native.js
@@ -23,8 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -51,8 +50,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = round( randu() * 10.0 );
-		max[ i ] = round( randu() * 10.0 ) + min[ i ];
+		min[ i ] = discreteUniform( 0, 10 );
+		max[ i ] = discreteUniform( min[ i ], min[ i ] + 10 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/variance/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/variance/benchmark/benchmark.js
@@ -22,8 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var variance = require( './../lib' );
@@ -42,8 +41,8 @@ bench( pkg, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = round( randu() * 10.0 );
-		max[ i ] = round( randu() * 10.0 ) + min[ i ];
+		min[ i ] = discreteUniform( 0, 10 );
+		max[ i ] = discreteUniform( min[ i ], min[ i ] + 10 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/variance/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/variance/benchmark/benchmark.native.js
@@ -23,8 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -51,8 +50,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = round( randu()*10.0 );
-		max[ i ] = round( randu() * 10.0 ) + min[ i ];
+		min[ i ] = discreteUniform( 0, 10 );
+		max[ i ] = discreteUniform( min[ i ], min[ i ] + 10 );
 	}
 
 	b.tic();


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

- Refactors random number generation in JS benchmarks for `stats/base/dists/discrete-uniform`.
- Replaces `randu()` with `uniform()` for cleaner and more consistent code.
- Moves the random number generation outside the benchmarking loops.

## Related Issues

> Does this pull request have any related issues?

This pull request:

- resolves none

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md