### PR TITLE
bench: refactor random number generation in stats/base/dists/weibull

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/cdf/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -34,17 +35,26 @@ bench( pkg, function benchmark( b ) {
 	var mode;
 	var min;
 	var max;
+	var len;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	min = new Float64Array( len );
+	max = new Float64Array( len );
+	mode = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 30.0 );
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ] + EPS, min[ i ] + 40.0 );
+		mode[ i ] = uniform( min[ i ], max[ i ] );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu() * 30.0;
-		min = randu() * 10.0;
-		max = min + ( randu() * 40.0 ) + EPS;
-		mode = min + ( ( max - min ) * randu() );
-		y = cdf( x, min, max, mode );
+		y = cdf( x[ i%len ], min[ i%len ], max[ i%len ], mode[ i%len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -62,6 +72,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mode;
 	var min;
 	var max;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -70,11 +81,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	max = 1.5;
 	mode = 0.5;
 	mycdf = cdf.factory( min, max, mode );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -2.0, 0.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*2.0 ) - 2.0;
-		y = mycdf( x );
+		y = mycdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/ctor/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,17 +33,25 @@ var Triangular = require( './../lib' );
 
 bench( pkg+'::instantiation', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var c;
 	var i;
 
+	len = 100;
+	a = new Float64Array( len );
+	b = new Float64Array( len );
+	c = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		a[ i ] = uniform( EPS, 10.0 );
+		b[ i ] = uniform( a[ i ] + EPS, a[ i ] + 10.0 );
+		c[ i ] = uniform( a[ i ], b[ i ] );
+	}
+
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		a = ( randu() * 10.0 ) + EPS;
-		b = ( randu() * 10.0 ) + a + EPS;
-		c = ( randu() * ( b-a ) ) + a;
-		dist = new Triangular( a, b, c );
+		dist = new Triangular( a[ i % len ], b[ i % len ], c[ i % len ] );
 		if ( !( dist instanceof Triangular ) ) {
 			bm.fail( 'should return a distribution instance' );
 		}
@@ -85,6 +94,7 @@ bench( pkg+'::get:a', function benchmark( bm ) {
 
 bench( pkg+'::set:a', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var c;
@@ -95,17 +105,21 @@ bench( pkg+'::set:a', function benchmark( bm ) {
 	b = 120.0;
 	c = 110.0;
 	dist = new Triangular( a, b, c );
+	len = 100;
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = uniform( EPS, 100.0 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		y = ( 100.0*randu() ) + EPS;
-		dist.a = y;
-		if ( dist.a !== y ) {
+		dist.a = y[ i % len ];
+		if ( dist.a !== y[ i % len ] ) {
 			bm.fail( 'should return set value' );
 		}
 	}
 	bm.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( y[ i % len ] ) ) {
 		bm.fail( 'should not return NaN' );
 	}
 	bm.pass( 'benchmark finished' );
@@ -142,6 +156,7 @@ bench( pkg+'::get:b', function benchmark( bm ) {
 
 bench( pkg+'::set:b', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var c;
@@ -152,17 +167,21 @@ bench( pkg+'::set:b', function benchmark( bm ) {
 	b = 40.0;
 	c = 30.0;
 	dist = new Triangular( a, b, c );
+	len = 100;
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = uniform( c + EPS, c + 100.0);
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		y = ( 100.0*randu() ) + c + EPS;
-		dist.b = y;
-		if ( dist.b !== y ) {
+		dist.b = y[ i % len ];
+		if ( dist.b !== y[ i % len ] ) {
 			bm.fail( 'should return set value' );
 		}
 	}
 	bm.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( y[ i % len ] ) ) {
 		bm.fail( 'should not return NaN' );
 	}
 	bm.pass( 'benchmark finished' );
@@ -199,6 +218,7 @@ bench( pkg+'::get:c', function benchmark( bm ) {
 
 bench( pkg+'::set:c', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var c;
@@ -209,17 +229,21 @@ bench( pkg+'::set:c', function benchmark( bm ) {
 	b = 40.0;
 	c = 30.0;
 	dist = new Triangular( a, b, c );
+	len = 100;
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = uniform( a, b );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		y = ( randu() * ( b-a ) ) + a;
-		dist.c = y;
-		if ( dist.c !== y ) {
+		dist.c = y[ i % len ];
+		if ( dist.c !== y[ i % len ] ) {
 			bm.fail( 'should return set value' );
 		}
 	}
 	bm.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( y[ i % len ] ) ) {
 		bm.fail( 'should not return NaN' );
 	}
 	bm.pass( 'benchmark finished' );
@@ -228,20 +252,27 @@ bench( pkg+'::set:c', function benchmark( bm ) {
 
 bench( pkg+':entropy', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var c;
 	var y;
+	var x;
 	var i;
 
 	a = 20.0;
 	b = 140.0;
 	c = 100.0;
 	dist = new Triangular( a, b, c );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, c );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = randu() * c;
+		dist.a = x[ i % len ];
 		y = dist.entropy;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -257,20 +288,27 @@ bench( pkg+':entropy', function benchmark( bm ) {
 
 bench( pkg+':kurtosis', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var c;
 	var y;
+	var x;
 	var i;
 
 	a = 20.0;
 	b = 140.0;
 	c = 120.0;
 	dist = new Triangular( a, b, c );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, c );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = randu() * c;
+		dist.a = x[ i % len ];
 		y = dist.kurtosis;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -286,6 +324,8 @@ bench( pkg+':kurtosis', function benchmark( bm ) {
 
 bench( pkg+':mean', function benchmark( bm ) {
 	var dist;
+	var len;
+	var x;
 	var a;
 	var b;
 	var c;
@@ -296,10 +336,15 @@ bench( pkg+':mean', function benchmark( bm ) {
 	b = 140.0;
 	c = 110.0;
 	dist = new Triangular( a, b, c );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, c );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = randu() * c;
+		dist.a = x[ i % len ];
 		y = dist.mean;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -315,6 +360,8 @@ bench( pkg+':mean', function benchmark( bm ) {
 
 bench( pkg+':median', function benchmark( bm ) {
 	var dist;
+	var len;
+	var x;
 	var a;
 	var b;
 	var c;
@@ -325,10 +372,15 @@ bench( pkg+':median', function benchmark( bm ) {
 	b = 140.0;
 	c = 110.0;
 	dist = new Triangular( a, b, c );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, c );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = randu() * c;
+		dist.a = x[ i % len ];
 		y = dist.median;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -344,6 +396,8 @@ bench( pkg+':median', function benchmark( bm ) {
 
 bench( pkg+':skewness', function benchmark( bm ) {
 	var dist;
+	var len;
+	var x;
 	var a;
 	var b;
 	var c;
@@ -354,10 +408,15 @@ bench( pkg+':skewness', function benchmark( bm ) {
 	b = 140.0;
 	c = 110.0;
 	dist = new Triangular( a, b, c );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, c );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = randu() * c;
+		dist.a = x[ i % len ];
 		y = dist.skewness;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -373,6 +432,8 @@ bench( pkg+':skewness', function benchmark( bm ) {
 
 bench( pkg+':stdev', function benchmark( bm ) {
 	var dist;
+	var len;
+	var x;
 	var a;
 	var b;
 	var c;
@@ -383,10 +444,15 @@ bench( pkg+':stdev', function benchmark( bm ) {
 	b = 140.0;
 	c = 80.0;
 	dist = new Triangular( a, b, c );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, c );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = randu() * c;
+		dist.a = x[ i % len ];
 		y = dist.stdev;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -402,6 +468,8 @@ bench( pkg+':stdev', function benchmark( bm ) {
 
 bench( pkg+':variance', function benchmark( bm ) {
 	var dist;
+	var len;
+	var x;
 	var a;
 	var b;
 	var c;
@@ -412,10 +480,15 @@ bench( pkg+':variance', function benchmark( bm ) {
 	b = 140.0;
 	c = 80.0;
 	dist = new Triangular( a, b, c );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, c );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		dist.a = randu() * c;
+		dist.a = x[ i % len ];
 		y = dist.variance;
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
@@ -431,6 +504,7 @@ bench( pkg+':variance', function benchmark( bm ) {
 
 bench( pkg+':cdf', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var c;
@@ -442,11 +516,15 @@ bench( pkg+':cdf', function benchmark( bm ) {
 	b = 40.0;
 	c = 30.0;
 	dist = new Triangular( a, b, c );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 60.0 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = randu() * 60.0;
-		y = dist.cdf( x );
+		y = dist.cdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
 		}
@@ -461,6 +539,7 @@ bench( pkg+':cdf', function benchmark( bm ) {
 
 bench( pkg+':mgf', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var c;
@@ -472,11 +551,15 @@ bench( pkg+':mgf', function benchmark( bm ) {
 	b = 40.0;
 	c = 30.0;
 	dist = new Triangular( a, b, c );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = randu();
-		y = dist.mgf( x );
+		y = dist.mgf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
 		}
@@ -491,6 +574,7 @@ bench( pkg+':mgf', function benchmark( bm ) {
 
 bench( pkg+':pdf', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var c;
@@ -502,11 +586,15 @@ bench( pkg+':pdf', function benchmark( bm ) {
 	b = 40.0;
 	c = 30;
 	dist = new Triangular( a, b, c );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 60.0 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = randu() * 60.0;
-		y = dist.pdf( x );
+		y = dist.pdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
 		}
@@ -521,6 +609,7 @@ bench( pkg+':pdf', function benchmark( bm ) {
 
 bench( pkg+':quantile', function benchmark( bm ) {
 	var dist;
+	var len;
 	var a;
 	var b;
 	var c;
@@ -532,11 +621,15 @@ bench( pkg+':quantile', function benchmark( bm ) {
 	b = 40.0;
 	c = 30.0;
 	dist = new Triangular( a, b, c );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	bm.tic();
 	for ( i = 0; i < bm.iterations; i++ ) {
-		x = randu();
-		y = dist.quantile( x );
+		y = dist.quantile( x[ i % len ] );
 		if ( isnan( y ) ) {
 			bm.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/entropy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/entropy/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -44,9 +44,9 @@ bench( pkg, function benchmark( b ) {
 	max = new Float64Array( len );
 	mode = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = ( randu()*10.0 );
-		max[ i ] = ( randu()*10.0 ) + min[ i ] + EPS;
-		mode[ i ] = ( ( max[ i ] - min[ i ] ) * randu() ) + min[ i ];
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ] + EPS, min[ i ] + 10.0 );
+		mode[ i ] = uniform( min[ i ], max[ i ] );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/entropy/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/entropy/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -53,9 +53,9 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	max = new Float64Array( len );
 	mode = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = ( randu()*10.0 );
-		max[ i ] = ( randu()*10.0 ) + min[ i ] + EPS;
-		mode[ i ] = ( ( max[ i ] - min[ i ] ) * randu() ) + min[ i ];
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ] + EPS, min[ i ] + 10.0 );
+		mode[ i ] = uniform( min[ i ], max[ i ] );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/kurtosis/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/kurtosis/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -44,9 +44,9 @@ bench( pkg, function benchmark( b ) {
 	max = new Float64Array( len );
 	mode = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = ( randu()*10.0 );
-		max[ i ] = ( randu()*10.0 ) + min[ i ] + EPS;
-		mode[ i ] = ( ( max[ i ] - min[ i ] ) * randu() ) + min[ i ];
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ] + EPS, min[ i ] + 10.0 );
+		mode[ i ] = uniform( min[ i ], max[ i ] );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/kurtosis/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/kurtosis/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -53,9 +53,9 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	max = new Float64Array( len );
 	mode = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = ( randu()*10.0 );
-		max[ i ] = ( randu()*10.0 ) + min[ i ] + EPS;
-		mode[ i ] = ( ( max[ i ] - min[ i ] ) * randu() ) + min[ i ];
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ] + EPS, min[ i ] + 10.0 );
+		mode[ i ] = uniform( min[ i ], max[ i ] );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/logcdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/logcdf/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -34,17 +35,26 @@ bench( pkg, function benchmark( b ) {
 	var mode;
 	var min;
 	var max;
+	var len;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	x = new Float64Array( len );
+	min = new Float64Array( len );
+	max = new Float64Array( len );
+	mode = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 30.0 );
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ] + EPS, min[ i ] + 40.0 );
+		mode[ i ] = uniform( min[ i ], max[ i ] );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu() * 30.0;
-		min = randu() * 10.0;
-		max = min + ( randu() * 40.0 ) + EPS;
-		mode = min + ( ( max - min ) * randu() );
-		y = logcdf( x, min, max, mode );
+		y = logcdf( x[ i%len ], min[ i%len ], max[ i%len ], mode[ i%len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -62,6 +72,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mode;
 	var min;
 	var max;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -70,11 +81,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	max = 1.5;
 	mode = 0.5;
 	mylogcdf = logcdf.factory( min, max, mode );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -2.0, 0.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*2.0 ) - 2.0;
-		y = mylogcdf( x );
+		y = mylogcdf( x[ i % len ]);
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/logpdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/logpdf/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -47,10 +47,10 @@ bench( pkg, function benchmark( b ) {
 	mode = new Float64Array( len );
 
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = randu() * 30.0;
-		min[ i ] = randu() * 10.0;
-		max[ i ] = min[ i ] + ( randu() * 40.0 ) + EPS;
-		mode[ i ] = min[ i ] + ( ( max[ i ] - min[ i ] ) * randu() );
+		x[ i ] = uniform( 0.0, 30.0 );
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ] + EPS, min[ i ] + 40.0 );
+		mode[ i ] = uniform( min[ i ], max[ i ] );
 	}
 
 	b.tic();
@@ -73,6 +73,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mode;
 	var min;
 	var max;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -81,11 +82,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	max = 1.5;
 	mode = 0.5;
 	mylogpdf = logpdf.factory( min, max, mode );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -2.0, 0.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*2.0 ) - 2.0;
-		y = mylogpdf( x );
+		y = mylogpdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/logpdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/logpdf/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -56,10 +56,10 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	mode = new Float64Array( len );
 
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = randu() * 30.0;
-		min[ i ] = randu() * 10.0;
-		max[ i ] = min[ i ] + ( randu() * 40.0 ) + EPS;
-		mode[ i ] = min[ i ] + ( ( max[ i ] - min[ i ] ) * randu() );
+		x[ i ] = uniform( 0.0, 30.0 );
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ] + EPS, min[ i ] + 40.0 );
+		mode[ i ] = uniform( min[ i ], max[ i ] );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/mean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/mean/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var mean = require( './../lib' );
@@ -43,9 +43,9 @@ bench( pkg, function benchmark( b ) {
 	bnd = new Float64Array( len );
 	c = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		a[ i ] = randu() * 20.0;
-		bnd[ i ] = ( randu() * 20.0 ) + a[ i ];
-		c[ i ] = ( randu() * ( bnd[i] - a[i] ) ) + a[i];
+		a[ i ] = uniform( 0.0, 20.0 );
+		bnd[ i ] = uniform( a[ i ], a[ i ] + 20.0 );
+		c[ i ] = uniform( a[ i ], bnd[ i ] );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/mean/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/mean/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -52,9 +52,9 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	bnd = new Float64Array( len );
 	c = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		a[ i ] = ( randu() * 20.0 );
-		bnd[ i ] = ( randu() * 20.0 ) + a[ i ];
-		c[ i ] = ( randu() * ( bnd[i] - a[i] ) ) + a[i];
+		a[ i ] = uniform( 0.0, 20.0 );
+		bnd[ i ] = uniform( a[ i ], a[ i ] + 20.0 );
+		c[ i ] = uniform( a[ i ], bnd[ i ] );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -44,9 +44,9 @@ bench( pkg, function benchmark( b ) {
 	max = new Float64Array( len );
 	mode = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = ( randu()*10.0 );
-		max[ i ] = ( randu()*10.0 ) + min[ i ] + EPS;
-		mode[ i ] = ( ( max[ i ] - min[ i ] ) * randu() ) + min[ i ];
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ] + EPS, min[ i ] + 10.0 );
+		mode[ i ] = uniform( min[ i ], max[ i ] );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -53,9 +53,9 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	max = new Float64Array( len );
 	mode = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = ( randu()*10.0 );
-		max[ i ] = ( randu()*10.0 ) + min[ i ] + EPS;
-		mode[ i ] = ( ( max[ i ] - min[ i ] ) * randu() ) + min[ i ];
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ] + EPS, min[ i ] + 10.0 );
+		mode[ i ] = uniform( min[ i ], max[ i ] );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/mgf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/mgf/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -47,10 +47,10 @@ bench( pkg, function benchmark( b ) {
 	mode = new Float64Array( len );
 
 	for ( i = 0; i < len; i++ ) {
-		t[ i ] = randu() * 5.0;
-		min[ i ] = randu() * 10.0;
-		max[ i ] = min[ i ] + ( randu() * 40.0 ) + EPS;
-		mode[ i ] = min[ i ] + ( ( max[ i ] - min[ i ] ) * randu() );
+		t[ i ] = uniform( 0.0, 5.0);
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ] + EPS, min[ i ] + 40.0 );
+		mode[ i ] = uniform( min[ i ], max[ i ] );
 	}
 
 	b.tic();
@@ -73,6 +73,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mode;
 	var min;
 	var max;
+	var len;
 	var t;
 	var y;
 	var i;
@@ -81,11 +82,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	max = 1.5;
 	mode = 0.5;
 	mymgf = mgf.factory( min, max, mode );
+	len = 100;
+	t = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		t[ i ] = uniform( 0.0, 5.0);
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		t = randu() * 5.0;
-		y = mymgf( t );
+		y = mymgf( t[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/mgf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/mgf/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -56,10 +56,10 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	mode = new Float64Array( len );
 
 	for ( i = 0; i < len; i++ ) {
-		t[ i ] = randu() * 5.0;
-		min[ i ] = randu() * 10.0;
-		max[ i ] = min[ i ] + ( randu() * 40.0 ) + EPS;
-		mode[ i ] = min[ i ] + ( ( max[ i ] - min[ i ] ) * randu() );
+		t[ i ] = uniform( 0.0, 5.0);
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ] + EPS, min[ i ] + 40.0 );
+		mode[ i ] = uniform( min[ i ], max[ i ] );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/mode/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/mode/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var mode = require( './../lib' );
@@ -43,9 +43,9 @@ bench( pkg, function benchmark( b ) {
 	bnd = new Float64Array( len );
 	c = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		a[ i ] = randu() * 20.0;
-		bnd[ i ] = ( randu() * 20.0 ) + a[ i ];
-		c[ i ] = ( randu() * ( bnd[i] - a[i] ) ) + a[i];
+		a[ i ] = uniform( 0.0, 20.0 );
+		bnd[ i ] = uniform( a[ i ], a[ i ] + 20.0 );
+		c[ i ] = uniform( a[ i ], bnd[ i ] );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/mode/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/mode/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -52,9 +52,9 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	bnd = new Float64Array( len );
 	c = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		a[ i ] = ( randu() * 20.0 ); // Lower bound
-		bnd[ i ] = ( randu() * 20.0 ) + a[ i ]; // Upper bound
-		c[ i ] = ( randu() * ( bnd[i] - a[i] ) ) + a[i]; // Mode
+		a[ i ] = uniform( 0.0, 20.0 ); // Lower bound
+		bnd[ i ] = uniform( a[ i ], a[ i ] + 20.0 ); // Upper bound
+		c[ i ] = uniform( a[ i ], bnd[ i ] ); // Mode
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/pdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/pdf/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -47,10 +47,10 @@ bench( pkg, function benchmark( b ) {
 	mode = new Float64Array( len );
 
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = randu() * 30.0;
-		min[ i ] = randu() * 10.0;
-		max[ i ] = min[ i ] + ( randu() * 40.0 ) + EPS;
-		mode[ i ] = min[ i ] + ( ( max[ i ] - min[ i ] ) * randu() );
+		x[ i ] = uniform( 0.0, 30.0 );
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ] + EPS, min[ i ] + 40.0 );
+		mode[ i ] = uniform( min[ i ], max[ i ] );
 	}
 
 	b.tic();
@@ -73,6 +73,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mode;
 	var min;
 	var max;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -81,11 +82,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	max = 1.5;
 	mode = 0.5;
 	mypdf = pdf.factory( min, max, mode );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( -2.0, 0.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*2.0 ) - 2.0;
-		y = mypdf( x );
+		y = mypdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/pdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/pdf/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -56,10 +56,10 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	mode = new Float64Array( len );
 
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = randu() * 30.0;
-		min[ i ] = randu() * 10.0;
-		max[ i ] = min[ i ] + ( randu() * 40.0 ) + EPS;
-		mode[ i ] = min[ i ] + ( ( max[ i ] - min[ i ] ) * randu() );
+		x[ i ] = uniform( 0.0, 30.0 );
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ] + EPS, min[ i ] + 40.0 );
+		mode[ i ] = uniform( min[ i ], max[ i ] );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/quantile/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -34,17 +35,27 @@ bench( pkg, function benchmark( b ) {
 	var mode;
 	var min;
 	var max;
+	var len;
 	var p;
 	var y;
 	var i;
 
+	len = 100;
+	p = new Float64Array( len );
+	min = new Float64Array( len );
+	max = new Float64Array( len );
+	mode = new Float64Array( len );
+
+	for ( i = 0; i < len; i++ ) {
+		p[ i ] = uniform( 0.0, 1.0 );
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ] + EPS, min[ i ] + 40.0 );
+		mode[ i ] = uniform( min[ i ], max[ i ] );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		min = randu() * 10.0;
-		max = min + ( randu() * 40.0 ) + EPS;
-		mode = min + ( ( max - min ) * randu() );
-		y = quantile( p, min, max, mode );
+		y = quantile( p[ i%len ][ i%len ], max[ i%len ], mode[ i%len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -62,6 +73,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mode;
 	var min;
 	var max;
+	var len;
 	var p;
 	var y;
 	var i;
@@ -70,11 +82,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	max = 1.5;
 	mode = 0.5;
 	myquantile = quantile.factory( min, max, mode );
+	len = 100;
+	p = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		p[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		y = myquantile( p );
+		y = myquantile( p[ i % len] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/skewness/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/skewness/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -43,10 +43,11 @@ bench( pkg, function benchmark( b ) {
 	min = new Float64Array( len );
 	max = new Float64Array( len );
 	mode = new Float64Array( len );
+
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = ( randu()*10.0 );
-		max[ i ] = ( randu()*10.0 ) + min[ i ] + EPS;
-		mode[ i ] = ( ( max[ i ] - min[ i ] ) * randu() ) + min[ i ];
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ] + EPS, min[ i ] + 10.0 );
+		mode[ i ] = uniform( min[ i ], max[ i ] );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/skewness/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/skewness/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -53,9 +53,9 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	max = new Float64Array( len );
 	mode = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = ( randu()*10.0 );
-		max[ i ] = ( randu()*10.0 ) + min[ i ] + EPS;
-		mode[ i ] = ( ( max[ i ] - min[ i ] ) * randu() ) + min[ i ];
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ] + EPS, min[ i ] + 10.0 );
+		mode[ i ] = uniform( min[ i ], max[ i ] );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/stdev/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/stdev/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -44,9 +44,9 @@ bench( pkg, function benchmark( b ) {
 	max = new Float64Array( len );
 	mode = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = ( randu()*10.0 );
-		max[ i ] = ( randu()*10.0 ) + min[ i ] + EPS;
-		mode[ i ] = ( ( max[ i ] - min[ i ] ) * randu() ) + min[ i ];
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ] + EPS, min[ i ] + 10.0 );
+		mode[ i ] = uniform( min[ i ], max[ i ] );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/stdev/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/stdev/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -53,9 +53,9 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	max = new Float64Array( len );
 	mode = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = ( randu()*10.0 );
-		max[ i ] = ( randu()*10.0 ) + min[ i ] + EPS;
-		mode[ i ] = ( ( max[ i ] - min[ i ] ) * randu() ) + min[ i ];
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ] + EPS, min[ i ] + 10.0 );
+		mode[ i ] = uniform( min[ i ], max[ i ] );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/variance/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/variance/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var variance = require( './../lib' );
@@ -43,9 +43,9 @@ bench( pkg, function benchmark( b ) {
 	max = new Float64Array( len );
 	mode = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = ( randu() * 10.0 );
-		max[ i ] = ( randu() * 10.0 ) + min[ i ];
-		mode[ i ] = min[ i ] + ( randu() * ( max[ i ] - min[ i ] ) );
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ], min[ i ] + 10.0 );
+		mode[ i ] = uniform( min[ i ], max[ i ] );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/variance/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/variance/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var variance = require( './../lib' );
@@ -43,9 +43,9 @@ bench( pkg+'::native', function benchmark( b ) {
 	max = new Float64Array( len );
 	mode = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		min[ i ] = ( randu() * 10.0 );
-		max[ i ] = ( randu() * 10.0 ) + min[ i ];
-		mode[ i ] = min[ i ] + ( randu() * ( max[ i ] - min[ i ] ) );
+		min[ i ] = uniform( 0.0, 10.0 );
+		max[ i ] = uniform( min[ i ], min[ i ] + 10.0 );
+		mode[ i ] = uniform( min[ i ], max[ i ] );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/cdf/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -44,9 +44,9 @@ bench( pkg, function benchmark( b ) {
 	lambda = new Float64Array( len );
 	k = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu()*100.0 ) + EPS;
-		lambda[ i ] = ( randu()*100.0 ) + EPS;
-		k[ i ] = ( randu()*100.0 ) + EPS;
+		x[ i ] = uniform( EPS, 100.0 );
+		lambda[ i ] = uniform( EPS, 100.0 );
+		k[ i ] = uniform( EPS, 100.0 );
 	}
 
 	b.tic();
@@ -67,6 +67,7 @@ bench( pkg, function benchmark( b ) {
 bench( pkg+':factory', function benchmark( b ) {
 	var lambda;
 	var mycdf;
+	var len;
 	var k;
 	var x;
 	var y;
@@ -75,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	lambda = 3.14;
 	k = 2.25;
 	mycdf = cdf.factory( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*100.0 ) + EPS;
-		y = mycdf( x );
+		y = mycdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/cdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/cdf/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var EPS = require( '@stdlib/constants/float64/eps' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -53,9 +53,9 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	lambda = new Float64Array( len );
 	k = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu()*100.0 ) + EPS;
-		lambda[ i ] = ( randu()*100.0 ) + EPS;
-		k[ i ] = ( randu()*100.0 ) + EPS;
+		x[ i ] = uniform( EPS, 100.0 );
+		lambda[ i ] = uniform( EPS, 100.0 );
+		k[ i ] = uniform( EPS, 100.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/ctor/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,14 +34,21 @@ var Weibull = require( './../lib' );
 bench( pkg+'::instantiation', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var i;
 	var k;
 
+	len = 100;
+	lambda = new Float64Array( len );
+	k = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		lambda[ i ] = uniform( EPS, 10.0 );
+		k[ i ] = uniform( EPS, 10.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		k = ( randu() * 10.0 ) + EPS;
-		lambda = ( randu() * 10.0 ) + EPS;
-		dist = new Weibull( k, lambda );
+		dist = new Weibull( k[ i % len ], lambda[ i % len ] );
 		if ( !( dist instanceof Weibull ) ) {
 			b.fail( 'should return a distribution instance' );
 		}
@@ -82,6 +90,7 @@ bench( pkg+'::get:k', function benchmark( b ) {
 bench( pkg+'::set:k', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var y;
 	var i;
 	var k;
@@ -89,17 +98,21 @@ bench( pkg+'::set:k', function benchmark( b ) {
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
+	len = 100;
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = uniform( EPS, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = ( 10.0*randu() ) + EPS;
-		dist.k = y;
-		if ( dist.k !== y ) {
+		dist.k = y[ i % len ];
+		if ( dist.k !== y[ i % len ] ) {
 			b.fail( 'should return set value' );
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( y[ i % len ] ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );
@@ -135,6 +148,7 @@ bench( pkg+'::get:lambda', function benchmark( b ) {
 bench( pkg+'::set:lambda', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var y;
 	var i;
 	var k;
@@ -142,17 +156,21 @@ bench( pkg+'::set:lambda', function benchmark( b ) {
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
+	len = 100;
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = uniform( EPS, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = ( 10.0*randu() ) + EPS;
-		dist.lambda = y;
-		if ( dist.lambda !== y ) {
+		dist.lambda = y[ i % len ];
+		if ( dist.lambda !== y[ i % len ] ) {
 			b.fail( 'should return set value' );
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( y[ i % len ] ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );
@@ -162,17 +180,24 @@ bench( pkg+'::set:lambda', function benchmark( b ) {
 bench( pkg+':entropy', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var y;
+	var x;
 	var i;
 	var k;
 
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = ( 10.0*randu() ) + EPS;
+		dist.k = x[ i % len ];
 		y = dist.entropy;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -189,17 +214,24 @@ bench( pkg+':entropy', function benchmark( b ) {
 bench( pkg+':kurtosis', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var y;
+	var x;
 	var i;
 	var k;
 
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS + 1.0, 11.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = ( 10.0*randu() ) + 1.0 + EPS;
+		dist.k = x[ i % len ];
 		y = dist.kurtosis;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -216,17 +248,24 @@ bench( pkg+':kurtosis', function benchmark( b ) {
 bench( pkg+':mean', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var y;
+	var x;
 	var i;
 	var k;
 
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = ( 10.0*randu() ) + EPS;
+		dist.k = x[ i % len ];
 		y = dist.mean;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -243,17 +282,24 @@ bench( pkg+':mean', function benchmark( b ) {
 bench( pkg+':median', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var y;
+	var x;
 	var i;
 	var k;
 
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = ( 10.0*randu() ) + EPS;
+		dist.k = x[ i % len ];
 		y = dist.median;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -270,17 +316,24 @@ bench( pkg+':median', function benchmark( b ) {
 bench( pkg+':mode', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var y;
+	var x;
 	var i;
 	var k;
 
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS + 1.0, 11.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = ( 10.0*randu() ) + 1.0 + EPS;
+		dist.k = x[ i % len ];
 		y = dist.mode;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -297,17 +350,24 @@ bench( pkg+':mode', function benchmark( b ) {
 bench( pkg+':skewness', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var y;
+	var x;
 	var i;
 	var k;
 
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS + 1.0, 11.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = ( 10.0*randu() ) + 1.0 + EPS;
+		dist.k = x[ i % len ];
 		y = dist.skewness;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -324,17 +384,24 @@ bench( pkg+':skewness', function benchmark( b ) {
 bench( pkg+':stdev', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var y;
+	var x;
 	var i;
 	var k;
 
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS + 1.0, 11.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = ( 10.0*randu() ) + 1.0 + EPS;
+		dist.k = x[ i % len ];
 		y = dist.stdev;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -351,17 +418,24 @@ bench( pkg+':stdev', function benchmark( b ) {
 bench( pkg+':variance', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var y;
+	var x;
 	var i;
 	var k;
 
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS + 1.0, 11.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.k = ( 10.0*randu() ) + 1.0 + EPS;
+		dist.k = x[ i % len ];
 		y = dist.variance;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -378,6 +452,7 @@ bench( pkg+':variance', function benchmark( b ) {
 bench( pkg+':cdf', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -386,11 +461,15 @@ bench( pkg+':cdf', function benchmark( b ) {
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.cdf( x );
+		y = dist.cdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -406,6 +485,7 @@ bench( pkg+':cdf', function benchmark( b ) {
 bench( pkg+':logpdf', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -414,11 +494,15 @@ bench( pkg+':logpdf', function benchmark( b ) {
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.logpdf( x );
+		y = dist.logpdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -434,6 +518,7 @@ bench( pkg+':logpdf', function benchmark( b ) {
 bench( pkg+':mgf', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -442,11 +527,15 @@ bench( pkg+':mgf', function benchmark( b ) {
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.mgf( x );
+		y = dist.mgf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -462,6 +551,7 @@ bench( pkg+':mgf', function benchmark( b ) {
 bench( pkg+':pdf', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -470,11 +560,15 @@ bench( pkg+':pdf', function benchmark( b ) {
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.pdf( x );
+		y = dist.pdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -490,6 +584,7 @@ bench( pkg+':pdf', function benchmark( b ) {
 bench( pkg+':quantile', function benchmark( b ) {
 	var lambda;
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -498,11 +593,15 @@ bench( pkg+':quantile', function benchmark( b ) {
 	k = 10.56;
 	lambda = 5.54;
 	dist = new Weibull( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.quantile( x );
+		y = dist.quantile( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/entropy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/entropy/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,15 +33,22 @@ var entropy = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
+	var len;
 	var k;
 	var y;
 	var i;
 
+	len = 100;
+	lambda = new Float64Array( len );
+	k = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		lambda[ i ] = uniform( EPS, 10.0 );
+		k[ i ] = uniform( EPS, 10.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		k = ( randu()*10.0 ) + EPS;
-		lambda = ( randu()*10.0 ) + EPS;
-		y = entropy( k, lambda );
+		y = entropy( k[ i % len ], lambda[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/kurtosis/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/kurtosis/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var kurtosis = require( './../lib' );
@@ -31,15 +32,22 @@ var kurtosis = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
+	var len;
 	var k;
 	var y;
 	var i;
 
+	len = 100;
+	lambda = new Float64Array( len );
+	k = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		lambda[ i ] = uniform( 1.0, 11.0 );
+		k[ i ] = uniform( 1.0, 11.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		k = ( randu()*10.0 ) + 1.0;
-		lambda = ( randu()*10.0 ) + 1.0;
-		y = kurtosis( k, lambda );
+		y = kurtosis( k[ i % len ], lambda[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/logcdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/logcdf/benchmark/benchmark.js
@@ -21,8 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
 var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -44,9 +44,9 @@ bench( pkg, function benchmark( b ) {
 	lambda = new Float64Array( len );
 	k = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu()*100.0 ) + EPS;
-		lambda[ i ] = ( randu()*100.0 ) + EPS;
-		k[ i ] = ( randu()*100.0 ) + EPS;
+		x[ i ] = uniform( EPS, 100.0 );
+		lambda[ i ] = uniform( EPS, 100.0 );
+		k[ i ] = uniform( EPS, 100.0 );
 	}
 
 	b.tic();
@@ -67,6 +67,7 @@ bench( pkg, function benchmark( b ) {
 bench( pkg+':factory', function benchmark( b ) {
 	var mylogcdf;
 	var lambda;
+	var len;
 	var k;
 	var x;
 	var y;
@@ -75,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	lambda = 3.14;
 	k = 2.25;
 	mylogcdf = logcdf.factory( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*100.0 ) + EPS;
-		y = mylogcdf( x );
+		y = mylogcdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/logcdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/logcdf/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var EPS = require( '@stdlib/constants/float64/eps' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -53,9 +53,9 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	lambda = new Float64Array( len );
 	k = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu()*100.0 ) + EPS;
-		lambda[ i ] = ( randu()*100.0 ) + EPS;
-		k[ i ] = ( randu()*100.0 ) + EPS;
+		x[ i ] = uniform( EPS, 100.0 );
+		lambda[ i ] = uniform( EPS, 100.0 );
+		k[ i ] = uniform( EPS, 100.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/logpdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/logpdf/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -44,9 +44,9 @@ bench( pkg, function benchmark( b ) {
 	lambda = new Float64Array( len );
 	k = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu()*100.0 ) + EPS;
-		lambda[ i ] = ( randu()*100.0 ) + EPS;
-		k[ i ] = ( randu()*100.0 ) + EPS;
+		x[ i ] = uniform( EPS, 100.0 );
+		lambda[ i ] = uniform( EPS, 100.0 );
+		k[ i ] = uniform( EPS, 100.0 );
 	}
 
 	b.tic();
@@ -67,6 +67,7 @@ bench( pkg, function benchmark( b ) {
 bench( pkg+':factory', function benchmark( b ) {
 	var mylogpdf;
 	var lambda;
+	var len;
 	var k;
 	var x;
 	var y;
@@ -75,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	lambda = 3.14;
 	k = 2.25;
 	mylogpdf = logpdf.factory( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*100.0 ) + EPS;
-		y = mylogpdf( x );
+		y = mylogpdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/logpdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/logpdf/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var EPS = require( '@stdlib/constants/float64/eps' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -53,9 +53,9 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	lambda = new Float64Array( len );
 	k = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu()*100.0 ) + EPS;
-		lambda[ i ] = ( randu()*100.0 ) + EPS;
-		k[ i ] = ( randu()*100.0 ) + EPS;
+		x[ i ] = uniform( EPS, 100.0 );
+		lambda[ i ] = uniform( EPS, 100.0 );
+		k[ i ] = uniform( EPS, 100.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	k = new Float64Array( len );
 	lambda = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		k[ i ] = ( randu() * 10.0 ) + EPS;
-		lambda[ i ] = ( randu() * 10.0 ) + EPS;
+		lambda[ i ] = uniform( EPS, 10.0 );
+		k[ i ] = uniform( EPS, 10.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mean/benchmark/benchmark.native.js
@@ -25,7 +25,7 @@ var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 
@@ -51,8 +51,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	k = new Float64Array( len );
 	lambda = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		k[ i ] = ( randu() * 10.0 ) + EPS;
-		lambda[ i ] = ( randu() * 10.0 ) + EPS;
+		lambda[ i ] = uniform( EPS, 10.0 );
+		k[ i ] = uniform( EPS, 10.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/median/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/median/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	lambda = new Float64Array( len );
 	k = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		lambda[ i ] = ( randu()*10.0 ) + EPS;
-		k[ i ] = ( randu()*10.0 ) + EPS;
+		lambda[ i ] = uniform( EPS, 10.0 );
+		k[ i ] = uniform( EPS, 10.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/median/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/median/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -51,8 +51,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	lambda = new Float64Array( len );
 	k = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		lambda[ i ] = ( randu()*10.0 ) + EPS;
-		k[ i ] = ( randu()*10.0 ) + EPS;
+		lambda[ i ] = uniform( EPS, 10.0 );
+		k[ i ] = uniform( EPS, 10.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mgf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mgf/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,17 +33,25 @@ var mgf = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
+	var len;
 	var k;
 	var t;
 	var y;
 	var i;
 
+	len = 100;
+	t = new Float64Array( len );
+	lambda = new Float64Array( len );
+	k = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		t[ i ] = uniform( EPS, 2.0 );
+		lambda[ i ] = uniform( EPS, 1.0 );
+		k[ i ] = uniform( 1.0, 2.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		t = ( randu()*2.0 ) + EPS;
-		lambda = ( randu()*1.0 ) + EPS;
-		k = ( randu()*1.0 ) + 1.0;
-		y = mgf( t, k, lambda );
+		y = mgf( t[ i % len ], k[ i % len ], lambda[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -58,6 +67,7 @@ bench( pkg, function benchmark( b ) {
 bench( pkg+':factory', function benchmark( b ) {
 	var lambda;
 	var mymgf;
+	var len;
 	var k;
 	var t;
 	var y;
@@ -66,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	lambda = 3.14;
 	k = 2.25;
 	mymgf = mgf.factory( k, lambda );
+	len = 100;
+	t = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		t[ i ] = uniform( EPS, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		t = ( randu()*10.0 ) + EPS;
-		y = mymgf( t );
+		y = mymgf( t[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/mode/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/mode/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,15 +33,22 @@ var mode = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
+	var len;
 	var k;
 	var y;
 	var i;
 
+	len = 100;
+	lambda = new Float64Array( len );
+	k = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		lambda[ i ] = uniform( EPS, 10.0 );
+		k[ i ] = uniform( EPS, 10.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		k = ( randu()*10.0 ) + EPS;
-		lambda = ( randu()*10.0 ) + EPS;
-		y = mode( k, lambda );
+		y = mode( k[ i % len ], lambda[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/pdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/pdf/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -44,9 +44,9 @@ bench( pkg, function benchmark( b ) {
 	lambda = new Float64Array( len );
 	k = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu()*100.0 ) + EPS;
-		lambda[ i ] = ( randu()*100.0 ) + EPS;
-		k[ i ] = ( randu()*100.0 ) + EPS;
+		x[ i ] = uniform( EPS, 100.0 );
+		lambda[ i ] = uniform( EPS, 100.0 );
+		k[ i ] = uniform( EPS, 100.0 );
 	}
 
 	b.tic();
@@ -67,6 +67,7 @@ bench( pkg, function benchmark( b ) {
 bench( pkg+':factory', function benchmark( b ) {
 	var lambda;
 	var mypdf;
+	var len;
 	var k;
 	var x;
 	var y;
@@ -75,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	lambda = 3.14;
 	k = 2.25;
 	mypdf = pdf.factory( k, lambda );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*100.0 ) + EPS;
-		y = mypdf( x );
+		y = mypdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/pdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/pdf/benchmark/benchmark.native.js
@@ -23,7 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -53,9 +53,9 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	lambda = new Float64Array( len );
 	k = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( randu()*100.0 ) + EPS;
-		lambda[ i ] = ( randu()*100.0 ) + EPS;
-		k[ i ] = ( randu()*100.0 ) + EPS;
+		x[ i ] = uniform( EPS, 100.0 );
+		lambda[ i ] = uniform( EPS, 100.0 );
+		k[ i ] = uniform( EPS, 100.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/quantile/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,17 +33,25 @@ var quantile = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
+	var len;
 	var k;
 	var p;
 	var y;
 	var i;
 
+	len = 100;
+	p = new Float64Array( len );
+	lambda = new Float64Array( len );
+	k = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		p[ i ] = uniform( 0.0, 1.0 );
+		lambda[ i ] = uniform( EPS, 100.0 );
+		k[ i ] = uniform( EPS, 100.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		lambda = ( randu()*100.0 ) + EPS;
-		k = ( randu()*100.0 ) + EPS;
-		y = quantile( p, k, lambda );
+		y = quantile( p[ i % len ], k[ i % len ], lambda[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -58,6 +67,7 @@ bench( pkg, function benchmark( b ) {
 bench( pkg+':factory', function benchmark( b ) {
 	var myquantile;
 	var lambda;
+	var len;
 	var k;
 	var p;
 	var y;
@@ -66,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	lambda = 3.14;
 	k = 2.25;
 	myquantile = quantile.factory( k, lambda );
+	len = 100;
+	p = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		p[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		y = myquantile( p );
+		y = myquantile( p[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/skewness/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/skewness/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,15 +33,22 @@ var skewness = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
+	var len;
 	var k;
 	var y;
 	var i;
 
+	len = 100;
+	lambda = new Float64Array( len );
+	k = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		lambda[ i ] = uniform( EPS + 1.0, 11.0 );
+		k[ i ] = uniform( EPS + 1.0, 11.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		k = ( randu()*10.0 ) + 1.0 + EPS;
-		lambda = ( randu()*10.0 ) + 1.0 + EPS;
-		y = skewness( k, lambda );
+		y = skewness( k[ i % len ], lambda[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/stdev/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/stdev/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,15 +33,22 @@ var stdev = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
+	var len;
 	var k;
 	var y;
 	var i;
 
+	len = 100;
+	lambda = new Float64Array( len );
+	k = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		lambda[ i ] = uniform( EPS + 1.0, 11.0 );
+		k[ i ] = uniform( EPS + 1.0, 11.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		k = ( randu()*10.0 ) + 1.0 + EPS;
-		lambda = ( randu()*10.0 ) + 1.0 + EPS;
-		y = stdev( k, lambda );
+		y = stdev( k[ i % len ], lambda[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/weibull/variance/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/weibull/variance/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var Float64Array = require( '@stdlib/array/float64' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -32,15 +33,22 @@ var variance = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
+	var len;
 	var k;
 	var y;
 	var i;
 
+	len = 100;
+	lambda = new Float64Array( len );
+	k = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		lambda[ i ] = uniform( EPS + 1.0, 11.0 );
+		k[ i ] = uniform( EPS + 1.0, 11.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		k = ( randu()*10.0 ) + 1.0 + EPS;
-		lambda = ( randu()*10.0 ) + 1.0 + EPS;
-		y = variance( k, lambda );
+		y = variance( k[ i % len ], lambda[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}


### PR DESCRIPTION
Resolves #4992 .

## Description

This pull request:

This pull request improves random number generation in JS benchmarks for stats/base/dists/weibull. Specifically:

Moves random number generation out of benchmarking loops to prevent interference with benchmark results.

Uses @stdlib/random/base/uniform and @stdlib/random/base/discrete-uniform instead of randu expressions.

Ensures generated random values maintain the same range as existing values for consistency.


## Related Issues

> Does this pull request have any related issues?

References https://github.com/stdlib-js/stdlib/pull/4837 and https://github.com/stdlib-js/stdlib/pull/4955 as examples of similar improvements.

This pull request:

-   resolves #4992  

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

✅ Build Native Add-on.
✅ Run JavaScript Benchmarks.
✅ Run JavaScript Native Benchmarks.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
