### PR TITLE
bench: fix `isnan` checks in `stats/base/dists`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/arcsine/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/arcsine/ctor/benchmark/benchmark.js
@@ -112,7 +112,7 @@ bench( pkg+'::set:a', function benchmark( bm ) {
 		}
 	}
 	bm.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.a ) ) {
 		bm.fail( 'should not return NaN' );
 	}
 	bm.pass( 'benchmark finished' );
@@ -170,7 +170,7 @@ bench( pkg+'::set:b', function benchmark( bm ) {
 		}
 	}
 	bm.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.b ) ) {
 		bm.fail( 'should not return NaN' );
 	}
 	bm.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/stats/base/dists/bernoulli/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bernoulli/ctor/benchmark/benchmark.js
@@ -106,7 +106,7 @@ bench( pkg+'::set:p', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.p ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/ctor/benchmark/benchmark.js
@@ -112,7 +112,7 @@ bench( pkg+'::set:alpha', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.alpha ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );
@@ -170,7 +170,7 @@ bench( pkg+'::set:beta', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.beta ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/ctor/benchmark/benchmark.js
@@ -112,7 +112,7 @@ bench( pkg+'::set:alpha', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.alpha ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );
@@ -170,7 +170,7 @@ bench( pkg+'::set:beta', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.beta ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/ctor/benchmark/benchmark.js
@@ -113,7 +113,7 @@ bench( pkg+'::set:n', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.n ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );
@@ -171,7 +171,7 @@ bench( pkg+'::set:p', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.p ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/stats/base/dists/cauchy/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cauchy/ctor/benchmark/benchmark.js
@@ -112,7 +112,7 @@ bench( pkg+'::set:x0', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.x0 ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );
@@ -170,7 +170,7 @@ bench( pkg+'::set:gamma', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.gamma ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/stats/base/dists/chi/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chi/ctor/benchmark/benchmark.js
@@ -105,7 +105,7 @@ bench( pkg+'::set:k', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.k ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/stats/base/dists/chisquare/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/chisquare/ctor/benchmark/benchmark.js
@@ -105,7 +105,7 @@ bench( pkg+'::set:k', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.k ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/ctor/benchmark/benchmark.js
@@ -112,7 +112,7 @@ bench( pkg+'::set:mu', function benchmark( bm ) {
 		}
 	}
 	bm.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.mu ) ) {
 		bm.fail( 'should not return NaN' );
 	}
 	bm.pass( 'benchmark finished' );
@@ -170,7 +170,7 @@ bench( pkg+'::set:s', function benchmark( bm ) {
 		}
 	}
 	bm.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.s ) ) {
 		bm.fail( 'should not return NaN' );
 	}
 	bm.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/stats/base/dists/degenerate/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/degenerate/ctor/benchmark/benchmark.js
@@ -105,7 +105,7 @@ bench( pkg+'::set:mu', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.mu ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/discrete-uniform/ctor/benchmark/benchmark.js
@@ -112,7 +112,7 @@ bench( pkg+'::set:a', function benchmark( bm ) {
 		}
 	}
 	bm.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.a ) ) {
 		bm.fail( 'should not return NaN' );
 	}
 	bm.pass( 'benchmark finished' );
@@ -170,7 +170,7 @@ bench( pkg+'::set:b', function benchmark( bm ) {
 		}
 	}
 	bm.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.b ) ) {
 		bm.fail( 'should not return NaN' );
 	}
 	bm.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/stats/base/dists/erlang/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/erlang/ctor/benchmark/benchmark.js
@@ -113,7 +113,7 @@ bench( pkg+'::set:k', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.k ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );
@@ -171,7 +171,7 @@ bench( pkg+'::set:lambda', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.lambda ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/stats/base/dists/exponential/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/exponential/ctor/benchmark/benchmark.js
@@ -105,7 +105,7 @@ bench( pkg+'::set:lambda', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.lambda ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/stats/base/dists/f/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/f/ctor/benchmark/benchmark.js
@@ -112,7 +112,7 @@ bench( pkg+'::set:d1', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.d1 ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );
@@ -170,7 +170,7 @@ bench( pkg+'::set:d2', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.d2 ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/stats/base/dists/frechet/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/frechet/ctor/benchmark/benchmark.js
@@ -119,7 +119,7 @@ bench( pkg+'::set:alpha', function benchmark( bm ) {
 		}
 	}
 	bm.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.a ) ) {
 		bm.fail( 'should not return NaN' );
 	}
 	bm.pass( 'benchmark finished' );
@@ -181,7 +181,7 @@ bench( pkg+'::set:s', function benchmark( bm ) {
 		}
 	}
 	bm.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.b ) ) {
 		bm.fail( 'should not return NaN' );
 	}
 	bm.pass( 'benchmark finished' );
@@ -243,7 +243,7 @@ bench( pkg+'::set:m', function benchmark( bm ) {
 		}
 	}
 	bm.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.c ) ) {
 		bm.fail( 'should not return NaN' );
 	}
 	bm.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/stats/base/dists/gamma/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gamma/ctor/benchmark/benchmark.js
@@ -112,7 +112,7 @@ bench( pkg+'::set:alpha', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.alpha ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );
@@ -170,7 +170,7 @@ bench( pkg+'::set:beta', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.beta ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/ctor/benchmark/benchmark.js
@@ -106,7 +106,7 @@ bench( pkg+'::set:p', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.p ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/ctor/benchmark/benchmark.js
@@ -112,7 +112,7 @@ bench( pkg+'::set:mu', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.mu ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );
@@ -170,7 +170,7 @@ bench( pkg+'::set:beta', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.beta ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/hypergeometric/ctor/benchmark/benchmark.js
@@ -119,7 +119,7 @@ bench( pkg+'::set:N', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.N ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );
@@ -181,7 +181,7 @@ bench( pkg+'::set:K', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.K ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );
@@ -243,7 +243,7 @@ bench( pkg+'::set:n', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.n ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/stats/base/dists/invgamma/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/invgamma/ctor/benchmark/benchmark.js
@@ -112,7 +112,7 @@ bench( pkg+'::set:alpha', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.alpha ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );
@@ -170,7 +170,7 @@ bench( pkg+'::set:beta', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.beta ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/stats/base/dists/logistic/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/logistic/ctor/benchmark/benchmark.js
@@ -112,7 +112,7 @@ bench( pkg+'::set:mu', function benchmark( bm ) {
 		}
 	}
 	bm.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.mu ) ) {
 		bm.fail( 'should not return NaN' );
 	}
 	bm.pass( 'benchmark finished' );
@@ -170,7 +170,7 @@ bench( pkg+'::set:s', function benchmark( bm ) {
 		}
 	}
 	bm.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.s ) ) {
 		bm.fail( 'should not return NaN' );
 	}
 	bm.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/ctor/benchmark/benchmark.js
@@ -112,7 +112,7 @@ bench( pkg+'::set:mu', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.mu ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );
@@ -170,7 +170,7 @@ bench( pkg+'::set:sigma', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.sigma ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/negative-binomial/ctor/benchmark/benchmark.js
@@ -113,7 +113,7 @@ bench( pkg+'::set:r', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.r ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );
@@ -171,7 +171,7 @@ bench( pkg+'::set:p', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.p ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/pareto-type1/ctor/benchmark/benchmark.js
@@ -112,7 +112,7 @@ bench( pkg+'::set:alpha', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.alpha ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );
@@ -170,7 +170,7 @@ bench( pkg+'::set:beta', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.beta ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/stats/base/dists/poisson/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/poisson/ctor/benchmark/benchmark.js
@@ -103,7 +103,7 @@ bench( pkg+'::set:lambda', function benchmark( b ) {
 		}
 	}
 	b.toc();
-	if ( isnan( y ) ) {
+	if ( isnan( dist.lambda ) ) {
 		b.fail( 'should not return NaN' );
 	}
 	b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/ctor/benchmark/benchmark.js
@@ -112,7 +112,7 @@ bench( pkg+'::set:a', function benchmark( bm ) {
 		}
 	}
 	bm.toc();
-	if ( isnan( y[ i % len] ) ) {
+	if ( isnan( dist.a ) ) {
 		bm.fail( 'should not return NaN' );
 	}
 	bm.pass( 'benchmark finished' );
@@ -170,7 +170,7 @@ bench( pkg+'::set:b', function benchmark( bm ) {
 		}
 	}
 	bm.toc();
-	if ( isnan( y[ i % len ] ) ) {
+	if ( isnan( dist.b ) ) {
 		bm.fail( 'should not return NaN' );
 	}
 	bm.pass( 'benchmark finished' );


### PR DESCRIPTION
Resolves none.

Thanks @G4URAV001 for pointing this bug.

## Description

> What is the purpose of this pull request?

This pull request:

- Replaces `isnan( y )` with `isnan( dist.a )`, `isnan( dist.b )`, etc., using the appropriate parameters.
- Ensures consistency and correctness in `isnan` checks throughout the package.

## Related Issues

> Does this pull request have any related issues?

This pull request:

- resolves none

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md