### PR TITLE
docs: fix missing ending `section` in various READMEs

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/entropy/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/entropy/README.md
@@ -233,6 +233,10 @@ int main( void ) {
 
 <!-- /.examples -->
 
+</section>
+
+<!-- /.c -->
+
 <!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 
 <section class="references">

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/kurtosis/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/kurtosis/README.md
@@ -233,6 +233,10 @@ int main( void ) {
 
 <!-- /.examples -->
 
+</section>
+
+<!-- /.c -->
+
 <!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 
 <section class="references">

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/logcdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/logcdf/README.md
@@ -158,6 +158,10 @@ for ( i = 0; i < 25; i++ ) {
 
 <!-- /.examples -->
 
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/logpdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/logpdf/README.md
@@ -158,10 +158,6 @@ for ( i = 0; i < 25; i++ ) {
 
 <!-- /.examples -->
 
-<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
-
-<section class="references">
-
 <!-- C interface documentation. -->
 
 * * *
@@ -256,6 +252,18 @@ int main( void ) {
     }
 }
 ```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
 
 </section>
 

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/mean/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/mean/README.md
@@ -235,6 +235,10 @@ int main( void ) {
 
 <!-- /.examples -->
 
+</section>
+
+<!-- /.c -->
+
 <!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 
 <section class="references">

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/median/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/median/README.md
@@ -235,6 +235,10 @@ int main( void ) {
 
 <!-- /.examples -->
 
+</section>
+
+<!-- /.c -->
+
 <!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 
 <section class="references">

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/mgf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/mgf/README.md
@@ -163,10 +163,6 @@ for ( i = 0; i < 10; i++ ) {
 
 <!-- /.examples -->
 
-<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
-
-<section class="references">
-
 <!-- C interface documentation. -->
 
 * * *
@@ -260,6 +256,18 @@ int main( void ) {
     }
 }
 ```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
 
 </section>
 

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/mode/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/mode/README.md
@@ -233,6 +233,10 @@ int main( void ) {
 
 <!-- /.examples -->
 
+</section>
+
+<!-- /.c -->
+
 <!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 
 <section class="references">

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/pdf/README.md
@@ -148,10 +148,6 @@ for ( i = 0; i < 25; i++ ) {
 
 <!-- /.examples -->
 
-<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
-
-<section class="references">
-
 <!-- C interface documentation. -->
 
 * * *
@@ -245,6 +241,18 @@ int main( void ) {
     }
 }
 ```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
 
 </section>
 

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/skewness/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/skewness/README.md
@@ -235,6 +235,10 @@ int main( void ) {
 
 <!-- /.examples -->
 
+</section>
+
+<!-- /.c -->
+
 <!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 
 <section class="references">

--- a/lib/node_modules/@stdlib/stats/base/dists/triangular/stdev/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/triangular/stdev/README.md
@@ -235,6 +235,10 @@ int main( void ) {
 
 <!-- /.examples -->
 
+</section>
+
+<!-- /.c -->
+
 <!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 
 <section class="references">

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/logcdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/logcdf/README.md
@@ -241,6 +241,10 @@ int main( void ) {
 
 <!-- /.examples -->
 
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/logpdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/logpdf/README.md
@@ -241,6 +241,10 @@ int main( void ) {
 
 <!-- /.examples -->
 
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/pdf/README.md
@@ -216,7 +216,7 @@ int main( void ) {
     double b;
     double y;
     int i;
-    
+
     for ( i = 0; i < 25; i++ ) {
         x = random_uniform( -10.0, 10.0 );
         a = random_uniform( -20.0, 0.0 );
@@ -230,6 +230,10 @@ int main( void ) {
 </section>
 
 <!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
 
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/stdev/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/stdev/README.md
@@ -224,6 +224,10 @@ int main( void ) {
 
 <!-- /.examples -->
 
+</section>
+
+<!-- /.c -->
+
 <!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 
 <section class="references">


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

-  Add `c` section ending statement and improve some readme.md.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves 
- none

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
