### PR TITLE
bench: refactor random number generation in JS benchmarks for `stats/base/dists/pareto-type1`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/cdf/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,15 +34,23 @@ var cdf = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var alpha;
 	var beta;
+	var len;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	alpha = new Float64Array( len );
+	beta = new Float64Array( len );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 20.0 );
+		alpha[ i ] = uniform( EPS, 100.0 );
+		beta[ i ] = uniform( EPS, 100.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*20.0 ) + EPS;
-		alpha = ( randu()*100.0 ) + EPS;
-		beta = ( randu()*100.0 ) + EPS;
 		y = cdf( x, alpha, beta );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -59,18 +68,23 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mycdf;
 	var alpha;
 	var beta;
+	var len;
 	var x;
 	var y;
 	var i;
 
 	alpha = 100.56789;
 	beta = 55.54321;
+	len = 100;
 	mycdf = cdf.factory( alpha, beta );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 50.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*50.0 ) + EPS;
-		y = mycdf( x );
+		y = mycdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/cdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/cdf/benchmark/benchmark.js
@@ -51,7 +51,7 @@ bench( pkg, function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = cdf( x, alpha, beta );
+		y = cdf( x[ i % len ], alpha[ i % len ], beta[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/ctor/benchmark/benchmark.js
@@ -48,7 +48,7 @@ bench( pkg+'::instantiation', function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist = new Pareto1( alpha[ i % len ], beta[ i % len] );
+		dist = new Pareto1( alpha[ i % len ], beta[ i % len ] );
 		if ( !( dist instanceof Pareto1 ) ) {
 			b.fail( 'should return a distribution instance' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/ctor/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -34,13 +35,20 @@ bench( pkg+'::instantiation', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
 	var i;
+
+	len = 100;
+	alpha = new Float64Array( len );
+	beta = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		alpha[ i ] = uniform( EPS, 10.0 );
+		beta[ i ] = uniform( EPS, 10.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		alpha = ( randu() * 10.0 ) + EPS;
-		beta = ( randu() * 10.0 ) + EPS;
-		dist = new Pareto1( alpha, beta );
+		dist = new Pareto1( alpha[ i % len ], beta[ i % len] );
 		if ( !( dist instanceof Pareto1 ) ) {
 			b.fail( 'should return a distribution instance' );
 		}
@@ -83,18 +91,23 @@ bench( pkg+'::set:alpha', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
 	var y;
 	var i;
 
 	alpha = 100.56789;
 	beta = 55.54321;
 	dist = new Pareto1( alpha, beta );
+	len = 100;
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = ( 100.0*randu() ) + EPS;
-		dist.alpha = y;
-		if ( dist.alpha !== y ) {
+		dist.alpha = y[ i % len ];
+		if ( dist.alpha !== y[ i % len ] ) {
 			b.fail( 'should return set value' );
 		}
 	}
@@ -136,18 +149,23 @@ bench( pkg+'::set:beta', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
 	var y;
 	var i;
 
 	alpha = 100.56789;
 	beta = 55.54321;
 	dist = new Pareto1( alpha, beta );
+	len = 100;
+	y = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		y[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = ( 100.0*randu() ) + EPS;
-		dist.beta = y;
-		if ( dist.beta !== y ) {
+		dist.beta = y[ i % len];
+		if ( dist.beta !== y[ i % len] ) {
 			b.fail( 'should return set value' );
 		}
 	}
@@ -163,16 +181,23 @@ bench( pkg+':entropy', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 
 	alpha = 100.56789;
 	beta = 55.54321;
 	dist = new Pareto1( alpha, beta );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.alpha = ( 100.0*randu() ) + EPS;
+		dist.alpha = x[ i % len ];
 		y = dist.entropy;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -190,16 +215,23 @@ bench( pkg+':kurtosis', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 
 	alpha = 100.56789;
 	beta = 55.54321;
 	dist = new Pareto1( alpha, beta );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 5.0 + EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.alpha = ( 100.0*randu() ) + 5.0 + EPS;
+		dist.alpha = x[ i % len ];
 		y = dist.kurtosis;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -217,16 +249,23 @@ bench( pkg+':mean', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 
 	alpha = 100.56789;
 	beta = 55.54321;
 	dist = new Pareto1( alpha, beta );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.alpha = ( 100.0*randu() ) + EPS;
+		dist.alpha = x[ i % len ];
 		y = dist.mean;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -244,16 +283,23 @@ bench( pkg+':median', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 
 	alpha = 100.56789;
 	beta = 55.54321;
 	dist = new Pareto1( alpha, beta );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.alpha = ( 100.0*randu() ) + EPS;
+		dist.alpha = x[ i % len ];
 		y = dist.median;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -271,16 +317,23 @@ bench( pkg+':mode', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 
 	alpha = 100.56789;
 	beta = 55.54321;
 	dist = new Pareto1( alpha, beta );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 1.0 + EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.alpha = ( 100.0*randu() ) + 1.0 + EPS;
+		dist.alpha = x[ i % len ];
 		y = dist.mode;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -298,16 +351,23 @@ bench( pkg+':skewness', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 
 	alpha = 100.56789;
 	beta = 55.54321;
 	dist = new Pareto1( alpha, beta );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 3.0 + EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.alpha = ( 100.0*randu() ) + 3.0 + EPS;
+		dist.alpha = x[ i % len ];
 		y = dist.skewness;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -325,16 +385,23 @@ bench( pkg+':variance', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
+	var x;
 	var y;
 	var i;
 
 	alpha = 100.56789;
 	beta = 55.54321;
 	dist = new Pareto1( alpha, beta );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		dist.alpha = ( 100.0*randu() ) + EPS;
+		dist.alpha = x[ i % len ];
 		y = dist.variance;
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
@@ -352,6 +419,7 @@ bench( pkg+':cdf', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -359,11 +427,15 @@ bench( pkg+':cdf', function benchmark( b ) {
 	alpha = 100.56789;
 	beta = 55.54321;
 	dist = new Pareto1( alpha, beta );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu() * 100.0;
-		y = dist.cdf( x );
+		y = dist.cdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -380,6 +452,7 @@ bench( pkg+':logcdf', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -387,11 +460,15 @@ bench( pkg+':logcdf', function benchmark( b ) {
 	alpha = 100.56789;
 	beta = 55.54321;
 	dist = new Pareto1( alpha, beta );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu() * 100.0;
-		y = dist.logcdf( x );
+		y = dist.logcdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -408,6 +485,7 @@ bench( pkg+':logpdf', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -415,11 +493,15 @@ bench( pkg+':logpdf', function benchmark( b ) {
 	alpha = 100.56789;
 	beta = 55.54321;
 	dist = new Pareto1( alpha, beta );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu() * 100.0;
-		y = dist.logpdf( x );
+		y = dist.logpdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -436,6 +518,7 @@ bench( pkg+':pdf', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -443,11 +526,15 @@ bench( pkg+':pdf', function benchmark( b ) {
 	alpha = 100.56789;
 	beta = 55.54321;
 	dist = new Pareto1( alpha, beta );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 100.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu() * 100.0;
-		y = dist.pdf( x );
+		y = dist.pdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -464,6 +551,7 @@ bench( pkg+':quantile', function benchmark( b ) {
 	var alpha;
 	var beta;
 	var dist;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -471,11 +559,15 @@ bench( pkg+':quantile', function benchmark( b ) {
 	alpha = 100.56789;
 	beta = 55.54321;
 	dist = new Pareto1( alpha, beta );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = dist.quantile( x );
+		y = dist.quantile( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/entropy/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/entropy/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,14 +34,21 @@ var entropy = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var alpha;
 	var beta;
+	var len;
 	var y;
 	var i;
 
+	len = 100;
+	alpha = new Float64Array( len );
+	beta = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		alpha[ i ] = uniform( EPS, 10.0 );
+		beta[ i ] = uniform( EPS, 10.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		alpha = ( randu()*10.0 ) + EPS;
-		beta = ( randu()*10.0 ) + EPS;
-		y = entropy( alpha, beta );
+		y = entropy( alpha[ i % len ], beta[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/kurtosis/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/kurtosis/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,14 +34,21 @@ var kurtosis = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var alpha;
 	var beta;
+	var len;
 	var y;
 	var i;
 
+	len = 100;
+	alpha = new Float64Array( len );
+	beta = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		alpha[ i ] = uniform( 4.0 + EPS, 10.0 );
+		beta[ i ] = uniform( EPS, 10.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		alpha = ( randu()*10.0 ) + 4.0 + EPS;
-		beta = ( randu()*10.0 ) + EPS;
-		y = kurtosis( alpha, beta );
+		y = kurtosis( alpha[ i % len ], beta[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/logcdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/logcdf/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,16 +34,24 @@ var logcdf = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var alpha;
 	var beta;
+	var len;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	alpha = new Float64Array( len );
+	beta = new Float64Array( len );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		alpha[ i ] = uniform( EPS, 100.0 );
+		beta[ i ] = uniform( EPS, 100.0 );
+		x[ i ] = uniform( EPS, 20.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*20.0 ) + EPS;
-		alpha = ( randu()*100.0 ) + EPS;
-		beta = ( randu()*100.0 ) + EPS;
-		y = logcdf( x, alpha, beta );
+		y = logcdf( x[ i % len ], alpha[ i % len ], beta[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -59,18 +68,23 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mylogcdf;
 	var alpha;
 	var beta;
+	var len;
 	var x;
 	var y;
 	var i;
 
 	alpha = 100.56789;
 	beta = 55.54321;
+	len = 100;
 	mylogcdf = logcdf.factory( alpha, beta );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 50.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*50.0 ) + EPS;
-		y = mylogcdf( x );
+		y = mylogcdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/logpdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/logpdf/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,16 +34,24 @@ var logpdf = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var alpha;
 	var beta;
+	var len;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	alpha = new Float64Array( len );
+	beta = new Float64Array( len );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		alpha[ i ] = uniform( EPS, 100.0 );
+		beta[ i ] = uniform( EPS, 100.0 );
+		x[ i ] = uniform( EPS, 20.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*20.0 ) + EPS;
-		alpha = ( randu()*100.0 ) + EPS;
-		beta = ( randu()*100.0 ) + EPS;
-		y = logpdf( x, alpha, beta );
+		y = logpdf( x[ i % len ], alpha[ i % len ], beta[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -59,6 +68,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mylogpdf;
 	var alpha;
 	var beta;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -66,11 +76,15 @@ bench( pkg+':factory', function benchmark( b ) {
 	alpha = 100.56789;
 	beta = 55.54321;
 	mylogpdf = logpdf.factory( alpha, beta );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 50.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*50.0 ) + EPS;
-		y = mylogpdf( x );
+		y = mylogpdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/mean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/mean/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,14 +34,21 @@ var mean = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var alpha;
 	var beta;
+	var len;
 	var y;
 	var i;
 
+	len = 100;
+	alpha = new Float64Array( len );
+	beta = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		alpha[ i ] = uniform( EPS, 10.0 );
+		beta[ i ] = uniform( EPS, 10.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		alpha = ( randu()*10.0 ) + EPS;
-		beta = ( randu()*10.0 ) + EPS;
-		y = mean( alpha, beta );
+		y = mean( alpha[ i % len ], beta[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/median/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/median/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,14 +34,21 @@ var median = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var alpha;
 	var beta;
+	var len;
 	var y;
 	var i;
 
+	len = 100;
+	alpha = new Float64Array( len );
+	beta = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		alpha[ i ] = uniform( EPS, 10.0 );
+		beta[ i ] = uniform( EPS, 10.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		alpha = ( randu()*10.0 ) + EPS;
-		beta = ( randu()*10.0 ) + EPS;
-		y = median( alpha, beta );
+		y = median( alpha[ i % len ], beta[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/mode/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/mode/benchmark/benchmark.js
@@ -48,7 +48,7 @@ bench( pkg, function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = mode( alpha[ i% len ], beta[ i % len ] );
+		y = mode( alpha[ i % len ], beta[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/mode/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/mode/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,14 +34,21 @@ var mode = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var alpha;
 	var beta;
+	var len;
 	var y;
 	var i;
 
+	len = 100;
+	alpha = new Float64Array( len );
+	beta = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		alpha[ i ] = uniform( EPS, 10.0 );
+		beta[ i ] = uniform( EPS, 10.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		alpha = ( randu()*10.0 ) + EPS;
-		beta = ( randu()*10.0 ) + EPS;
-		y = mode( alpha, beta );
+		y = mode( alpha[ i% len ], beta[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/pdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/pdf/benchmark/benchmark.js
@@ -81,7 +81,6 @@ bench( pkg+':factory', function benchmark( b ) {
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = uniform( EPS, 50.0 );
 	}
-	mypdf = pdf.factory( alpha, beta );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/pdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/pdf/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,16 +34,24 @@ var pdf = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var alpha;
 	var beta;
+	var len;
 	var x;
 	var y;
 	var i;
 
+	len = 100;
+	alpha = new Float64Array( len );
+	beta = new Float64Array( len );
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		alpha[ i ] = uniform( EPS, 100.0 );
+		beta[ i ] = uniform( EPS, 100.0 );
+		x[ i ] = uniform( EPS, 20.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*20.0 ) + EPS;
-		alpha = ( randu()*100.0 ) + EPS;
-		beta = ( randu()*100.0 ) + EPS;
-		y = pdf( x, alpha, beta );
+		y = pdf( x[ i % len ], alpha[ i % len ], beta[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -59,6 +68,7 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mypdf;
 	var alpha;
 	var beta;
+	var len;
 	var x;
 	var y;
 	var i;
@@ -66,11 +76,16 @@ bench( pkg+':factory', function benchmark( b ) {
 	alpha = 100.56789;
 	beta = 55.54321;
 	mypdf = pdf.factory( alpha, beta );
+	len = 100;
+	x = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		x[ i ] = uniform( EPS, 50.0 );
+	}
+	mypdf = pdf.factory( alpha, beta );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*50.0 ) + EPS;
-		y = mypdf( x );
+		y = mypdf( x[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/quantile/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,16 +34,24 @@ var quantile = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var alpha;
 	var beta;
+	var len;
 	var p;
 	var y;
 	var i;
 
+	len = 100;
+	alpha = new Float64Array( len );
+	beta = new Float64Array( len );
+	p = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		p[ i ] = uniform( 0.0, 1.0 );
+		alpha[ i ] = uniform( EPS, 100.0 );
+		beta[ i ] = uniform( EPS, 100.0 );
+	}
+	
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		alpha = ( randu()*100.0 ) + EPS;
-		beta = ( randu()*100.0 ) + EPS;
-		y = quantile( p, alpha, beta );
+		y = quantile( p[ i % len ], alpha[ i % len ], beta[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -59,18 +68,23 @@ bench( pkg+':factory', function benchmark( b ) {
 	var myquantile;
 	var alpha;
 	var beta;
+	var len;
 	var p;
 	var y;
 	var i;
 
 	alpha = 100.56789;
+	len = 100;
 	beta = 55.54321;
 	myquantile = quantile.factory( alpha, beta );
+	p = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		p[ i ] = uniform( 0.0, 1.0 );
+	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		p = randu();
-		y = myquantile( p );
+		y = myquantile( p[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/quantile/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/quantile/benchmark/benchmark.js
@@ -48,7 +48,7 @@ bench( pkg, function benchmark( b ) {
 		alpha[ i ] = uniform( EPS, 100.0 );
 		beta[ i ] = uniform( EPS, 100.0 );
 	}
-	
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
 		y = quantile( p[ i % len ], alpha[ i % len ], beta[ i % len ] );

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/skewness/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/skewness/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	alpha = new Float64Array( len );
 	beta = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = ( randu() * 10.0 ) + 3.0 + EPS;
-		beta[ i ] = ( randu() * 10.0 ) + EPS;
+		alpha[ i ] = uniform( 3.0 + EPS, 10.0 );
+		beta[ i ] = uniform( EPS, 10.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/skewness/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/skewness/benchmark/benchmark.native.js
@@ -51,7 +51,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	alpha = new Float64Array( len );
 	beta = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = uniform( 3.0 + EPS, 10.0);
+		alpha[ i ] = uniform( 3.0 + EPS, 10.0 );
 		beta[ i ] = uniform( EPS, 10.0 );
 	}
 

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/skewness/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/skewness/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var tryRequire = require( '@stdlib/utils/try-require' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -51,8 +51,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	alpha = new Float64Array( len );
 	beta = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = ( randu() * 10.0 ) + 3.0 + EPS;
-		beta[ i ] = ( randu() * 10.0 ) + EPS;
+		alpha[ i ] = uniform( 3.0 + EPS, 10.0);
+		beta[ i ] = uniform( EPS, 10.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/stdev/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/stdev/benchmark/benchmark.js
@@ -22,7 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -42,8 +42,8 @@ bench( pkg, function benchmark( b ) {
 	alpha = new Float64Array( len );
 	beta = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = ( randu() * 10.0 ) + EPS;
-		beta[ i ] = ( randu() * 10.0 ) + EPS;
+		alpha[ i ] = uniform( EPS, 10.0 );
+		beta[ i ] = uniform( EPS, 10.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/stdev/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/stdev/benchmark/benchmark.native.js
@@ -24,7 +24,7 @@ var resolve = require( 'path' ).resolve;
 var tryRequire = require( '@stdlib/utils/try-require' );
 var Float64Array = require( '@stdlib/array/float64' );
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -51,8 +51,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	alpha = new Float64Array( len );
 	beta = new Float64Array( len );
 	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = ( randu() * 10.0 ) + EPS;
-		beta[ i ] = ( randu() * 10.0 ) + EPS;
+		alpha[ i ] = uniform( EPS, 10.0 );
+		beta[ i ] = uniform( EPS, 10.0 );
 	}
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/variance/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/variance/benchmark/benchmark.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -33,14 +34,21 @@ var variance = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var alpha;
 	var beta;
+	var len;
 	var y;
 	var i;
 
+	len = 100;
+	alpha = new Float64Array( len );
+	beta = new Float64Array( len );
+	for ( i = 0; i < len; i++ ) {
+		alpha[ i ] = uniform( EPS, 10.0 );
+		beta[ i ] = uniform( EPS, 10.0 );
+	}
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		alpha = ( randu()*10.0 ) + EPS;
-		beta = ( randu()*10.0 ) + EPS;
-		y = variance( alpha, beta );
+		y = variance( alpha[ i % len ], beta[ i % len ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}


### PR DESCRIPTION

Resolves #4982 

## Description  
### What is the purpose of this pull request?  

This pull request:  

- Refactors random number generation in JS benchmarks for `stats/base/dists/pareto-type1`.  
- Replaces `randu()` with `uniform()` for cleaner and more consistent code.  
- Moves the random number generation outside the benchmarking loops to improve efficiency.  

## Related Issues  
### Does this pull request have any related issues?  

This pull request:  

- Resolves #4982 

## Questions  
### Any questions for reviewers of this pull request?  

No.  

## Other  
### Any other information relevant to this pull request?  

No.  

## Checklist  
Please ensure the following tasks are completed before submitting this pull request.  

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)  
