### PR TITLE
bench: refactor random number generation in JS benchmarks for `stats/base/dists/uniform`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/cdf/benchmark/benchmark.js
@@ -39,18 +39,18 @@ bench( pkg, function benchmark( b ) {
 	var i;
 
 	len = 100;
-	x = new Float64Array(len);
-	min = new Float64Array(len);
-	max = new Float64Array(len);
-	for(i = 0; i < len; i++){
-		x[ i ] = uniform(-10.0, 20.0);
-		min[ i ] = uniform(-20.0, 20.0);
-		max[ i ] = min[ i ] + uniform(0.0, 40.0);
+	x = new Float64Array( len );
+	min = new Float64Array( len );
+	max = new Float64Array( len );
+	for( i = 0; i < len; i++ ){
+		x[ i ] = uniform( -10.0, 10.0 );
+		min[ i ] = uniform( -20.0, 0.0 );
+		max[ i ] = uniform( min[ i ], min[ i ] + 40.0 );
 	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = cdf( x[ i % len], min[ i % len], max[ i % len] );
+		y = cdf( x[ i % len ], min[ i % len ], max[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -76,14 +76,14 @@ bench( pkg+':factory', function benchmark( b ) {
 	max = 1.5;
 	mycdf = cdf.factory( min, max );
 	len = 100;
-	x = new Float64Array(len);
-	for(i = 0; i < len; i++){
-		x[ i ] = uniform(-2.0, 2.0);
+	x = new Float64Array( len );
+	for( i = 0; i < len; i++ ){
+		x[ i ] = uniform( -2.0, 0.0 );
 	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = mycdf( x[i % len] );
+		y = mycdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/cdf/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var cdf = require( './../lib' );
@@ -32,16 +33,24 @@ var cdf = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var min;
 	var max;
+	var len;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array(len);
+	min = new Float64Array(len);
+	max = new Float64Array(len);
+	for(i = 0; i < len; i++){
+		x[ i ] = uniform(-10.0, 20.0);
+		min[ i ] = uniform(-20.0, 20.0);
+		max[ i ] = min[ i ] + uniform(0.0, 40.0);
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu() * 20.0 ) - 10.0;
-		min = ( randu() * 20.0 ) - 20.0;
-		max = min + ( randu() * 40.0 );
-		y = cdf( x, min, max );
+		y = cdf( x[ i % len], min[ i % len], max[ i % len] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -58,6 +67,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mycdf;
 	var min;
 	var max;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -65,11 +75,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	min = -1.5;
 	max = 1.5;
 	mycdf = cdf.factory( min, max );
+	len = 100;
+	x = new Float64Array(len);
+	for(i = 0; i < len; i++){
+		x[ i ] = uniform(-2.0, 2.0);
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*2.0 ) - 2.0;
-		y = mycdf( x );
+		y = mycdf( x[i % len] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/cdf/benchmark/benchmark.js
@@ -42,7 +42,7 @@ bench( pkg, function benchmark( b ) {
 	x = new Float64Array( len );
 	min = new Float64Array( len );
 	max = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
+	for ( i = 0; i < len; i++ ) {
 		x[ i ] = uniform( -10.0, 10.0 );
 		min[ i ] = uniform( -20.0, 0.0 );
 		max[ i ] = uniform( min[ i ], min[ i ] + 40.0 );
@@ -77,7 +77,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	mycdf = cdf.factory( min, max );
 	len = 100;
 	x = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
+	for ( i = 0; i < len; i++ ) {
 		x[ i ] = uniform( -2.0, 0.0 );
 	}
 

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/ctor/benchmark/benchmark.js
@@ -43,7 +43,7 @@ bench( pkg+'::instantiation', function benchmark( bm ) {
 	b = new Float64Array( len );
 	for( i = 0; i < len; i++ ){
 		a[ i ] = uniform( EPS, 10.0 );
-		b[ i ] = uniform( EPS + a, 10.0 + a );
+		b[ i ] = uniform( EPS + a[ i ], 10.0 + a[ i ] );
 	}
 
 	bm.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/ctor/benchmark/benchmark.js
@@ -39,11 +39,11 @@ bench( pkg+'::instantiation', function benchmark( bm ) {
 	var i;
 
 	len = 100;
-	a = new Float64Array(len);
-	b = new Float64Array(len);
-	for(i = 0; i < len; i++){
-		a[ i ] = uniform(EPS, 10.0);
-		b[ i ] = uniform(EPS, 10.0);
+	a = new Float64Array( len );
+	b = new Float64Array( len );
+	for( i = 0; i < len; i++ ){
+		a[ i ] = uniform( EPS, 10.0 );
+		b[ i ] = uniform( EPS + a, 10.0 + a );
 	}
 
 	bm.tic();
@@ -99,9 +99,9 @@ bench( pkg+'::set:a', function benchmark( bm ) {
 	b = 120.0;
 	dist = new Uniform( a, b );
 	len = 100;
-	y = new Float64Array(len);
-	for(i = 0; i < len; i++){
-		y[ i ] = uniform(EPS, 100.0)
+	y = new Float64Array( len );
+	for( i = 0; i < len; i++ ){
+		y[ i ] = uniform( EPS, 100.0 )
 	}
 
 	bm.tic();
@@ -157,15 +157,15 @@ bench( pkg+'::set:b', function benchmark( bm ) {
 	b = 40.0;
 	dist = new Uniform( a, b );
 	len = 100;
-	y = new Float64Array(len);
-	for(i = 0; i < len; i++){
-		y[ i ] = uniform(a + EPS, 100.0)
+	y = new Float64Array( len );
+	for( i = 0; i < len; i++ ){
+		y[ i ] = uniform( EPS + a, 100.0 + a)
 	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
 		dist.b = y[ i % len ];
-		if ( dist.b !== y ) {
+		if ( dist.b !== y[ i % len ] ) {
 			bm.fail( 'should return set value' );
 		}
 	}
@@ -190,9 +190,9 @@ bench( pkg+':entropy', function benchmark( bm ) {
 	b = 140.0;
 	dist = new Uniform( a, b );
 	len = 100;
-	x = new Float64Array(len);
-	for(i = 0; i < len; i++){
-		x[ i ] = uniform(EPS, 100.0)
+	x = new Float64Array( len );
+	for( i = 0; i < len; i++ ){
+		x[ i ] = uniform( EPS, 100.0 )
 	}
 
 	bm.tic();
@@ -224,9 +224,9 @@ bench( pkg+':kurtosis', function benchmark( bm ) {
 	b = 140.0;
 	dist = new Uniform( a, b );
 	len = 100;
-	x = new Float64Array(len);
-	for(i = 0; i < len; i++){
-		x[ i ] = uniform(EPS, 100.0)
+	x = new Float64Array( len );
+	for( i = 0; i < len; i++ ){
+		x[ i ] = uniform( EPS, 100.0 )
 	}
 
 
@@ -259,9 +259,9 @@ bench( pkg+':mean', function benchmark( bm ) {
 	b = 140.0;
 	dist = new Uniform( a, b );
 	len = 100;
-	x = new Float64Array(len);
-	for(i = 0; i < len; i++){
-		x[ i ] = uniform(EPS, 100.0)
+	x = new Float64Array( len );
+	for( i = 0; i < len; i++ ){
+		x[ i ] = uniform( EPS, 100.0 )
 	}
 
 	bm.tic();
@@ -293,9 +293,9 @@ bench( pkg+':median', function benchmark( bm ) {
 	b = 140.0;
 	dist = new Uniform( a, b );
 	len = 100;
-	x = new Float64Array(len);
-	for(i = 0; i < len; i++){
-		x[ i ] = uniform(EPS, 100.0)
+	x = new Float64Array( len );
+	for( i = 0; i < len; i++ ){
+		x[ i ] = uniform( EPS, 100.0 )
 	}
 
 	bm.tic();
@@ -327,9 +327,9 @@ bench( pkg+':skewness', function benchmark( bm ) {
 	b = 140.0;
 	dist = new Uniform( a, b );
 	len = 100;
-	x = new Float64Array(len);
-	for(i = 0; i < len; i++){
-		x[ i ] = uniform(EPS, 100.0)
+	x = new Float64Array( len );
+	for( i = 0; i < len; i++ ){
+		x[ i ] = uniform( EPS, 100.0 )
 	}
 
 	bm.tic();
@@ -361,9 +361,9 @@ bench( pkg+':stdev', function benchmark( bm ) {
 	b = 140.0;
 	dist = new Uniform( a, b );
 	len = 100;
-	x = new Float64Array(len);
-	for(i = 0; i < len; i++){
-		x[ i ] = uniform(EPS, 100.0)
+	x = new Float64Array( len );
+	for( i = 0; i < len; i++ ){
+		x[ i ] = uniform( EPS, 100.0 )
 	}
 
 	bm.tic();
@@ -395,9 +395,9 @@ bench( pkg+':variance', function benchmark( bm ) {
 	b = 140.0;
 	dist = new Uniform( a, b );
 	len = 100;
-	x = new Float64Array(len);
-	for(i = 0; i < len; i++){
-		x[ i ] = uniform(EPS, 100.0)
+	x = new Float64Array( len );
+	for( i = 0; i < len; i++ ){
+		x[ i ] = uniform( EPS, 100.0 )
 	}
 
 	bm.tic();
@@ -429,9 +429,9 @@ bench( pkg+':cdf', function benchmark( bm ) {
 	b = 40.0;
 	dist = new Uniform( a, b );
 	len = 100;
-	x = new Float64Array(len);
-	for(i = 0; i < len; i++){
-		x[ i ] = uniform(0.0, 60.0)
+	x = new Float64Array( len );
+	for( i = 0; i < len; i++ ){
+		x[ i ] = uniform( 0.0, 60.0 )
 	}
 
 	bm.tic();
@@ -462,9 +462,9 @@ bench( pkg+':logcdf', function benchmark( bm ) {
 	b = 40.0;
 	dist = new Uniform( a, b );
 	len = 100;
-	x = new Float64Array(len);
-	for(i = 0; i < len; i++){
-		x[ i ] = uniform(0.0, 60.0)
+	x = new Float64Array( len );
+	for( i = 0; i < len; i++ ){
+		x[ i ] = uniform( 0.0, 60.0 )
 	}
 
 	bm.tic();
@@ -495,9 +495,9 @@ bench( pkg+':logpdf', function benchmark( bm ) {
 	b = 40.0;
 	dist = new Uniform( a, b );
 	len = 100;
-	x = new Float64Array(len);
-	for(i = 0; i < len; i++){
-		x[ i ] = uniform(0.0, 60.0)
+	x = new Float64Array( len );
+	for( i = 0; i < len; i++ ){
+		x[ i ] = uniform( 0.0, 60.0 )
 	}
 
 	bm.tic();
@@ -528,9 +528,9 @@ bench( pkg+':mgf', function benchmark( bm ) {
 	b = 40.0;
 	dist = new Uniform( a, b );
 	len = 100;
-	x = new Float64Array(len);
-	for(i = 0; i < len; i++){
-		x[ i ] = uniform(0.0, 1.0)
+	x = new Float64Array( len );
+	for( i = 0; i < len; i++ ){
+		x[ i ] = uniform( 0.0, 1.0 )
 	}
 
 	bm.tic();
@@ -561,9 +561,9 @@ bench( pkg+':pdf', function benchmark( bm ) {
 	b = 40.0;
 	dist = new Uniform( a, b );
 	len = 100;
-	x = new Float64Array(len);
-	for(i = 0; i < len; i++){
-		x[ i ] = uniform(0.0, 60.0)
+	x = new Float64Array( len );
+	for( i = 0; i < len; i++ ){
+		x[ i ] = uniform( 0.0, 60.0 )
 	}
 
 	bm.tic();
@@ -594,9 +594,9 @@ bench( pkg+':quantile', function benchmark( bm ) {
 	b = 40.0;
 	dist = new Uniform( a, b );
 	len = 100;
-	x = new Float64Array(len);
-	for(i = 0; i < len; i++){
-		x[ i ] = uniform(0.0, 1.0)
+	x = new Float64Array( len );
+	for( i = 0; i < len; i++ ){
+		x[ i ] = uniform( 0.0, 1.0 )
 	}
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/ctor/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,15 +33,22 @@ var Uniform = require( './../lib' );
 
 bench( pkg+'::instantiation', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var i;
 
+	len = 100;
+	a = new Float64Array(len);
+	b = new Float64Array(len);
+	for(i = 0; i < len; i++){
+		a[ i ] = uniform(EPS, 10.0);
+		b[ i ] = uniform(EPS, 10.0);
+	}
+
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		a = ( randu() * 10.0 ) + EPS;
-		b = ( randu() * 10.0 ) + a + EPS;
-		dist = new Uniform( a, b );
+		dist = new Uniform( a[ i % len ], b[ i % len ] );
 		if ( !( dist instanceof Uniform ) ) {
 			bm.fail( 'should return a distribution instance' );
 		}
@@ -81,6 +89,7 @@ bench( pkg+'::get:a', function benchmark( bm ) {
 
 bench( pkg+'::set:a', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var y;
@@ -89,17 +98,21 @@ bench( pkg+'::set:a', function benchmark( bm ) {
 	a = 20.0;
 	b = 120.0;
 	dist = new Uniform( a, b );
+	len = 100;
+	y = new Float64Array(len);
+	for(i = 0; i < len; i++){
+		y[ i ] = uniform(EPS, 100.0)
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		y = ( 100.0*randu() ) + EPS;
-		dist.a = y;
-		if ( dist.a !== y ) {
+		dist.a = y[ i % len ];
+		if ( dist.a !== y[ i % len ] ) {
 			bm.fail( 'should return set value' );
 		}
 	}
 	bm.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( y[ i % len] ) ) {
 		bm.fail( 'should not return NaN' );
 	}
 	bm.pass( 'benchmark finished' );
@@ -134,6 +147,7 @@ bench( pkg+'::get:b', function benchmark( bm ) {
 
 bench( pkg+'::set:b', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var y;
@@ -142,17 +156,21 @@ bench( pkg+'::set:b', function benchmark( bm ) {
 	a = 20.0;
 	b = 40.0;
 	dist = new Uniform( a, b );
+	len = 100;
+	y = new Float64Array(len);
+	for(i = 0; i < len; i++){
+		y[ i ] = uniform(a + EPS, 100.0)
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		y = ( 100.0*randu() ) + a + EPS;
-		dist.b = y;
+		dist.b = y[ i % len ];
 		if ( dist.b !== y ) {
 			bm.fail( 'should return set value' );
 		}
 	}
 	bm.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( y[ i % len ] ) ) {
 		bm.fail( 'should not return NaN' );
 	}
 	bm.pass( 'benchmark finished' );
@@ -161,18 +179,25 @@ bench( pkg+'::set:b', function benchmark( bm ) {
 
 bench( pkg+':entropy', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var y;
+	var x;
 	var i;
 
 	a = 20.0;
 	b = 140.0;
 	dist = new Uniform( a, b );
+	len = 100;
+	x = new Float64Array(len);
+	for(i = 0; i < len; i++){
+		x[ i ] = uniform(EPS, 100.0)
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = ( 100.0*randu() ) + EPS;
+		dist.a = x[ i % len ];
 		y = dist.entropy;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -188,18 +213,26 @@ bench( pkg+':entropy', function benchmark( bm ) {
 
 bench( pkg+':kurtosis', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var y;
+	var x;
 	var i;
 
 	a = 20.0;
 	b = 140.0;
 	dist = new Uniform( a, b );
+	len = 100;
+	x = new Float64Array(len);
+	for(i = 0; i < len; i++){
+		x[ i ] = uniform(EPS, 100.0)
+	}
+
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = ( 100.0*randu() ) + EPS;
+		dist.a = x[ i % len ];
 		y = dist.kurtosis;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -215,18 +248,25 @@ bench( pkg+':kurtosis', function benchmark( bm ) {
 
 bench( pkg+':mean', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var y;
+	var x;
 	var i;
 
 	a = 20.0;
 	b = 140.0;
 	dist = new Uniform( a, b );
+	len = 100;
+	x = new Float64Array(len);
+	for(i = 0; i < len; i++){
+		x[ i ] = uniform(EPS, 100.0)
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = ( 100.0*randu() ) + EPS;
+		dist.a = x[ i % len ];
 		y = dist.mean;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -242,18 +282,25 @@ bench( pkg+':mean', function benchmark( bm ) {
 
 bench( pkg+':median', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var y;
+	var x;
 	var i;
 
 	a = 20.0;
 	b = 140.0;
 	dist = new Uniform( a, b );
+	len = 100;
+	x = new Float64Array(len);
+	for(i = 0; i < len; i++){
+		x[ i ] = uniform(EPS, 100.0)
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = ( 100.0*randu() ) + EPS;
+		dist.a = x[ i % len ];
 		y = dist.median;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -269,18 +316,25 @@ bench( pkg+':median', function benchmark( bm ) {
 
 bench( pkg+':skewness', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var y;
+	var x;
 	var i;
 
 	a = 20.0;
 	b = 140.0;
 	dist = new Uniform( a, b );
+	len = 100;
+	x = new Float64Array(len);
+	for(i = 0; i < len; i++){
+		x[ i ] = uniform(EPS, 100.0)
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = ( 100.0*randu() ) + EPS;
+		dist.a = x[ i % len ];
 		y = dist.skewness;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -296,18 +350,25 @@ bench( pkg+':skewness', function benchmark( bm ) {
 
 bench( pkg+':stdev', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var y;
+	var x;
 	var i;
 
 	a = 20.0;
 	b = 140.0;
 	dist = new Uniform( a, b );
+	len = 100;
+	x = new Float64Array(len);
+	for(i = 0; i < len; i++){
+		x[ i ] = uniform(EPS, 100.0)
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = ( 100.0*randu() ) + EPS;
+		dist.a = x[ i % len ];
 		y = dist.stdev;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -323,18 +384,25 @@ bench( pkg+':stdev', function benchmark( bm ) {
 
 bench( pkg+':variance', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var y;
+	var x;
 	var i;
 
 	a = 20.0;
 	b = 140.0;
 	dist = new Uniform( a, b );
+	len = 100;
+	x = new Float64Array(len);
+	for(i = 0; i < len; i++){
+		x[ i ] = uniform(EPS, 100.0)
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = ( 100.0*randu() ) + EPS;
+		dist.a = x[ i % len ];
 		y = dist.variance;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -350,6 +418,7 @@ bench( pkg+':variance', function benchmark( bm ) {
 
 bench( pkg+':cdf', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var x;
@@ -359,11 +428,15 @@ bench( pkg+':cdf', function benchmark( bm ) {
 	a = 20.0;
 	b = 40.0;
 	dist = new Uniform( a, b );
+	len = 100;
+	x = new Float64Array(len);
+	for(i = 0; i < len; i++){
+		x[ i ] = uniform(0.0, 60.0)
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = randu() * 60.0;
-		y = dist.cdf( x );
+		y = dist.cdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
 		}
@@ -378,6 +451,7 @@ bench( pkg+':cdf', function benchmark( bm ) {
 
 bench( pkg+':logcdf', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var x;
@@ -387,11 +461,15 @@ bench( pkg+':logcdf', function benchmark( bm ) {
 	a = 20.0;
 	b = 40.0;
 	dist = new Uniform( a, b );
+	len = 100;
+	x = new Float64Array(len);
+	for(i = 0; i < len; i++){
+		x[ i ] = uniform(0.0, 60.0)
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = randu() * 60.0;
-		y = dist.logcdf( x );
+		y = dist.logcdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
 		}
@@ -406,6 +484,7 @@ bench( pkg+':logcdf', function benchmark( bm ) {
 
 bench( pkg+':logpdf', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var x;
@@ -415,11 +494,15 @@ bench( pkg+':logpdf', function benchmark( bm ) {
 	a = 20.0;
 	b = 40.0;
 	dist = new Uniform( a, b );
+	len = 100;
+	x = new Float64Array(len);
+	for(i = 0; i < len; i++){
+		x[ i ] = uniform(0.0, 60.0)
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = randu() * 60.0;
-		y = dist.logpdf( x );
+		y = dist.logpdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
 		}
@@ -434,6 +517,7 @@ bench( pkg+':logpdf', function benchmark( bm ) {
 
 bench( pkg+':mgf', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var x;
@@ -443,11 +527,15 @@ bench( pkg+':mgf', function benchmark( bm ) {
 	a = 20.0;
 	b = 40.0;
 	dist = new Uniform( a, b );
+	len = 100;
+	x = new Float64Array(len);
+	for(i = 0; i < len; i++){
+		x[ i ] = uniform(0.0, 1.0)
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = randu();
-		y = dist.mgf( x );
+		y = dist.mgf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
 		}
@@ -462,6 +550,7 @@ bench( pkg+':mgf', function benchmark( bm ) {
 
 bench( pkg+':pdf', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var x;
@@ -471,11 +560,15 @@ bench( pkg+':pdf', function benchmark( bm ) {
 	a = 20.0;
 	b = 40.0;
 	dist = new Uniform( a, b );
+	len = 100;
+	x = new Float64Array(len);
+	for(i = 0; i < len; i++){
+		x[ i ] = uniform(0.0, 60.0)
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = randu() * 60.0;
-		y = dist.pdf( x );
+		y = dist.pdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
 		}
@@ -490,6 +583,7 @@ bench( pkg+':pdf', function benchmark( bm ) {
 
 bench( pkg+':quantile', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var x;
@@ -499,11 +593,14 @@ bench( pkg+':quantile', function benchmark( bm ) {
 	a = 20.0;
 	b = 40.0;
 	dist = new Uniform( a, b );
-
+	len = 100;
+	x = new Float64Array(len);
+	for(i = 0; i < len; i++){
+		x[ i ] = uniform(0.0, 1.0)
+	}
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = randu();
-		y = dist.quantile( x );
+		y = dist.quantile( x[ i % len ] );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/ctor/benchmark/benchmark.js
@@ -41,7 +41,7 @@ bench( pkg+'::instantiation', function benchmark( bm ) {
 	len = 100;
 	a = new Float64Array( len );
 	b = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
+	for ( i = 0; i < len; i++ ) {
 		a[ i ] = uniform( EPS, 10.0 );
 		b[ i ] = uniform( EPS + a[ i ], 10.0 + a[ i ] );
 	}
@@ -100,8 +100,8 @@ bench( pkg+'::set:a', function benchmark( bm ) {
 	dist = new Uniform( a, b );
 	len = 100;
 	y = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
-		y[ i ] = uniform( EPS, 100.0 )
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = uniform( EPS, 100.0 );
 	}
 
 	bm.tic();
@@ -158,8 +158,8 @@ bench( pkg+'::set:b', function benchmark( bm ) {
 	dist = new Uniform( a, b );
 	len = 100;
 	y = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
-		y[ i ] = uniform( EPS + a, 100.0 + a)
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = uniform( EPS + a, 100.0 + a);
 	}
 
 	bm.tic();
@@ -191,8 +191,8 @@ bench( pkg+':entropy', function benchmark( bm ) {
 	dist = new Uniform( a, b );
 	len = 100;
 	x = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
-		x[ i ] = uniform( EPS, 100.0 )
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
 	}
 
 	bm.tic();
@@ -225,10 +225,9 @@ bench( pkg+':kurtosis', function benchmark( bm ) {
 	dist = new Uniform( a, b );
 	len = 100;
 	x = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
-		x[ i ] = uniform( EPS, 100.0 )
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
 	}
-
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
@@ -260,8 +259,8 @@ bench( pkg+':mean', function benchmark( bm ) {
 	dist = new Uniform( a, b );
 	len = 100;
 	x = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
-		x[ i ] = uniform( EPS, 100.0 )
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
 	}
 
 	bm.tic();
@@ -294,8 +293,8 @@ bench( pkg+':median', function benchmark( bm ) {
 	dist = new Uniform( a, b );
 	len = 100;
 	x = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
-		x[ i ] = uniform( EPS, 100.0 )
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
 	}
 
 	bm.tic();
@@ -328,8 +327,8 @@ bench( pkg+':skewness', function benchmark( bm ) {
 	dist = new Uniform( a, b );
 	len = 100;
 	x = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
-		x[ i ] = uniform( EPS, 100.0 )
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
 	}
 
 	bm.tic();
@@ -362,8 +361,8 @@ bench( pkg+':stdev', function benchmark( bm ) {
 	dist = new Uniform( a, b );
 	len = 100;
 	x = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
-		x[ i ] = uniform( EPS, 100.0 )
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
 	}
 
 	bm.tic();
@@ -396,8 +395,8 @@ bench( pkg+':variance', function benchmark( bm ) {
 	dist = new Uniform( a, b );
 	len = 100;
 	x = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
-		x[ i ] = uniform( EPS, 100.0 )
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
 	}
 
 	bm.tic();
@@ -430,8 +429,8 @@ bench( pkg+':cdf', function benchmark( bm ) {
 	dist = new Uniform( a, b );
 	len = 100;
 	x = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
-		x[ i ] = uniform( 0.0, 60.0 )
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 60.0 );
 	}
 
 	bm.tic();
@@ -463,8 +462,8 @@ bench( pkg+':logcdf', function benchmark( bm ) {
 	dist = new Uniform( a, b );
 	len = 100;
 	x = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
-		x[ i ] = uniform( 0.0, 60.0 )
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 60.0 );
 	}
 
 	bm.tic();
@@ -496,8 +495,8 @@ bench( pkg+':logpdf', function benchmark( bm ) {
 	dist = new Uniform( a, b );
 	len = 100;
 	x = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
-		x[ i ] = uniform( 0.0, 60.0 )
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 60.0 );
 	}
 
 	bm.tic();
@@ -529,8 +528,8 @@ bench( pkg+':mgf', function benchmark( bm ) {
 	dist = new Uniform( a, b );
 	len = 100;
 	x = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
-		x[ i ] = uniform( 0.0, 1.0 )
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
 	}
 
 	bm.tic();
@@ -562,8 +561,8 @@ bench( pkg+':pdf', function benchmark( bm ) {
 	dist = new Uniform( a, b );
 	len = 100;
 	x = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
-		x[ i ] = uniform( 0.0, 60.0 )
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 60.0 );
 	}
 
 	bm.tic();
@@ -595,8 +594,8 @@ bench( pkg+':quantile', function benchmark( bm ) {
 	dist = new Uniform( a, b );
 	len = 100;
 	x = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
-		x[ i ] = uniform( 0.0, 1.0 )
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
 	}
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/entropy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/entropy/benchmark/benchmark.js
@@ -22,10 +22,10 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var entropy = require( './../lib' );
+var uniform = require('@stdlib/random/base/uniform');
 
 
 // MAIN //
@@ -41,8 +41,8 @@ bench( pkg, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = ( randu()*10.0 );
-		max[ i ] = ( randu()*10.0 ) + min[ i ];
+		min[ i ] = uniform(0.0, 10.0);
+		max[ i ] = uniform(0.0, 10.0) + min[ i ];
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/entropy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/entropy/benchmark/benchmark.js
@@ -23,9 +23,9 @@
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var pkg = require( './../package.json' ).name;
 var entropy = require( './../lib' );
-var uniform = require('@stdlib/random/base/uniform');
 
 
 // MAIN //

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/entropy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/entropy/benchmark/benchmark.js
@@ -41,8 +41,8 @@ bench( pkg, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = uniform(0.0, 10.0);
-		max[ i ] = uniform(0.0, 10.0) + min[ i ];
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ], 10.0 + min[ i ] );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/entropy/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/entropy/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var uniform = require('@stdlib/random/base/uniform');
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/entropy/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/entropy/benchmark/benchmark.native.js
@@ -50,8 +50,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = uniform(0.0, 10.0);
-		max[ i ] = uniform(0.0, 10.0) + min[ i ];
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ], 10.0 + min[ i ] );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/entropy/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/entropy/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require('@stdlib/random/base/uniform');
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 
@@ -50,8 +50,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = ( randu()*10.0 );
-		max[ i ] = ( randu()*10.0 ) + min[ i ];
+		min[ i ] = uniform(0.0, 10.0);
+		max[ i ] = uniform(0.0, 10.0) + min[ i ];
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/kurtosis/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/kurtosis/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require('@stdlib/random/base/uniform');
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var kurtosis = require( './../lib' );
@@ -41,8 +41,8 @@ bench( pkg, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = ( randu()*10.0 );
-		max[ i ] = ( randu()*10.0 ) + min[ i ];
+		min[ i ] = uniform(0.0, 10.0);
+		max[ i ] = uniform(0.0, 10.0) + min[ i ];
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/kurtosis/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/kurtosis/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require('@stdlib/random/base/uniform');
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var kurtosis = require( './../lib' );

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/kurtosis/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/kurtosis/benchmark/benchmark.js
@@ -41,8 +41,8 @@ bench( pkg, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = uniform(0.0, 10.0);
-		max[ i ] = uniform(0.0, 10.0) + min[ i ];
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ], 10.0 + min[ i ] );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/kurtosis/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/kurtosis/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var uniform = require('@stdlib/random/base/uniform');
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/kurtosis/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/kurtosis/benchmark/benchmark.native.js
@@ -50,8 +50,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = uniform(0.0, 10.0);
-		max[ i ] = uniform(0.0, 10.0) + min[ i ];
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ], 10.0 + min[ i ] );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/kurtosis/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/kurtosis/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require('@stdlib/random/base/uniform');
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 
@@ -50,8 +50,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = ( randu()*10.0 );
-		max[ i ] = ( randu()*10.0 ) + min[ i ];
+		min[ i ] = uniform(0.0, 10.0);
+		max[ i ] = uniform(0.0, 10.0) + min[ i ];
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/logcdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/logcdf/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require('@stdlib/random/base/uniform');
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var logcdf = require( './../lib' );
@@ -32,16 +32,24 @@ var logcdf = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var min;
 	var max;
+	var len;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array(len);
+	min = new Float64Array(len);
+	max = new Float64Array(len);
+	for(i = 0; i < len; i++){
+		x[ i ] = uniform(-10.0, 20.0);
+		min[ i ] = uniform(-20.0, 20.0);
+		max[ i ] = min[ i ] + uniform(0.0, 40.0);
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu() * 20.0 ) - 10.0;
-		min = ( randu() * 20.0 ) - 20.0;
-		max = min + ( randu() * 40.0 );
-		y = logcdf( x, min, max );
+		y = logcdf( x[ i % len ], min[ i % len ], max[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -58,6 +66,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mylogcdf;
 	var min;
 	var max;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -65,11 +74,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	min = -1.5;
 	max = 1.5;
 	mylogcdf = logcdf.factory( min, max );
+	len = 100;
+	x = new Float64Array(len);
+	for(i = 0; i < len; i++){
+		x[ i ] = uniform(-2.0, 2.0);
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*2.0 ) - 2.0;
-		y = mylogcdf( x );
+		y = mylogcdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/logcdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/logcdf/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var uniform = require('@stdlib/random/base/uniform');
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var logcdf = require( './../lib' );
@@ -41,7 +41,7 @@ bench( pkg, function benchmark( b ) {
 	x = new Float64Array( len );
 	min = new Float64Array( len );
 	max = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
+	for ( i = 0; i < len; i++ ) {
 		x[ i ] = uniform( -10.0, 10.0 );
 		min[ i ] = uniform( -20.0, 0.0 );
 		max[ i ] = uniform( min[ i ], min[ i ] + 40.0 );
@@ -76,7 +76,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	mylogcdf = logcdf.factory( min, max );
 	len = 100;
 	x = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
+	for ( i = 0; i < len; i++ ) {
 		x[ i ] = uniform( -2.0, 0.0 );
 	}
 

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/logcdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/logcdf/benchmark/benchmark.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var Float64Array = require( '@stdlib/array/float64' );
 var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/logcdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/logcdf/benchmark/benchmark.js
@@ -38,13 +38,13 @@ bench( pkg, function benchmark( b ) {
 	var i;
 
 	len = 100;
-	x = new Float64Array(len);
-	min = new Float64Array(len);
-	max = new Float64Array(len);
-	for(i = 0; i < len; i++){
-		x[ i ] = uniform(-10.0, 20.0);
-		min[ i ] = uniform(-20.0, 20.0);
-		max[ i ] = min[ i ] + uniform(0.0, 40.0);
+	x = new Float64Array( len );
+	min = new Float64Array( len );
+	max = new Float64Array( len );
+	for( i = 0; i < len; i++ ){
+		x[ i ] = uniform( -10.0, 10.0 );
+		min[ i ] = uniform( -20.0, 0.0 );
+		max[ i ] = uniform( min[ i ], min[ i ] + 40.0 );
 	}
 
 	b.tic();
@@ -75,9 +75,9 @@ bench( pkg+':factory', function benchmark( b ) {
 	max = 1.5;
 	mylogcdf = logcdf.factory( min, max );
 	len = 100;
-	x = new Float64Array(len);
-	for(i = 0; i < len; i++){
-		x[ i ] = uniform(-2.0, 2.0);
+	x = new Float64Array( len );
+	for( i = 0; i < len; i++ ){
+		x[ i ] = uniform( -2.0, 0.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/logpdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/logpdf/benchmark/benchmark.js
@@ -38,13 +38,13 @@ bench( pkg, function benchmark( b ) {
 	var i;
 
 	len = 100;
-	x = new Float64Array(len);
-	min = new Float64Array(len);
-	max = new Float64Array(len);
-	for(i = 0; i < len; i++){
-		x[ i ] = uniform(-10.0, 20.0);
-		min[ i ] = uniform(-20.0, 20.0);
-		max[ i ] = min[ i ] + uniform(0.0, 40.0);
+	x = new Float64Array( len );
+	min = new Float64Array( len );
+	max = new Float64Array( len );
+	for( i = 0; i < len; i++ ){
+		x[ i ] = uniform( -10.0, 10.0 );
+		min[ i ] = uniform( -20.0, 0.0 );
+		max[ i ] = uniform( min[ i ], min[ i ] + 40.0 );
 	}
 
 	b.tic();
@@ -75,9 +75,9 @@ bench( pkg+':factory', function benchmark( b ) {
 	max = 1.5;
 	mylogpdf = logpdf.factory( min, max );
 	len = 100;
-	x = new Float64Array(len);
-	for(i = 0; i < len; i++){
-		x[ i ] = uniform(-2.0, 2.0);
+	x = new Float64Array( len );
+	for( i = 0; i < len; i++ ){
+		x[ i ] = uniform( -2.0, 0.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/logpdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/logpdf/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require('@stdlib/random/base/uniform');
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var logpdf = require( './../lib' );
@@ -32,16 +32,24 @@ var logpdf = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var min;
 	var max;
+	var len;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array(len);
+	min = new Float64Array(len);
+	max = new Float64Array(len);
+	for(i = 0; i < len; i++){
+		x[ i ] = uniform(-10.0, 20.0);
+		min[ i ] = uniform(-20.0, 20.0);
+		max[ i ] = min[ i ] + uniform(0.0, 40.0);
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu() * 20.0 ) - 10.0;
-		min = ( randu() * 20.0 ) - 20.0;
-		max = min + ( randu() * 40.0 );
-		y = logpdf( x, min, max );
+		y = logpdf( x[ i % len ], min[ i % len ], max[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -58,6 +66,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mylogpdf;
 	var min;
 	var max;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -65,11 +74,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	min = -1.5;
 	max = 1.5;
 	mylogpdf = logpdf.factory( min, max );
+	len = 100;
+	x = new Float64Array(len);
+	for(i = 0; i < len; i++){
+		x[ i ] = uniform(-2.0, 2.0);
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*2.0 ) - 2.0;
-		y = mylogpdf( x );
+		y = mylogpdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/logpdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/logpdf/benchmark/benchmark.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var Float64Array = require( '@stdlib/array/float64' );
 var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/logpdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/logpdf/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var uniform = require('@stdlib/random/base/uniform');
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var logpdf = require( './../lib' );
@@ -41,7 +41,7 @@ bench( pkg, function benchmark( b ) {
 	x = new Float64Array( len );
 	min = new Float64Array( len );
 	max = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
+	for ( i = 0; i < len; i++ ) {
 		x[ i ] = uniform( -10.0, 10.0 );
 		min[ i ] = uniform( -20.0, 0.0 );
 		max[ i ] = uniform( min[ i ], min[ i ] + 40.0 );
@@ -76,7 +76,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	mylogpdf = logpdf.factory( min, max );
 	len = 100;
 	x = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
+	for ( i = 0; i < len; i++ ) {
 		x[ i ] = uniform( -2.0, 0.0 );
 	}
 

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/mean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/mean/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require('@stdlib/random/base/uniform');
 var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	bval = new Float64Array( len );
 
 	for ( i = 0; i < len; i++ ) {
-		a[ i ] = randu() * 100.0;
-		bval[ i ] = a[ i ] + ( randu() * 50.0 );
+		a[ i ] = uniform( 0.0, 100.0);
+		bval[ i ] = a[ i ] + uniform( 0.0, 50.0);
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/mean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/mean/benchmark/benchmark.js
@@ -43,7 +43,7 @@ bench( pkg, function benchmark( b ) {
 
 	for ( i = 0; i < len; i++ ) {
 		a[ i ] = uniform( 0.0, 100.0);
-		bval[ i ] = a[ i ] + uniform( 0.0, 50.0);
+		bval[ i ] = uniform( a[ i ], 50.0 + a[ i ] );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/mean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/mean/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var uniform = require('@stdlib/random/base/uniform');
+var uniform = require( '@stdlib/random/base/uniform' );
 var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/mean/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/mean/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require('@stdlib/random/base/uniform');
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/mean/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/mean/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require('@stdlib/random/base/uniform');
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -50,8 +50,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	a = new Float64Array( len );
 	bnd = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		a[ i ] = randu() * 100.0;
-		bnd[ i ] = a[ i ] + ( randu() * 100.0 );
+		a[ i ] = uniform( 0.0, 100.0);
+		bnd[ i ] = a[ i ] + uniform( 0.0, 100.0);
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/mean/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/mean/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	bnd = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
 		a[ i ] = uniform( 0.0, 100.0);
-		bnd[ i ] = a[ i ] + uniform( 0.0, 100.0);
+		bnd[ i ] = uniform( a[ i ], 100.0 + a[ i ] );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/median/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/median/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require('@stdlib/random/base/uniform');
 var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	bnd = new Float64Array( len );
 
 	for ( i = 0; i < len; i++ ) {
-		a[ i ] = randu() * 100.0;
-		bnd[ i ] = a[ i ] + ( randu() * 50.0 );
+		a[ i ] = uniform( 0.0, 100.0);
+		bnd[ i ] = a[ i ] + uniform( 0.0, 50.0);
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/median/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/median/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var uniform = require('@stdlib/random/base/uniform');
+var uniform = require( '@stdlib/random/base/uniform' );
 var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/median/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/median/benchmark/benchmark.js
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	bnd = new Float64Array( len );
 
 	for ( i = 0; i < len; i++ ) {
-		a[ i ] = uniform( 0.0, 100.0);
-		bnd[ i ] = a[ i ] + uniform( 0.0, 50.0);
+		a[ i ] = uniform( 0.0, 100.0 );
+		bnd[ i ] = uniform( a[ i ], 50.0 + a[ i ] );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/median/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/median/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require('@stdlib/random/base/uniform');
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/median/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/median/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require('@stdlib/random/base/uniform');
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -50,8 +50,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	a = new Float64Array( len );
 	bnd = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		a[ i ] = randu() * 100.0;
-		bnd[ i ] = a[ i ] + ( randu() * 100.0 );
+		a[ i ] = uniform( 0.0, 100.0);
+		bnd[ i ] = a[ i ] + uniform( 0.0, 100.0);
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/median/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/median/benchmark/benchmark.native.js
@@ -50,8 +50,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	a = new Float64Array( len );
 	bnd = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		a[ i ] = uniform( 0.0, 100.0);
-		bnd[ i ] = a[ i ] + uniform( 0.0, 100.0);
+		a[ i ] = uniform( 0.0, 100.0 );
+		bnd[ i ] = uniform( a[ i ], 100.0 + a[ i ] );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/mgf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/mgf/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require('@stdlib/random/base/uniform');
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var mgf = require( './../lib' );
@@ -32,16 +32,24 @@ var mgf = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var min;
 	var max;
+	var len;
 	var t;
 	var y;
 	var i;
 
+	len = 100;
+	t = new Float64Array(len);
+	min = new Float64Array(len);
+	max = new Float64Array(len);
+	for(i = 0; i < len; i++){
+		t[ i ] = uniform(-10.0, 20.0);
+		min[ i ] = uniform(-20.0, 20.0);
+		max[ i ] = min[ i ] + uniform(0.0, 40.0);
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		t = ( randu() * 20.0 ) - 10.0;
-		min = ( randu() * 20.0 ) - 20.0;
-		max = min + ( randu() * 40.0 );
-		y = mgf( t, min, max );
+		y = mgf( t[ i % len ], min[ i % len ], max[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -58,6 +66,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mymgf;
 	var min;
 	var max;
+	var len;
 	var t;
 	var y;
 	var i;
@@ -65,11 +74,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	min = -1.5;
 	max = 1.5;
 	mymgf = mgf.factory( min, max );
+	len = 100;
+	t = new Float64Array(len);
+	for(i = 0; i < len; i++){
+		t[ i ] = uniform(-2.0, 2.0);
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		t = ( randu()*2.0 ) - 2.0;
-		y = mymgf( t );
+		y = mymgf( t[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/mgf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/mgf/benchmark/benchmark.js
@@ -38,13 +38,13 @@ bench( pkg, function benchmark( b ) {
 	var i;
 
 	len = 100;
-	t = new Float64Array(len);
-	min = new Float64Array(len);
-	max = new Float64Array(len);
-	for(i = 0; i < len; i++){
-		t[ i ] = uniform(-10.0, 20.0);
-		min[ i ] = uniform(-20.0, 20.0);
-		max[ i ] = min[ i ] + uniform(0.0, 40.0);
+	t = new Float64Array( len );
+	min = new Float64Array( len );
+	max = new Float64Array( len );
+	for( i = 0; i < len; i++ ){
+		t[ i ] = uniform( -10.0, 10.0 );
+		min[ i ] = uniform( -20.0, 0.0 );
+		max[ i ] = uniform( min[ i ], min[ i ] + 40.0 );
 	}
 
 	b.tic();
@@ -75,9 +75,9 @@ bench( pkg+':factory', function benchmark( b ) {
 	max = 1.5;
 	mymgf = mgf.factory( min, max );
 	len = 100;
-	t = new Float64Array(len);
-	for(i = 0; i < len; i++){
-		t[ i ] = uniform(-2.0, 2.0);
+	t = new Float64Array( len );
+	for( i = 0; i < len; i++ ){
+		t[ i ] = uniform( -2.0, 0.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/mgf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/mgf/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var uniform = require('@stdlib/random/base/uniform');
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var mgf = require( './../lib' );
@@ -41,7 +42,7 @@ bench( pkg, function benchmark( b ) {
 	t = new Float64Array( len );
 	min = new Float64Array( len );
 	max = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
+	for ( i = 0; i < len; i++ ) {
 		t[ i ] = uniform( -10.0, 10.0 );
 		min[ i ] = uniform( -20.0, 0.0 );
 		max[ i ] = uniform( min[ i ], min[ i ] + 40.0 );
@@ -76,7 +77,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	mymgf = mgf.factory( min, max );
 	len = 100;
 	t = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
+	for ( i = 0; i < len; i++ ) {
 		t[ i ] = uniform( -2.0, 0.0 );
 	}
 

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/pdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/pdf/benchmark/benchmark.js
@@ -39,13 +39,11 @@ bench( pkg, function benchmark( b ) {
 	var i;
 
 	len = 100;
-	x = new Float64Array( len );
-	min = new Float64Array( len );
-	max = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
-		x[ i ] = uniform( -10.0, 10.0 );
-		min[ i ] = uniform( -20.0, 0.0 );
-		max[ i ] = uniform( min[ i ], min[ i ] + 40.0 );
+	x = uniform(len, -10.0, 10.0);
+	min = uniform(len, -20.0, 0.0);
+	max = new Float64Array(len);
+	for (i = 0; i < len; i++) {
+    	max[i] = uniform(1, min[i], min[i] + 40.0)[0];
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/pdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/pdf/benchmark/benchmark.js
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	x = uniform(len, -10.0, 10.0);
 	min = uniform(len, -20.0, 0.0);
 	max = new Float64Array(len);
-	for (i = 0; i < len; i++) {
-    	max[i] = uniform(1, min[i], min[i] + 40.0)[0];
+	for ( i = 0; i < len; i++ ) {
+		max[i] = uniform(1, min[i], min[i] + 40.0)[0];
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/pdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/pdf/benchmark/benchmark.js
@@ -23,7 +23,6 @@
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var randu = require( '@stdlib/random/base/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var pdf = require( './../lib' );
@@ -44,9 +43,9 @@ bench( pkg, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu() * 20.0 ) - 10.0;
-		min[ i ] = ( randu() * 20.0 ) - 20.0;
-		max[ i ] = min[ i ] + ( randu() * 40.0 );
+		x[ i ] = uniform(-10.0, 20.0);
+		min[ i ] = uniform(-20.0, 20.0);
+		max[ i ] = min[ i ] + uniform(0.0, 40.0);
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/pdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/pdf/benchmark/benchmark.js
@@ -42,10 +42,10 @@ bench( pkg, function benchmark( b ) {
 	x = new Float64Array( len );
 	min = new Float64Array( len );
 	max = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform(-10.0, 20.0);
-		min[ i ] = uniform(-20.0, 20.0);
-		max[ i ] = min[ i ] + uniform(0.0, 40.0);
+	for( i = 0; i < len; i++ ){
+		x[ i ] = uniform( -10.0, 10.0 );
+		min[ i ] = uniform( -20.0, 0.0 );
+		max[ i ] = uniform( min[ i ], min[ i ] + 40.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/pdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/pdf/benchmark/benchmark.native.js
@@ -51,10 +51,10 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	x = new Float64Array( len );
 	min = new Float64Array( len );
 	max = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform(-10.0, 20.0);
-		min[ i ] = uniform(-20.0, 20.0);
-		max[ i ] = min[ i ] + uniform(0.0, 40.0);
+	for( i = 0; i < len; i++ ){
+		x[ i ] = uniform( -10.0, 10.0 );
+		min[ i ] = uniform( -20.0, 0.0 );
+		max[ i ] = uniform( min[ i ], min[ i ] + 40.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/pdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/pdf/benchmark/benchmark.native.js
@@ -48,13 +48,11 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var i;
 
 	len = 100;
-	x = new Float64Array( len );
-	min = new Float64Array( len );
-	max = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
-		x[ i ] = uniform( -10.0, 10.0 );
-		min[ i ] = uniform( -20.0, 0.0 );
-		max[ i ] = uniform( min[ i ], min[ i ] + 40.0 );
+	x = uniform(len, -10.0, 10.0);
+	min = uniform(len, -20.0, 0.0);
+	max = new Float64Array(len);
+	for (i = 0; i < len; i++) {
+    	max[i] = uniform(1, min[i], min[i] + 40.0)[0];
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/pdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/pdf/benchmark/benchmark.native.js
@@ -24,6 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var uniform = require( '@stdlib/random/array/uniform' );
+var runif = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -48,11 +49,11 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var i;
 
 	len = 100;
-	x = uniform(len, -10.0, 10.0);
-	min = uniform(len, -20.0, 0.0);
-	max = new Float64Array(len);
-	for (i = 0; i < len; i++) {
-    	max[i] = uniform(1, min[i], min[i] + 40.0)[0];
+	x = uniform( len, -10.0, 10.0 );
+	min = uniform( len, -20.0, 0.0 );
+	max = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		max[ i ] = runif( min[ i ], min[ i ] + 40.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/pdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/pdf/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -52,9 +52,9 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu() * 20.0 ) - 10.0;
-		min[ i ] = ( randu() * 20.0 ) - 20.0;
-		max[ i ] = min[ i ] + ( randu() * 40.0 );
+		x[ i ] = uniform(-10.0, 20.0);
+		min[ i ] = uniform(-20.0, 20.0);
+		max[ i ] = min[ i ] + uniform(0.0, 40.0);
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/quantile/benchmark/benchmark.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var Float64Array = require( '@stdlib/array/float64' );
 var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
@@ -41,7 +42,7 @@ bench( pkg, function benchmark( b ) {
 	p = new Float64Array( len );
 	min = new Float64Array( len );
 	max = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
+	for ( i = 0; i < len; i++ ) {
 		p[ i ] = uniform( 0.0, 1.0 );
 		min[ i ] = uniform( -20.0, 0.0 );
 		max[ i ] = uniform( min[ i ], min[ i ] + 40.0 );
@@ -76,7 +77,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	myquantile = quantile.factory( min, max );
 	len = 100;
 	p = new Float64Array( len );
-	for(i = 0; i < len; i++){
+	for ( i = 0; i < len; i++ ) {
 		p[ i ] = uniform( 0.0, 1.0 );
 	}
 

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/quantile/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var quantile = require( './../lib' );
@@ -32,16 +32,24 @@ var quantile = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var min;
 	var max;
+	var len;
 	var p;
 	var y;
 	var i;
 
+	len = 100;
+	p = new Float64Array(len);
+	min = new Float64Array(len);
+	max = new Float64Array(len);
+	for(i = 0; i < len; i++){
+		p[ i ] = uniform(0.0, 1.0);
+		min[ i ] = uniform(-20.0, 20.0);
+		max[ i ] = min[ i ] + uniform(0.0, 40.0);
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		min = ( randu() * 20.0 ) - 20.0;
-		max = min + ( randu() * 40.0 );
-		y = quantile( p, min, max );
+		y = quantile( p[ i % len ], min[ i % len ], max[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -58,6 +66,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	var myquantile;
 	var min;
 	var max;
+	var len;
 	var p;
 	var y;
 	var i;
@@ -65,11 +74,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	min = -1.5;
 	max = 1.5;
 	myquantile = quantile.factory( min, max );
+	len = 100;
+	p = new Float64Array(len);
+	for(i = 0; i < len; i++){
+		x[ i ] = uniform(0.0, 1.0);
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		y = myquantile( p );
+		y = myquantile( p[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/quantile/benchmark/benchmark.js
@@ -38,13 +38,13 @@ bench( pkg, function benchmark( b ) {
 	var i;
 
 	len = 100;
-	p = new Float64Array(len);
-	min = new Float64Array(len);
-	max = new Float64Array(len);
-	for(i = 0; i < len; i++){
-		p[ i ] = uniform(0.0, 1.0);
-		min[ i ] = uniform(-20.0, 20.0);
-		max[ i ] = min[ i ] + uniform(0.0, 40.0);
+	p = new Float64Array( len );
+	min = new Float64Array( len );
+	max = new Float64Array( len );
+	for( i = 0; i < len; i++ ){
+		p[ i ] = uniform( 0.0, 1.0 );
+		min[ i ] = uniform( -20.0, 0.0 );
+		max[ i ] = uniform( min[ i ], min[ i ] + 40.0 );
 	}
 
 	b.tic();
@@ -75,9 +75,9 @@ bench( pkg+':factory', function benchmark( b ) {
 	max = 1.5;
 	myquantile = quantile.factory( min, max );
 	len = 100;
-	p = new Float64Array(len);
+	p = new Float64Array( len );
 	for(i = 0; i < len; i++){
-		x[ i ] = uniform(0.0, 1.0);
+		p[ i ] = uniform( 0.0, 1.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/quantile/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var uniform = require( '@stdlib/random/array/uniform' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var quantile = require( './../lib' );

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/skewness/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/skewness/benchmark/benchmark.js
@@ -37,11 +37,11 @@ bench( pkg, function benchmark( b ) {
 	var i;
 
 	len = 100;
-	min = new Float64Array(len);
-	max = new Float64Array(len);
-	for(i = 0; i < len; i++){
-		min[ i ] = uniform(0.0, 10.0);
-		max[ i ] = min[i] + uniform(0.0, 10.0);
+	min = new Float64Array( len );
+	max = new Float64Array( len );
+	for( i = 0; i < len; i++ ){
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ], 10.0 + min[ i ] );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/skewness/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/skewness/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var skewness = require( './../lib' );
@@ -32,14 +32,21 @@ var skewness = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var min;
 	var max;
+	var len;
 	var y;
 	var i;
 
+	len = 100;
+	min = new Float64Array(len);
+	max = new Float64Array(len);
+	for(i = 0; i < len; i++){
+		min[ i ] = uniform(0.0, 10.0);
+		max[ i ] = min[i] + uniform(0.0, 10.0);
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		min = ( randu()*10.0 );
-		max = ( randu()*10.0 ) + min;
-		y = skewness( min, max );
+		y = skewness( min[ i % len ], max[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/skewness/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/skewness/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var uniform = require( '@stdlib/random/array/uniform' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var skewness = require( './../lib' );

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/skewness/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/skewness/benchmark/benchmark.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var Float64Array = require( '@stdlib/array/float64' );
 var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
@@ -39,7 +40,7 @@ bench( pkg, function benchmark( b ) {
 	len = 100;
 	min = new Float64Array( len );
 	max = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
+	for ( i = 0; i < len; i++ ) {
 		min[ i ] = uniform( 0.0, 10.0 );
 		max[ i ] = uniform( min[ i ], 10.0 + min[ i ] );
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/stdev/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/stdev/benchmark/benchmark.js
@@ -37,11 +37,11 @@ bench( pkg, function benchmark( b ) {
 	var i;
 
 	len = 100;
-	min = new Float64Array(len);
-	max = new Float64Array(len);
-	for(i = 0; i < len; i++){
-		min[ i ] = uniform(0.0, 10.0);
-		max[ i ] = min[i] + uniform(0.0, 10.0);
+	min = new Float64Array( len );
+	max = new Float64Array( len );
+	for( i = 0; i < len; i++ ){
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ], 10.0 + min[ i ] );
 	}
 
 

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/stdev/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/stdev/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var stdev = require( './../lib' );
@@ -32,14 +32,22 @@ var stdev = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var min;
 	var max;
+	var len;
 	var y;
 	var i;
 
+	len = 100;
+	min = new Float64Array(len);
+	max = new Float64Array(len);
+	for(i = 0; i < len; i++){
+		min[ i ] = uniform(0.0, 10.0);
+		max[ i ] = min[i] + uniform(0.0, 10.0);
+	}
+
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		min = ( randu()*10.0 );
-		max = ( randu()*10.0 ) + min;
-		y = stdev( min, max );
+		y = stdev( min[ i % len ], max[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/stdev/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/stdev/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var uniform = require( '@stdlib/random/array/uniform' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var stdev = require( './../lib' );

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/stdev/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/stdev/benchmark/benchmark.js
@@ -21,6 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var Float64Array = require( '@stdlib/array/float64' );
 var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
@@ -39,11 +40,10 @@ bench( pkg, function benchmark( b ) {
 	len = 100;
 	min = new Float64Array( len );
 	max = new Float64Array( len );
-	for( i = 0; i < len; i++ ){
+	for ( i = 0; i < len; i++ ) {
 		min[ i ] = uniform( 0.0, 10.0 );
 		max[ i ] = uniform( min[ i ], 10.0 + min[ i ] );
 	}
-
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/variance/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/variance/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require( '@stdlib/random/array/uniform' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var variance = require( './../lib' );

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/variance/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/variance/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var variance = require( './../lib' );
@@ -41,8 +41,8 @@ bench( pkg, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = ( randu() * 10.0 );
-		max[ i ] = ( randu() * 10.0 ) + min[ i ];
+		min[ i ] = uniform(0.0, 10.0);
+		max[ i ] = min[i] + uniform(0.0, 10.0);
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/variance/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/variance/benchmark/benchmark.js
@@ -41,8 +41,8 @@ bench( pkg, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = uniform(0.0, 10.0);
-		max[ i ] = min[i] + uniform(0.0, 10.0);
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ], 10.0 + min[ i ] );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/variance/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/variance/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 
@@ -50,8 +50,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = ( randu() * 10.0 );
-		max[ i ] = ( randu() * 10.0 ) + min[ i ];
+		min[ i ] = uniform(0.0, 10.0);
+		max[ i ] = min[i] + uniform(0.0, 10.0);
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/variance/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/variance/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var uniform = require( '@stdlib/random/array/uniform' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/variance/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/variance/benchmark/benchmark.native.js
@@ -50,8 +50,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = uniform(0.0, 10.0);
-		max[ i ] = min[i] + uniform(0.0, 10.0);
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ], 10.0 + min[ i ] );
 	}
 
 	b.tic();


### PR DESCRIPTION
…ts/uniform

#4991

Resolves #4991 .

## Description

> What is the purpose of this pull request?

This pull request improves random number generation in JS benchmarks for `stats/base/dists/uniform`. Specifically:

- Moves random number generation out of benchmarking loops to prevent interference with benchmark results.
- Uses `@stdlib/random/base/uniform` and `@stdlib/random/base/discrete-uniform` instead of `randu` expressions.
- Ensures generated random values maintain the same range as existing values for consistency.

## Related Issues

>This pull request:

- Resolves #4991
- References #4837 and #4955 as examples of similar improvements.


## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

   ✅ Read, understood, and followed the [contributing guidelines][contributing].
   ✅ Build Native Add-on.
   ✅ Run JavaScript Benchmarks.
   ✅ Run JavaScript Native Benchmarks.



* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
