### PR TITLE
build: refactor rule to disallow tabs in entire JSDoc comment

### DIFF
--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-no-tabs/README.md
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-no-tabs/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # No Tabs
 
-> [ESLint rule][eslint-rules] forbidding the use of tabs in JSDoc descriptions.
+> [ESLint rule][eslint-rules] forbidding the use of tabs in JSDoc comments.
 
 <section class="intro">
 
@@ -38,7 +38,7 @@ var rule = require( '@stdlib/_tools/eslint/rules/jsdoc-no-tabs' );
 
 #### rule
 
-[ESLint rule][eslint-rules] forbidding the use of tabs in JSDoc descriptions.
+[ESLint rule][eslint-rules] forbidding the use of tabs in JSDoc comments.
 
 **Bad**:
 

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-no-tabs/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-no-tabs/lib/main.js
@@ -20,7 +20,6 @@
 
 // MODULES //
 
-var parseJSDoc = require( 'doctrine' ).parse;
 var remark = require( 'remark' );
 var remarkLint = require( 'remark-lint' );
 var remarkPlugin = require( 'remark-lint-no-tabs' );
@@ -30,17 +29,13 @@ var findJSDoc = require( '@stdlib/_tools/eslint/utils/find-jsdoc' );
 
 // VARIABLES //
 
-var DOPTS = {
-	'sloppy': true,
-	'unwrap': true
-};
 var rule;
 
 
 // FUNCTIONS //
 
 /**
-* Rule forbidding the use of tabs in JSDoc descriptions.
+* Rule forbidding the use of tabs in JSDoc comments.
 *
 * @param {Object} context - ESLint context
 * @returns {Object} validators
@@ -67,7 +62,7 @@ function main( context ) {
 	};
 
 	/**
-	* Lints JSDoc descriptions.
+	* Lints entire JSDoc comments for tabs.
 	*
 	* @private
 	* @param {ASTNode} node - AST node
@@ -75,16 +70,12 @@ function main( context ) {
 	function validate( node ) {
 		var jsdoc;
 		var vfile;
-		var ast;
 
 		jsdoc = findJSDoc( source, node );
 		if ( isObject( jsdoc ) ) {
-			ast = parseJSDoc( jsdoc.value, DOPTS );
-			if ( ast.description ) {
-				vfile = lint( ast.description );
-				if ( vfile.messages.length ) {
-					reportErrors( vfile.messages, jsdoc.loc );
-				}
+			vfile = lint( jsdoc.value );
+			if ( vfile.messages.length ) {
+				reportErrors( vfile.messages, jsdoc.loc );
 			}
 		}
 	}
@@ -154,7 +145,7 @@ function main( context ) {
 rule = {
 	'meta': {
 		'docs': {
-			'description': 'forbid the use of tabs in JSDoc descriptions'
+			'description': 'forbid the use of tabs in JSDoc comments'
 		},
 		'schema': []
 	},

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-no-tabs/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-no-tabs/lib/main.js
@@ -23,12 +23,14 @@
 var remark = require( 'remark' );
 var remarkLint = require( 'remark-lint' );
 var remarkPlugin = require( 'remark-lint-no-tabs' );
+var replace = require( '@stdlib/string/replace' );
 var isObject = require( '@stdlib/assert/is-object' );
 var findJSDoc = require( '@stdlib/_tools/eslint/utils/find-jsdoc' );
 
 
 // VARIABLES //
 
+var RE_LEADING_TABS = /^\t+(\*|$)/gm;
 var rule;
 
 
@@ -70,10 +72,13 @@ function main( context ) {
 	function validate( node ) {
 		var jsdoc;
 		var vfile;
+		var text;
 
 		jsdoc = findJSDoc( source, node );
 		if ( isObject( jsdoc ) ) {
-			vfile = lint( jsdoc.value );
+			text = jsdoc.value;
+			text = replace( text, RE_LEADING_TABS, '*' );
+			vfile = lint( text );
 			if ( vfile.messages.length ) {
 				reportErrors( vfile.messages, jsdoc.loc );
 			}

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-no-tabs/test/fixtures/invalid.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-no-tabs/test/fixtures/invalid.js
@@ -70,6 +70,66 @@ test = {
 };
 invalid.push( test );
 
+test = {
+	'code': [
+		'/**',
+		'* Beep boop.',
+		'*',
+		'* [foo]: http://foo.bar/baz',
+		'*',
+		'* @param {string} str	- input value',
+		'* @returns {string}	output value',
+		'*',
+		'* @example',
+		'* var out = beep( "boop" );',
+		'* // returns "beepboop"',
+		'*/',
+		'function beep( str ) {',
+		'    return "beep" + str;',
+		'}'
+	].join( '\n' ),
+	'errors': [
+		{
+			'message': 'Use spaces instead of tabs',
+			'type': null
+		},
+		{
+			'message': 'Use spaces instead of tabs',
+			'type': null
+		}
+	]
+};
+invalid.push( test );
+
+test = {
+	'code': [
+		'/**',
+		'* Beep boop.',
+		'*',
+		'* @param {string} str - input value',
+		'* @returns {string} output value',
+		'*',
+		'* @example',
+		'*	var out = beep( "boop" );',
+		'*	// returns "beepboop"',
+		'*/',
+		'function beep( str ) {',
+		'    return "beep" + str;',
+		'}'
+	].join( '\n' ),
+	'errors': [
+		{
+			'message': 'Use spaces instead of tabs',
+			'type': null
+		},
+		{
+			'message': 'Use spaces instead of tabs',
+			'type': null
+		}
+	]
+};
+invalid.push( test );
+
 
 // EXPORTS //
 

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-no-tabs/test/fixtures/valid.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-no-tabs/test/fixtures/valid.js
@@ -51,6 +51,72 @@ valid.push( test );
 test = {
 	'code': [
 		'/**',
+		'* @license Apache-2.0',
+		'*',
+		'* Copyright (c) 2018 The Stdlib Authors.',
+		'*',
+		'* Licensed under the Apache License, Version 2.0 (the "License");',
+		'* you may not use this file except in compliance with the License.',
+		'* You may obtain a copy of the License at',
+		'*',
+		'*    http://www.apache.org/licenses/LICENSE-2.0',
+		'*',
+		'* Unless required by applicable law or agreed to in writing, software',
+		'* distributed under the License is distributed on an "AS IS" BASIS,',
+		'* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.',
+		'* See the License for the specific language governing permissions and',
+		'* limitations under the License.',
+		'*/',
+		'',
+		'/**',
+		'* Squares a number.',
+		'* ',
+		'* @param {number} x - input number',
+		'* @returns {number} x squared',
+		'*',
+		'* @example',
+		'* var y = square( 2.0 );',
+		'* // returns 4.0',
+		'*/',
+		'function square( x ) {',
+		'  return x*x;',
+		'}'
+	].join( '\n' )
+};
+valid.push( test );
+
+test = {
+	'code': [
+		'/**',
+		'* Creates a function to calculate powers.',
+		'*',
+		'* @param {number} base - base number',
+		'* @returns {Function} function to calculate powers',
+		'*',
+		'* @example',
+		'* var powerFn = createPowerFn( 2 );',
+		'* var result = powerFn( 3 );',
+		'* // returns 8',
+		'*/',
+		'function createPowerFn( base ) {',
+		'	/**',
+		'	* Calculates power of base number.',
+		'	*',
+		'	* @private',
+		'	* @param {number} exponent - power to raise base to',
+		'	* @returns {number} result of base raised to exponent',
+		'	*/',
+		'	return function power( exponent ) {',
+		'		return Math.pow( base, exponent );',
+		'	};',
+		'}'
+	].join( '\n' )
+};
+valid.push( test );
+
+test = {
+	'code': [
+		'/**',
 		'* Returns a pseudo-random number on `[0,1]`.',
 		'* ',
 		'* @returns {number} uniform random number',


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   refactors the `jsdoc-no-tabs` lint rule to disallow TABs in the entirety of the JSDoc comment, nut just the description.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves https://github.com/stdlib-js/metr-issue-tracker/issues/36

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

None.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md