### PR TITLE
fix: do not break subsequent exclamation points or question marks in `nlp/sentencize`

### DIFF
--- a/lib/node_modules/@stdlib/nlp/sentencize/lib/main.js
+++ b/lib/node_modules/@stdlib/nlp/sentencize/lib/main.js
@@ -68,7 +68,8 @@ function isEndOfSentence( tokens, i ) {
 	if (
 		( token === '!' || token === '?' ) &&
 		!RE_PREFIXES.test( tokens[ im1 ] ) &&
-		!RE_SUFFIXES.test( tokens[ ip1 ] )
+		!RE_SUFFIXES.test( tokens[ ip1 ] ) &&
+		( tokens[ ip1 ] !== '!' && tokens[ ip1 ] !== '?' )
 	) {
 		return true;
 	}

--- a/lib/node_modules/@stdlib/nlp/sentencize/test/test.js
+++ b/lib/node_modules/@stdlib/nlp/sentencize/test/test.js
@@ -289,6 +289,28 @@ tape( 'the function splits a string into an array of sentences (unfinished last 
 	t.end();
 });
 
+tape( 'the function splits a string into an array of sentences (multiple punctuation marks)', function test( t ) {
+	var expected;
+	var actual;
+	var str;
+
+	str = 'HAPPY BIRTHDAY!!! Have an awesome day!';
+	expected = [ 'HAPPY BIRTHDAY!!!', 'Have an awesome day!' ];
+	actual = sentencize( str );
+	t.deepEqual( actual, expected, 'returns an array of sentences' );
+
+	str = 'What?? How can that be??';
+	expected = [ 'What??', 'How can that be??' ];
+	actual = sentencize( str );
+	t.deepEqual( actual, expected, 'returns an array of sentences' );
+
+	str = 'How dare you!?!';
+	expected = [ 'How dare you!?!' ];
+	actual = sentencize( str );
+	t.deepEqual( actual, expected, 'returns an array of sentences' );
+	t.end();
+});
+
 tape( 'the function returns an empty array if provided an empty string', function test( t ) {
 	var out = sentencize( '' );
 	t.equal( isArray( out ), true, 'returns an array' );


### PR DESCRIPTION
Resolves https://github.com/stdlib-js/stdlib/issues/3013.

## Description

> What is the purpose of this pull request?

This pull request:

-   ensures that multiple subsequent question marks or exclamation points are not split into multiple sentences.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves https://github.com/stdlib-js/stdlib/issues/3013 and https://github.com/stdlib-js/metr-issue-tracker/issues/1

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
