### PR TITLE
bench: refactor random number generation in `stats/base/dists/studentized-range`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/cdf/benchmark/benchmark.js
@@ -30,19 +30,26 @@ var uniform = require('@stdlib/random/base/uniform')
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var v;
 	var r;
 	var q;
 	var y;
 	var i;
 
-	q = uniform( 0.0, 12.0 );
-	r = uniform( 2.0, 20.0 );
-	v = uniform( 2.0, 20.0 );
-	y = cdf( q, r, v );
+	len = 100;
+	q = new Float64Array( len );
+	r = new Float64Array( len );
+	v = new Float64Array( len );
+	for( i = 0; i < len; i++ ) {
+		q[i] = uniform( 0.0, 12.0 );
+		r[i] = uniform( 2.0, 20.0 );
+		v[i] = uniform( 2.0, 20.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
+		y = cdf( q[ i % len ], r[ i % len ], v[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -57,20 +64,25 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var mycdf;
+	var len;
 	var r;
 	var q;
 	var v;
 	var y;
 	var i;
 
+	len = 100;
 	v = 5.0;
 	r = 3.0;
+	q = new Float64Array( len );
 	mycdf = cdf.factory( v, r );
-	q = uniform( 0.0, 1.0 );
-	y = mycdf( q );
+	for ( i = 0; i < len; i++ ) {
+		q[i] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
+		y = mycdf( q[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/cdf/benchmark/benchmark.js
@@ -27,6 +27,7 @@ var Float64Array = require( '@stdlib/array/float64' );
 var pkg = require( './../package.json' ).name;
 var cdf = require( './../lib' );
 
+
 // MAIN //
 
 bench( pkg, function benchmark( b ) {

--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/cdf/benchmark/benchmark.js
@@ -42,9 +42,9 @@ bench( pkg, function benchmark( b ) {
 	r = new Float64Array( len );
 	v = new Float64Array( len );
 	for( i = 0; i < len; i++ ) {
-		q[i] = uniform( 0.0, 12.0 );
-		r[i] = uniform( 2.0, 20.0 );
-		v[i] = uniform( 2.0, 20.0 );
+		q[ i ] = uniform( 0.0, 12.0 );
+		r[ i ] = uniform( 2.0, 20.0 );
+		v[ i ] = uniform( 2.0, 20.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/cdf/benchmark/benchmark.js
@@ -25,7 +25,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var cdf = require( './../lib' );
 var uniform = require('@stdlib/random/base/uniform')
-
+var Float64Array = require( '@stdlib/array/float64' );
 
 // MAIN //
 

--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/cdf/benchmark/benchmark.js
@@ -22,10 +22,10 @@
 
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var Float64Array = require( '@stdlib/array/float64' );
 var pkg = require( './../package.json' ).name;
 var cdf = require( './../lib' );
-var uniform = require('@stdlib/random/base/uniform')
-var Float64Array = require( '@stdlib/array/float64' );
 
 // MAIN //
 
@@ -41,7 +41,7 @@ bench( pkg, function benchmark( b ) {
 	q = new Float64Array( len );
 	r = new Float64Array( len );
 	v = new Float64Array( len );
-	for( i = 0; i < len; i++ ) {
+	for ( i = 0; i < len; i++ ) {
 		q[ i ] = uniform( 0.0, 12.0 );
 		r[ i ] = uniform( 2.0, 20.0 );
 		v[ i ] = uniform( 2.0, 20.0 );

--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/cdf/benchmark/benchmark.js
@@ -21,10 +21,10 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var cdf = require( './../lib' );
+var uniform = require('@stdlib/random/base/uniform')
 
 
 // MAIN //
@@ -36,12 +36,13 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	q = uniform( 0.0, 12.0 );
+	r = uniform( 2.0, 20.0 );
+	v = uniform( 2.0, 20.0 );
+	y = cdf( q, r, v );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		q = randu() * 12.0;
-		r = ( randu()*20.0 ) + 2.0;
-		v = ( randu()*20.0 ) + 2.0;
-		y = cdf( q, r, v );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -65,11 +66,11 @@ bench( pkg+':factory', function benchmark( b ) {
 	v = 5.0;
 	r = 3.0;
 	mycdf = cdf.factory( v, r );
+	q = uniform( 0.0, 1.0 );
+	y = mycdf( q );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		q = randu();
-		y = mycdf( q );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/cdf/benchmark/benchmark.js
@@ -77,7 +77,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	q = new Float64Array( len );
 	mycdf = cdf.factory( v, r );
 	for ( i = 0; i < len; i++ ) {
-		q[i] = uniform( 0.0, 1.0 );
+		q[ i ] = uniform( 0.0, 1.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/benchmark/benchmark.js
@@ -21,10 +21,10 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var quantile = require( './../lib' );
+const uniform = require('@stdlib/random/base/uniform');
 
 
 // MAIN //
@@ -36,12 +36,13 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	p = uniform( 0.0, 1.0 );
+	r = uniform( 2.0, 20.0 );
+	v = uniform( 2.0, 20.0 );
+	y = quantile( p, r, v );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		r = ( randu()*20.0 ) + 2.0;
-		v = ( randu()*20.0 ) + 2.0;
-		y = quantile( p, r, v );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -65,11 +66,11 @@ bench( pkg+':factory', function benchmark( b ) {
 	v = 5.0;
 	r = 3.0;
 	myquantile = quantile.factory( v, r );
+	p = uniform( 0.0, 1.0 );
+	y = myquantile( p );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		y = myquantile( p );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/benchmark/benchmark.js
@@ -25,6 +25,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var quantile = require( './../lib' );
 var uniform = require('@stdlib/random/base/uniform');
+var Float64Array = require( '@stdlib/array/float64' );
 
 
 // MAIN //

--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/benchmark/benchmark.js
@@ -24,7 +24,7 @@ var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var quantile = require( './../lib' );
-const uniform = require('@stdlib/random/base/uniform');
+var uniform = require('@stdlib/random/base/uniform');
 
 
 // MAIN //

--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/benchmark/benchmark.js
@@ -30,19 +30,27 @@ const uniform = require('@stdlib/random/base/uniform');
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
+	var len;
 	var v;
 	var r;
 	var p;
 	var y;
 	var i;
 
-	p = uniform( 0.0, 1.0 );
-	r = uniform( 2.0, 20.0 );
-	v = uniform( 2.0, 20.0 );
-	y = quantile( p, r, v );
 
+	len = 100;
+	p = new Float64Array( len );
+	r = new Float64Array( len );
+	v = new Float64Array( len );
+	for( i = 0; i < len; i++ ) {
+		p[i] = uniform( 0.0, 1.0 );
+		r[i] = uniform( 2.0, 20.0 );
+		v[i] = uniform( 2.0, 20.0 );
+	}
+	
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
+		y = quantile( p[ i % len ], r[ i % len ], v[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -57,20 +65,25 @@ bench( pkg, function benchmark( b ) {
 
 bench( pkg+':factory', function benchmark( b ) {
 	var myquantile;
+	var len;
 	var r;
 	var p;
 	var v;
 	var y;
 	var i;
 
+	len = 100;
 	v = 5.0;
 	r = 3.0;
+	p = new Float64Array( len );
 	myquantile = quantile.factory( v, r );
-	p = uniform( 0.0, 1.0 );
-	y = myquantile( p );
+	for ( i = 0; i < len; i++ ) {
+		p[i] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
+		y = myquantile( p[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/benchmark/benchmark.js
@@ -37,7 +37,6 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
-
 	len = 100;
 	p = new Float64Array( len );
 	r = new Float64Array( len );

--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/benchmark/benchmark.js
@@ -42,9 +42,9 @@ bench( pkg, function benchmark( b ) {
 	r = new Float64Array( len );
 	v = new Float64Array( len );
 	for( i = 0; i < len; i++ ) {
-		p[i] = uniform( 0.0, 1.0 );
-		r[i] = uniform( 2.0, 20.0 );
-		v[i] = uniform( 2.0, 20.0 );
+		p[ i ] = uniform( 0.0, 1.0 );
+		r[ i ] = uniform( 2.0, 20.0 );
+		v[ i ] = uniform( 2.0, 20.0 );
 	}
 	
 	b.tic();
@@ -77,7 +77,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	p = new Float64Array( len );
 	myquantile = quantile.factory( v, r );
 	for ( i = 0; i < len; i++ ) {
-		p[i] = uniform( 0.0, 1.0 );
+		p[ i ] = uniform( 0.0, 1.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/benchmark/benchmark.js
@@ -24,7 +24,7 @@ var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var quantile = require( './../lib' );
-var uniform = require('@stdlib/random/base/uniform');
+var uniform = require( '@stdlib/random/base/uniform' );
 var Float64Array = require( '@stdlib/array/float64' );
 
 

--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/benchmark/benchmark.js
@@ -22,10 +22,10 @@
 
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var pkg = require( './../package.json' ).name;
-var quantile = require( './../lib' );
 var uniform = require( '@stdlib/random/base/uniform' );
 var Float64Array = require( '@stdlib/array/float64' );
+var pkg = require( './../package.json' ).name;
+var quantile = require( './../lib' );
 
 
 // MAIN //
@@ -42,12 +42,12 @@ bench( pkg, function benchmark( b ) {
 	p = new Float64Array( len );
 	r = new Float64Array( len );
 	v = new Float64Array( len );
-	for( i = 0; i < len; i++ ) {
+	for ( i = 0; i < len; i++ ) {
 		p[ i ] = uniform( 0.0, 1.0 );
 		r[ i ] = uniform( 2.0, 20.0 );
 		v[ i ] = uniform( 2.0, 20.0 );
 	}
-	
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
 		y = quantile( p[ i % len ], r[ i % len ], v[ i % len ] );


### PR DESCRIPTION
---
type: pre_push_report
description: Results of running various checks prior to pushing changes. report:
  - task: run_javascript_examples status: na
  - task: run_c_examples status: na
  - task: run_cpp_examples status: na
  - task: run_javascript_readme_examples status: na
  - task: run_c_benchmarks status: na
  - task: run_cpp_benchmarks status: na
  - task: run_fortran_benchmarks status: na
  - task: run_javascript_benchmarks status: na
  - task: run_julia_benchmarks status: na
  - task: run_python_benchmarks status: na
  - task: run_r_benchmarks status: na
  - task: run_javascript_tests status: na ---

Resolves #4987 

## Description

> What is the purpose of this pull request?

This pull request:

-   Fix the random number generation operation by moving it out of the benchmarking loops and initializing it beforehand to avoid interfering with the results. #4987 

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   performs changes similar to #4837 #4955 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
