### PR TITLE
build: run affected tests in sub-directories

### DIFF
--- a/.github/workflows/scripts/run_affected_tests
+++ b/.github/workflows/scripts/run_affected_tests
@@ -151,7 +151,7 @@ main() {
 	done
 
 	# Find all test files in package directories:
-	files=$(find ${directories} -maxdepth 2 -wholename '**/test/test*.js' | grep -v '/fixtures/' | sort -u | tr '\n' ' ') || true
+	files=$(find ${directories} -maxdepth 3 \( -wholename '**/test/test*.js' -or -wholename '**/test/**/test*.js' \) | grep -v '/fixtures/' | sort -u | tr '\n' ' ') || true
 
 	# Exclude files residing in test fixtures directories:
 	files=$(echo "${files}" | grep -v '/fixtures/') || true


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   refactors the `run_affected_tests` script to run tests located in sub-directories in `test`, for example `test/integration` as in `@stdlib/repl` (see: https://github.com/stdlib-js/stdlib/pull/1680)

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves https://github.com/stdlib-js/stdlib/issues/2096 and https://github.com/stdlib-js/metr-issue-tracker/issues/4.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
