### PR TITLE
bench: refactor random number generation in stats/base/dists/normal

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,17 +33,24 @@ var cdf = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var sigma;
+	var len;
 	var mu;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	mu = new Float64Array( len );
+	sigma = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -100.0, 100.0 );
+		mu[ i ] = uniform( -50.0, 50.0 );
+		sigma[ i ] = uniform( EPS, 20.0 );
+	}
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*200.0 ) - 100;
-		mu = ( randu()*100.0 ) - 50.0;
-		sigma = ( randu()*20.0 ) + EPS;
-		y = cdf( x, mu, sigma );
+		y = cdf( x[ i % len ], mu[ i % len ], sigma[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -58,6 +66,7 @@ bench( pkg, function benchmark( b ) {
 bench( pkg+':factory', function benchmark( b ) {
 	var mycdf;
 	var sigma;
+	var len;
 	var mu;
 	var x;
 	var y;
@@ -66,11 +75,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	mu = 0.0;
 	sigma = 1.5;
 	mycdf = cdf.factory( mu, sigma );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -3.0, 3.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*6.0 ) - 3.0;
-		y = mycdf( x );
+		y = mycdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/cdf/benchmark/benchmark.js
@@ -48,6 +48,7 @@ bench( pkg, function benchmark( b ) {
 		mu[ i ] = uniform( -50.0, 50.0 );
 		sigma[ i ] = uniform( EPS, 20.0 );
 	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
 		y = cdf( x[ i % len ], mu[ i % len ], sigma[ i % len ] );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/ctor/benchmark/benchmark.js
@@ -534,7 +534,6 @@ bench( pkg+':mgf', function benchmark( b ) {
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = uniform( 0.0, 1.0 );
 	}
-
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
 		y = dist.mgf( x[ i % len ] );
@@ -567,6 +566,7 @@ bench( pkg+':pdf', function benchmark( b ) {
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = uniform( -3.0, 3.0 );
 	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
 		y = dist.pdf( x[ i % len ] );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/ctor/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,18 +34,26 @@ var Normal = require( './../lib' );
 bench( pkg+'::instantiation', function benchmark( b ) {
 	var sigma;
 	var dist;
+	var len;
 	var mu;
 	var i;
 
+	len = 100;
+	mu = new Float64Array( len );
+	sigma = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		mu[ i ] = uniform( EPS, 10.0 );
+		sigma[ i ] = uniform( EPS, 10.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		mu = ( randu() * 10.0 ) + EPS;
-		sigma = ( randu() * 10.0 ) + EPS;
-		dist = new Normal( mu, sigma );
+		dist = new Normal( mu[ i % len ], sigma[ i % len ] );
 		if ( !( dist instanceof Normal ) ) {
 			b.fail( 'should return a distribution instance' );
 		}
 	}
+
 	b.toc();
 	if ( !( dist instanceof Normal ) ) {
 		b.fail( 'should return a distribution instance' );
@@ -71,6 +80,7 @@ bench( pkg+'::get:mu', function benchmark( b ) {
 			b.fail( 'should return set value' );
 		}
 	}
+
 	b.toc();
 	if ( isnan( y ) ) {
 		b.fail( 'should not return NaN' );
@@ -82,6 +92,7 @@ bench( pkg+'::get:mu', function benchmark( b ) {
 bench( pkg+'::set:mu', function benchmark( b ) {
 	var sigma;
 	var dist;
+	var len;
 	var mu;
 	var y;
 	var i;
@@ -89,12 +100,16 @@ bench( pkg+'::set:mu', function benchmark( b ) {
 	mu = 2.0;
 	sigma = 3.0;
 	dist = new Normal( mu, sigma );
+	len = 100;
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = ( 100.0*randu() ) + EPS;
-		dist.mu = y;
-		if ( dist.mu !== y ) {
+		dist.mu = y[ i % len ];
+		if ( dist.mu !== y[ i % len ] ) {
 			b.fail( 'should return set value' );
 		}
 	}
@@ -124,6 +139,7 @@ bench( pkg+'::get:sigma', function benchmark( b ) {
 			b.fail( 'should return set value' );
 		}
 	}
+
 	b.toc();
 	if ( isnan( y ) ) {
 		b.fail( 'should not return NaN' );
@@ -135,6 +151,7 @@ bench( pkg+'::get:sigma', function benchmark( b ) {
 bench( pkg+'::set:sigma', function benchmark( b ) {
 	var sigma;
 	var dist;
+	var len;
 	var mu;
 	var y;
 	var i;
@@ -142,12 +159,16 @@ bench( pkg+'::set:sigma', function benchmark( b ) {
 	mu = 2.0;
 	sigma = 3.0;
 	dist = new Normal( mu, sigma );
+	len = 100;
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = ( 100.0*randu() ) + EPS;
-		dist.sigma = y;
-		if ( dist.sigma !== y ) {
+		dist.sigma = y[ i % len ];
+		if ( dist.sigma !== y[ i % len ] ) {
 			b.fail( 'should return set value' );
 		}
 	}
@@ -162,17 +183,24 @@ bench( pkg+'::set:sigma', function benchmark( b ) {
 bench( pkg+':entropy', function benchmark( b ) {
 	var sigma;
 	var dist;
+	var len;
 	var mu;
+	var x;
 	var y;
 	var i;
 
 	mu = 2.0;
 	sigma = 3.0;
 	dist = new Normal( mu, sigma );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.mu = ( 100.0*randu() ) + EPS;
+		dist.mu = x[ i % len ];
 		y = dist.entropy;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -189,17 +217,24 @@ bench( pkg+':entropy', function benchmark( b ) {
 bench( pkg+':kurtosis', function benchmark( b ) {
 	var sigma;
 	var dist;
+	var len;
 	var mu;
+	var x;
 	var y;
 	var i;
 
 	mu = 2.0;
 	sigma = 3.0;
 	dist = new Normal( mu, sigma );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.mu = ( 100.0*randu() ) + EPS;
+		dist.mu = x[ i % len ];
 		y = dist.kurtosis;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -216,17 +251,24 @@ bench( pkg+':kurtosis', function benchmark( b ) {
 bench( pkg+':mean', function benchmark( b ) {
 	var sigma;
 	var dist;
+	var len;
 	var mu;
+	var x;
 	var y;
 	var i;
 
 	mu = 2.0;
 	sigma = 3.0;
 	dist = new Normal( mu, sigma );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.mu = ( 100.0*randu() ) + EPS;
+		dist.mu = x[ i % len ];
 		y = dist.mean;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -243,17 +285,24 @@ bench( pkg+':mean', function benchmark( b ) {
 bench( pkg+':median', function benchmark( b ) {
 	var sigma;
 	var dist;
+	var len;
 	var mu;
+	var x;
 	var y;
 	var i;
 
 	mu = 2.0;
 	sigma = 3.0;
 	dist = new Normal( mu, sigma );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.mu = ( 100.0*randu() ) + EPS;
+		dist.mu = x[ i % len ];
 		y = dist.median;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -270,17 +319,24 @@ bench( pkg+':median', function benchmark( b ) {
 bench( pkg+':mode', function benchmark( b ) {
 	var sigma;
 	var dist;
+	var len;
 	var mu;
+	var x;
 	var y;
 	var i;
 
 	mu = 2.0;
 	sigma = 3.0;
 	dist = new Normal( mu, sigma );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS + 1.0, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.mu = ( 100.0*randu() ) + 1.0 + EPS;
+		dist.mu = x[ i % len ];
 		y = dist.mode;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -297,17 +353,24 @@ bench( pkg+':mode', function benchmark( b ) {
 bench( pkg+':skewness', function benchmark( b ) {
 	var sigma;
 	var dist;
+	var len;
 	var mu;
+	var x;
 	var y;
 	var i;
 
 	mu = 2.0;
 	sigma = 3.0;
 	dist = new Normal( mu, sigma );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.mu = ( 100.0*randu() ) + EPS;
+		dist.mu = x[ i % len ];
 		y = dist.skewness;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -324,17 +387,23 @@ bench( pkg+':skewness', function benchmark( b ) {
 bench( pkg+':variance', function benchmark( b ) {
 	var sigma;
 	var dist;
+	var len;
 	var mu;
+	var x;
 	var y;
 	var i;
 
 	mu = 2.0;
 	sigma = 3.0;
 	dist = new Normal( mu, sigma );
-
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.mu = ( 100.0*randu() ) + EPS;
+		dist.mu = x[ i % len ];
 		y = dist.stdev;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -351,17 +420,24 @@ bench( pkg+':variance', function benchmark( b ) {
 bench( pkg+':variance', function benchmark( b ) {
 	var sigma;
 	var dist;
+	var len;
 	var mu;
+	var x;
 	var y;
 	var i;
 
 	mu = 2.0;
 	sigma = 3.0;
 	dist = new Normal( mu, sigma );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.mu = ( 100.0*randu() ) + EPS;
+		dist.mu = x[ i % len ];
 		y = dist.variance;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -378,6 +454,7 @@ bench( pkg+':variance', function benchmark( b ) {
 bench( pkg+':cdf', function benchmark( b ) {
 	var sigma;
 	var dist;
+	var len;
 	var mu;
 	var x;
 	var y;
@@ -386,11 +463,15 @@ bench( pkg+':cdf', function benchmark( b ) {
 	mu = 2.0;
 	sigma = 3.0;
 	dist = new Normal( mu, sigma );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -3.0, 3.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*6.0 ) - 3.0;
-		y = dist.cdf( x );
+		y = dist.cdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -406,6 +487,7 @@ bench( pkg+':cdf', function benchmark( b ) {
 bench( pkg+':logpdf', function benchmark( b ) {
 	var sigma;
 	var dist;
+	var len;
 	var mu;
 	var x;
 	var y;
@@ -414,11 +496,15 @@ bench( pkg+':logpdf', function benchmark( b ) {
 	mu = 2.0;
 	sigma = 3.0;
 	dist = new Normal( mu, sigma );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -3.0, 3.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*6.0 ) - 3.0;
-		y = dist.logpdf( x );
+		y = dist.logpdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -434,6 +520,7 @@ bench( pkg+':logpdf', function benchmark( b ) {
 bench( pkg+':mgf', function benchmark( b ) {
 	var sigma;
 	var dist;
+	var len;
 	var mu;
 	var x;
 	var y;
@@ -442,11 +529,15 @@ bench( pkg+':mgf', function benchmark( b ) {
 	mu = 2.0;
 	sigma = 0.2;
 	dist = new Normal( mu, sigma );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.mgf( x );
+		y = dist.mgf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -462,6 +553,7 @@ bench( pkg+':mgf', function benchmark( b ) {
 bench( pkg+':pdf', function benchmark( b ) {
 	var sigma;
 	var dist;
+	var len;
 	var mu;
 	var x;
 	var y;
@@ -470,11 +562,14 @@ bench( pkg+':pdf', function benchmark( b ) {
 	mu = 2.0;
 	sigma = 3.0;
 	dist = new Normal( mu, sigma );
-
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -3.0, 3.0 );
+	}
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*6.0 ) - 3.0;
-		y = dist.pdf( x );
+		y = dist.pdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -490,6 +585,7 @@ bench( pkg+':pdf', function benchmark( b ) {
 bench( pkg+':quantile', function benchmark( b ) {
 	var sigma;
 	var dist;
+	var len;
 	var mu;
 	var x;
 	var y;
@@ -498,11 +594,15 @@ bench( pkg+':quantile', function benchmark( b ) {
 	mu = 2.0;
 	sigma = 3.0;
 	dist = new Normal( mu, sigma );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.quantile( x );
+		y = dist.quantile( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/ctor/benchmark/benchmark.js
@@ -53,7 +53,6 @@ bench( pkg+'::instantiation', function benchmark( b ) {
 			b.fail( 'should return a distribution instance' );
 		}
 	}
-
 	b.toc();
 	if ( !( dist instanceof Normal ) ) {
 		b.fail( 'should return a distribution instance' );
@@ -80,7 +79,6 @@ bench( pkg+'::get:mu', function benchmark( b ) {
 			b.fail( 'should return set value' );
 		}
 	}
-
 	b.toc();
 	if ( isnan( y ) ) {
 		b.fail( 'should not return NaN' );
@@ -139,7 +137,6 @@ bench( pkg+'::get:sigma', function benchmark( b ) {
 			b.fail( 'should return set value' );
 		}
 	}
-
 	b.toc();
 	if ( isnan( y ) ) {
 		b.fail( 'should not return NaN' );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/ctor/benchmark/benchmark.js
@@ -398,6 +398,7 @@ bench( pkg+':variance', function benchmark( b ) {
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = uniform( EPS, 100.0 );
 	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
 		dist.mu = x[ i % len ];
@@ -531,6 +532,7 @@ bench( pkg+':mgf', function benchmark( b ) {
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = uniform( 0.0, 1.0 );
 	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
 		y = dist.mgf( x[ i % len ] );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/ctor/benchmark/benchmark.js
@@ -328,7 +328,7 @@ bench( pkg+':mode', function benchmark( b ) {
 	len = 100;
 	x = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( EPS + 1.0, 100.0 );
+		x[ i ] = uniform( 1.0 + EPS, 100.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/entropy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/entropy/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	mu = new Float64Array( len );
 	sigma = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = ( randu() * 100.0 ) - 50.0;
-		sigma[ i ] = ( randu() * 20.0 ) + EPS;
+		mu[ i ] = uniform( -50.0, 50.0 );
+		sigma[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/entropy/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/entropy/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -51,9 +51,10 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	mu = new Float64Array( len );
 	sigma = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = ( randu() * 100.0 ) - 50.0;
-		sigma[ i ] = ( randu() * 20.0 ) + EPS;
+		mu[ i ] = uniform( -50.0, 50.0 );
+		sigma[ i ] = uniform( EPS, 20.0 );
 	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
 		y = entropy( mu[ i % len ], sigma[ i % len ] );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/kurtosis/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/kurtosis/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,15 +33,22 @@ var kurtosis = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var sigma;
+	var len;
 	var mu;
 	var y;
 	var i;
 
+	len = 100;
+	mu = new Float64Array( len );
+	sigma = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		mu[ i ] = uniform( -50.0, 50.0 );
+		sigma[ i ] = uniform( EPS, 20.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		mu = ( randu()*100.0 ) - 50.0;
-		sigma = ( randu()*20.0 ) + EPS;
-		y = kurtosis( mu, sigma );
+		y = kurtosis( mu[ i % len ], sigma[ i % len] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logcdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logcdf/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform	= require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,17 +33,25 @@ var logcdf = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var sigma;
+	var len;
 	var mu;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	mu = new Float64Array( len );
+	sigma = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -100.0, 100.0 );
+		mu[ i ] = uniform( -50.0, 50.0 );
+		sigma[ i ] = uniform( EPS, 20.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*200.0 ) - 100;
-		mu = ( randu()*100.0 ) - 50.0;
-		sigma = ( randu()*20.0 ) + EPS;
-		y = logcdf( x, mu, sigma );
+		y = logcdf( x[ i % len ], mu[ i % len ], sigma[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -58,6 +67,7 @@ bench( pkg, function benchmark( b ) {
 bench( pkg+':factory', function benchmark( b ) {
 	var mylogcdf;
 	var sigma;
+	var len;
 	var mu;
 	var x;
 	var y;
@@ -66,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	mu = 0.0;
 	sigma = 1.5;
 	mylogcdf = logcdf.factory( mu, sigma );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -3.0, 3.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*6.0 ) - 3.0;
-		y = mylogcdf( x );
+		y = mylogcdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logcdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logcdf/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var uniform	= require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/logpdf/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform	= require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,17 +33,25 @@ var logpdf = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var sigma;
+	var len;
 	var mu;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	mu = new Float64Array( len );
+	sigma = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -100.0, 100.0 );
+		mu[ i ] = uniform( -50.0, 50.0 );
+		sigma[ i ] = uniform( EPS, 20.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*200.0 ) - 100;
-		mu = ( randu()*100.0 ) - 50.0;
-		sigma = ( randu()*20.0 ) + EPS;
-		y = logpdf( x, mu, sigma );
+		y = logpdf( x[ i % len ], mu[ i % len ], sigma[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -58,6 +67,7 @@ bench( pkg, function benchmark( b ) {
 bench( pkg+':factory', function benchmark( b ) {
 	var mylogpdf;
 	var sigma;
+	var len;
 	var mu;
 	var x;
 	var y;
@@ -66,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	mu = 0.0;
 	sigma = 1.5;
 	mylogpdf = logpdf.factory( mu, sigma );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -3.0, 3.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*6.0 ) - 3.0;
-		y = mylogpdf( x );
+		y = mylogpdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mean/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,15 +33,22 @@ var mean = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var sigma;
+	var len;
 	var mu;
 	var y;
 	var i;
 
+	len = 100;
+	mu = new Float64Array( len );
+	sigma = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		mu[ i ] = uniform( -50.0, 50.0 );
+		sigma[ i ] = uniform( EPS, 20.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		mu = ( randu()*100.0 ) - 50.0;
-		sigma = ( randu()*20.0 ) + EPS;
-		y = mean( mu, sigma );
+		y = mean( mu[ i % len ], sigma[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/median/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/median/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,15 +33,22 @@ var median = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var sigma;
+	var len;
 	var mu;
 	var y;
 	var i;
 
+	len = 100;
+	mu = new Float64Array( len );
+	sigma = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		mu[ i ] = uniform( -50.0, 50.0 );
+		sigma[ i ] = uniform( EPS, 20.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		mu = ( randu()*100.0 ) - 50.0;
-		sigma = ( randu()*20.0 ) + EPS;
-		y = median( mu, sigma );
+		y = median( mu[ i % len ], sigma[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mgf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mgf/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,17 +33,25 @@ var mgf = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var sigma;
+	var len;
 	var mu;
 	var t;
 	var y;
 	var i;
 
+	len = 100;
+	t = new Float64Array( len );
+	mu = new Float64Array( len );
+	sigma = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		t[ i ] = uniform( 0.0, 1.0 );
+		mu[ i ] = uniform( -50.0, 50.0 );
+		sigma[ i ] = uniform( EPS, 20.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		t = randu();
-		mu = ( randu()*100.0 ) - 50.0;
-		sigma = ( randu()*20.0 ) + EPS;
-		y = mgf( t, mu, sigma );
+		y = mgf( t[ i % len ], mu[ i % len ], sigma[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -58,6 +67,7 @@ bench( pkg, function benchmark( b ) {
 bench( pkg+':factory', function benchmark( b ) {
 	var mymgf;
 	var sigma;
+	var len;
 	var mu;
 	var t;
 	var y;
@@ -66,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	mu = 0.0;
 	sigma = 1.5;
 	mymgf = mgf.factory( mu, sigma );
+	len = 100;
+	t = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		t[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		t = randu();
-		y = mymgf( t );
+		y = mymgf( t[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,15 +33,22 @@ var mode = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var sigma;
+	var len;
 	var mu;
 	var y;
 	var i;
 
+	len = 100;
+	mu = new Float64Array( len );
+	sigma = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		mu[ i ] = uniform( -50.0, 50.0 );
+		sigma[ i ] = uniform( EPS, 20.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		mu = ( randu()*100.0 ) - 50.0;
-		sigma = ( randu()*20.0 ) + EPS;
-		y = mode( mu, sigma );
+		y = mode( mu[ i % 100 ], sigma[ i % 100 ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/mode/benchmark/benchmark.js
@@ -48,7 +48,7 @@ bench( pkg, function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = mode( mu[ i % 100 ], sigma[ i % 100 ] );
+		y = mode( mu[ i % len ], sigma[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/benchmark/benchmark.js
@@ -84,7 +84,7 @@ bench( pkg+':factory', function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = mypdf( x[ i % 100 ] );
+		y = mypdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/benchmark/benchmark.js
@@ -51,7 +51,7 @@ bench( pkg, function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = pdf( x[ i % 100 ], mu[ i % 100 ], sigma[ i % 100 ] );
+		y = pdf( x[ i % len ], mu[ i % len ], sigma[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/pdf/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,17 +33,25 @@ var pdf = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var sigma;
+	var len;
 	var mu;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	mu = new Float64Array( len );
+	sigma = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -100.0, 100.0 );
+		mu[ i ] = uniform( -50.0, 50.0 );
+		sigma[ i ] = uniform( EPS, 20.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*200.0 ) - 100;
-		mu = ( randu()*100.0 ) - 50.0;
-		sigma = ( randu()*20.0 ) + EPS;
-		y = pdf( x, mu, sigma );
+		y = pdf( x[ i % 100 ], mu[ i % 100 ], sigma[ i % 100 ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -58,6 +67,7 @@ bench( pkg, function benchmark( b ) {
 bench( pkg+':factory', function benchmark( b ) {
 	var mypdf;
 	var sigma;
+	var len;
 	var mu;
 	var x;
 	var y;
@@ -66,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	mu = 0.0;
 	sigma = 1.5;
 	mypdf = pdf.factory( mu, sigma );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -3.0, 3.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*6.0 ) - 3.0;
-		y = mypdf( x );
+		y = mypdf( x[ i % 100 ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/benchmark/benchmark.js
@@ -51,7 +51,7 @@ bench( pkg, function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = quantile( p[ i % 100 ], mu[ i % 100 ], sigma[ i % 100 ] );
+		y = quantile( p[ i % len ], mu[ i % len ], sigma[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,17 +33,25 @@ var quantile = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var sigma;
+	var len;
 	var mu;
 	var p;
 	var y;
 	var i;
 
+	len = 100;
+	p = new Float64Array( len );
+	mu = new Float64Array( len );
+	sigma = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		p[ i ] = uniform( 0.0, 1.0 );
+		mu[ i ] = uniform( -50.0, 50.0 );
+		sigma[ i ] = uniform( EPS, 20.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		mu = ( randu()*100.0 ) - 50.0;
-		sigma = ( randu()*20.0 ) + EPS;
-		y = quantile( p, mu, sigma );
+		y = quantile( p[ i % 100 ], mu[ i % 100 ], sigma[ i % 100 ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -58,6 +67,7 @@ bench( pkg, function benchmark( b ) {
 bench( pkg+':factory', function benchmark( b ) {
 	var myquantile;
 	var sigma;
+	var len;
 	var mu;
 	var p;
 	var y;
@@ -66,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	mu = 0.0;
 	sigma = 1.5;
 	myquantile = quantile.factory( mu, sigma );
+	len = 100;
+	p = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		p[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		y = myquantile( p );
+		y = myquantile( p[ i % 100 ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/benchmark/benchmark.js
@@ -84,7 +84,7 @@ bench( pkg+':factory', function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = myquantile( p[ i % 100 ] );
+		y = myquantile( p[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/skewness/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/skewness/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,15 +33,22 @@ var skewness = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var sigma;
+	var len;
 	var mu;
 	var y;
 	var i;
 
+	len = 100;
+	mu = new Float64Array( len );
+	sigma = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		mu[ i ] = uniform( -50.0, 50.0 );
+		sigma[ i ] = uniform( EPS, 20.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		mu = ( randu()*100.0 ) - 50.0;
-		sigma = ( randu()*20.0 ) + EPS;
-		y = skewness( mu, sigma );
+		y = skewness( mu[ i % len ], sigma[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/stdev/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/stdev/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	mu = new Float64Array( len );
 	sigma = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = ( randu() * 100.0 ) - 50.0;
-		sigma[ i ] = ( randu() * 20.0 ) + EPS;
+		mu[ i ] = uniform( -50.0, 50.0 );
+		sigma[ i ] = uniform( EPS, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/stdev/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/stdev/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -51,9 +51,10 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	mu = new Float64Array( len );
 	sigma = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		mu[ i ] = ( randu() * 100.0 ) - 50.0;
-		sigma[ i ] = ( randu() * 20.0 ) + EPS;
+		mu[ i ] = uniform( -50.0, 50.0 );
+		sigma[ i ] = uniform( EPS, 20.0 );
 	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
 		y = stdev( mu[ i % len ], sigma[ i % len ] );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/variance/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/variance/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,15 +33,22 @@ var variance = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var sigma;
+	var len;
 	var mu;
 	var y;
 	var i;
 
+	len = 100;
+	mu = new Float64Array( len );
+	sigma = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		mu[ i ] = uniform( -50.0, 50.0 );
+		sigma[ i ] = uniform( EPS, 20.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		mu = ( randu()*100.0 ) - 50.0;
-		sigma = ( randu()*20.0 ) + EPS;
-		y = variance( mu, sigma );
+		y = variance( mu[ i % len ], sigma[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}


### PR DESCRIPTION
Resolves [#4981](https://github.com/stdlib-js/stdlib/issues/4981).

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors random number generation in JS benchmarks for stats/base/dists/normal.
-   Replaces randu() with uniform() for cleaner and more consistent code.
-   Moves the random number generation outside the benchmarking loops.
## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves [#4981](https://github.com/stdlib-js/stdlib/issues/4981).

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
