### PR TITLE
fix: catch unexpected errors from `acorn-loose` in REPL tokenizer

### DIFF
--- a/lib/node_modules/@stdlib/repl/lib/tokenizer.js
+++ b/lib/node_modules/@stdlib/repl/lib/tokenizer.js
@@ -67,11 +67,15 @@ function tokenizer( line, context ) {
 	var i;
 
 	// Parse the given line into tokens & comments...
-	ast = parse( line, {
-		'ecmaVersion': 'latest',
-		'onToken': onToken,
-		'onComment': onComment
-	});
+	try {
+		ast = parse( line, {
+			'ecmaVersion': 'latest',
+			'onToken': onToken,
+			'onComment': onComment
+		});
+	} catch ( error ) { // eslint-disable-line no-unused-vars
+		return tokens;
+	}
 
 	// Resolve variable declarations from the given line as tokens...
 	declarations = resolveLocalScopes( ast );


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   fixes unexpected errors from `acorn-loose` when parsing in the tokenizer.
	Honestly, didn't know `acorn-loose` also threw errors.. or is it a bug on their end..?
- The input triggering the error was `1_`.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
