### PR TITLE
docs: fix line wrapping

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/cdf/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/cdf/docs/repl.txt
@@ -1,8 +1,7 @@
 
 {{alias}}( x, c )
-    Evaluates the cumulative distribution function
-    (CDF) for a Bradford distribution
-    with shape parameter `c` at a value `x`.
+    Evaluates the cumulative distribution function (CDF) for a Bradford
+    distribution with shape parameter `c` at a value `x`.
 
     If provided `NaN` as any argument, the function returns `NaN`.
 


### PR DESCRIPTION
Resolves Issue #5382.

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes line wrapping for the Bradford distribution CDF documentation, ensuring all lines wrap at 80 characters in repl.txt.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves Issue #5382

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
