### PR TITLE
bench: refactor random number generation in `stats/base/dists/uniform`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/cdf/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var cdf = require( './../lib' );
@@ -36,11 +36,12 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( -10.0, 10.0 );
+	min = uniform( -20.0, 0.0 );
+	max = uniform( min, min + 40.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu() * 20.0 ) - 10.0;
-		min = ( randu() * 20.0 ) - 20.0;
-		max = min + ( randu() * 40.0 );
 		y = cdf( x, min, max );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -68,7 +69,7 @@ bench( pkg+':factory', function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*2.0 ) - 2.0;
+		x = uniform( -2.0, 0.0 );
 		y = mycdf( x );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/ctor/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -38,8 +38,8 @@ bench( pkg+'::instantiation', function benchmark( bm ) {
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		a = ( randu() * 10.0 ) + EPS;
-		b = ( randu() * 10.0 ) + a + EPS;
+		a = uniform( EPS, EPS + 10.0 );
+		b = uniform( a + EPS, a + EPS + 10.0 );
 		dist = new Uniform( a, b );
 		if ( !( dist instanceof Uniform ) ) {
 			bm.fail( 'should return a distribution instance' );
@@ -92,7 +92,7 @@ bench( pkg+'::set:a', function benchmark( bm ) {
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		y = ( 100.0*randu() ) + EPS;
+		y = uniform( EPS, EPS + 100.0 );
 		dist.a = y;
 		if ( dist.a !== y ) {
 			bm.fail( 'should return set value' );
@@ -145,7 +145,7 @@ bench( pkg+'::set:b', function benchmark( bm ) {
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		y = ( 100.0*randu() ) + a + EPS;
+		y = uniform( a + EPS, a + EPS + 100.0 );
 		dist.b = y;
 		if ( dist.b !== y ) {
 			bm.fail( 'should return set value' );
@@ -172,7 +172,7 @@ bench( pkg+':entropy', function benchmark( bm ) {
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = ( 100.0*randu() ) + EPS;
+		dist.a = uniform( EPS, EPS + 100.0 );
 		y = dist.entropy;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -199,7 +199,7 @@ bench( pkg+':kurtosis', function benchmark( bm ) {
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = ( 100.0*randu() ) + EPS;
+		dist.a = uniform( EPS, EPS + 100.0 );
 		y = dist.kurtosis;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -226,7 +226,7 @@ bench( pkg+':mean', function benchmark( bm ) {
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = ( 100.0*randu() ) + EPS;
+		dist.a = uniform( EPS, EPS + 100.0 );
 		y = dist.mean;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -253,7 +253,7 @@ bench( pkg+':median', function benchmark( bm ) {
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = ( 100.0*randu() ) + EPS;
+		dist.a = uniform( EPS, EPS + 100.0 );
 		y = dist.median;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -280,7 +280,7 @@ bench( pkg+':skewness', function benchmark( bm ) {
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = ( 100.0*randu() ) + EPS;
+		dist.a = uniform( EPS, EPS + 100.0 );
 		y = dist.skewness;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -307,7 +307,7 @@ bench( pkg+':stdev', function benchmark( bm ) {
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = ( 100.0*randu() ) + EPS;
+		dist.a = uniform( EPS, EPS + 100.0 );
 		y = dist.stdev;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -334,7 +334,7 @@ bench( pkg+':variance', function benchmark( bm ) {
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = ( 100.0*randu() ) + EPS;
+		dist.a = uniform( EPS, EPS + 100.0 );
 		y = dist.variance;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -362,7 +362,7 @@ bench( pkg+':cdf', function benchmark( bm ) {
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = randu() * 60.0;
+		x = uniform( 0.0, 60.0 );
 		y = dist.cdf( x );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -390,7 +390,7 @@ bench( pkg+':logcdf', function benchmark( bm ) {
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = randu() * 60.0;
+		x = uniform( 0.0, 60.0 );
 		y = dist.logcdf( x );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -418,7 +418,7 @@ bench( pkg+':logpdf', function benchmark( bm ) {
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = randu() * 60.0;
+		x = uniform( 0.0, 60.0 );
 		y = dist.logpdf( x );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -446,7 +446,7 @@ bench( pkg+':mgf', function benchmark( bm ) {
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = randu();
+		x = uniform( 0.0, 1.0 );
 		y = dist.mgf( x );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -474,7 +474,7 @@ bench( pkg+':pdf', function benchmark( bm ) {
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = randu() * 60.0;
+		x = uniform( 0.0, 60.0 );
 		y = dist.pdf( x );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -502,7 +502,7 @@ bench( pkg+':quantile', function benchmark( bm ) {
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = randu();
+		x = uniform( 0.0, 1.0 );
 		y = dist.quantile( x );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/entropy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/entropy/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var entropy = require( './../lib' );
@@ -41,8 +41,8 @@ bench( pkg, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = ( randu()*10.0 );
-		max[ i ] = ( randu()*10.0 ) + min[ i ];
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ], min[ i ] + 10.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/entropy/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/entropy/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 
@@ -50,8 +50,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = ( randu()*10.0 );
-		max[ i ] = ( randu()*10.0 ) + min[ i ];
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ], min[ i ] + 10.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/kurtosis/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/kurtosis/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var kurtosis = require( './../lib' );
@@ -37,8 +37,8 @@ bench( pkg, function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		min = ( randu()*10.0 );
-		max = ( randu()*10.0 ) + min;
+		min = uniform( 0.0, 10.0 );
+		max = uniform( min, min + 10.0 );
 		y = kurtosis( min, max );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/logcdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/logcdf/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var logcdf = require( './../lib' );
@@ -38,9 +38,9 @@ bench( pkg, function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu() * 20.0 ) - 10.0;
-		min = ( randu() * 20.0 ) - 20.0;
-		max = min + ( randu() * 40.0 );
+		x = uniform( -10.0, 10.0 );
+		min = uniform( -20.0, 0.0 );
+		max = uniform( min, min + 40.0 );
 		y = logcdf( x, min, max );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -68,7 +68,7 @@ bench( pkg+':factory', function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*2.0 ) - 2.0;
+		x = uniform( -2.0, 0.0 );
 		y = mylogcdf( x );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/logpdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/logpdf/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var logpdf = require( './../lib' );
@@ -38,9 +38,9 @@ bench( pkg, function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu() * 20.0 ) - 10.0;
-		min = ( randu() * 20.0 ) - 20.0;
-		max = min + ( randu() * 40.0 );
+		x = uniform( -10.0, 10.0 );
+		min = uniform( -20.0, 0.0 );
+		max = uniform( min, min + 40.0 );
 		y = logpdf( x, min, max );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -68,7 +68,7 @@ bench( pkg+':factory', function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*2.0 ) - 2.0;
+		x = uniform( -2.0, 0.0 );
 		y = mylogpdf( x );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/mean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/mean/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	bval = new Float64Array( len );
 
 	for ( i = 0; i < len; i++ ) {
-		a[ i ] = randu() * 100.0;
-		bval[ i ] = a[ i ] + ( randu() * 50.0 );
+		a[ i ] = uniform( 0.0, 100.0 );
+		bval[ i ] = uniform( a[ i ], a[ i ] + 50.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/mean/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/mean/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -50,8 +50,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	a = new Float64Array( len );
 	bnd = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		a[ i ] = randu() * 100.0;
-		bnd[ i ] = a[ i ] + ( randu() * 100.0 );
+		a[ i ] = uniform( 0.0, 100.0 );
+		bnd[ i ] = uniform( a[ i ], a[ i ] + 100.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/median/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/median/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	bnd = new Float64Array( len );
 
 	for ( i = 0; i < len; i++ ) {
-		a[ i ] = randu() * 100.0;
-		bnd[ i ] = a[ i ] + ( randu() * 50.0 );
+		a[ i ] = uniform( 0.0, 100.0 );
+		bnd[ i ] = uniform( a[ i ], a[ i ] + 50.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/median/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/median/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -50,8 +50,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	a = new Float64Array( len );
 	bnd = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		a[ i ] = randu() * 100.0;
-		bnd[ i ] = a[ i ] + ( randu() * 100.0 );
+		a[ i ] = uniform( 0.0, 100.0 );
+		bnd[ i ] = uniform( a[ i ], a[ i ] + 100.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/mgf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/mgf/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var mgf = require( './../lib' );
@@ -38,9 +38,9 @@ bench( pkg, function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		t = ( randu() * 20.0 ) - 10.0;
-		min = ( randu() * 20.0 ) - 20.0;
-		max = min + ( randu() * 40.0 );
+		t = uniform( -10.0, 10.0 );
+		min = uniform( -20.0, 0.0 );
+		max = uniform( min, min + 40.0 );
 		y = mgf( t, min, max );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -68,7 +68,7 @@ bench( pkg+':factory', function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		t = ( randu()*2.0 ) - 2.0;
+		t = uniform( -2.0, 0.0 );
 		y = mymgf( t );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/pdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/pdf/benchmark/benchmark.js
@@ -23,7 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var pdf = require( './../lib' );
@@ -44,9 +44,9 @@ bench( pkg, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu() * 20.0 ) - 10.0;
-		min[ i ] = ( randu() * 20.0 ) - 20.0;
-		max[ i ] = min[ i ] + ( randu() * 40.0 );
+		x[ i ] = uniformBase( -10.0, 10.0 );
+		min[ i ] = uniformBase( -20.0, 0.0 );
+		max[ i ] = uniformBase( min[ i ], min[ i ] + 40.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/pdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/pdf/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -52,9 +52,9 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu() * 20.0 ) - 10.0;
-		min[ i ] = ( randu() * 20.0 ) - 20.0;
-		max[ i ] = min[ i ] + ( randu() * 40.0 );
+		x[ i ] = uniform( -10.0, 10.0 );
+		min[ i ] = uniform( -20.0, 0.0 );
+		max[ i ] = uniform( min[ i ], min[ i ] + 40.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/quantile/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var quantile = require( './../lib' );
@@ -38,9 +38,9 @@ bench( pkg, function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		min = ( randu() * 20.0 ) - 20.0;
-		max = min + ( randu() * 40.0 );
+		p = uniform( 0.0, 1.0 );
+		min = uniform( -20.0, 0.0 );
+		max = uniform( min, min + 40.0 );
 		y = quantile( p, min, max );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -68,7 +68,7 @@ bench( pkg+':factory', function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
+		p = uniform( 0.0, 1.0 );
 		y = myquantile( p );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/skewness/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/skewness/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var skewness = require( './../lib' );
@@ -37,8 +37,8 @@ bench( pkg, function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		min = ( randu()*10.0 );
-		max = ( randu()*10.0 ) + min;
+		min = uniform( 0.0, 10.0 );
+		max = uniform( min, min + 10.0 );
 		y = skewness( min, max );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/stdev/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/stdev/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var stdev = require( './../lib' );
@@ -37,8 +37,8 @@ bench( pkg, function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		min = ( randu()*10.0 );
-		max = ( randu()*10.0 ) + min;
+		min = uniform( 0.0, 10.0 );
+		max = uniform( min, min + 10.0 );
 		y = stdev( min, max );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/variance/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/variance/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var variance = require( './../lib' );
@@ -41,8 +41,8 @@ bench( pkg, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = ( randu() * 10.0 );
-		max[ i ] = ( randu() * 10.0 ) + min[ i ];
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ], min[ i ] + 10.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/variance/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/variance/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 
@@ -50,8 +50,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = ( randu() * 10.0 );
-		max[ i ] = ( randu() * 10.0 ) + min[ i ];
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ], min[ i ] + 10.0 );
 	}
 
 	b.tic();


### PR DESCRIPTION
This issue is related to #4991 i.e RFC:

## Description

This PR has changes to benchmarking file located at [stats/base/dists/uniform](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/base/dists/uniform)

This pull request:

-   Replaced `rand()` with corresponding `uniform()` implementation within the benchmarking files.



## Questions

No

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
