### PR TITLE
test: add tests to achieve 100% code coverage in `stats/base/max`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/max/test/test.main.js
+++ b/lib/node_modules/@stdlib/stats/base/max/test/test.main.js
@@ -218,6 +218,18 @@ tape( 'if provided a `stride` parameter equal to `0`, the function returns the f
 	t.end();
 });
 
+tape( 'if provided a `stride` parameter equal to `0`, the function returns the first element (accessors)', function test( t ) {
+	var x;
+	var v;
+
+	x = [ 1.0, -2.0, -4.0, 5.0, 3.0 ];
+
+	v = max( x.length, toAccessorArray( x ), 0 );
+	t.strictEqual( v, 1.0, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function supports view offsets', function test( t ) {
 	var x0;
 	var x1;

--- a/lib/node_modules/@stdlib/stats/base/max/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/base/max/test/test.ndarray.js
@@ -196,6 +196,18 @@ tape( 'if provided a `stride` parameter equal to `0`, the function returns the f
 	t.end();
 });
 
+tape( 'if provided a `stride` parameter equal to `0`, the function returns the first indexed element (accessors)', function test( t ) {
+	var x;
+	var v;
+
+	x = [ 1.0, -2.0, -4.0, 5.0, 3.0 ];
+
+	v = max( x.length, toAccessorArray( x ), 0, 0 );
+	t.strictEqual( v, 1.0, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function supports an `offset` parameter', function test( t ) {
 	var x;
 	var v;


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   add test case for `strideX === 0` for accessor array implementation in `stats/base/max`

## Related Issues

> Does this pull request have any related issues?

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
