### PR TITLE
build: add ESLint rule to enforce empty lines between requires and code

### DIFF
--- a/etc/eslint/rules/stdlib.js
+++ b/etc/eslint/rules/stdlib.js
@@ -2964,6 +2964,8 @@ rules[ 'stdlib/jsdoc-no-space-aligned-asterisks' ] = 'error';
 */
 rules[ 'stdlib/jsdoc-no-table-indentation' ] = 'error';
 
+/* eslint-disable stdlib/jsdoc-no-tabs */
+
 /**
 * Forbid the use of tabs.
 *
@@ -3009,6 +3011,8 @@ rules[ 'stdlib/jsdoc-no-table-indentation' ] = 'error';
 * }
 */
 rules[ 'stdlib/jsdoc-no-tabs' ] = 'error';
+
+/* eslint-enable stdlib/jsdoc-no-tabs */
 
 /**
 * Prevent references to undefined definitions.

--- a/etc/eslint/rules/stdlib.js
+++ b/etc/eslint/rules/stdlib.js
@@ -16,7 +16,7 @@
 * limitations under the License.
 */
 
-/* eslint-disable stdlib/jsdoc-doctest-marker, stdlib/jsdoc-doctest */
+/* eslint-disable stdlib/jsdoc-doctest-marker, stdlib/jsdoc-doctest, stdlib/jsdoc-example-require-spacing */
 
 'use strict';
 
@@ -837,6 +837,49 @@ rules[ 'stdlib/jsdoc-emphasis-marker' ] = [ 'error', '_' ];
 * var ceil = Math.ceil;
 */
 rules[ 'stdlib/jsdoc-empty-line-before-example' ] = 'error';
+
+/**
+* Enforce empty lines between requires and code in JSDoc examples.
+*
+* @name jsdoc-example-require-spacing
+* @memberof rules
+* @type {string}
+* @default 'error'
+*
+* @example
+* // Bad...
+*
+* /**
+* * Fréchet distribution constructor.
+* *
+* * @module @stdlib/stats/base/dists/frechet/ctor
+* *
+* * @example
+* * var Frechet = require( '@stdlib/stats/base/dists/frechet/ctor' );
+* * var frechet = new Frechet( 1.0, 1.0, 0.5 );
+* *
+* * var y = frechet.cdf( 0.8 );
+* * // returns ~0.036
+* *\/
+*
+* @example
+* // Good...
+*
+* /**
+* * Fréchet distribution constructor.
+* *
+* * @module @stdlib/stats/base/dists/frechet/ctor
+* *
+* * @example
+* * var Frechet = require( '@stdlib/stats/base/dists/frechet/ctor' );
+* *
+* * var frechet = new Frechet( 1.0, 1.0, 0.5 );
+* *
+* * var y = frechet.cdf( 0.8 );
+* * // returns ~0.036
+* *\/
+*/
+rules[ 'stdlib/jsdoc-example-require-spacing' ] = 'error';
 
 /**
 * Require `\`` be used as the fenced code marker.

--- a/etc/eslint/rules/stdlib.js
+++ b/etc/eslint/rules/stdlib.js
@@ -1,3 +1,5 @@
+/* eslint-disable stdlib/jsdoc-doctest-marker, stdlib/jsdoc-doctest, stdlib/jsdoc-example-require-spacing, stdlib/jsdoc-no-tabs */
+
 /**
 * @license Apache-2.0
 *
@@ -15,8 +17,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-
-/* eslint-disable stdlib/jsdoc-doctest-marker, stdlib/jsdoc-doctest, stdlib/jsdoc-example-require-spacing */
 
 'use strict';
 
@@ -2964,8 +2964,6 @@ rules[ 'stdlib/jsdoc-no-space-aligned-asterisks' ] = 'error';
 */
 rules[ 'stdlib/jsdoc-no-table-indentation' ] = 'error';
 
-/* eslint-disable stdlib/jsdoc-no-tabs */
-
 /**
 * Forbid the use of tabs.
 *
@@ -3011,8 +3009,6 @@ rules[ 'stdlib/jsdoc-no-table-indentation' ] = 'error';
 * }
 */
 rules[ 'stdlib/jsdoc-no-tabs' ] = 'error';
-
-/* eslint-enable stdlib/jsdoc-no-tabs */
 
 /**
 * Prevent references to undefined definitions.

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/README.md
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/README.md
@@ -42,7 +42,7 @@ var rule = require( '@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing' 
 
 **Bad**:
 
-<!-- eslint-disable stdlib/jsdoc-example-require-spacing -->
+<!-- eslint stdlib/jsdoc-example-require-spacing: "off", @cspell/spellchecker: "off" -->
 
 ```javascript
 /**
@@ -60,6 +60,8 @@ var rule = require( '@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing' 
 ```
 
 **Good**:
+
+<!-- eslint @cspell/spellchecker: "off" -->
 
 ```javascript
 /**

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/README.md
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # jsdoc-example-require-spacing
 
-> [ESLint rule][eslint-rules] to enforce empty lines between requires and code in JSDoc examples.
+> [ESLint rule][eslint-rules] to enforce empty lines between `require` statements and code in JSDoc examples.
 
 <section class="intro">
 
@@ -38,7 +38,7 @@ var rule = require( '@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing' 
 
 #### rule
 
-[ESLint rule][eslint-rules] to enforce empty lines between requires and code in JSDoc examples.
+[ESLint rule][eslint-rules] to enforce empty lines between `require` statements and code in JSDoc examples.
 
 **Bad**:
 

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/README.md
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/README.md
@@ -1,0 +1,157 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2025 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# jsdoc-example-require-spacing
+
+> [ESLint rule][eslint-rules] to enforce empty lines between requires and code in JSDoc examples.
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var rule = require( '@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing' );
+```
+
+#### rule
+
+[ESLint rule][eslint-rules] to enforce empty lines between requires and code in JSDoc examples.
+
+**Bad**:
+
+<!-- eslint-disable stdlib/jsdoc-example-require-spacing -->
+
+```javascript
+/**
+* Fréchet distribution constructor.
+*
+* @module @stdlib/stats/base/dists/frechet/ctor
+*
+* @example
+* var Frechet = require( '@stdlib/stats/base/dists/frechet/ctor' );
+* var frechet = new Frechet( 1.0, 1.0, 0.5 );
+*
+* var y = frechet.cdf( 0.8 );
+* // returns ~0.036
+*/
+```
+
+**Good**:
+
+```javascript
+/**
+* Fréchet distribution constructor.
+*
+* @module @stdlib/stats/base/dists/frechet/ctor
+*
+* @example
+* var Frechet = require( '@stdlib/stats/base/dists/frechet/ctor' );
+*
+* var frechet = new Frechet( 1.0, 1.0, 0.5 );
+*
+* var y = frechet.cdf( 0.8 );
+* // returns ~0.036
+*/
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var Linter = require( 'eslint' ).Linter;
+var rule = require( '@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing' );
+
+var linter = new Linter();
+var result;
+var code;
+
+code = [
+    '/**',
+    '* Fréchet distribution constructor.',
+    '*',
+    '* @module @stdlib/stats/base/dists/frechet/ctor',
+    '*',
+    '* @example',
+    '* var Frechet = require( \'@stdlib/stats/base/dists/frechet/ctor\' );',
+    '* var frechet = new Frechet( 1.0, 1.0, 0.5 );',
+    '*',
+    '* var y = frechet.cdf( 0.8 );',
+    '* // returns ~0.036',
+    '*/',
+    'function Frechet() {}'
+].join( '\n' );
+
+linter.defineRule( 'jsdoc-example-require-spacing', rule );
+
+result = linter.verify( code, {
+    'rules': {
+        'jsdoc-example-require-spacing': 'error'
+    }
+});
+/* returns
+    [
+        {
+            'ruleId': 'jsdoc-example-require-spacing',
+            'severity': 2,
+            'message': 'Missing empty line between require statement and code',
+            'line': 13,
+            'column': 1,
+            'nodeType': 'FunctionDeclaration',
+            'endLine': 13,
+            'endColumn': 21
+        }
+    ]
+*/
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[eslint-rules]: https://eslint.org/docs/developer-guide/working-with-rules
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/examples/index.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/examples/index.js
@@ -1,0 +1,75 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var Linter = require( 'eslint' ).Linter;
+var rule = require( './../lib' );
+
+var linter = new Linter();
+
+// Valid example with empty line after require:
+var valid = [
+	'/**',
+	'* Fréchet distribution constructor.',
+	'*',
+	'* @example',
+	'* var Frechet = require( \'@stdlib/stats/base/dists/frechet/ctor\' );',
+	'*',
+	'* var frechet = new Frechet( 1.0, 1.0, 0.5 );',
+	'*',
+	'* var y = frechet.cdf( 0.8 );',
+	'* // returns ~0.036',
+	'*/',
+	'function Frechet() {}'
+].join( '\n' );
+
+// Invalid example without empty line after require:
+var invalid = [
+	'/**',
+	'* Fréchet distribution constructor.',
+	'*',
+	'* @example',
+	'* var Frechet = require( \'@stdlib/stats/base/dists/frechet/ctor\' );',
+	'* var frechet = new Frechet( 1.0, 1.0, 0.5 );',
+	'*',
+	'* var y = frechet.cdf( 0.8 );',
+	'* // returns ~0.036',
+	'*/',
+	'function Frechet() {}'
+].join( '\n' );
+
+// Register the rule:
+linter.defineRule( 'jsdoc-example-require-spacing', rule );
+
+// Lint the valid example:
+var validResult = linter.verify( valid, {
+	'rules': {
+		'jsdoc-example-require-spacing': 'error'
+	}
+});
+console.log( 'Valid example - Number of errors: %d', validResult.length );
+
+// Lint the invalid example:
+var invalidResult = linter.verify( invalid, {
+	'rules': {
+		'jsdoc-example-require-spacing': 'error'
+	}
+});
+console.log( 'Invalid example - Number of errors: %d', invalidResult.length );
+console.log( 'Error message: %s', invalidResult[ 0 ].message );

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/lib/index.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/lib/index.js
@@ -1,0 +1,45 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var rule = require( './main.js' );
+
+
+// MAIN //
+
+/**
+* ESLint rule to enforce empty lines between requires and code in JSDoc examples.
+*
+* @module @stdlib/_tools/eslint/rules/jsdoc-example-require-spacing
+*
+* @example
+* var rule = require( '@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing' );
+*
+* var config = {
+*     'rules': {
+*         'stdlib/jsdoc-example-require-spacing': 'error'
+*     }
+* };
+*/
+
+// EXPORTS //
+
+module.exports = rule;

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/lib/index.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/lib/index.js
@@ -26,7 +26,7 @@ var rule = require( './main.js' );
 // MAIN //
 
 /**
-* ESLint rule to enforce empty lines between requires and code in JSDoc examples.
+* ESLint rule to enforce empty lines between `require` statements and code in JSDoc examples.
 *
 * @module @stdlib/_tools/eslint/rules/jsdoc-example-require-spacing
 *

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/lib/main.js
@@ -41,7 +41,7 @@ var rule;
 // MAIN //
 
 /**
-* Rule to enforce empty lines between requires and code in JSDoc examples.
+* Rule to enforce empty lines between `require` statements and code in JSDoc examples.
 *
 * @param {Object} context - ESLint context
 * @returns {Object} rule object
@@ -117,7 +117,7 @@ function main( context ) {
 	}
 
 	/**
-	* Checks if a JSDoc comment contains examples with require statements not followed by empty lines.
+	* Checks if a JSDoc comment contains examples with `require` statements which are not followed by empty lines.
 	*
 	* @private
 	* @param {Object} node - node to examine

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/lib/main.js
@@ -1,0 +1,172 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var parseJSDoc = require( 'doctrine' ).parse;
+var trim = require( '@stdlib/string/base/trim' );
+var isObject = require( '@stdlib/assert/is-object' );
+var isEmptyArray = require( '@stdlib/assert/is-empty-array' );
+var findJSDoc = require( '@stdlib/_tools/eslint/utils/find-jsdoc' );
+
+
+// VARIABLES //
+
+var RE_NEWLINE = /\r?\n/g;
+var DOPTS = {
+	'sloppy': true,
+	'unwrap': true,
+	'tags': [ 'example' ]
+};
+var rule;
+
+
+// MAIN //
+
+/**
+* Rule to enforce empty lines between requires and code in JSDoc examples.
+*
+* @param {Object} context - ESLint context
+* @returns {Object} rule object
+*/
+function main( context ) {
+	var source = context.getSourceCode();
+
+	/**
+	* Reports the error message.
+	*
+	* @private
+	* @param {Object} node - node to report
+	*/
+	function report( node ) {
+		context.report({
+			'node': node,
+			'message': 'Missing empty line between require statement and code in JSDoc example'
+		});
+	}
+
+	/**
+	* Checks if a line contains a require statement.
+	*
+	* @private
+	* @param {string} line - line to check
+	* @returns {boolean} boolean indicating if line contains a require statement
+	*/
+	function hasRequire( line ) {
+		return trim( line ).indexOf( 'require(' ) !== -1;
+	}
+
+	/**
+	* Checks if a line is empty.
+	*
+	* @private
+	* @param {string} line - line to check
+	* @returns {boolean} boolean indicating if line is empty
+	*/
+	function isEmpty( line ) {
+		return trim( line ) === '';
+	}
+
+	/**
+	* Processes an example tag description.
+	*
+	* @private
+	* @param {string} description - example description
+	* @param {Object} node - node to report
+	*/
+	function processExample( description, node ) {
+		var nextLine;
+		var lines;
+		var i;
+
+		lines = description.split( RE_NEWLINE );
+		for ( i = 0; i < lines.length; i++ ) {
+			if ( hasRequire( lines[ i ] ) ) {
+				if ( i + 1 >= lines.length ) {
+					break;
+				}
+				nextLine = lines[ i+1 ];
+				if ( isEmpty( nextLine ) ) {
+					continue;
+				}
+
+				// If next line is neither empty nor another require, report the error:
+				if ( !hasRequire( nextLine ) ) {
+					report( node );
+					return;
+				}
+			}
+		}
+	}
+
+	/**
+	* Checks if a JSDoc comment contains examples with require statements not followed by empty lines.
+	*
+	* @private
+	* @param {Object} node - node to examine
+	*/
+	function validate( node ) {
+		var jsdoc;
+		var tags;
+		var tag;
+		var ast;
+		var j;
+
+		jsdoc = findJSDoc( source, node );
+		if ( isObject( jsdoc ) ) {
+			ast = parseJSDoc( jsdoc.value, DOPTS );
+			tags = ast.tags;
+			if ( isEmptyArray( tags ) ) {
+				return;
+			}
+			for ( j = 0; j < tags.length; j++ ) {
+				tag = tags[ j ];
+				if ( tag.title === 'example' && tag.description ) {
+					processExample( tag.description, node );
+				}
+			}
+		}
+	}
+
+	return {
+		'FunctionDeclaration': validate,
+		'VariableDeclaration': validate,
+		'ExpressionStatement': validate
+	};
+}
+
+
+// MAIN //
+
+rule = {
+	'meta': {
+		'type': 'suggestion',
+		'docs': {
+			'description': 'enforce empty lines between requires and code in JSDoc examples'
+		},
+		'schema': []
+	},
+	'create': main
+};
+
+
+// EXPORTS //
+
+module.exports = rule;

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/lib/main.js
@@ -38,6 +38,31 @@ var DOPTS = {
 var rule;
 
 
+// FUNCTIONS //
+
+/**
+* Checks if a line contains a require statement.
+*
+* @private
+* @param {string} line - line to check
+* @returns {boolean} boolean indicating if line contains a require statement
+*/
+function hasRequire( line ) {
+	return trim( line ).indexOf( 'require(' ) !== -1;
+}
+
+/**
+* Checks if a line is empty.
+*
+* @private
+* @param {string} line - line to check
+* @returns {boolean} boolean indicating if line is empty
+*/
+function isEmpty( line ) {
+	return trim( line ) === '';
+}
+
+
 // MAIN //
 
 /**
@@ -60,28 +85,6 @@ function main( context ) {
 			'node': node,
 			'message': 'Missing empty line between require statement and code in JSDoc example'
 		});
-	}
-
-	/**
-	* Checks if a line contains a require statement.
-	*
-	* @private
-	* @param {string} line - line to check
-	* @returns {boolean} boolean indicating if line contains a require statement
-	*/
-	function hasRequire( line ) {
-		return trim( line ).indexOf( 'require(' ) !== -1;
-	}
-
-	/**
-	* Checks if a line is empty.
-	*
-	* @private
-	* @param {string} line - line to check
-	* @returns {boolean} boolean indicating if line is empty
-	*/
-	function isEmpty( line ) {
-		return trim( line ) === '';
 	}
 
 	/**

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/lib/main.js
@@ -22,6 +22,7 @@
 
 var parseJSDoc = require( 'doctrine' ).parse;
 var trim = require( '@stdlib/string/base/trim' );
+var reEOL = require( '@stdlib/regexp/eol' );
 var isObject = require( '@stdlib/assert/is-object' );
 var isEmptyArray = require( '@stdlib/assert/is-empty-array' );
 var findJSDoc = require( '@stdlib/_tools/eslint/utils/find-jsdoc' );
@@ -29,7 +30,6 @@ var findJSDoc = require( '@stdlib/_tools/eslint/utils/find-jsdoc' );
 
 // VARIABLES //
 
-var RE_NEWLINE = /\r?\n/g;
 var DOPTS = {
 	'sloppy': true,
 	'unwrap': true,
@@ -99,7 +99,7 @@ function main( context ) {
 		var lines;
 		var i;
 
-		lines = description.split( RE_NEWLINE );
+		lines = description.split( reEOL.REGEXP );
 		for ( i = 0; i < lines.length; i++ ) {
 			if ( hasRequire( lines[ i ] ) ) {
 				if ( i + 1 >= lines.length ) {

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/package.json
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing",
+  "version": "0.0.0",
+  "description": "ESLint rule to enforce empty lines between requires and code in JSDoc examples.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "bin": {},
+  "main": "./lib",
+  "directories": {
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "tools",
+    "tool",
+    "eslint",
+    "lint",
+    "custom",
+    "rules",
+    "rule",
+    "plugin",
+    "jsdoc",
+    "example",
+    "require",
+    "spacing"
+  ]
+}

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/package.json
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing",
   "version": "0.0.0",
-  "description": "ESLint rule to enforce empty lines between requires and code in JSDoc examples.",
+  "description": "ESLint rule to enforce empty lines between `require` statements and code in JSDoc examples.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/test/fixtures/invalid.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/test/fixtures/invalid.js
@@ -1,0 +1,90 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var invalid = [];
+var test;
+
+test = {
+	'code': [
+		'/**',
+		'* Single require without proper spacing.',
+		'*',
+		'* @example',
+		'* var foo = require( \'foo\' );',
+		'* var x = foo();',
+		'*/',
+		'function test1() {}'
+	].join( '\n' ),
+	'errors': [
+		{
+			'message': 'Missing empty line between require statement and code in JSDoc example',
+			'type': 'FunctionDeclaration'
+		}
+	]
+};
+invalid.push( test );
+
+test = {
+	'code': [
+		'/**',
+		'* Multiple requires without proper spacing.',
+		'*',
+		'* @example',
+		'* var foo = require( \'foo\' );',
+		'* var bar = require( \'bar\' );',
+		'* var x = foo( bar() );',
+		'*/',
+		'function test2() {}'
+	].join( '\n' ),
+	'errors': [
+		{
+			'message': 'Missing empty line between require statement and code in JSDoc example',
+			'type': 'FunctionDeclaration'
+		}
+	]
+};
+invalid.push( test );
+
+test = {
+	'code': [
+		'/**',
+		'* Mixed spacing - second require without proper spacing.',
+		'*',
+		'* @example',
+		'* var foo = require( \'foo\' );',
+		'*',
+		'* var bar = require( \'bar\' );',
+		'* var x = foo( bar() );',
+		'*/',
+		'function test4() {}'
+	].join( '\n' ),
+	'errors': [
+		{
+			'message': 'Missing empty line between require statement and code in JSDoc example',
+			'type': 'FunctionDeclaration'
+		}
+	]
+};
+invalid.push( test );
+
+
+// EXPORTS //
+
+module.exports = invalid;

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/test/fixtures/valid.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/test/fixtures/valid.js
@@ -1,0 +1,90 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var valid = [];
+var test;
+
+test = {
+	'code': [
+		'/**',
+		'* Single require with proper spacing.',
+		'*',
+		'* @example',
+		'* var foo = require( \'foo\' );',
+		'*',
+		'* var x = foo();',
+		'*/',
+		'function test1() {}'
+	].join( '\n' )
+};
+valid.push( test );
+
+test = {
+	'code': [
+		'/**',
+		'* Multiple requires with proper spacing.',
+		'*',
+		'* @example',
+		'* var foo = require( \'foo\' );',
+		'*',
+		'* var bar = require( \'bar\' );',
+		'*',
+		'* var x = foo( bar() );',
+		'*/',
+		'function test2() {}'
+	].join( '\n' )
+};
+valid.push( test );
+
+test = {
+	'code': [
+		'/**',
+		'* Example without requires.',
+		'*',
+		'* @example',
+		'* var x = 5;',
+		'* var y = x * 2;',
+		'*/',
+		'function test3() {}'
+	].join( '\n' )
+};
+valid.push( test );
+
+test = {
+	'code': [
+		'/**',
+		'* Example with requires and comments.',
+		'*',
+		'* @example',
+		'* var foo = require( \'foo\' );',
+		'*',
+		'* // This is a comment',
+		'*',
+		'* var x = foo();',
+		'*/',
+		'function test4() {}'
+	].join( '\n' )
+};
+valid.push( test );
+
+
+// EXPORTS //
+
+module.exports = valid;

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/test/test.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing/test/test.js
@@ -1,0 +1,70 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var RuleTester = require( 'eslint' ).RuleTester;
+var rule = require( './../lib' );
+
+
+// FIXTURES //
+
+var valid = require( './fixtures/valid.js' );
+var invalid = require( './fixtures/invalid.js' );
+
+
+// TESTS //
+
+tape( 'main export is an object', function test( t ) {
+	t.ok( true, __filename );
+	t.equal( typeof rule, 'object', 'main export is an object' );
+	t.end();
+});
+
+tape( 'the function positively validates JSDoc examples with proper spacing after require statements', function test( t ) {
+	var tester = new RuleTester();
+
+	try {
+		tester.run( 'jsdoc-example-require-spacing', rule, {
+			'valid': valid,
+			'invalid': []
+		});
+		t.pass( 'passed without errors' );
+	} catch ( err ) {
+		t.fail( 'encountered an error: ' + err.message );
+	}
+	t.end();
+});
+
+tape( 'the function negatively validates JSDoc examples without proper spacing after require statements', function test( t ) {
+	var tester = new RuleTester();
+
+	try {
+		tester.run( 'jsdoc-example-require-spacing', rule, {
+			'valid': [],
+			'invalid': invalid
+		});
+		t.pass( 'passed without errors' );
+	} catch ( err ) {
+		t.fail( 'encountered an error: ' + err.message );
+	}
+	t.end();
+});

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/lib/index.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/lib/index.js
@@ -208,6 +208,15 @@ setReadOnly( rules, 'jsdoc-emphasis-marker', require( '@stdlib/_tools/eslint/rul
 setReadOnly( rules, 'jsdoc-empty-line-before-example', require( '@stdlib/_tools/eslint/rules/jsdoc-empty-line-before-example' ) );
 
 /**
+* @name jsdoc-example-require-spacing
+* @memberof rules
+* @readonly
+* @type {Function}
+* @see {@link module:@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing}
+*/
+setReadOnly( rules, 'jsdoc-example-require-spacing', require( '@stdlib/_tools/eslint/rules/jsdoc-example-require-spacing' ) );
+
+/**
 * @name jsdoc-fenced-code-flag
 * @memberof rules
 * @readonly


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds and enables a new ESLint rule that enforces an empty line between require statements and following code

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves https://github.com/stdlib-js/metr-issue-tracker/issues/42

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

None.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md