### PR TITLE
chore: refactor random number generation in `stats/base/dists/rayleigh`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/cdf/benchmark/benchmark.js
@@ -76,7 +76,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = uniform( -25.0, 25.0 );
 	}
-	
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
 		y = mycdf( x[ i % len ] );

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/cdf/benchmark/benchmark.js
@@ -74,7 +74,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	len = 100;
 	x = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( -25.0, 50.0 );
+		x[ i ] = uniform( -25.0, 25.0 );
 	}
 	
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/rayleigh/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/rayleigh/cdf/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	x = new Float64Array( len );
 	sigma = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu() * 100.0 ) - 100.0;
-		sigma[ i ] = ( randu() * 20.0 ) + EPS;
+		x[ i ] = uniform( -100.0, 100.0 );
+		sigma[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();
@@ -64,17 +64,22 @@ bench( pkg, function benchmark( b ) {
 bench( pkg+':factory', function benchmark( b ) {
 	var sigma;
 	var mycdf;
+	var len;
 	var x;
 	var y;
 	var i;
 
 	sigma = 4.0;
 	mycdf = cdf.factory( sigma );
-
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -25.0, 50.0 );
+	}
+	
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*50.0 ) - 25.0;
-		y = mycdf( x );
+		y = mycdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}


### PR DESCRIPTION
…ps and used uniform instead of randu

Resolves #4985

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors random number generation in JS benchmarks for stats/base/dists/rayleigh.
-   Replaces randu() with uniform() for cleaner and more consistent code.
-   Moves the random number generation outside the benchmarking loops.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #{{TODO: add issue number}} 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
