### PR TITLE
build: install Cephes dependency in CI if used in benchmarks

### DIFF
--- a/.github/workflows/scripts/run_affected_benchmarks
+++ b/.github/workflows/scripts/run_affected_benchmarks
@@ -145,6 +145,12 @@ main() {
 	echo "Finding C benchmark files in ${directories}..."
 	c_bench_files=$(find "${directories}" -maxdepth 5 \( -wholename '**/benchmark/c/benchmark*.c' -or -wholename '**/benchmark/c/**/benchmark*.c' \) -exec realpath {} \; | grep -v '/fixtures/' | sort -u | tr '\n' ' ') || true
 
+	# If benchmarks requiring Cephes are found, install the Cephes library:
+	c_cephes_makefiles=$(find "${directories}" -maxdepth 5 -wholename '**/benchmark/c/**/Makefile' -exec grep -l 'CEPHES' {} + || true)
+	if [ -n "${c_cephes_makefiles}" ]; then
+		make install-deps-cephes
+	fi
+
 	if [ -n "${c_bench_files}" ]; then
 		make benchmark-c-files FILES="${c_bench_files}"
 	else


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   installs Cephes dependency if used in any of the run C benchmarks

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves https://github.com/stdlib-js/metr-issue-tracker/issues/8.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
