### PR TITLE
refactor: update benchmarks and tests in `math/base/special/acosh`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/acosh/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/acosh/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var acosh = require( './../lib' );
@@ -41,10 +41,11 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, 1.0, 100.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*100.0 ) + 1.0;
-		y = acosh( x );
+		y = acosh( x[ i % x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -62,10 +63,11 @@ bench( pkg+'::built-in', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, 1.0, 100.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*100.0 ) + 1.0;
-		y = Math.acosh( x ); // eslint-disable-line stdlib/no-builtin-math
+		y = Math.acosh( x[ i % x.length ] ); // eslint-disable-line stdlib/no-builtin-math
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/acosh/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/acosh/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -43,10 +43,11 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, 1.0, 100.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*100.0 ) + 1.0;
-		y = acosh( x );
+		y = acosh( x[ i % x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/acosh/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/acosh/benchmark/c/benchmark.c
@@ -89,16 +89,19 @@ static double rand_double( void ) {
 * @return elapsed time in seconds
 */
 static double benchmark( void ) {
+	double x[ 100 ];
 	double elapsed;
-	double x;
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 100.0*rand_double() ) + 1.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 100.0*rand_double() ) + 1.0;
-		y = acosh( x );
+		y = acosh( x[ i % 100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/acosh/benchmark/c/cephes/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/acosh/benchmark/c/cephes/benchmark.c
@@ -94,16 +94,19 @@ static double rand_double( void ) {
 * @return elapsed time in seconds
 */
 static double benchmark( void ) {
+	double x[ 100 ];
 	double elapsed;
-	double x;
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 100.0*rand_double() ) + 1.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 100.0*rand_double() ) + 1.0;
-		y = acosh( x );
+		y = acosh( x[ i % 100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/acosh/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/acosh/benchmark/c/native/benchmark.c
@@ -90,16 +90,19 @@ static double rand_double( void ) {
 * @return elapsed time in seconds
 */
 static double benchmark( void ) {
+	double x[ 100 ];
 	double elapsed;
-	double x;
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 100.0*rand_double() ) + 1.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 100.0*rand_double() ) + 1.0;
-		y = stdlib_base_acosh( x );
+		y = stdlib_base_acosh( x[ i % 100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/acosh/benchmark/cpp/boost/benchmark.cpp
+++ b/lib/node_modules/@stdlib/math/base/special/acosh/benchmark/cpp/boost/benchmark.cpp
@@ -85,8 +85,8 @@ double tic() {
 * @return elapsed time in seconds
 */
 double benchmark() {
+	double x[ 100 ];
 	double elapsed;
-	double x;
 	double y;
 	double t;
 	int i;
@@ -97,10 +97,13 @@ double benchmark() {
 	// Define a uniform distribution for generating pseudorandom numbers as "doubles" between a minimum value (inclusive) and a maximum value (exclusive):
 	uniform_real_distribution<> randu( 1.0, 101.0 );
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = randu( rng );
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = randu( rng );
-		y = boost::math::acosh( x );
+		y = boost::math::acosh( x[ i % 100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/acosh/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/acosh/test/test.js
@@ -24,6 +24,7 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var abs = require( '@stdlib/math/base/special/abs' );
 var acosh = require( './../lib' );
 
 
@@ -45,6 +46,8 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the hyperbolic arccosine on the interval [1.0,3.0]', function test( t ) {
 	var expected;
+	var delta;
+	var tol;
 	var x;
 	var y;
 	var i;
@@ -56,6 +59,10 @@ tape( 'the function computes the hyperbolic arccosine on the interval [1.0,3.0]'
 		y = acosh( x[i] );
 		if ( y === expected[ i ] ) {
 			t.equal( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
+		} else {
+			delta = abs( y - expected[i] );
+			tol = 1.0 * EPS * abs( expected[i] );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
 		}
 	}
 	t.end();
@@ -63,6 +70,8 @@ tape( 'the function computes the hyperbolic arccosine on the interval [1.0,3.0]'
 
 tape( 'the function computes the hyperbolic arccosine on the interval [3.0,28.0]', function test( t ) {
 	var expected;
+	var delta;
+	var tol;
 	var x;
 	var y;
 	var i;
@@ -74,6 +83,10 @@ tape( 'the function computes the hyperbolic arccosine on the interval [3.0,28.0]
 		y = acosh( x[i] );
 		if ( y === expected[ i ] ) {
 			t.equal( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
+		} else {
+			delta = abs( y - expected[i] );
+			tol = 1.0 * EPS * abs( expected[i] );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
 		}
 	}
 	t.end();
@@ -81,6 +94,8 @@ tape( 'the function computes the hyperbolic arccosine on the interval [3.0,28.0]
 
 tape( 'the function computes the hyperbolic arccosine on the interval [28.0,100.0]', function test( t ) {
 	var expected;
+	var delta;
+	var tol;
 	var x;
 	var y;
 	var i;
@@ -92,6 +107,10 @@ tape( 'the function computes the hyperbolic arccosine on the interval [28.0,100.
 		y = acosh( x[i] );
 		if ( y === expected[ i ] ) {
 			t.equal( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
+		} else {
+			delta = abs( y - expected[i] );
+			tol = 1.0 * EPS * abs( expected[i] );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
 		}
 	}
 	t.end();
@@ -99,6 +118,8 @@ tape( 'the function computes the hyperbolic arccosine on the interval [28.0,100.
 
 tape( 'the function computes the hyperbolic arccosine for huge values', function test( t ) {
 	var expected;
+	var delta;
+	var tol;
 	var x;
 	var y;
 	var i;
@@ -110,6 +131,10 @@ tape( 'the function computes the hyperbolic arccosine for huge values', function
 		y = acosh( x[i] );
 		if ( y === expected[ i ] ) {
 			t.equal( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
+		} else {
+			delta = abs( y - expected[i] );
+			tol = 1.0 * EPS * abs( expected[i] );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/math/base/special/acosh/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/acosh/test/test.js
@@ -24,7 +24,6 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
 var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var acosh = require( './../lib' );
 
 
@@ -46,8 +45,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the hyperbolic arccosine on the interval [1.0,3.0]', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -59,10 +56,6 @@ tape( 'the function computes the hyperbolic arccosine on the interval [1.0,3.0]'
 		y = acosh( x[i] );
 		if ( y === expected[ i ] ) {
 			t.equal( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
 		}
 	}
 	t.end();
@@ -70,8 +63,6 @@ tape( 'the function computes the hyperbolic arccosine on the interval [1.0,3.0]'
 
 tape( 'the function computes the hyperbolic arccosine on the interval [3.0,28.0]', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -83,10 +74,6 @@ tape( 'the function computes the hyperbolic arccosine on the interval [3.0,28.0]
 		y = acosh( x[i] );
 		if ( y === expected[ i ] ) {
 			t.equal( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
 		}
 	}
 	t.end();
@@ -94,8 +81,6 @@ tape( 'the function computes the hyperbolic arccosine on the interval [3.0,28.0]
 
 tape( 'the function computes the hyperbolic arccosine on the interval [28.0,100.0]', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -107,10 +92,6 @@ tape( 'the function computes the hyperbolic arccosine on the interval [28.0,100.
 		y = acosh( x[i] );
 		if ( y === expected[ i ] ) {
 			t.equal( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
 		}
 	}
 	t.end();
@@ -118,8 +99,6 @@ tape( 'the function computes the hyperbolic arccosine on the interval [28.0,100.
 
 tape( 'the function computes the hyperbolic arccosine for huge values', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -131,10 +110,6 @@ tape( 'the function computes the hyperbolic arccosine for huge values', function
 		y = acosh( x[i] );
 		if ( y === expected[ i ] ) {
 			t.equal( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
 		}
 	}
 	t.end();
@@ -142,7 +117,7 @@ tape( 'the function computes the hyperbolic arccosine for huge values', function
 
 tape( 'the function returns `NaN` if provided `NaN`', function test( t ) {
 	var v = acosh( NaN );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 	t.end();
 });
 
@@ -152,7 +127,7 @@ tape( 'the function returns `NaN` if provided value less than `1`', function tes
 
 	for ( i = 0; i < 1e3; i++ ) {
 		v = -(randu()*1.0e6) + (1-EPS);
-		t.equal( isnan( acosh( v ) ), true, 'returns NaN when provided '+v );
+		t.equal( isnan( acosh( v ) ), true, 'returns expected value when provided '+v );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/acosh/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/acosh/test/test.native.js
@@ -25,7 +25,6 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
 var EPS = require( '@stdlib/constants/float64/eps' );
-var abs = require( '@stdlib/math/base/special/abs' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -55,8 +54,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the hyperbolic arccosine on the interval [1.0,3.0]', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -68,10 +65,6 @@ tape( 'the function computes the hyperbolic arccosine on the interval [1.0,3.0]'
 		y = acosh( x[i] );
 		if ( y === expected[ i ] ) {
 			t.equal( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
 		}
 	}
 	t.end();
@@ -79,8 +72,6 @@ tape( 'the function computes the hyperbolic arccosine on the interval [1.0,3.0]'
 
 tape( 'the function computes the hyperbolic arccosine on the interval [3.0,28.0]', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -92,10 +83,6 @@ tape( 'the function computes the hyperbolic arccosine on the interval [3.0,28.0]
 		y = acosh( x[i] );
 		if ( y === expected[ i ] ) {
 			t.equal( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
 		}
 	}
 	t.end();
@@ -103,8 +90,6 @@ tape( 'the function computes the hyperbolic arccosine on the interval [3.0,28.0]
 
 tape( 'the function computes the hyperbolic arccosine on the interval [28.0,100.0]', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -116,10 +101,6 @@ tape( 'the function computes the hyperbolic arccosine on the interval [28.0,100.
 		y = acosh( x[i] );
 		if ( y === expected[ i ] ) {
 			t.equal( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
 		}
 	}
 	t.end();
@@ -127,8 +108,6 @@ tape( 'the function computes the hyperbolic arccosine on the interval [28.0,100.
 
 tape( 'the function computes the hyperbolic arccosine for huge values', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -140,10 +119,6 @@ tape( 'the function computes the hyperbolic arccosine for huge values', opts, fu
 		y = acosh( x[i] );
 		if ( y === expected[ i ] ) {
 			t.equal( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[i] );
-			tol = 1.0 * EPS * abs( expected[i] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
 		}
 	}
 	t.end();
@@ -151,7 +126,7 @@ tape( 'the function computes the hyperbolic arccosine for huge values', opts, fu
 
 tape( 'the function returns `NaN` if provided `NaN`', opts, function test( t ) {
 	var v = acosh( NaN );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 	t.end();
 });
 
@@ -161,7 +136,7 @@ tape( 'the function returns `NaN` if provided value less than `1`', opts, functi
 
 	for ( i = 0; i < 1e3; i++ ) {
 		v = -(randu()*1.0e6) + (1-EPS);
-		t.equal( isnan( acosh( v ) ), true, 'returns NaN when provided '+v );
+		t.equal( isnan( acosh( v ) ), true, 'returns expected value when provided '+v );
 	}
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/acosh/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/acosh/test/test.native.js
@@ -25,6 +25,7 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var randu = require( '@stdlib/random/base/randu' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var abs = require( '@stdlib/math/base/special/abs' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -54,6 +55,8 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the hyperbolic arccosine on the interval [1.0,3.0]', opts, function test( t ) {
 	var expected;
+	var delta;
+	var tol;
 	var x;
 	var y;
 	var i;
@@ -65,6 +68,10 @@ tape( 'the function computes the hyperbolic arccosine on the interval [1.0,3.0]'
 		y = acosh( x[i] );
 		if ( y === expected[ i ] ) {
 			t.equal( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
+		} else {
+			delta = abs( y - expected[i] );
+			tol = 1.0 * EPS * abs( expected[i] );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
 		}
 	}
 	t.end();
@@ -72,6 +79,8 @@ tape( 'the function computes the hyperbolic arccosine on the interval [1.0,3.0]'
 
 tape( 'the function computes the hyperbolic arccosine on the interval [3.0,28.0]', opts, function test( t ) {
 	var expected;
+	var delta;
+	var tol;
 	var x;
 	var y;
 	var i;
@@ -83,6 +92,10 @@ tape( 'the function computes the hyperbolic arccosine on the interval [3.0,28.0]
 		y = acosh( x[i] );
 		if ( y === expected[ i ] ) {
 			t.equal( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
+		} else {
+			delta = abs( y - expected[i] );
+			tol = 1.0 * EPS * abs( expected[i] );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
 		}
 	}
 	t.end();
@@ -90,6 +103,8 @@ tape( 'the function computes the hyperbolic arccosine on the interval [3.0,28.0]
 
 tape( 'the function computes the hyperbolic arccosine on the interval [28.0,100.0]', opts, function test( t ) {
 	var expected;
+	var delta;
+	var tol;
 	var x;
 	var y;
 	var i;
@@ -101,6 +116,10 @@ tape( 'the function computes the hyperbolic arccosine on the interval [28.0,100.
 		y = acosh( x[i] );
 		if ( y === expected[ i ] ) {
 			t.equal( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
+		} else {
+			delta = abs( y - expected[i] );
+			tol = 1.0 * EPS * abs( expected[i] );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
 		}
 	}
 	t.end();
@@ -108,6 +127,8 @@ tape( 'the function computes the hyperbolic arccosine on the interval [28.0,100.
 
 tape( 'the function computes the hyperbolic arccosine for huge values', opts, function test( t ) {
 	var expected;
+	var delta;
+	var tol;
 	var x;
 	var y;
 	var i;
@@ -119,6 +140,10 @@ tape( 'the function computes the hyperbolic arccosine for huge values', opts, fu
 		y = acosh( x[i] );
 		if ( y === expected[ i ] ) {
 			t.equal( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
+		} else {
+			delta = abs( y - expected[i] );
+			tol = 1.0 * EPS * abs( expected[i] );
+			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

- Refactors random number generation in JS benchmarks for `math/base/special/acosh`
- Replaces `randu()` with `uniform()` from `@stdlib/random/array/uniform` for cleaner and more consistent code.
- Moves the random number generation outside the benchmarking loops.
- Updates the test messages to follow code conventions.

## Related Issues

> Does this pull request have any related issues?

This pull request:

- resolves none

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md