### PR TITLE
fix: revert uniform implementation and remove unnecessary loop

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/planck/median/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/median/benchmark/benchmark.js
@@ -31,14 +31,11 @@ var median = require( './../lib' );
 
 bench( pkg, function benchmark( b ) {
 	var lambda;
-	var len;
 	var y;
 	var i;
 
-	len =100;
-	lambda = new Float64Array( len );
 
-	lambda = uniform(100, 1.0, 10.0); 
+	lambda = uniform( 100, 1.0, 10.0 ); 
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/median/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/median/benchmark/benchmark.js
@@ -34,7 +34,6 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
-
 	lambda = uniform( 100, 1.0, 10.0 ); 
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/median/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/median/benchmark/benchmark.js
@@ -34,7 +34,7 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
-	lambda = uniform( 100, 0.1, 10.0 ); 
+	lambda = uniform( 100, 0.1, 10.0 );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/median/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/median/benchmark/benchmark.js
@@ -34,7 +34,7 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
-	lambda = uniform( 100, 1.0, 10.0 ); 
+	lambda = uniform( 100, 0.1, 10.0 ); 
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/median/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/median/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/median/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/median/benchmark/benchmark.js
@@ -22,7 +22,6 @@
 
 var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
-var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var median = require( './../lib' );
@@ -38,13 +37,12 @@ bench( pkg, function benchmark( b ) {
 
 	len =100;
 	lambda = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		lambda[ i ] = uniform( 1.0, 10.0);
-	}
+
+	lambda = uniform(100, 1.0, 10.0); 
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = median( lambda[ i % len ] );
+		y = median( lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/median/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/median/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/median/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/median/benchmark/benchmark.native.js
@@ -43,7 +43,6 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
-	
 	lambda = uniform( 100, 0.1, 10.0 );
 
 	b.tic();

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/median/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/median/benchmark/benchmark.native.js
@@ -47,12 +47,12 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 
 	len = 100;
 	
-	lambda = uniform(len, 0.1, 10.0);
+	lambda = uniform(100, 0.1, 10.0);
 
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = median( lambda[ i % len ] );
+		y = median( lambda[ i % lambda.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/median/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/median/benchmark/benchmark.native.js
@@ -22,7 +22,6 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
 var uniform = require( '@stdlib/random/base/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -41,14 +40,11 @@ var opts = {
 
 bench( pkg+'::native', opts, function benchmark( b ) {
 	var lambda;
-	var len;
 	var y;
 	var i;
 
-	len = 100;
 	
-	lambda = uniform(100, 0.1, 10.0);
-
+	lambda = uniform( 100, 0.1, 10.0 );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/stats/base/dists/planck/median/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/planck/median/benchmark/benchmark.native.js
@@ -46,10 +46,9 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var i;
 
 	len = 100;
-	lambda = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		lambda[ i ] = uniform( 1.0, 10.0 );
-	}
+	
+	lambda = uniform(len, 0.1, 10.0);
+
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {


### PR DESCRIPTION

---
type: pre_push_report
description: Results of running various checks prior to pushing changes.  
report:
  - task: run_javascript_examples status: na
  - task: run_c_examples status: na
  - task: run_cpp_examples status: na
  - task: run_javascript_readme_examples status: na
  - task: run_c_benchmarks status: na
  - task: run_cpp_benchmarks status: na
  - task: run_fortran_benchmarks status: na
  - task: run_javascript_benchmarks status: na
  - task: run_julia_benchmarks status: na
  - task: run_python_benchmarks status: na
  - task: run_r_benchmarks status: na
  - task: run_javascript_tests status: na
---

# Resolves #5228  


## Description

> What is the purpose of this pull request?

This pull request:

- Reverts `@stdlib/random/base/uniform` back to `@stdlib/random/array/uniform` as per review feedback in fb90f93#r152597788.
- Updates `benchmark.native.js` to match the expected implementation.
- Removes unnecessary for loop and directly initializes the uniform array.

## Related Issues

> Does this pull request have any related issues?

This pull request:

- Address commit comments (commit fb90f93).

## Questions

> Any questions for reviewers?

No.

## Other

> Any other relevant information?

- `make lint` produced filename errors in unrelated files. These files were not modified as part of this PR.
- Skipping lint fixes since they are unrelated to this issue.

## Checklist

- [x] Read, understood, and followed the [contributing guidelines]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md

* * *

@stdlib-js/reviewers
