### PR TITLE
bench: refactor benchmarks and update test messages in `math/base/special/acos`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/acos/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/acos/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var acos = require( './../lib' );
@@ -34,10 +34,11 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -1.0, 1.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*2.0 ) - 1.0;
-		y = acos( x );
+		y = acos( x[ i % x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -55,10 +56,11 @@ bench( pkg+'::built-in', function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -1.0, 1.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*2.0 ) - 1.0;
-		y = Math.acos( x ); // eslint-disable-line stdlib/no-builtin-math
+		y = Math.acos( x[ i % x.length ] ); // eslint-disable-line stdlib/no-builtin-math
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/acos/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/acos/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -43,10 +43,11 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -1.0, 1.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*2.0 ) - 1.0;
-		y = acos( x );
+		y = acos( x[ i % x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/acos/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/acos/benchmark/c/benchmark.c
@@ -89,16 +89,19 @@ static double rand_double( void ) {
 * @return elapsed time in seconds
 */
 static double benchmark( void ) {
+	double x[ 100 ];
 	double elapsed;
-	double x;
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 2.0*rand_double() ) - 1.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 2.0*rand_double() ) - 1.0;
-		y = acos( x );
+		y = acos( x[ i % 100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/acos/benchmark/c/cephes/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/acos/benchmark/c/cephes/benchmark.c
@@ -94,16 +94,19 @@ static double rand_double( void ) {
 * @return elapsed time in seconds
 */
 static double benchmark( void ) {
+	double x[ 100 ];
 	double elapsed;
-	double x;
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 2.0*rand_double() ) - 1.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 2.0*rand_double() ) - 1.0;
-		y = acos( x );
+		y = acos( x[ i % 100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/acos/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/acos/benchmark/c/native/benchmark.c
@@ -90,16 +90,19 @@ static double rand_double( void ) {
 * @return elapsed time in seconds
 */
 static double benchmark( void ) {
+	double x[ 100 ];
 	double elapsed;
-	double x;
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 2.0*rand_double() ) - 1.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 2.0*rand_double() ) - 1.0;
-		y = stdlib_base_acos( x );
+		y = stdlib_base_acos( x[ i % 100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/acos/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/acos/test/test.js
@@ -126,7 +126,7 @@ tape( 'the function returns `NaN` if provided a value less than `-1`', function 
 	var i;
 	for ( i = 0; i < 1e4; i++ ) {
 		v = -(randu()*1.0e6) - (1.0+EPS);
-		t.equal( isnan( acos( v ) ), true, 'returns expected value' );
+		t.equal( isnan( acos( v ) ), true, 'returns expected value when provided '+v );
 	}
 	t.end();
 });
@@ -136,7 +136,7 @@ tape( 'the function returns `NaN` if provided a value greater than `+1`', functi
 	var i;
 	for ( i = 0; i < 1e4; i++ ) {
 		v = (randu()*1.0e6) + 1.0 + EPS;
-		t.equal( isnan( acos( v ) ), true, 'returns expected value' );
+		t.equal( isnan( acos( v ) ), true, 'returns expected value when provided '+v );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/acos/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/acos/test/test.js
@@ -117,7 +117,7 @@ tape( 'the function computes the arccosine (small positive numbers)', function t
 
 tape( 'the function returns `NaN` if provided a `NaN`', function test( t ) {
 	var v = acos( NaN );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 	t.end();
 });
 
@@ -126,7 +126,7 @@ tape( 'the function returns `NaN` if provided a value less than `-1`', function 
 	var i;
 	for ( i = 0; i < 1e4; i++ ) {
 		v = -(randu()*1.0e6) - (1.0+EPS);
-		t.equal( isnan( acos( v ) ), true, 'returns NaN when provided '+v );
+		t.equal( isnan( acos( v ) ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -136,7 +136,7 @@ tape( 'the function returns `NaN` if provided a value greater than `+1`', functi
 	var i;
 	for ( i = 0; i < 1e4; i++ ) {
 		v = (randu()*1.0e6) + 1.0 + EPS;
-		t.equal( isnan( acos( v ) ), true, 'returns NaN when provided '+v );
+		t.equal( isnan( acos( v ) ), true, 'returns expected value' );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/acos/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/acos/test/test.native.js
@@ -135,7 +135,7 @@ tape( 'the function returns `NaN` if provided a value less than `-1`', opts, fun
 	var i;
 	for ( i = 0; i < 1e4; i++ ) {
 		v = -(randu()*1.0e6) - (1.0+EPS);
-		t.equal( isnan( acos( v ) ), true, 'returns expected value' );
+		t.equal( isnan( acos( v ) ), true, 'returns expected value when provided '+v );
 	}
 	t.end();
 });
@@ -145,7 +145,7 @@ tape( 'the function returns `NaN` if provided a value greater than `+1`', opts, 
 	var i;
 	for ( i = 0; i < 1e4; i++ ) {
 		v = (randu()*1.0e6) + 1.0 + EPS;
-		t.equal( isnan( acos( v ) ), true, 'returns expected value' );
+		t.equal( isnan( acos( v ) ), true, 'returns expected value when provided '+v );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/acos/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/acos/test/test.native.js
@@ -126,7 +126,7 @@ tape( 'the function computes the arccosine (small positive numbers)', opts, func
 
 tape( 'the function returns `NaN` if provided a `NaN`', opts, function test( t ) {
 	var v = acos( NaN );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 	t.end();
 });
 
@@ -135,7 +135,7 @@ tape( 'the function returns `NaN` if provided a value less than `-1`', opts, fun
 	var i;
 	for ( i = 0; i < 1e4; i++ ) {
 		v = -(randu()*1.0e6) - (1.0+EPS);
-		t.equal( isnan( acos( v ) ), true, 'returns NaN when provided '+v );
+		t.equal( isnan( acos( v ) ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -145,7 +145,7 @@ tape( 'the function returns `NaN` if provided a value greater than `+1`', opts, 
 	var i;
 	for ( i = 0; i < 1e4; i++ ) {
 		v = (randu()*1.0e6) + 1.0 + EPS;
-		t.equal( isnan( acos( v ) ), true, 'returns NaN when provided '+v );
+		t.equal( isnan( acos( v ) ), true, 'returns expected value' );
 	}
 	t.end();
 });


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

- Refactors random number generation in JS benchmarks for `math/base/special/acos`
- Replaces `randu()` with `uniform()` from `@stdlib/random/array/uniform` for cleaner and more consistent code.
- Moves the random number generation outside the benchmarking loops.
- Updates the test messages to follow code conventions.

## Related Issues

> Does this pull request have any related issues?

This pull request:

- resolves none

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md