### PR TITLE
bench: refactor random number generation in `stats/base/dists/invgamma`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/cdf/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,16 +34,24 @@ var cdf = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var alpha;
 	var beta;
+	var len;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	alpha = new Float64Array( len );
+	beta = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 200.0 );
+		alpha[ i ] = uniform( EPS, 100.0 );
+		beta[ i ] = uniform( EPS, 100.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*200.0 ) + EPS;
-		alpha = ( randu()*100.0 ) + EPS;
-		beta = ( randu()*100.0 ) + EPS;
-		y = cdf( x, alpha, beta );
+		y = cdf( x[ i % len ], alpha[ i % len ], beta[ i % len ]);
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -59,18 +68,23 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mycdf;
 	var alpha;
 	var beta;
+	var len;
 	var x;
 	var y;
 	var i;
 
 	alpha = 1.5;
 	beta = 2.3;
+	len = 100;
 	mycdf = cdf.factory( alpha, beta );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*10.0 );
-		y = mycdf( x );
+		y = mycdf( x[ i % len ]);
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/ctor/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -34,13 +35,20 @@ bench( pkg+'::instantiation', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
 	var i;
+
+	len = 100;
+	alpha = new Float64Array( len );
+	beta = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		alpha[ i ] = uniform( EPS, 10.0 );
+		beta[ i ] = uniform( EPS, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		alpha = ( randu() * 10.0 ) + EPS;
-		beta = ( randu() * 10.0 ) + EPS;
-		dist = new InvGamma( alpha, beta );
+		dist = new InvGamma( alpha[ i % len ], beta[ i % len ] );
 		if ( !( dist instanceof InvGamma ) ) {
 			b.fail( 'should return a distribution instance' );
 		}
@@ -83,18 +91,23 @@ bench( pkg+'::set:alpha', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
 	var y;
 	var i;
 
 	alpha = 10.332;
 	beta = 15.54321;
+	len = 100;
 	dist = new InvGamma( alpha, beta );
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = ( 100.0*randu() ) + EPS;
-		dist.alpha = y;
-		if ( dist.alpha !== y ) {
+		dist.alpha = y[ i % len ];
+		if ( dist.alpha !== y[ i % len ] ) {
 			b.fail( 'should return set value' );
 		}
 	}
@@ -136,18 +149,23 @@ bench( pkg+'::set:beta', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
 	var y;
 	var i;
 
 	alpha = 10.332;
 	beta = 15.54321;
+	len = 100;
 	dist = new InvGamma( alpha, beta );
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = ( 100.0*randu() ) + EPS;
-		dist.beta = y;
-		if ( dist.beta !== y ) {
+		dist.beta = y[ i % len ];
+		if ( dist.beta !== y[ i % len ] ) {
 			b.fail( 'should return set value' );
 		}
 	}
@@ -163,16 +181,23 @@ bench( pkg+':entropy', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 
 	alpha = 10.332;
 	beta = 15.54321;
+	len = 100;
 	dist = new InvGamma( alpha, beta );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.alpha = ( 100.0*randu() ) + EPS;
+		dist.alpha = x[ i % len ];
 		y = dist.entropy;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -190,16 +215,23 @@ bench( pkg+':kurtosis', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 
 	alpha = 10.332;
 	beta = 15.54321;
+	len = 100;
 	dist = new InvGamma( alpha, beta );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 4.0 + EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.alpha = ( 100.0*randu() ) + 4.0 + EPS;
+		dist.alpha = x[ i % len ];
 		y = dist.kurtosis;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -217,16 +249,23 @@ bench( pkg+':mean', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 
 	alpha = 10.332;
 	beta = 15.54321;
+	len = 100;
 	dist = new InvGamma( alpha, beta );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 1.0 + EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.alpha = ( 100.0*randu() ) + 1.0 + EPS;
+		dist.alpha = x[ i % len ];
 		y = dist.mean;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -244,16 +283,23 @@ bench( pkg+':mode', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 
 	alpha = 10.332;
 	beta = 15.54321;
+	len = 100;
 	dist = new InvGamma( alpha, beta );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.alpha = ( 100.0*randu() ) + EPS;
+		dist.alpha = x[ i % len ];
 		y = dist.mode;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -271,16 +317,23 @@ bench( pkg+':skewness', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 
 	alpha = 10.332;
 	beta = 15.54321;
+	len = 100;
 	dist = new InvGamma( alpha, beta );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 3.0 + EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.alpha = ( 100.0*randu() ) + 3.0 + EPS;
+		dist.alpha = x[ i % len ];
 		y = dist.skewness;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -298,16 +351,23 @@ bench( pkg+':stdev', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 
 	alpha = 10.332;
 	beta = 15.54321;
+	len = 100;
 	dist = new InvGamma( alpha, beta );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 2.0 + EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.alpha = ( 100.0*randu() ) + 2.0 + EPS;
+		dist.alpha = x[ i % len ];
 		y = dist.stdev;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -325,16 +385,23 @@ bench( pkg+':variance', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 
 	alpha = 10.332;
 	beta = 15.54321;
+	len = 100;
 	dist = new InvGamma( alpha, beta );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 2.0 + EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.alpha = ( 100.0*randu() ) + 2.0 + EPS;
+		dist.alpha = x[ i % len ];
 		y = dist.variance;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -352,18 +419,23 @@ bench( pkg+':cdf', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
 
 	alpha = 10.332;
 	beta = 15.54321;
+	len = 100;
 	dist = new InvGamma( alpha, beta );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.cdf( x );
+		y = dist.cdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -380,18 +452,23 @@ bench( pkg+':logpdf', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
 
 	alpha = 10.332;
 	beta = 15.54321;
+	len = 100;
 	dist = new InvGamma( alpha, beta );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.logpdf( x );
+		y = dist.logpdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -408,18 +485,23 @@ bench( pkg+':pdf', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
 
 	alpha = 10.332;
 	beta = 15.54321;
+	len = 100;
 	dist = new InvGamma( alpha, beta );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.pdf( x );
+		y = dist.pdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -436,18 +518,23 @@ bench( pkg+':quantile', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
 
 	alpha = 10.332;
 	beta = 15.54321;
+	len = 100;
 	dist = new InvGamma( alpha, beta );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.quantile( x );
+		y = dist.quantile( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/entropy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/entropy/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	alpha = new Float64Array( len );
 	beta = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = ( randu() * 20.0 ) + EPS;
-		beta[ i ] = ( randu() * 20.0 ) + EPS;
+		alpha[ i ] = uniform( EPS, 20.0 );
+		beta[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/entropy/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/entropy/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -51,8 +51,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	alpha = new Float64Array( len );
 	beta = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = ( randu() * 20.0 ) + EPS;
-		beta[ i ] = ( randu() * 20.0 ) + EPS;
+		alpha[ i ] = uniform( EPS, 20.0 );
+		beta[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/kurtosis/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/kurtosis/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	alpha = new Float64Array( len );
 	beta = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = ( randu()*10.0 ) + 4.0 + EPS;
-		beta[ i ] = ( randu()*10.0 ) + EPS;
+		alpha[ i ] = uniform( 4.0 + EPS, 10.0 );
+		beta[ i ] = uniform( EPS, 10.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/kurtosis/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/kurtosis/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -51,8 +51,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	alpha = new Float64Array( len );
 	beta = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = ( randu()*10.0 ) + 4.0 + EPS;
-		beta[ i ] = ( randu()*10.0 ) + EPS;
+		alpha[ i ] = uniform( 4.0 + EPS, 10.0 );
+		beta[ i ] = uniform( EPS, 10.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/logpdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/logpdf/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,16 +34,24 @@ var logpdf = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var alpha;
 	var beta;
+	var len;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	alpha = new Float64Array( len );
+	beta = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 200.0 );
+		alpha[ i ] = uniform( EPS, 100.0 );
+		beta[ i ] = uniform( EPS, 100.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*200.0 ) + EPS;
-		alpha = ( randu()*100.0 ) + EPS;
-		beta = ( randu()*100.0 ) + EPS;
-		y = logpdf( x, alpha, beta );
+		y = logpdf( x[ i % len ], alpha[ i % len ], beta[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -59,18 +68,23 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mylogpdf;
 	var alpha;
 	var beta;
+	var len;
 	var x;
 	var y;
 	var i;
 
 	alpha = 1.5;
 	beta = 2.3;
+	len = 100;
 	mylogpdf = logpdf.factory( alpha, beta );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu() * 10.0;
-		y = mylogpdf( x );
+		y = mylogpdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	alpha = new Float64Array( len );
 	beta = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = ( randu()*10.0 ) + 1.0 + EPS;
-		beta[ i ] = ( randu()*10.0 ) + EPS;
+		alpha[ i ] = uniform( 1.0 + EPS, 10.0 );
+		beta[ i ] = uniform( EPS, 10.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/mean/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -51,8 +51,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	alpha = new Float64Array( len );
 	beta = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = ( randu()*10.0 ) + 1.0 + EPS;
-		beta[ i ] = ( randu()*10.0 ) + EPS;
+		alpha[ i ] = uniform( 1.0 + EPS, 10.0 );
+		beta[ i ] = uniform( EPS, 10.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/mode/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/mode/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	alpha = new Float64Array( len );
 	beta = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = ( randu()*10.0 ) + EPS;
-		beta[ i ] = ( randu()*10.0 ) + EPS;
+		alpha[ i ] = uniform( EPS, 10.0 );
+		beta[ i ] = uniform( EPS, 10.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/mode/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/mode/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -51,8 +51,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	alpha = new Float64Array( len );
 	beta = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = ( randu()*10.0 ) + EPS;
-		beta[ i ] = ( randu()*10.0 ) + EPS;
+		alpha[ i ] = uniform( EPS, 10.0 );
+		beta[ i ] = uniform( EPS, 10.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/pdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/pdf/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,16 +34,24 @@ var pdf = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var alpha;
 	var beta;
+	var len;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	alpha = new Float64Array( len );
+	beta = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 200.0 );
+		alpha[ i ] = uniform( EPS, 100.0 );
+		beta[ i ] = uniform( EPS, 100.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*200.0 ) + EPS;
-		alpha = ( randu()*100.0 ) + EPS;
-		beta = ( randu()*100.0 ) + EPS;
-		y = pdf( x, alpha, beta );
+		y = pdf( x[ i % len ], alpha[ i % len ], beta[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -59,18 +68,23 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mypdf;
 	var alpha;
 	var beta;
+	var len;
 	var x;
 	var y;
 	var i;
 
 	alpha = 1.5;
 	beta = 2.3;
+	len = 100;
 	mypdf = pdf.factory( alpha, beta );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu() * 10.0;
-		y = mypdf( x );
+		y = mypdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/quantile/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,16 +34,24 @@ var quantile = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var alpha;
 	var beta;
+	var len;
 	var p;
 	var y;
 	var i;
 
+	len = 100;
+	p = new Float64Array( len );
+	alpha = new Float64Array( len );
+	beta = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		p[ i ] = uniform( 0.0, 1.0 );
+		alpha[ i ] = uniform( EPS, 100.0 );
+		beta[ i ] = uniform( EPS, 100.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		alpha = ( randu()*100.0 ) + EPS;
-		beta = ( randu()*100.0 ) + EPS;
-		y = quantile( p, alpha, beta );
+		y = quantile( p[ i % len ], alpha[ i % len ], beta[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -59,18 +68,23 @@ bench( pkg+':factory', function benchmark( b ) {
 	var myquantile;
 	var alpha;
 	var beta;
+	var len;
 	var p;
 	var y;
 	var i;
 
 	alpha = 1.5;
 	beta = 2.3;
+	len = 100;
 	myquantile = quantile.factory( alpha, beta );
+	p = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		p[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		y = myquantile( p );
+		y = myquantile( p[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/skewness/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/skewness/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	alpha = new Float64Array( len );
 	beta = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = ( randu()*10.0 ) + 3.0 + EPS;
-		beta[ i ] = ( randu()*10.0 ) + EPS;
+		alpha[ i ] = uniform( 3.0 + EPS, 10.0 );
+		beta[ i ] = uniform( EPS, 10.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/skewness/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/skewness/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -51,8 +51,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	alpha = new Float64Array( len );
 	beta = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = ( randu()*10.0 ) + 3.0 + EPS;
-		beta[ i ] = ( randu()*10.0 ) + EPS;
+		alpha[ i ] = uniform( 3.0 + EPS, 10.0 );
+		beta[ i ] = uniform( EPS, 10.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/stdev/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/stdev/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	alpha = new Float64Array( len );
 	beta = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = ( randu()*10.0 ) + 2.0 + EPS;
-		beta[ i ] = ( randu()*10.0 ) + EPS;
+		alpha[ i ] = uniform( 2.0 + EPS, 10.0 );
+		beta[ i ] = uniform( EPS, 10.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/stdev/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/stdev/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -51,8 +51,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	alpha = new Float64Array( len );
 	beta = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = ( randu()*10.0 ) + 2.0 + EPS;
-		beta[ i ] = ( randu()*10.0 ) + EPS;
+		alpha[ i ] = uniform( 2.0 + EPS, 10.0 );
+		beta[ i ] = uniform( EPS, 10.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/variance/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/variance/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,14 +34,21 @@ var variance = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var alpha;
 	var beta;
+	var len;
 	var y;
 	var i;
 
+	len = 100;
+	alpha = new Float64Array( len );
+	beta = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		alpha[ i ] = uniform( 2.0 + EPS, 10.0 );
+		beta[ i ] = uniform( EPS, 10.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		alpha = ( randu()*10.0 ) + 2.0 + EPS;
-		beta = ( randu()*10.0 ) + EPS;
-		y = variance( alpha, beta );
+		y = variance( alpha[ i % len ], beta[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

- Refactors random number generation in JS benchmarks for `stats/base/dists/invgamma`.
- Replaces `randu()` with `uniform()` for cleaner and more consistent code.
- Moves the random number generation outside the benchmarking loops.

## Related Issues

> Does this pull request have any related issues?

This pull request:

- resolves none

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md