### PR TITLE
bench: refactor random number generation in `stats/base/dists/exponential`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/cdf/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,15 +33,22 @@ var cdf = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
+	var len;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	lambda = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 100.0 );
+		lambda[ i ] = uniform( EPS, 100.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*100.0 );
-		lambda = ( randu()*100.0 ) + EPS;
-		y = cdf( x, lambda );
+		y = cdf( x[ i % len ], lambda[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -56,17 +64,22 @@ bench( pkg, function benchmark( b ) {
 bench( pkg+':factory', function benchmark( b ) {
 	var lambda;
 	var mycdf;
+	var len;
 	var x;
 	var y;
 	var i;
 
 	lambda = 10.0;
 	mycdf = cdf.factory( lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*100.0 ) + EPS;
-		y = mycdf( x );
+		y = mycdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/ctor/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,12 +34,18 @@ var Exponential = require( './../lib' );
 bench( pkg+'::instantiation', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var i;
+
+	len = 100;
+	lambda = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		lambda[ i ] = uniform( EPS, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		lambda = ( randu() * 10.0 ) + EPS;
-		dist = new Exponential( lambda );
+		dist = new Exponential( lambda[ i % len ] );
 		if ( !( dist instanceof Exponential ) ) {
 			b.fail( 'should return a distribution instance' );
 		}
@@ -78,17 +85,22 @@ bench( pkg+'::get:lambda', function benchmark( b ) {
 bench( pkg+'::set:lambda', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var y;
 	var i;
 
 	lambda = 5.54;
 	dist = new Exponential( lambda );
+	len = 100;
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = uniform( EPS, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = ( 10.0*randu() ) + EPS;
-		dist.lambda = y;
-		if ( dist.lambda !== y ) {
+		dist.lambda = y[ i % len ];
+		if ( dist.lambda !== y[ i % len ] ) {
 			b.fail( 'should return set value' );
 		}
 	}
@@ -103,15 +115,22 @@ bench( pkg+'::set:lambda', function benchmark( b ) {
 bench( pkg+':entropy', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 
 	lambda = 5.54;
 	dist = new Exponential( lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.lambda = ( 10.0*randu() ) + EPS;
+		dist.lambda = x[ i % len ];
 		y = dist.entropy;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -128,15 +147,22 @@ bench( pkg+':entropy', function benchmark( b ) {
 bench( pkg+':kurtosis', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 
 	lambda = 5.54;
 	dist = new Exponential( lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 1.0 + EPS, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.lambda = ( 10.0*randu() ) + 1.0 + EPS;
+		dist.lambda = x[ i % len ];
 		y = dist.kurtosis;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -153,15 +179,22 @@ bench( pkg+':kurtosis', function benchmark( b ) {
 bench( pkg+':mean', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 
 	lambda = 5.54;
 	dist = new Exponential( lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.lambda = ( 10.0*randu() ) + EPS;
+		dist.lambda = x[ i % len ];
 		y = dist.mean;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -178,15 +211,22 @@ bench( pkg+':mean', function benchmark( b ) {
 bench( pkg+':median', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 
 	lambda = 5.54;
 	dist = new Exponential( lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.lambda = ( 10.0*randu() ) + EPS;
+		dist.lambda = x[ i % len ];
 		y = dist.median;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -203,15 +243,22 @@ bench( pkg+':median', function benchmark( b ) {
 bench( pkg+':mode', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 
 	lambda = 5.54;
 	dist = new Exponential( lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 1.0 + EPS, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.lambda = ( 10.0*randu() ) + 1.0 + EPS;
+		dist.lambda = x[ i % len ];
 		y = dist.mode;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -228,15 +275,22 @@ bench( pkg+':mode', function benchmark( b ) {
 bench( pkg+':skewness', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 
 	lambda = 5.54;
 	dist = new Exponential( lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 1.0 + EPS, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.lambda = ( 10.0*randu() ) + 1.0 + EPS;
+		dist.lambda = x[ i % len ];
 		y = dist.skewness;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -253,15 +307,22 @@ bench( pkg+':skewness', function benchmark( b ) {
 bench( pkg+':stdev', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 
 	lambda = 5.54;
 	dist = new Exponential( lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 1.0 + EPS, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.lambda = ( 10.0*randu() ) + 1.0 + EPS;
+		dist.lambda = x[ i % len ];
 		y = dist.stdev;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -278,15 +339,22 @@ bench( pkg+':stdev', function benchmark( b ) {
 bench( pkg+':variance', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 
 	lambda = 5.54;
 	dist = new Exponential( lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 1.0 + EPS, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.lambda = ( 10.0*randu() ) + 1.0 + EPS;
+		dist.lambda = x[ i % len ];
 		y = dist.variance;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -303,17 +371,22 @@ bench( pkg+':variance', function benchmark( b ) {
 bench( pkg+':cdf', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
 
 	lambda = 5.54;
 	dist = new Exponential( lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.cdf( x );
+		y = dist.cdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -329,17 +402,22 @@ bench( pkg+':cdf', function benchmark( b ) {
 bench( pkg+':mgf', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
 
 	lambda = 5.54;
 	dist = new Exponential( lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.mgf( x );
+		y = dist.mgf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -355,17 +433,22 @@ bench( pkg+':mgf', function benchmark( b ) {
 bench( pkg+':pdf', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
 
 	lambda = 5.54;
 	dist = new Exponential( lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.pdf( x );
+		y = dist.pdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -381,17 +464,22 @@ bench( pkg+':pdf', function benchmark( b ) {
 bench( pkg+':quantile', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
 
 	lambda = 5.54;
 	dist = new Exponential( lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.quantile( x );
+		y = dist.quantile( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/entropy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/entropy/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,13 +33,19 @@ var entropy = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
+	var len;
 	var y;
 	var i;
 
+	len = 100;
+	lambda = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		lambda[ i ] = uniform( EPS, 20.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		lambda = ( randu()*20.0 ) + EPS;
-		y = entropy( lambda );
+		y = entropy( lambda[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/kurtosis/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/kurtosis/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -40,7 +40,7 @@ bench( pkg, function benchmark( b ) {
 	len = 100;
 	lambda = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		lambda[ i ] = ( randu() * 20.0 ) + EPS;
+		lambda[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/kurtosis/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/kurtosis/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -49,7 +49,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	len = 100;
 	lambda = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		lambda[ i ] = ( randu() * 20.0 ) + EPS;
+		lambda[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/logcdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/logcdf/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	x = new Float64Array( len );
 	lambda = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu()*100.0 );
-		lambda[ i ] = ( randu()*100.0 ) + EPS;
+		x[ i ] = uniform( 0.0, 100.0 );
+		lambda[ i ] = uniform( EPS, 100.0 );
 	}
 
 	b.tic();
@@ -64,17 +64,22 @@ bench( pkg, function benchmark( b ) {
 bench( pkg+':factory', function benchmark( b ) {
 	var mylogcdf;
 	var lambda;
+	var len;
 	var x;
 	var y;
 	var i;
 
 	lambda = 10.0;
 	mylogcdf = logcdf.factory( lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*100.0 ) + EPS;
-		y = mylogcdf( x );
+		y = mylogcdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/logcdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/logcdf/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -51,8 +51,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	x = new Float64Array( len );
 	lambda = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu()*100.0 );
-		lambda[ i ] = ( randu()*100.0 ) + EPS;
+		x[ i ] = uniform( 0.0, 100.0 );
+		lambda[ i ] = uniform( EPS, 100.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/logpdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/logpdf/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,15 +33,22 @@ var logpdf = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
+	var len;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	lambda = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 100.0 );
+		lambda[ i ] = uniform( EPS, 100.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*100.0 );
-		lambda = ( randu()*100.0 ) + EPS;
-		y = logpdf( x, lambda );
+		y = logpdf( x[ i % len ], lambda[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -56,17 +64,22 @@ bench( pkg, function benchmark( b ) {
 bench( pkg+':factory', function benchmark( b ) {
 	var mylogpdf;
 	var lambda;
+	var len;
 	var x;
 	var y;
 	var i;
 
 	lambda = 10.0;
 	mylogpdf = logpdf.factory( lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*100.0 ) + EPS;
-		y = mylogpdf( x );
+		y = mylogpdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/mean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/mean/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -40,7 +40,7 @@ bench( pkg, function benchmark( b ) {
 	len = 100;
 	lambda = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		lambda[ i ] = ( randu() * 20.0 ) + EPS;
+		lambda[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/mean/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/mean/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -49,7 +49,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	len = 100;
 	lambda = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		lambda[ i ] = ( randu() * 20.0 ) + EPS;
+		lambda[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/median/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/median/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -40,7 +40,7 @@ bench( pkg, function benchmark( b ) {
 	len = 100;
 	lambda = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		lambda[ i ] = ( randu() * 20.0 ) + EPS;
+		lambda[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/median/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/median/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -49,7 +49,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	len = 100;
 	lambda = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		lambda[ i ] = ( randu() * 20.0 ) + EPS;
+		lambda[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/mgf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/mgf/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,15 +33,22 @@ var mgf = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
+	var len;
 	var t;
 	var y;
 	var i;
 
+	len = 100;
+	lambda = new Float64Array( len );
+	t = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		lambda[ i ] = uniform( EPS, 100.0 );
+		t[ i ] = uniform( 0.0, lambda[ i ] );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		lambda = ( randu()*100.0 ) + EPS;
-		t = randu() * lambda;
-		y = mgf( t, lambda );
+		y = mgf( t[ i % len ], lambda[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -56,17 +64,22 @@ bench( pkg, function benchmark( b ) {
 bench( pkg+':factory', function benchmark( b ) {
 	var lambda;
 	var mymgf;
+	var len;
 	var t;
 	var y;
 	var i;
 
 	lambda = 10.0;
 	mymgf = mgf.factory( lambda );
+	len = 100;
+	t = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		t[ i ] = uniform( 0.0, lambda );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		t = randu() * lambda;
-		y = mymgf( t );
+		y = mymgf( t[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/mode/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/mode/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -40,7 +40,7 @@ bench( pkg, function benchmark( b ) {
 	len = 100;
 	lambda = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		lambda[ i ] = ( randu() * 20.0 ) + EPS;
+		lambda[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/mode/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/mode/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -49,7 +49,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	len = 100;
 	lambda = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		lambda[ i ] = ( randu() * 20.0 ) + EPS;
+		lambda[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/pdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/pdf/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,15 +33,22 @@ var pdf = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
+	var len;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	lambda = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 100.0 );
+		lambda[ i ] = uniform( EPS, 100.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*100.0 );
-		lambda = ( randu()*100.0 ) + EPS;
-		y = pdf( x, lambda );
+		y = pdf( x[ i % len ], lambda[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -56,17 +64,22 @@ bench( pkg, function benchmark( b ) {
 bench( pkg+':factory', function benchmark( b ) {
 	var lambda;
 	var mypdf;
+	var len;
 	var x;
 	var y;
 	var i;
 
 	lambda = 10.0;
 	mypdf = pdf.factory( lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*100.0 ) + EPS;
-		y = mypdf( x );
+		y = mypdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/quantile/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,15 +33,22 @@ var quantile = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
+	var len;
 	var p;
 	var y;
 	var i;
 
+	len = 100;
+	p = new Float64Array( len );
+	lambda = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		p[ i ] = uniform( 0.0, 1.0 );
+		lambda[ i ] = uniform( EPS, 100.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		lambda = ( randu()*100.0 ) + EPS;
-		y = quantile( p, lambda );
+		y = quantile( p[ i % len ], lambda[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -56,17 +64,22 @@ bench( pkg, function benchmark( b ) {
 bench( pkg+':factory', function benchmark( b ) {
 	var myquantile;
 	var lambda;
+	var len;
 	var p;
 	var y;
 	var i;
 
 	lambda = 10.0;
 	myquantile = quantile.factory( lambda );
+	len = 100;
+	p = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		p[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		y = myquantile( p );
+		y = myquantile( p[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/skewness/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/skewness/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -40,7 +40,7 @@ bench( pkg, function benchmark( b ) {
 	len = 100;
 	lambda = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		lambda[ i ] = ( randu() * 20.0 ) + EPS;
+		lambda[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/skewness/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/skewness/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -49,7 +49,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	len = 100;
 	lambda = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		lambda[ i ] = ( randu() * 20.0 ) + EPS;
+		lambda[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/stdev/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/stdev/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -40,7 +40,7 @@ bench( pkg, function benchmark( b ) {
 	len = 100;
 	lambda = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		lambda[ i ] = ( randu() * 20.0 ) + EPS;
+		lambda[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/stdev/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/stdev/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -49,7 +49,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	len = 100;
 	lambda = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		lambda[ i ] = ( randu() * 20.0 ) + EPS;
+		lambda[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/variance/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/variance/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,13 +33,19 @@ var variance = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
+	var len;
 	var y;
 	var i;
 
+	len = 100;
+	lambda = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		lambda[ i ] = uniform( EPS, 20.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		lambda = ( randu()*20.0 ) + EPS;
-		y = variance( lambda );
+		y = variance( lambda[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

- Refactors random number generation in JS benchmarks for `stats/base/dists/exponential`.
- Replaces `randu()` with `uniform()` for cleaner and more consistent code.
- Moves the random number generation outside the benchmarking loops.

## Related Issues

> Does this pull request have any related issues?

This pull request:

- resolves none

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md