### PR TITLE
docs: fix use of weight parameter in example

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/wmean/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/wmean/examples/index.js
@@ -35,7 +35,7 @@ console.log( '\nValue\tWeight\tWeighted Mean\n' );
 for ( i = 0; i < 100; i++ ) {
 	x = randu() * 100.0;
 	w = randu() * 100.0;
-	mu = accumulator( x );
+	mu = accumulator( x, w );
 	console.log( '%d\t%d\t%d', x.toFixed( 4 ), w.toFixed( 4 ), mu.toFixed( 4 ) );
 }
 console.log( '\nFinal weighted mean: %d\n', accumulator() );


### PR DESCRIPTION
Resolves None

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixed a bug where the weight parameter was not passed to the accumulator function in the JS example file. The code has been updated to include the weight parameter.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves None

## Questions

> Any questions for reviewers of this pull request?

- Based on the recent refactoring to use `uniform` instead of `randu` and update the random number generation in benchmarks, should I also change the benchmark and example files accordingly?

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
