### PR TITLE
docs: use correct types in `blas/ext/base/gsumkbn`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/gsumkbn/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/gsumkbn/docs/types/index.d.ts
@@ -62,7 +62,7 @@ interface Routine {
 	* var v = gsumkbn.ndarray( x.length, x, 1, 0 );
 	* // returns 1.0
 	*/
-	ndarray( N: number, x: NumericArray, strideX: number, offsetX: number ): number;
+	ndarray( N: number, x: InputArray, strideX: number, offsetX: number ): number;
 }
 
 /**


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   uses correct types for accessor arrays in `blas/ext/base/gsumkbn` (sorry for missing that!!!)

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
