### PR TITLE
bench: refactor random number generation in `stats/base/dists/hypergeometric`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/cdf/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var round = require( '@stdlib/math/base/special/round' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var cdf = require( './../lib' );
@@ -31,6 +32,7 @@ var cdf = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var N;
 	var K;
 	var n;
@@ -38,13 +40,21 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	N = new Float64Array( len );
+	K = new Float64Array( len );
+	n = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 1, 50 );
+		N[ i ] = discreteUniform( 1, 100 );
+		K[ i ] = discreteUniform( 1, N[ i ] );
+		n[ i ] = discreteUniform( 1, N[ i ] );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = round( randu()*50.0 );
-		N = round( randu()*100.0 );
-		K = round( randu()*N );
-		n = round( randu()*N );
-		y = cdf( x, N, K, n );
+		y = cdf( x[ i % len ], N[ i % len ], K[ i % len ], n[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -59,6 +69,7 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var mycdf;
+	var len;
 	var N;
 	var K;
 	var n;
@@ -66,15 +77,19 @@ bench( pkg+':factory', function benchmark( b ) {
 	var y;
 	var i;
 
-	N = round( randu()*100.0 );
-	K = round( randu()*N );
-	n = round( randu()*N );
+	len = 100;
+	N = discreteUniform( 1, 100 );
+	K = discreteUniform( 1, N );
+	n = discreteUniform( 1, N );
 	mycdf = cdf.factory( N, K, n );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 40.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu()*40.0;
-		y = mycdf( x );
+		y = mycdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/ctor/benchmark/benchmark.js
@@ -21,10 +21,10 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
 var Hypergeometric = require( './../lib' );
 
@@ -33,17 +33,25 @@ var Hypergeometric = require( './../lib' );
 
 bench( pkg+'::instantiation', function benchmark( b ) {
 	var dist;
+	var len;
 	var N;
 	var K;
 	var n;
 	var i;
 
+	len = 100;
+	N = new Float64Array( len );
+	K = new Float64Array( len );
+	n = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		N[ i ] = discreteUniform( 1, 100 );
+		K[ i ] = discreteUniform( 1, N[ i ] );
+		n[ i ] = discreteUniform( 1, N[ i ] );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		N = ceil( ( randu() * 50.0 ) + EPS );
-		K = ceil( randu() * N );
-		n = ceil( randu() * N );
-		dist = new Hypergeometric( N, K, n );
+		dist = new Hypergeometric( N[ i % len ], K[ i % len ], n[ i % len ] );
 		if ( !( dist instanceof Hypergeometric ) ) {
 			b.fail( 'should return a distribution instance' );
 		}
@@ -86,6 +94,7 @@ bench( pkg+'::get:N', function benchmark( b ) {
 
 bench( pkg+'::set:N', function benchmark( b ) {
 	var dist;
+	var len;
 	var N;
 	var K;
 	var n;
@@ -95,13 +104,17 @@ bench( pkg+'::set:N', function benchmark( b ) {
 	N = 20;
 	K = 10;
 	n = 5;
+	len = 100;
 	dist = new Hypergeometric( N, K, n );
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = discreteUniform( K, 100 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = ceil( ( randu()*100.0 ) + K );
-		dist.N = y;
-		if ( dist.N !== y ) {
+		dist.N = y[ i % len ];
+		if ( dist.N !== y[ i % len ] ) {
 			b.fail( 'should return set value' );
 		}
 	}
@@ -143,6 +156,7 @@ bench( pkg+'::get:K', function benchmark( b ) {
 
 bench( pkg+'::set:K', function benchmark( b ) {
 	var dist;
+	var len;
 	var N;
 	var K;
 	var n;
@@ -152,13 +166,17 @@ bench( pkg+'::set:K', function benchmark( b ) {
 	N = 20;
 	K = 10;
 	n = 5;
+	len = 100;
 	dist = new Hypergeometric( N, K, n );
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = discreteUniform( 1, N );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = ceil( randu()*N );
-		dist.K = y;
-		if ( dist.K !== y ) {
+		dist.K = y[ i % len ];
+		if ( dist.K !== y[ i % len ] ) {
 			b.fail( 'should return set value' );
 		}
 	}
@@ -200,6 +218,7 @@ bench( pkg+'::get:n', function benchmark( b ) {
 
 bench( pkg+'::set:n', function benchmark( b ) {
 	var dist;
+	var len;
 	var N;
 	var K;
 	var n;
@@ -209,13 +228,17 @@ bench( pkg+'::set:n', function benchmark( b ) {
 	N = 20;
 	K = 10;
 	n = 5;
+	len = 100;
 	dist = new Hypergeometric( N, K, n );
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = discreteUniform( 1, N );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = ceil( randu()*N );
-		dist.n = y;
-		if ( dist.n !== y ) {
+		dist.n = y[ i % len ];
+		if ( dist.n !== y[ i % len ] ) {
 			b.fail( 'should return set value' );
 		}
 	}
@@ -229,20 +252,27 @@ bench( pkg+'::set:n', function benchmark( b ) {
 
 bench( pkg+':kurtosis', function benchmark( b ) {
 	var dist;
+	var len;
 	var N;
 	var K;
 	var n;
+	var x;
 	var y;
 	var i;
 
 	N = 20;
 	K = 10;
 	n = 5;
+	len = 100;
 	dist = new Hypergeometric( N, K, n );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 1, 20 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.n = ceil( 20.0*randu() );
+		dist.n = x[ i % len ];
 		y = dist.kurtosis;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -258,20 +288,27 @@ bench( pkg+':kurtosis', function benchmark( b ) {
 
 bench( pkg+':mean', function benchmark( b ) {
 	var dist;
+	var len;
 	var N;
 	var K;
 	var n;
+	var x;
 	var y;
 	var i;
 
 	N = 20;
 	K = 10;
 	n = 5;
+	len = 100;
 	dist = new Hypergeometric( N, K, n );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 1, 20 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.n = ceil( 20.0*randu() );
+		dist.n = x[ i % len ];
 		y = dist.mean;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -287,20 +324,27 @@ bench( pkg+':mean', function benchmark( b ) {
 
 bench( pkg+':mode', function benchmark( b ) {
 	var dist;
+	var len;
 	var N;
 	var K;
 	var n;
+	var x;
 	var y;
 	var i;
 
 	N = 20;
 	K = 10;
 	n = 5;
+	len = 100;
 	dist = new Hypergeometric( N, K, n );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 1, 20 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.n = ceil( 20.0*randu() );
+		dist.n = x[ i % len ];
 		y = dist.mode;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -316,20 +360,27 @@ bench( pkg+':mode', function benchmark( b ) {
 
 bench( pkg+':skewness', function benchmark( b ) {
 	var dist;
+	var len;
 	var N;
 	var K;
 	var n;
+	var x;
 	var y;
 	var i;
 
 	N = 20;
 	K = 10;
 	n = 5;
+	len = 100;
 	dist = new Hypergeometric( N, K, n );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( K + 1, 50 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.N = ceil( randu()*50.0 ) + K;
+		dist.N = x[ i % len ];
 		y = dist.skewness;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -345,20 +396,27 @@ bench( pkg+':skewness', function benchmark( b ) {
 
 bench( pkg+':stdev', function benchmark( b ) {
 	var dist;
+	var len;
 	var N;
 	var K;
 	var n;
+	var x;
 	var y;
 	var i;
 
 	N = 20;
 	K = 10;
 	n = 5;
+	len = 100;
 	dist = new Hypergeometric( N, K, n );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 1, 20 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.n = ceil( 20.0*randu() );
+		dist.n = x[ i % len ];
 		y = dist.stdev;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -374,20 +432,27 @@ bench( pkg+':stdev', function benchmark( b ) {
 
 bench( pkg+':variance', function benchmark( b ) {
 	var dist;
+	var len;
 	var N;
 	var K;
 	var n;
+	var x;
 	var y;
 	var i;
 
 	N = 20;
 	K = 10;
 	n = 5;
+	len = 100;
 	dist = new Hypergeometric( N, K, n );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 1, 20 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.n = ceil( 20.0*randu() );
+		dist.n = x[ i % len ];
 		y = dist.variance;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -403,6 +468,7 @@ bench( pkg+':variance', function benchmark( b ) {
 
 bench( pkg+':cdf', function benchmark( b ) {
 	var dist;
+	var len;
 	var N;
 	var K;
 	var n;
@@ -413,12 +479,16 @@ bench( pkg+':cdf', function benchmark( b ) {
 	N = 20;
 	K = 10;
 	n = 5;
+	len = 100;
 	dist = new Hypergeometric( N, K, n );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 20.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu() * 20.0;
-		y = dist.cdf( x );
+		y = dist.cdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -433,6 +503,7 @@ bench( pkg+':cdf', function benchmark( b ) {
 
 bench( pkg+':logpmf', function benchmark( b ) {
 	var dist;
+	var len;
 	var N;
 	var K;
 	var n;
@@ -443,12 +514,16 @@ bench( pkg+':logpmf', function benchmark( b ) {
 	N = 20;
 	K = 10;
 	n = 5;
+	len = 100;
 	dist = new Hypergeometric( N, K, n );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 1, n );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ceil( randu() * n );
-		y = dist.logpmf( x );
+		y = dist.logpmf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -463,6 +538,7 @@ bench( pkg+':logpmf', function benchmark( b ) {
 
 bench( pkg+':pmf', function benchmark( b ) {
 	var dist;
+	var len;
 	var N;
 	var K;
 	var n;
@@ -473,12 +549,16 @@ bench( pkg+':pmf', function benchmark( b ) {
 	N = 20;
 	K = 10;
 	n = 5;
+	len = 100;
 	dist = new Hypergeometric( N, K, n );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 1, n );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ceil( randu() * n );
-		y = dist.pmf( x );
+		y = dist.pmf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -493,6 +573,7 @@ bench( pkg+':pmf', function benchmark( b ) {
 
 bench( pkg+':quantile', function benchmark( b ) {
 	var dist;
+	var len;
 	var N;
 	var K;
 	var n;
@@ -503,12 +584,16 @@ bench( pkg+':quantile', function benchmark( b ) {
 	N = 20;
 	K = 10;
 	n = 5;
+	len = 100;
 	dist = new Hypergeometric( N, K, n );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.quantile( x );
+		y = dist.quantile( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/kurtosis/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/kurtosis/benchmark/benchmark.js
@@ -21,8 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
+var Float64Array = require( '@stdlib/array/float64' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var kurtosis = require( './../lib' );
@@ -31,18 +31,26 @@ var kurtosis = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var N;
 	var K;
 	var n;
 	var y;
 	var i;
 
+	len = 100;
+	N = new Float64Array( len );
+	K = new Float64Array( len );
+	n = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		N[ i ] = discreteUniform( 20, 100 );
+		K[ i ] = discreteUniform( 1, N[ i ] - 1 );
+		n[ i ] = discreteUniform( 1, N[ i ] - 1 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		N = ceil( randu()*100.0 ) + 20.0;
-		K = ceil( randu()*(N-1) );
-		n = ceil( randu()*(N-1) );
-		y = kurtosis( N, K, n );
+		y = kurtosis( N[ i % len ], K[ i % len ], n[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/logpmf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/logpmf/benchmark/benchmark.js
@@ -21,8 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var round = require( '@stdlib/math/base/special/round' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var logpmf = require( './../lib' );
@@ -31,6 +31,7 @@ var logpmf = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var N;
 	var K;
 	var n;
@@ -38,13 +39,21 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	N = new Float64Array( len );
+	K = new Float64Array( len );
+	n = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 1, 10 );
+		N[ i ] = discreteUniform( 1, 100 );
+		K[ i ] = discreteUniform( 1, N[ i ] );
+		n[ i ] = discreteUniform( 1, N[ i ] );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = round( randu()*10.0 );
-		N = round( randu()*100.0 );
-		K = round( randu()*N );
-		n = round( randu()*N );
-		y = logpmf( x, N, K, n );
+		y = logpmf( x[ i % len ], N[ i % len ], K[ i % len ], n[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -59,6 +68,7 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var mylogpmf;
+	var len;
 	var N;
 	var K;
 	var n;
@@ -66,15 +76,19 @@ bench( pkg+':factory', function benchmark( b ) {
 	var y;
 	var i;
 
-	N = round( randu()*100.0 );
-	K = round( randu()*N );
-	n = round( randu()*N );
+	len = 100;
+	N = discreteUniform( 1, 100 );
+	K = discreteUniform( 1, N );
+	n = discreteUniform( 1, N );
 	mylogpmf = logpmf.factory( N, K, n );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 1, 40 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = round( randu()*40.0 );
-		y = mylogpmf( x );
+		y = mylogpmf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/mean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/mean/benchmark/benchmark.js
@@ -21,9 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var floor = require( '@stdlib/math/base/special/floor' );
-var randu = require( '@stdlib/random/base/randu' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
+var Float64Array = require( '@stdlib/array/float64' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var mean = require( './../lib' );
@@ -32,18 +31,26 @@ var mean = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var N;
 	var K;
 	var n;
 	var y;
 	var i;
 
+	len = 100;
+	N = new Float64Array( len );
+	K = new Float64Array( len );
+	n = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		N[ i ] = discreteUniform( 1, 100 );
+		K[ i ] = discreteUniform( 1, N[ i ] );
+		n[ i ] = discreteUniform( 1, N[ i ] );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		N = ceil( randu()*100.0 );
-		K = floor( randu()*N );
-		n = floor( randu()*N );
-		y = mean( N, K, n );
+		y = mean( N[ i % len ], K[ i % len ], n[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/mode/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/mode/benchmark/benchmark.js
@@ -21,9 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var floor = require( '@stdlib/math/base/special/floor' );
-var randu = require( '@stdlib/random/base/randu' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
+var Float64Array = require( '@stdlib/array/float64' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var mode = require( './../lib' );
@@ -32,18 +31,26 @@ var mode = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var N;
 	var K;
 	var n;
 	var y;
 	var i;
 
+	len = 100;
+	N = new Float64Array( len );
+	K = new Float64Array( len );
+	n = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		N[ i ] = discreteUniform( 1, 100 );
+		K[ i ] = discreteUniform( 1, N[ i ] );
+		n[ i ] = discreteUniform( 1, N[ i ] );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		N = ceil( randu()*100.0 );
-		K = floor( randu()*N );
-		n = floor( randu()*N );
-		y = mode( N, K, n );
+		y = mode( N[ i % len ], K[ i % len ], n[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/pmf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/pmf/benchmark/benchmark.js
@@ -21,8 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var round = require( '@stdlib/math/base/special/round' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var pmf = require( './../lib' );
@@ -31,6 +31,7 @@ var pmf = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var N;
 	var K;
 	var n;
@@ -38,13 +39,21 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	N = new Float64Array( len );
+	K = new Float64Array( len );
+	n = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 1, 10 );
+		N[ i ] = discreteUniform( 1, 100 );
+		K[ i ] = discreteUniform( 1, N[ i ] );
+		n[ i ] = discreteUniform( 1, N[ i ] );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = round( randu()*10.0 );
-		N = round( randu()*100.0 );
-		K = round( randu()*N );
-		n = round( randu()*N );
-		y = pmf( x, N, K, n );
+		y = pmf( x[ i % len ], N[ i % len ], K[ i % len ], n[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -59,6 +68,7 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var mypmf;
+	var len;
 	var N;
 	var K;
 	var n;
@@ -66,15 +76,19 @@ bench( pkg+':factory', function benchmark( b ) {
 	var y;
 	var i;
 
-	N = round( randu()*100.0 );
-	K = round( randu()*N );
-	n = round( randu()*N );
+	len = 100;
+	N = discreteUniform( 1, 100 );
+	K = discreteUniform( 1, N );
+	n = discreteUniform( 1, N );
 	mypmf = pmf.factory( N, K, n );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = discreteUniform( 1, 40 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = round( randu()*40.0 );
-		y = mypmf( x );
+		y = mypmf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/quantile/benchmark/benchmark.js
@@ -21,8 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var round = require( '@stdlib/math/base/special/round' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var quantile = require( './../lib' );
@@ -31,6 +32,7 @@ var quantile = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var N;
 	var K;
 	var n;
@@ -38,13 +40,21 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	len = 100;
+	p = new Float64Array( len );
+	N = new Float64Array( len );
+	K = new Float64Array( len );
+	n = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		p[ i ] = uniform( 0.0, 1.0 );
+		N[ i ] = discreteUniform( 1, 100 );
+		K[ i ] = discreteUniform( 1, N[ i ] );
+		n[ i ] = discreteUniform( 1, N[ i ] );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		N = round( randu()*100.0 );
-		K = round( randu()*N );
-		n = round( randu()*N );
-		y = quantile( p, N, K, n );
+		y = quantile( p[ i % len ], N[ i % len ], K[ i % len ], n[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -59,6 +69,7 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var myquantile;
+	var len;
 	var N;
 	var K;
 	var n;
@@ -66,15 +77,19 @@ bench( pkg+':factory', function benchmark( b ) {
 	var y;
 	var i;
 
-	N = round( randu()*100.0 );
-	K = round( randu()*N );
-	n = round( randu()*N );
+	len = 100;
+	N = discreteUniform( 1, 100 );
+	K = discreteUniform( 1, N );
+	n = discreteUniform( 1, N );
 	myquantile = quantile.factory( N, K, n );
+	p = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		p[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		y = myquantile( p );
+		y = myquantile( p[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/skewness/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/skewness/benchmark/benchmark.js
@@ -21,8 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
+var Float64Array = require( '@stdlib/array/float64' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var skewness = require( './../lib' );
@@ -31,18 +31,26 @@ var skewness = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var N;
 	var K;
 	var n;
 	var y;
 	var i;
 
+	len = 100;
+	N = new Float64Array( len );
+	K = new Float64Array( len );
+	n = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		N[ i ] = discreteUniform( 10, 100 );
+		K[ i ] = discreteUniform( 1, N[ i ] - 1 );
+		n[ i ] = discreteUniform( 1, N[ i ] - 1 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		N = ceil( randu()*100.0 ) + 10;
-		K = ceil( randu()*(N-1) );
-		n = ceil( randu()*(N-1) );
-		y = skewness( N, K, n );
+		y = skewness( N[ i % len ], K[ i % len ], n[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/stdev/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/stdev/benchmark/benchmark.js
@@ -21,9 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var floor = require( '@stdlib/math/base/special/floor' );
-var randu = require( '@stdlib/random/base/randu' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
+var Float64Array = require( '@stdlib/array/float64' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var stdev = require( './../lib' );
@@ -32,18 +31,26 @@ var stdev = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var N;
 	var K;
 	var n;
 	var y;
 	var i;
 
+	len = 100;
+	N = new Float64Array( len );
+	K = new Float64Array( len );
+	n = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		N[ i ] = discreteUniform( 1, 100 );
+		K[ i ] = discreteUniform( 1, N[ i ] );
+		n[ i ] = discreteUniform( 1, N[ i ] );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		N = ceil( randu()*100.0 ) + 1.0;
-		K = floor( randu()*N );
-		n = floor( randu()*N );
-		y = stdev( N, K, n );
+		y = stdev( N[ i % len ], K[ i % len ], n[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/variance/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/variance/benchmark/benchmark.js
@@ -21,9 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var floor = require( '@stdlib/math/base/special/floor' );
-var randu = require( '@stdlib/random/base/randu' );
-var ceil = require( '@stdlib/math/base/special/ceil' );
+var Float64Array = require( '@stdlib/array/float64' );
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var variance = require( './../lib' );
@@ -32,18 +31,26 @@ var variance = require( './../lib' );
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var N;
 	var K;
 	var n;
 	var y;
 	var i;
 
+	len = 100;
+	N = new Float64Array( len );
+	K = new Float64Array( len );
+	n = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		N[ i ] = discreteUniform( 2, 100 );
+		K[ i ] = discreteUniform( 1, N[ i ] );
+		n[ i ] = discreteUniform( 1, N[ i ] );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		N = ceil( randu()*100.0 ) + 1.0;
-		K = floor( randu()*N );
-		n = floor( randu()*N );
-		y = variance( N, K, n );
+		y = variance( N[ i % len ], K[ i % len ], n[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

- Refactors random number generation in JS benchmarks for `stats/base/dists/hypergeometric`.
- Replaces `randu()` with `uniform()` for cleaner and more consistent code.
- Moves the random number generation outside the benchmarking loops.

## Related Issues

> Does this pull request have any related issues?

This pull request:

- resolves none

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md