### PR TITLE
bench: refactor random number generation in `stats/base/dists/erlang`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/cdf/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,17 +34,25 @@ var cdf = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
+	var len;
 	var k;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	k = new Float64Array( len );
+	lambda = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 0, 100 );
+		k[ i ] = discreteUniform( 0, 100 );
+		lambda[ i ] = uniform( EPS, 20.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ceil( randu()*100.0 );
-		k = ceil( randu()*100.0 );
-		lambda = ( randu()*20.0 ) + EPS;
-		y = cdf( x, k, lambda );
+		y = cdf( x[ i % len ], k[ i % len ], lambda[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -59,6 +68,7 @@ bench( pkg, function benchmark( b ) {
 bench( pkg+':factory', function benchmark( b ) {
 	var lambda;
 	var mycdf;
+	var len;
 	var k;
 	var x;
 	var y;
@@ -67,11 +77,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	k = 2.0;
 	lambda = 1.5;
 	mycdf = cdf.factory( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 50.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*50.0 ) + EPS;
-		y = mycdf( x );
+		y = mycdf( x[ i % len ]);
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/ctor/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -34,14 +35,21 @@ var Erlang = require( './../lib' );
 bench( pkg+'::instantiation', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var i;
 	var k;
 
+	len = 100;
+	k = new Float64Array( len );
+	lambda = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		k[ i ] = discreteUniform( 1, 10 );
+		lambda[ i ] = uniform( EPS, 10.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		k = ceil( ( randu() * 10.0 ) + EPS );
-		lambda = ( randu() * 10.0 ) + EPS;
-		dist = new Erlang( k, lambda );
+		dist = new Erlang( k[ i % len ], lambda[ i % len ] );
 		if ( !( dist instanceof Erlang ) ) {
 			b.fail( 'should return a distribution instance' );
 		}
@@ -83,6 +91,7 @@ bench( pkg+'::get:k', function benchmark( b ) {
 bench( pkg+'::set:k', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var y;
 	var i;
 	var k;
@@ -90,12 +99,16 @@ bench( pkg+'::set:k', function benchmark( b ) {
 	k = 10;
 	lambda = 5.54;
 	dist = new Erlang( k, lambda );
+	len = 100;
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = discreteUniform( 1, 10 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = ceil( ( 10.0*randu() ) + EPS );
-		dist.k = y;
-		if ( dist.k !== y ) {
+		dist.k = y[ i % len ];
+		if ( dist.k !== y[ i % len ] ) {
 			b.fail( 'should return set value' );
 		}
 	}
@@ -136,6 +149,7 @@ bench( pkg+'::get:lambda', function benchmark( b ) {
 bench( pkg+'::set:lambda', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var y;
 	var i;
 	var k;
@@ -143,12 +157,16 @@ bench( pkg+'::set:lambda', function benchmark( b ) {
 	k = 10;
 	lambda = 5.54;
 	dist = new Erlang( k, lambda );
+	len = 100;
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = uniform( EPS, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = ( 10.0*randu() ) + EPS;
-		dist.lambda = y;
-		if ( dist.lambda !== y ) {
+		dist.lambda = y[ i % len ];
+		if ( dist.lambda !== y[ i % len ] ) {
 			b.fail( 'should return set value' );
 		}
 	}
@@ -163,6 +181,8 @@ bench( pkg+'::set:lambda', function benchmark( b ) {
 bench( pkg+':entropy', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 	var k;
@@ -170,10 +190,15 @@ bench( pkg+':entropy', function benchmark( b ) {
 	k = 10;
 	lambda = 5.54;
 	dist = new Erlang( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 1, 10 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = ceil( ( 10.0*randu() ) + EPS );
+		dist.k = x[ i % len ];
 		y = dist.entropy;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -190,6 +215,8 @@ bench( pkg+':entropy', function benchmark( b ) {
 bench( pkg+':kurtosis', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 	var k;
@@ -197,10 +224,15 @@ bench( pkg+':kurtosis', function benchmark( b ) {
 	k = 10;
 	lambda = 5.54;
 	dist = new Erlang( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 1, 10 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = ceil( ( 10.0*randu() ) + 1.0 );
+		dist.k = x[ i % len ];
 		y = dist.kurtosis;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -217,6 +249,8 @@ bench( pkg+':kurtosis', function benchmark( b ) {
 bench( pkg+':mean', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 	var k;
@@ -224,10 +258,15 @@ bench( pkg+':mean', function benchmark( b ) {
 	k = 10;
 	lambda = 5.54;
 	dist = new Erlang( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 1, 10 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = ceil( ( 10.0*randu() ) + EPS );
+		dist.k = x[ i % len ];
 		y = dist.mean;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -244,6 +283,8 @@ bench( pkg+':mean', function benchmark( b ) {
 bench( pkg+':median', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 	var k;
@@ -251,10 +292,15 @@ bench( pkg+':median', function benchmark( b ) {
 	k = 10;
 	lambda = 5.54;
 	dist = new Erlang( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 1, 10 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = ceil( ( 10.0*randu() ) + EPS );
+		dist.k = x[ i % len ];
 		y = dist.median;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -271,6 +317,8 @@ bench( pkg+':median', function benchmark( b ) {
 bench( pkg+':mode', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 	var k;
@@ -278,10 +326,15 @@ bench( pkg+':mode', function benchmark( b ) {
 	k = 10;
 	lambda = 5.54;
 	dist = new Erlang( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 1, 10 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = ceil( ( 10.0*randu() ) + 1.0 );
+		dist.k = x[ i % len ];
 		y = dist.mode;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -298,6 +351,8 @@ bench( pkg+':mode', function benchmark( b ) {
 bench( pkg+':skewness', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 	var k;
@@ -305,10 +360,15 @@ bench( pkg+':skewness', function benchmark( b ) {
 	k = 10;
 	lambda = 5.54;
 	dist = new Erlang( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 1, 10 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = ceil( ( 10.0*randu() ) + 1.0 );
+		dist.k = x[ i % len ];
 		y = dist.skewness;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -325,6 +385,8 @@ bench( pkg+':skewness', function benchmark( b ) {
 bench( pkg+':stdev', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 	var k;
@@ -332,10 +394,15 @@ bench( pkg+':stdev', function benchmark( b ) {
 	k = 10;
 	lambda = 5.54;
 	dist = new Erlang( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 1, 10 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = ceil( ( 10.0*randu() ) + 1.0 );
+		dist.k = x[ i % len ];
 		y = dist.stdev;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -352,6 +419,8 @@ bench( pkg+':stdev', function benchmark( b ) {
 bench( pkg+':variance', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 	var k;
@@ -359,10 +428,15 @@ bench( pkg+':variance', function benchmark( b ) {
 	k = 10;
 	lambda = 5.54;
 	dist = new Erlang( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 1, 10 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = ceil( ( 10.0*randu() ) + 1.0 );
+		dist.k = x[ i % len ];
 		y = dist.variance;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -379,6 +453,7 @@ bench( pkg+':variance', function benchmark( b ) {
 bench( pkg+':cdf', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -387,11 +462,15 @@ bench( pkg+':cdf', function benchmark( b ) {
 	k = 10;
 	lambda = 5.54;
 	dist = new Erlang( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.cdf( x );
+		y = dist.cdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -407,6 +486,7 @@ bench( pkg+':cdf', function benchmark( b ) {
 bench( pkg+':logpdf', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -415,11 +495,15 @@ bench( pkg+':logpdf', function benchmark( b ) {
 	k = 10;
 	lambda = 5.54;
 	dist = new Erlang( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.logpdf( x );
+		y = dist.logpdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -435,6 +519,7 @@ bench( pkg+':logpdf', function benchmark( b ) {
 bench( pkg+':mgf', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -443,11 +528,15 @@ bench( pkg+':mgf', function benchmark( b ) {
 	k = 10;
 	lambda = 5.54;
 	dist = new Erlang( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.mgf( x );
+		y = dist.mgf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -463,6 +552,7 @@ bench( pkg+':mgf', function benchmark( b ) {
 bench( pkg+':pdf', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -471,11 +561,15 @@ bench( pkg+':pdf', function benchmark( b ) {
 	k = 10;
 	lambda = 5.54;
 	dist = new Erlang( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.pdf( x );
+		y = dist.pdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -491,6 +585,7 @@ bench( pkg+':pdf', function benchmark( b ) {
 bench( pkg+':quantile', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -499,11 +594,15 @@ bench( pkg+':quantile', function benchmark( b ) {
 	k = 10;
 	lambda = 5.54;
 	dist = new Erlang( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.quantile( x );
+		y = dist.quantile( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/entropy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/entropy/benchmark/benchmark.js
@@ -21,9 +21,10 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
 var entropy = require( './../lib' );
@@ -33,15 +34,22 @@ var entropy = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
+	var len;
 	var k;
 	var y;
 	var i;
 
+	len = 100;
+	k = new Float64Array( len );
+	lambda = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		k[ i ] = discreteUniform( 0, 10 );
+		lambda[ i ] = uniform( EPS, 10.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		k = ceil( randu()*10.0 );
-		lambda = ( randu()*10.0 ) + EPS;
-		y = entropy( k, lambda );
+		y = entropy( k[ i % len ], lambda[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/kurtosis/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/kurtosis/benchmark/benchmark.js
@@ -21,9 +21,10 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
 var kurtosis = require( './../lib' );
@@ -33,15 +34,22 @@ var kurtosis = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
+	var len;
 	var k;
 	var y;
 	var i;
 
+	len = 100;
+	k = new Float64Array( len );
+	lambda = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		k[ i ] = discreteUniform( 0, 10 );
+		lambda[ i ] = uniform( EPS, 10.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		k = ceil( randu()*10.0 );
-		lambda = ( randu()*10.0 ) + EPS;
-		y = kurtosis( k, lambda );
+		y = kurtosis( k[ i % len ], lambda[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/logpdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/logpdf/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,17 +34,25 @@ var logpdf = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
+	var len;
 	var k;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	k = new Float64Array( len );
+	lambda = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 0, 100 );
+		k[ i ] = discreteUniform( 0, 100 );
+		lambda[ i ] = uniform( EPS, 20.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ceil( randu()*100.0 );
-		k = ceil( randu()*100.0 );
-		lambda = ( randu()*20.0 ) + EPS;
-		y = logpdf( x, k, lambda );
+		y = logpdf( x[ i % len ], k[ i % len ], lambda[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -59,6 +68,7 @@ bench( pkg, function benchmark( b ) {
 bench( pkg+':factory', function benchmark( b ) {
 	var mylogpdf;
 	var lambda;
+	var len;
 	var k;
 	var x;
 	var y;
@@ -67,11 +77,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	k = 2.0;
 	lambda = 1.5;
 	mylogpdf = logpdf.factory( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 50.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*50.0 ) + EPS;
-		y = mylogpdf( x );
+		y = mylogpdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/mean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/mean/benchmark/benchmark.js
@@ -21,9 +21,10 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
 var mean = require( './../lib' );
@@ -33,15 +34,22 @@ var mean = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
+	var len;
 	var k;
 	var y;
 	var i;
 
+	len = 100;
+	k = new Float64Array( len );
+	lambda = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		k[ i ] = discreteUniform( 0, 10 );
+		lambda[ i ] = uniform( EPS, 10.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		k = ceil( randu()*10.0 );
-		lambda = ( randu()*10.0 ) + EPS;
-		y = mean( k, lambda );
+		y = mean( k[ i % len ], lambda[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/mgf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/mgf/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,17 +34,25 @@ var mgf = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
+	var len;
 	var k;
 	var t;
 	var y;
 	var i;
 
+	len = 100;
+	k = new Float64Array( len );
+	lambda = new Float64Array( len );
+	t = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		k[ i ] = discreteUniform( 0, 100 );
+		lambda[ i ] = uniform( EPS, 20.0 );
+		t[ i ] = uniform( 0.0, lambda[ i ] );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		k = ceil( randu()*100.0 );
-		lambda = ( randu()*20.0 ) + EPS;
-		t = randu()*lambda;
-		y = mgf( t, k, lambda );
+		y = mgf( t[ i % len ], k[ i % len ], lambda[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -59,6 +68,7 @@ bench( pkg, function benchmark( b ) {
 bench( pkg+':factory', function benchmark( b ) {
 	var lambda;
 	var mymgf;
+	var len;
 	var k;
 	var t;
 	var y;
@@ -67,11 +77,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	k = 2;
 	lambda = 1.5;
 	mymgf = mgf.factory( k, lambda );
+	len = 100;
+	t = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		t[ i ] = uniform( 0.0, lambda );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		t = randu()*lambda;
-		y = mymgf( t );
+		y = mymgf( t[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/mode/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/mode/benchmark/benchmark.js
@@ -21,9 +21,10 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
 var mode = require( './../lib' );
@@ -33,15 +34,22 @@ var mode = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
+	var len;
 	var k;
 	var y;
 	var i;
 
+	len = 100;
+	k = new Float64Array( len );
+	lambda = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		k[ i ] = discreteUniform( 0, 10 );
+		lambda[ i ] = uniform( EPS, 10.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		k = ceil( randu()*10.0 );
-		lambda = ( randu()*10.0 ) + EPS;
-		y = mode( k, lambda );
+		y = mode( k[ i % len ], lambda[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/pdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/pdf/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,17 +34,25 @@ var pdf = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
+	var len;
 	var k;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	k = new Float64Array( len );
+	lambda = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 0, 100 );
+		k[ i ] = discreteUniform( 0, 100 );
+		lambda[ i ] = uniform( EPS, 20.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ceil( randu()*100.0 );
-		k = ceil( randu()*100.0 );
-		lambda = ( randu()*20.0 ) + EPS;
-		y = pdf( x, k, lambda );
+		y = pdf( x[ i % len ], k[ i % len ], lambda[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -59,6 +68,7 @@ bench( pkg, function benchmark( b ) {
 bench( pkg+':factory', function benchmark( b ) {
 	var lambda;
 	var mypdf;
+	var len;
 	var k;
 	var x;
 	var y;
@@ -67,11 +77,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	k = 2.0;
 	lambda = 1.5;
 	mypdf = pdf.factory( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 50.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*50.0 ) + EPS;
-		y = mypdf( x );
+		y = mypdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/quantile/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,17 +34,25 @@ var quantile = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
+	var len;
 	var k;
 	var p;
 	var y;
 	var i;
 
+	len = 100;
+	p = new Float64Array( len );
+	k = new Float64Array( len );
+	lambda = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		p[ i ] = uniform( 0.0, 1.0 );
+		k[ i ] = discreteUniform( 0, 20 );
+		lambda[ i ] = uniform( EPS, 20.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		k = ceil( randu()*20.0 );
-		lambda = ( randu()*20.0 ) + EPS;
-		y = quantile( p, k, lambda );
+		y = quantile( p[ i % len ], k[ i % len ], lambda[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -59,6 +68,7 @@ bench( pkg, function benchmark( b ) {
 bench( pkg+':factory', function benchmark( b ) {
 	var myquantile;
 	var lambda;
+	var len;
 	var k;
 	var p;
 	var y;
@@ -67,11 +77,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	k = 2;
 	lambda = 1.5;
 	myquantile = quantile.factory( k, lambda );
+	len = 100;
+	p = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		p[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		y = myquantile( p );
+		y = myquantile( p[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/skewness/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/skewness/benchmark/benchmark.js
@@ -21,9 +21,10 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
 var skewness = require( './../lib' );
@@ -33,15 +34,22 @@ var skewness = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
+	var len;
 	var k;
 	var y;
 	var i;
 
+	len = 100;
+	k = new Float64Array( len );
+	lambda = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		k[ i ] = discreteUniform( 0, 10 );
+		lambda[ i ] = uniform( EPS, 10.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		k = ceil( randu()*10.0 );
-		lambda = ( randu()*10.0 ) + EPS;
-		y = skewness( k, lambda );
+		y = skewness( k[ i % len ], lambda[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/stdev/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/stdev/benchmark/benchmark.js
@@ -21,9 +21,10 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
 var stdev = require( './../lib' );
@@ -33,15 +34,22 @@ var stdev = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
+	var len;
 	var k;
 	var y;
 	var i;
 
+	len = 100;
+	k = new Float64Array( len );
+	lambda = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		k[ i ] = discreteUniform( 0, 10 );
+		lambda[ i ] = uniform( EPS, 10.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		k = ceil( randu()*10.0 );
-		lambda = ( randu()*10.0 ) + EPS;
-		y = stdev( k, lambda );
+		y = stdev( k[ i % len ], lambda[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/variance/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/variance/benchmark/benchmark.js
@@ -21,9 +21,10 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
 var variance = require( './../lib' );
@@ -33,15 +34,22 @@ var variance = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
+	var len;
 	var k;
 	var y;
 	var i;
 
+	len = 100;
+	k = new Float64Array( len );
+	lambda = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		k[ i ] = discreteUniform( 0, 10 );
+		lambda[ i ] = uniform( EPS, 10.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		k = ceil( randu()*10.0 );
-		lambda = ( randu()*10.0 ) + EPS;
-		y = variance( k, lambda );
+		y = variance( k[ i % len ], lambda[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

- Refactors random number generation in JS benchmarks for `stats/base/dists/erlang`.
- Replaces `randu()` with `uniform()` for cleaner and more consistent code.
- Moves the random number generation outside the benchmarking loops.

## Related Issues

> Does this pull request have any related issues?

This pull request:

- resolves none

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md