### PR TITLE
feat: add `math/base/special/cceilnf`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cceilnf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/cceilnf/README.md
@@ -1,0 +1,293 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2025 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# cceiln
+
+> Round each component of a single-precision complex floating-point number to the nearest multiple of `10^n` toward positive infinity.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var cceilnf = require( '@stdlib/math/base/special/cceilnf' );
+```
+
+#### cceilnf( z, n )
+
+Rounds each component of a single-precision complex floating-point number to the nearest multiple of `10^n` toward positive infinity.
+
+```javascript
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var real = require( '@stdlib/complex/float32/real' );
+var imag = require( '@stdlib/complex/float32/imag' );
+
+// Round components to 2 decimal places:
+var z = new Complex64(-3.1415927, 3.1415927)
+var v = cceilnf( z, -2 );
+// returns <Complex128>
+
+var re = real( v );
+// returns -3.14
+
+var im = imag( v );
+// returns 3.15
+
+// If n = 0, `cceilnf` behaves like `cceilf`:
+z = new Complex64( 9.99999, 0.1 );
+v = cceilnf( z, 0 );
+// returns <Complex64>
+
+re = real( v );
+// returns 10.0
+
+im = imag( v );
+// returns 1.0
+
+// Round components to the nearest thousand:
+z = new Complex64( 12368.0, -12368.0 );
+v = cceilnf( z, 3 );
+// returns <Complex64>
+
+re = real( v );
+// returns 13000.0
+
+im = imag( v );
+// returns -12000.0
+
+v = cceilnf( new Complex64( NaN, NaN ), 2 );
+// returns <Complex64>
+
+re = real( v );
+// returns NaN
+
+im = imag( v );
+// returns NaN
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   When operating on [floating-point numbers][ieee754] in bases other than `2`, rounding to specified digits can be **inexact**. For example,
+
+    ```javascript
+    var Complex64 = require( '@stdlib/complex/float32/ctor' );
+    var real = require( '@stdlib/complex/float32/real' );
+    var imag = require( '@stdlib/complex/float32/imag' );
+
+    var x = 0.2 + 0.1;
+    // returns 0.3
+
+    // Should round components to 0.3:
+    var v = cceilnf( new Complex64( x, x ), -16 );
+    // returns <Complex64>
+
+    var re = real( v );
+    // returns 0.3
+
+    var im = imag( v );
+    // returns 0.3
+    ```
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var uniform = require( '@stdlib/random/base/uniform' ).factory;
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' ).factory;
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var cceilnf = require( '@stdlib/math/base/special/cceilnf' );
+
+var rand1 = uniform( -50.0, 50.0 );
+var rand2 = discreteUniform( -5.0, 0.0 );
+
+var z;
+var i;
+var n;
+for ( i = 0; i < 100; i++ ) {
+    n = rand2();
+    z = new Complex64( rand1(), rand1() );
+    console.log( 'cceilnf(%s, %s) = %s', z, n, cceilnf( z, n ) );
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/math/base/special/cceiln.h"
+```
+
+#### stdlib_base_cceilnf( z, n )
+
+Rounds each component of a single-precision complex floating-point number to the nearest multiple of `10^n` toward positive infinity.
+
+```c
+#include "stdlib/complex/float32/ctor.h"
+#include "stdlib/complex/float32/real.h"
+#include "stdlib/complex/float32/imag.h"
+
+stdlib_complex64_t z = stdlib_complex64( -3.1415927, 3.1415927 );
+
+stdlib_complex64_t out = stdlib_base_cceilnf( z, -2 );
+
+float re = stdlib_complex64_real( out );
+// returns -3.14
+
+float im = stdlib_complex64_imag( out );
+// returns 3.15
+```
+
+The function accepts the following arguments:
+
+-   **z**: `[in] stdlib_complex64_t` input value.
+-   **n**: `[in] int32_t` integer power of 10.
+
+```c
+stdlib_complex64_t stdlib_base_cceilnf( const stdlib_complex64_t z, int32_t n );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/math/base/special/cceilnf.h"
+#include "stdlib/complex/float32/ctor.h"
+#include "stdlib/complex/float32/reim.h"
+#include <stdio.h>
+
+int main() {
+    const stdlib_complex64_t x[] = {
+        stdlib_complex64( 3.14, 1.5 ),
+        stdlib_complex64( -3.14, -1.5 ),
+        stdlib_complex64( 0.0, 0.0 ),
+        stdlib_complex64( 0.0/0.0, 0.0/0.0 )
+    };
+
+    stdlib_complex64_t v;
+    stdlib_complex64_t y;
+    float re1;
+    float im1;
+    float re2;
+    float im2;
+    int i;
+    for ( i = 0; i < 4; i++ ) {
+        v = x[ i ];
+        y = stdlib_base_cceilnf( v, -2 );
+        stdlib_complex64_reim( v, &re1, &im1 );
+        stdlib_complex64_reim( y, &re2, &im2 );
+        printf( "cceilnf(%f + %fi, -2) = %f + %fi\n", re1, im1, re2, im2 );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/math/base/special/cceilf`][@stdlib/math/base/special/cceilf]</span><span class="delimiter">: </span><span class="description">round each component of a single-precision complex floating-point number toward positive infinity.</span>
+-   <span class="package-name">[`@stdlib/math/base/special/cfloorn`][@stdlib/math/base/special/cfloorn]</span><span class="delimiter">: </span><span class="description">round each component of a double-precision complex floating-point number to the nearest multiple of 10^n toward negative infinity.</span>
+-   <span class="package-name">[`@stdlib/math/base/special/croundn`][@stdlib/math/base/special/croundn]</span><span class="delimiter">: </span><span class="description">round each component of a double-precision complex floating-point number to the nearest multiple of 10^n.</span>
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[ieee754]: https://en.wikipedia.org/wiki/IEEE_754-1985
+
+<!-- <related-links> -->
+
+[@stdlib/math/base/special/cceilf]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/cceilf
+
+[@stdlib/math/base/special/cfloorn]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/cfloorn
+
+[@stdlib/math/base/special/croundn]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/croundn
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/math/base/special/cceilnf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/cceilnf/benchmark/benchmark.js
@@ -1,0 +1,58 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var real = require( '@stdlib/complex/float32/real' );
+var imag = require( '@stdlib/complex/float32/imag' );
+var pkg = require( './../package.json' ).name;
+var cceilnf = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var values;
+	var y;
+	var i;
+
+	values = [
+		new Complex64( uniform( -500.0, 500.0 ), uniform( -500.0, 500.0 ) ),
+		new Complex64( uniform( -500.0, 500.0 ), uniform( -500.0, 500.0 ) )
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		y = cceilnf( values[ i % values.length ], -2 );
+		if ( isnan( real( y ) ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnan( imag( y ) ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/cceilnf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cceilnf/benchmark/benchmark.native.js
@@ -1,0 +1,67 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var real = require( '@stdlib/complex/float32/real' );
+var imag = require( '@stdlib/complex/float32/imag' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var cceilnf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( cceilnf instanceof Error )
+};
+
+
+// MAIN //
+
+bench( pkg+'::native', opts, function benchmark( b ) {
+	var values;
+	var y;
+	var i;
+
+	values = [
+		new Complex64( uniform( -500.0, 500.0 ), uniform( -500.0, 500.0 ) ),
+		new Complex64( uniform( -500.0, 500.0 ), uniform( -500.0, 500.0 ) )
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		y = cceilnf( values[ i % values.length ], -2 );
+		if ( isnan( real( y ) ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnan( imag( y ) ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/cceilnf/benchmark/c/native/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/cceilnf/benchmark/c/native/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2025 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/cceilnf/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/cceilnf/benchmark/c/native/benchmark.c
@@ -1,0 +1,144 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/cceilnf.h"
+#include "stdlib/complex/float32/ctor.h"
+#include "stdlib/complex/float32/reim.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "cceilnf"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+static void print_version( void ) {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+static void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+static void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+static double tic( void ) {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1).
+*
+* @return random number
+*/
+static float rand_float( void ) {
+	int r = rand();
+	return (float)r / ( (float)RAND_MAX + 1.0f );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+static double benchmark( void ) {
+	double elapsed;
+	float re;
+	float im;
+	double t;
+	double v[ 100 ];
+	int i;
+
+	stdlib_complex64_t x;
+	stdlib_complex64_t y;
+
+	for ( i = 0; i < 100; i++ ) {
+		v[ i ] = ( 1000.0f*rand_float() ) - 500.0f;
+	}
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		x = stdlib_complex64( v[ i%100 ], v[ i%100 ] );
+		y = stdlib_base_cceilnf( x, -2 );
+		stdlib_complex64_reim( y, &re, &im );
+		if ( re != re ) {
+			printf( "unexpected result\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( im != im ) {
+		printf( "unexpected result\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::native::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/math/base/special/cceilnf/binding.gyp
+++ b/lib/node_modules/@stdlib/math/base/special/cceilnf/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2025 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/math/base/special/cceilnf/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/cceilnf/docs/repl.txt
@@ -1,0 +1,30 @@
+
+{{alias}}( z, n )
+    Rounds each component of a single-precision complex number to the nearest
+    multiple of `10^n` toward positive infinity.
+
+    Parameters
+    ----------
+    z: Complex64
+        Complex number.
+
+    n: integer
+        Integer power of 10.
+
+    Returns
+    -------
+    out: Complex64
+        Real and imaginary components.
+
+    Examples
+    --------
+    > var out = {{alias}}( new {{alias:@stdlib/complex/float32/ctor}}( 5.555, -3.333 ), -2 )
+    <Complex64>
+    > var re = {{alias:@stdlib/complex/float32/real}}( out )
+    5.56
+    > var im = {{alias:@stdlib/complex/float32/imag}}( out )
+    -3.33
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/math/base/special/cceilnf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/cceilnf/docs/types/index.d.ts
@@ -1,0 +1,51 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { Complex64 } from '@stdlib/types/complex';
+
+/**
+* Rounds each component of a single-precision complex number to the nearest multiple of `10^n` toward positive infinity.
+*
+* @param z - input value
+* @param n - integer power of 10
+* @returns result
+*
+* @example
+* var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var real = require( '@stdlib/complex/float32/real' );
+* var imag = require( '@stdlib/complex/float32/imag' );
+*
+* var v = cceilnf( new Complex64( 5.555, -3.333 ), -2 );
+* // returns <Complex64>
+*
+* var re = real( v );
+* // returns 5.56
+*
+* var im = imag( v );
+* // returns -3.33
+*/
+declare function cceilnf( z: Complex64, n: number ): Complex64;
+
+
+// EXPORTS //
+
+export = cceilnf;

--- a/lib/node_modules/@stdlib/math/base/special/cceilnf/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/math/base/special/cceilnf/docs/types/test.ts
@@ -1,0 +1,57 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import Complex64 = require( '@stdlib/complex/float32/ctor' );
+import cceilnf = require( './index' );
+
+
+// TESTS //
+
+// The function returns a double-precision complex floating-point number...
+{
+	cceilnf( new Complex64( 5.0, 3.0 ), -2 ); // $ExpectType Complex128
+}
+
+// The compiler throws an error if the function is provided a first argument which is not a complex number...
+{
+	cceilnf( true, -2 ); // $ExpectError
+	cceilnf( false, -2 ); // $ExpectError
+	cceilnf( null, -2 ); // $ExpectError
+	cceilnf( undefined, -2 ); // $ExpectError
+	cceilnf( '5', -2 ); // $ExpectError
+	cceilnf( [], -2 ); // $ExpectError
+	cceilnf( {}, -2 ); // $ExpectError
+	cceilnf( ( x: number ): number => x, -2 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an integer power which is not a number...
+{
+	cceilnf( new Complex64( 5.0, 3.0 ), true ); // $ExpectError
+	cceilnf( new Complex64( 5.0, 3.0 ), false ); // $ExpectError
+	cceilnf( new Complex64( 5.0, 3.0 ), null ); // $ExpectError
+	cceilnf( new Complex64( 5.0, 3.0 ), undefined ); // $ExpectError
+	cceilnf( new Complex64( 5.0, 3.0 ), '5' ); // $ExpectError
+	cceilnf( new Complex64( 5.0, 3.0 ), [] ); // $ExpectError
+	cceilnf( new Complex64( 5.0, 3.0 ), {} ); // $ExpectError
+	cceilnf( new Complex64( 5.0, 3.0 ), ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided insufficient arguments...
+{
+	cceilnf(); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/math/base/special/cceilnf/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/cceilnf/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2025 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/cceilnf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/cceilnf/examples/c/example.c
@@ -1,0 +1,46 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/cceilnf.h"
+#include "stdlib/complex/float32/ctor.h"
+#include "stdlib/complex/float32/reim.h"
+#include <stdio.h>
+
+int main() {
+	const stdlib_complex64_t x[] = {
+		stdlib_complex64( 3.14, 1.5 ),
+		stdlib_complex64( -3.14, -1.5 ),
+		stdlib_complex64( 0.0, 0.0 ),
+		stdlib_complex64( 0.0/0.0, 0.0/0.0 )
+	};
+
+	stdlib_complex64_t v;
+	stdlib_complex64_t y;
+	float re1;
+	float im1;
+	float re2;
+	float im2;
+	int i;
+	for ( i = 0; i < 4; i++ ) {
+		v = x[ i ];
+		y = stdlib_base_cceilnf( v, -2 );
+		stdlib_complex64_reim( v, &re1, &im1 );
+		stdlib_complex64_reim( y, &re2, &im2 );
+		printf( "cceilnf(%f + %fi, -2) = %f + %fi\n", re1, im1, re2, im2 );
+	}
+}

--- a/lib/node_modules/@stdlib/math/base/special/cceilnf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/cceilnf/examples/index.js
@@ -1,0 +1,36 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var uniform = require( '@stdlib/random/base/uniform' ).factory;
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' ).factory;
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var cceilnf = require( './../lib' );
+
+var rand1 = uniform( -50.0, 50.0 );
+var rand2 = discreteUniform( -5.0, 0.0 );
+
+var z;
+var i;
+var n;
+for ( i = 0; i < 100; i++ ) {
+	n = rand2();
+	z = new Complex64( rand1(), rand1() );
+	console.log( 'cceilnf(%s, %s) = %s', z, n, cceilnf( z, n ) );
+}

--- a/lib/node_modules/@stdlib/math/base/special/cceilnf/include.gypi
+++ b/lib/node_modules/@stdlib/math/base/special/cceilnf/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2023 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/math/base/special/cceilnf/include/stdlib/math/base/special/cceilnf.h
+++ b/lib/node_modules/@stdlib/math/base/special/cceilnf/include/stdlib/math/base/special/cceilnf.h
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_MATH_BASE_SPECIAL_CCEILNF_H
+#define STDLIB_MATH_BASE_SPECIAL_CCEILNF_H
+
+#include "stdlib/complex/float32/ctor.h"
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Rounds each component of a single-precision complex floating-point number to the nearest multiple of `10^n` toward positive infinity.
+*/
+stdlib_complex64_t stdlib_base_cceilnf( const stdlib_complex64_t z, const int32_t n );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_MATH_BASE_SPECIAL_CCEILNF_H

--- a/lib/node_modules/@stdlib/math/base/special/cceilnf/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/cceilnf/lib/index.js
@@ -1,0 +1,82 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Round each component of a single-precision floating-point complex number to the nearest multiple of `10^n` toward positive infinity.
+*
+* @module @stdlib/math/base/special/cceilnf
+*
+* @example
+* var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var real = require( '@stdlib/complex/float32/real' );
+* var imag = require( '@stdlib/complex/float32/imag' );
+* var cceilnf = require( '@stdlib/math/base/special/cceilnf' );
+*
+* // Round components to 2 decimal places:
+* var z = new Complex64(-3.1415927, 3.1415927)
+* var v = cceilnf( z, -2 );
+* // returns <Complex64>
+*
+* var re = real( v );
+* // returns -3.14
+*
+* var im = imag( v );
+* // returns 3.15
+*
+* // If n = 0, `cceilnf` behaves like `cceilf`:
+* z = new Complex64( 9.99999, 0.1 )
+* v = cceilnf( z, 0 );
+* // returns <Complex46>
+*
+* re = real( v );
+* // returns 10.0
+*
+* im = imag( v );
+* // returns 1.0
+*
+* // Round components to the nearest thousand:
+* z = new Complex64( 12368.0, -12368.0 )
+* v = cceilnf( z, 3 );
+* // returns <Complex64>
+*
+* re = real( v );
+* // returns 13000.0
+*
+* im = imag( v );
+* // returns -12000.0
+*
+* v = cceilnf( new Complex64( NaN, NaN ), 2 );
+* // returns <Complex64>
+*
+* re = real( v );
+* // returns NaN
+*
+* im = imag( v );
+* // returns NaN
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/math/base/special/cceilnf/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/cceilnf/lib/main.js
@@ -1,0 +1,91 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var ceilnf = require( '@stdlib/math/base/special/ceilnf' );
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var real = require( '@stdlib/complex/float32/real' );
+var imag = require( '@stdlib/complex/float32/imag' );
+
+
+// MAIN //
+
+/**
+* Round each component of a single-precision floating-point complex number to the nearest multiple of `10^n` toward positive infinity.
+*
+* @module @stdlib/math/base/special/cceilnf
+*
+* @example
+* var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var real = require( '@stdlib/complex/float32/real' );
+* var imag = require( '@stdlib/complex/float32/imag' );
+* var cceilnf = require( '@stdlib/math/base/special/cceilnf' );
+*
+* // Round components to 2 decimal places:
+* var z = new Complex64(-3.1415927, 3.1415927)
+* var v = cceilnf( z, -2 );
+* // returns <Complex64>
+*
+* var re = real( v );
+* // returns -3.14
+*
+* var im = imag( v );
+* // returns 3.15
+*
+* // If n = 0, `cceilnf` behaves like `cceilf`:
+* z = new Complex64( 9.99999, 0.1 )
+* v = cceilnf( z, 0 );
+* // returns <Complex46>
+*
+* re = real( v );
+* // returns 10.0
+*
+* im = imag( v );
+* // returns 1.0
+*
+* // Round components to the nearest thousand:
+* z = new Complex64( 12368.0, -12368.0 )
+* v = cceilnf( z, 3 );
+* // returns <Complex64>
+*
+* re = real( v );
+* // returns 13000.0
+*
+* im = imag( v );
+* // returns -12000.0
+*
+* v = cceilnf( new Complex64( NaN, NaN ), 2 );
+* // returns <Complex64>
+*
+* re = real( v );
+* // returns NaN
+*
+* im = imag( v );
+* // returns NaN
+*/
+function cceilnf( z, n ) {
+	return new Complex64( ceilnf( real( z ), n ), ceilnf( imag( z ), n ) );
+}
+
+
+// EXPORTS //
+
+module.exports = cceilnf;

--- a/lib/node_modules/@stdlib/math/base/special/cceilnf/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cceilnf/lib/native.js
@@ -1,0 +1,92 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Rounds each component of a single-precision complex floating-point number to the nearest multiple of `10^n` toward positive infinity.
+*
+* @private
+* @param {Complex64} z - complex number
+* @param {integer} n - integer power of 10
+* @returns {Complex128} result
+*
+* @example
+* var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var real = require( '@stdlib/complex/float32/real' );
+* var imag = require( '@stdlib/complex/float32/imag' );
+*
+* // Round components to 2 decimal places:
+* var z = new Complex64(-3.1415927, 3.1415927)
+* var v = cceilnf( z, -2 );
+* // returns <Complex64>
+*
+* var re = real( v );
+* // returns -3.14
+*
+* var im = imag( v );
+* // returns 3.15
+*
+* // If n = 0, `cceilnf` behaves like `cceilf`:
+* z = new Complex64( 9.99999, 0.1 )
+* v = cceilnf( z, 0 );
+* // returns <Complex46>
+*
+* re = real( v );
+* // returns 10.0
+*
+* im = imag( v );
+* // returns 1.0
+*
+* // Round components to the nearest thousand:
+* z = new Complex64( 12368.0, -12368.0 )
+* v = cceilnf( z, 3 );
+* // returns <Complex64>
+*
+* re = real( v );
+* // returns 13000.0
+*
+* im = imag( v );
+* // returns -12000.0
+*
+* v = cceilnf( new Complex64( NaN, NaN ), 2 );
+* // returns <Complex64>
+*
+* re = real( v );
+* // returns NaN
+*
+* im = imag( v );
+* // returns NaN
+*/
+function cceilnf( z, n ) {
+	var v = addon( z, n );
+	return new Complex64( v.re, v.im );
+}
+
+
+// EXPORTS //
+
+module.exports = cceilnf;

--- a/lib/node_modules/@stdlib/math/base/special/cceilnf/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/cceilnf/manifest.json
@@ -1,0 +1,78 @@
+{
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/napi/binary",
+        "@stdlib/complex/float32/ctor",
+        "@stdlib/complex/float32/reim",
+        "@stdlib/math/base/special/ceilnf"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/complex/float32/ctor",
+        "@stdlib/complex/float32/reim",
+        "@stdlib/math/base/special/ceilnf"
+      ]
+    },
+    {
+      "task": "examples",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/complex/float32/ctor",
+        "@stdlib/complex/float32/reim",
+        "@stdlib/math/base/special/ceilnf"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/special/cceilnf/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/cceilnf/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@stdlib/math/base/special/cceilnf",
+  "version": "0.0.0",
+  "description": "Round each component of a single-precision complex floating-point number to the nearest multiple of 10^n toward positive infinity.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "gypfile": true,
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "src": "./src",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
+    "math.ceilf",
+    "ceilf",
+    "cceilf",
+    "round",
+    "integer",
+    "nearest",
+    "value",
+    "fix",
+    "tofixed",
+    "complex",
+    "cmplx",
+    "number"
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/special/cceilnf/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/cceilnf/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2025 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/cceilnf/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/cceilnf/src/addon.c
@@ -1,0 +1,23 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/cceilnf.h"
+#include "stdlib/math/base/napi/binary.h"
+
+// cppcheck-suppress shadowFunction
+STDLIB_MATH_BASE_NAPI_MODULE_CI_C( stdlib_base_cceilnf )

--- a/lib/node_modules/@stdlib/math/base/special/cceilnf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/cceilnf/src/main.c
@@ -1,0 +1,55 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/cceilnf.h"
+#include "stdlib/math/base/special/ceilnf.h"
+#include "stdlib/complex/float32/ctor.h"
+#include "stdlib/complex/float32/reim.h"
+
+/**
+* Rounds each component of a single-precision complex floating-point number to the nearest multiple of `10^n` toward positive infinity.
+*
+* @param z       input value
+* @param n       integer power of 10
+* @return        result
+*
+* @example
+* #include "stdlib/complex/float32/ctor.h"
+* #include "stdlib/complex/float32/real.h"
+* #include "stdlib/complex/float32/imag.h"
+*
+* stdlib_complex64_t z = stdlib_complex64(-3.1415927, 3.1415927);
+*
+* stdlib_complex64_t out = stdlib_base_cceilnf( z, -2 );
+*
+* float re = stdlib_complex64_real( out );
+* // returns -3.14
+*
+* float im = stdlib_complex64_imag( out );
+* // returns 3.15
+*/
+stdlib_complex64_t stdlib_base_cceilnf( const stdlib_complex64_t z, const int32_t n ) {
+	float re;
+	float im;
+
+	stdlib_complex64_reim( z, &re, &im );
+
+	re = stdlib_base_ceilnf( re, n );
+	im = stdlib_base_ceilnf( im, n );
+	return stdlib_complex64( re, im );
+}

--- a/lib/node_modules/@stdlib/math/base/special/cceilnf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/cceilnf/test/test.js
@@ -1,0 +1,348 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var PINF = require( '@stdlib/constants/float32/pinf' );
+var NINF = require( '@stdlib/constants/float32/ninf' );
+var PI = require( '@stdlib/constants/float32/pi' );
+var EPS = require( '@stdlib/constants/float32/eps' );
+var randu = require( '@stdlib/random/base/randu' );
+var round = require( '@stdlib/math/base/special/round' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var abs = require( '@stdlib/math/base/special/abs' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
+var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var real = require( '@stdlib/complex/float32/real' );
+var imag = require( '@stdlib/complex/float32/imag' );
+var cceilnf = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof cceilnf, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns a `NaN` if provided a `NaN`', function test( t ) {
+	var v;
+
+	v = cceilnf( new Complex64( NaN, NaN ), 0 );
+	t.strictEqual( isnan( real( v ) ), true, 'returns expected value' );
+	t.strictEqual( isnan( imag( v ) ), true, 'returns expected value' );
+
+	v = cceilnf( new Complex64( NaN, NaN ), NaN );
+	t.strictEqual( isnan( real( v ) ), true, 'returns expected value' );
+	t.strictEqual( isnan( imag( v ) ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `NaNs` if provided `n = +-infinity`', function test( t ) {
+	var v;
+
+	v = cceilnf( new Complex64( 3.14, 3.14 ), PINF );
+	t.strictEqual( isnan( real( v ) ), true, 'returns expected value' );
+	t.strictEqual( isnan( imag( v ) ), true, 'returns expected value' );
+
+	v = cceilnf( new Complex64( 3.14, 3.14 ), NINF );
+	t.strictEqual( isnan( real( v ) ), true, 'returns expected value' );
+	t.strictEqual( isnan( imag( v ) ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `-0` if provided `-0`', function test( t ) {
+	var v;
+
+	v = cceilnf( new Complex64( -0.0, -0.0 ), 0 );
+	t.strictEqual( isNegativeZero( real( v ) ), true, 'returns expected value' );
+	t.strictEqual( isNegativeZero( imag( v ) ), true, 'returns expected value' );
+
+	v = cceilnf( new Complex64( -0.0, -0.0 ), -2 );
+	t.strictEqual( isNegativeZero( real( v ) ), true, 'returns expected value' );
+	t.strictEqual( isNegativeZero( imag( v ) ), true, 'returns expected value' );
+
+	v = cceilnf( new Complex64( -0.0, -0.0 ), 2 );
+	t.strictEqual( isNegativeZero( real( v ) ), true, 'returns expected value' );
+	t.strictEqual( isNegativeZero( imag( v ) ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `+0` if provided `+0`', function test( t ) {
+	var v;
+
+	v = cceilnf( new Complex64( +0.0, +0.0 ), 0 );
+	t.strictEqual( isPositiveZero( real( v ) ), true, 'returns expected value' );
+	t.strictEqual( isPositiveZero( imag( v ) ), true, 'returns expected value' );
+
+	v = cceilnf( new Complex64( +0.0, +0.0 ), -2 );
+	t.strictEqual( isPositiveZero( real( v ) ), true, 'returns expected value' );
+	t.strictEqual( isPositiveZero( imag( v ) ), true, 'returns expected value' );
+
+	v = cceilnf( new Complex64( +0.0, +0.0 ), 2 );
+	t.strictEqual( isPositiveZero( real( v ) ), true, 'returns expected value' );
+	t.strictEqual( isPositiveZero( imag( v ) ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `+infinity` if provided `+infinity`', function test( t ) {
+	var v = cceilnf( new Complex64( PINF, PINF ), 5 );
+	t.strictEqual( real( v ), PINF, 'returns expected value' );
+	t.strictEqual( imag( v ), PINF, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `-infinity` if provided `-infinity`', function test( t ) {
+	var v = cceilnf( new Complex64( NINF, NINF ), -3 );
+	t.strictEqual( real( v ), NINF, 'returns expected value' );
+	t.strictEqual( imag( v ), NINF, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports rounding real and imaginary components to a desired number of decimals', function test( t ) {
+	var expected;
+	var v;
+
+	v = cceilnf( new Complex64( -PI, PI ), -2 );
+	expected = new Complex64( -3.14, 3.15 );
+	t.strictEqual( real( v ), real( expected ), 'returns expected value' );
+	t.strictEqual( imag( v ), imag( expected ), 'returns expected value' );
+
+	v = cceilnf( new Complex64( PI, -PI ), -2 );
+	expected = new Complex64( 3.15, -3.14 );
+	t.strictEqual( real( v ), real( expected ), 'returns expected value' );
+	t.strictEqual( imag( v ), imag( expected ), 'returns expected value' );
+
+	v = cceilnf( new Complex64( 9.99999, 9.9999 ), -2 );
+	expected = new Complex64( 10.0, 10.0 );
+	t.strictEqual( real( v ), real( expected ), 'returns expected value' );
+	t.strictEqual( imag( v ), imag( expected ), 'returns expected value' );
+
+	v = cceilnf( new Complex64( -9.99999, -9.9999 ), -2 );
+	expected = new Complex64( -9.99, -9.99 );
+	t.strictEqual( real( v ), real( expected ), 'returns expected value' );
+	t.strictEqual( imag( v ), imag( expected ), 'returns expected value' );
+
+	v = cceilnf( new Complex64( 0.0, 0.0 ), -2 );
+	expected = new Complex64( 0.0, 0.0 );
+	t.strictEqual( real( v ), real( expected ), 'returns expected value' );
+	t.strictEqual( imag( v ), imag( expected ), 'returns expected value' );
+
+	v = cceilnf( new Complex64( -12368.0, 12368.0 ), -2 );
+	expected = new Complex64( -12368.0, 12368.0 );
+	t.strictEqual( real( v ), real( expected ), 'returns expected value' );
+	t.strictEqual( imag( v ), imag( expected ), 'returns expected value' );
+	t.end();
+});
+
+tape( 'rounding components to a desired number of decimals can result in unexpected behavior', function test( t ) {
+	var x;
+	var v;
+
+	x = 0.2 + 0.1; // => 0.30000000000000004
+	v = cceilnf( new Complex64( x, x ), -16 );
+
+	t.strictEqual( real( v ), 0.3000000000000001, 'returns 0.3000000000000001 and not 0.3' );
+	t.strictEqual( imag( v ), 0.3000000000000001, 'returns 0.3000000000000001 and not 0.3' );
+	t.end();
+});
+
+tape( 'the function supports rounding components to a desired number of digits', function test( t ) {
+	var expected;
+	var v;
+
+	v = cceilnf( new Complex64( -PI, PI ), 4 );
+	expected = new Complex64( 0.0, 10000.0 );
+	t.strictEqual( real( v ), real( expected ), 'returns expected value' );
+	t.strictEqual( imag( v ), imag( expected ), 'returns expected value' );
+
+	v = cceilnf( new Complex64( -12368.0, 12368.0 ), 3 );
+	expected = new Complex64( -12000.0, 13000.0 );
+	t.strictEqual( real( v ), real( expected ), 'returns expected value' );
+	t.strictEqual( imag( v ), imag( expected ), 'returns expected value' );
+
+	v = cceilnf( new Complex64( 12363.0, -12363.0 ), 1 );
+	expected = new Complex64( 12370.0, -12360.0 );
+	t.strictEqual( real( v ), real( expected ), 'returns expected value' );
+	t.strictEqual( imag( v ), imag( expected ), 'returns expected value' );
+
+	v = cceilnf( new Complex64( PI, -PI ), 3 );
+	t.strictEqual( real( v ), 1000.0, 'returns expected value' );
+	t.strictEqual( isNegativeZero( imag( v ) ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns the components unchanged if provided an `n` which is less than the minimum decimal exponential (-324)', function test( t ) {
+	var exp;
+	var n;
+	var x;
+	var v;
+	var i;
+	for ( i = 0; i < 100; i++ ) {
+		exp = round( randu()*616.0 ) - 308;
+		x = (1.0+randu()) * pow( 10.0, exp );
+		n = -(round( randu()*1000.0 ) + 325);
+		v = cceilnf( new Complex64( x, x ), n );
+		t.strictEqual( real( v ), x, 'returns expected value when provided re='+x+', im='+x+', n='+n+'.' );
+		t.strictEqual( imag( v ), x, 'returns expected value when provided re='+x+', im='+x+', n='+n+'.' );
+	}
+	t.end();
+});
+
+tape( 'if a component is too large a double to have decimals and `n < 0`, the component is returned unchanged', function test( t ) {
+	var sign;
+	var exp;
+	var x;
+	var n;
+	var v;
+	var i;
+	for ( i = 0; i < 100; i++ ) {
+		sign = ( randu()<0.5 ) ? -1.0 : 1.0;
+		exp = 54 + round( randu()*254.0 );
+		x = sign * (1.0+randu()) * pow( 10.0, exp );
+		n = -( round( randu()*324.0) );
+		v = cceilnf( new Complex64( x, x ), n );
+		t.strictEqual( real( v ), x, 'returns expected value when provided re='+x+', im='+x+', n='+n+'.' );
+		t.strictEqual( imag( v ), x, 'returns expected value when provided re='+x+', im='+x+', n='+n+'.' );
+	}
+	t.end();
+});
+
+tape( 'if `n > 308` and a component is greater than zero, the function returns `+infinity`', function test( t ) {
+	var exp;
+	var x;
+	var n;
+	var v;
+	var i;
+	for ( i = 0; i < 100; i++ ) {
+		exp = round( randu()*37.0 );
+		x = (1.0+randu()) * pow( 10.0, exp );
+		n = round( randu()*100.0 ) + 39;
+		v = cceilnf( new Complex64( x, x ), n );
+		t.strictEqual( real( v ), PINF, 'returns expected value when provided re='+x+', im='+x+', n='+n+'.' );
+		t.strictEqual( imag( v ), PINF, 'returns expected value when provided re='+x+', im='+x+', n='+n+'.' );
+	}
+	t.end();
+});
+
+tape( 'if `n > 308` and a component is less than zero, the function returns `-0` (sign preserving)', function test( t ) {
+	var exp;
+	var x;
+	var n;
+	var v;
+	var i;
+	for ( i = 0; i < 100; i++ ) {
+		exp = round( randu()*37.0 );
+		x = -(1.0+randu()) * pow( 10.0, exp );
+		n = round( randu()*100.0 ) + 39;
+		v = cceilnf( new Complex64( x, x ), n );
+		t.strictEqual( isNegativeZero( real( v ) ), true, ' returns -0 when provided re='+x+', n='+n+'.' );
+		t.strictEqual( isNegativeZero( imag( v ) ), true, ' returns -0 when provided im='+x+', n='+n+'.' );
+	}
+	t.end();
+});
+
+tape( 'the function supports rounding very small numbers (including subnormals)', function test( t ) {
+	var expected;
+	var delta;
+	var tol;
+	var x;
+	var n;
+	var v;
+	var i;
+
+	x = 3.1468234 * pow( 10.0, -38 );
+
+	n = [];
+	for ( i = -38; i > -325; i-- ) {
+		n.push( i );
+	}
+	expected = [
+		4e-38,
+		3.2e-38,
+		3.15e-38,
+		3.147e-38,
+		3.1469e-38,
+		3.14683e-38,
+		3.146824e-38,
+		3.1468235e-38,
+		3.14682344e-38,
+		3.146823435e-38,
+		3.1468234344e-38,
+		3.14682343431e-38,
+		3.146823434303e-38,
+		3.1468234343024e-38,
+		3.14682343430234e-38,
+		3.146823434302340e-38,
+		3.1468234343023397e-38
+	];
+
+	for ( i = 0; i < n.length; i++ ) {
+		v = cceilnf( new Complex64( x, x ), n[i] );
+		if ( real( v ) === expected[i] ) {
+			t.strictEqual( real( v ), expected[i], 'returns '+expected[i]+' when provided re='+x+', im='+x+', and n='+n[i]+'.' );
+		} else {
+			delta = abs( real( v ) - expected[i] );
+			tol = EPS * abs( expected[i] );
+			t.strictEqual( delta <= tol, true, 're: '+x+'. n: '+n[i]+'. v: '+v[0]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol );
+
+			delta = abs( imag( v ) - expected[i] );
+			tol = EPS * abs( expected[i] );
+			t.strictEqual( delta <= tol, true, 'im: '+x+'. n: '+n[i]+'. v: '+v[1]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol );
+		}
+	}
+	t.end();
+});
+
+tape( 'if the function encounters overflow, the function returns the input component', function test( t ) {
+	var x;
+	var v;
+
+	x = 3.1468234343023397;
+	v = cceilnf( new Complex64( x, x ), -314 );
+	t.strictEqual( real( v ), x, 'returns expected value' );
+	t.strictEqual( imag( v ), x, 'returns expected value' );
+
+	x = -3.1468234343023397;
+	v = cceilnf( new Complex64( x, x ), -314 );
+	t.strictEqual( real( v ), x, 'returns expected value' );
+	t.strictEqual( imag( v ), x, 'returns expected value' );
+
+	x = 9007199254740000;
+	v = cceilnf( new Complex64( x, x ), -300 );
+	t.strictEqual( real( v ), x, 'returns expected value' );
+	t.strictEqual( imag( v ), x, 'returns expected value' );
+
+	x = -9007199254740000;
+	v = cceilnf( new Complex64( x, x ), -300 );
+	t.strictEqual( real( v ), x, 'returns expected value' );
+	t.strictEqual( imag( v ), x, 'returns expected value' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/cceilnf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cceilnf/test/test.native.js
@@ -1,0 +1,357 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var PINF = require( '@stdlib/constants/float32/pinf' );
+var NINF = require( '@stdlib/constants/float32/ninf' );
+var PI = require( '@stdlib/constants/float32/pi' );
+var EPS = require( '@stdlib/constants/float32/eps' );
+var randu = require( '@stdlib/random/base/randu' );
+var round = require( '@stdlib/math/base/special/round' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var abs = require( '@stdlib/math/base/special/abs' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
+var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var real = require( '@stdlib/complex/float32/real' );
+var imag = require( '@stdlib/complex/float32/imag' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var cceilnf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( cceilnf instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof cceilnf, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns a `NaN` if provided a `NaN`', opts, function test( t ) {
+	var v;
+
+	v = cceilnf( new Complex64( NaN, NaN ), 0 );
+	t.strictEqual( isnan( real( v ) ), true, 'returns expected value' );
+	t.strictEqual( isnan( imag( v ) ), true, 'returns expected value' );
+
+	v = cceilnf( new Complex64( NaN, NaN ), NaN );
+	t.strictEqual( isnan( real( v ) ), true, 'returns expected value' );
+	t.strictEqual( isnan( imag( v ) ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `NaNs` if provided `n = +-infinity`', opts, function test( t ) {
+	var v;
+
+	v = cceilnf( new Complex64( 3.14, 3.14 ), PINF );
+	t.strictEqual( isnan( real( v ) ), true, 'returns expected value' );
+	t.strictEqual( isnan( imag( v ) ), true, 'returns expected value' );
+
+	v = cceilnf( new Complex64( 3.14, 3.14 ), NINF );
+	t.strictEqual( isnan( real( v ) ), true, 'returns expected value' );
+	t.strictEqual( isnan( imag( v ) ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `-0` if provided `-0`', opts, function test( t ) {
+	var v;
+
+	v = cceilnf( new Complex64( -0.0, -0.0 ), 0 );
+	t.strictEqual( isNegativeZero( real( v ) ), true, 'returns expected value' );
+	t.strictEqual( isNegativeZero( imag( v ) ), true, 'returns expected value' );
+
+	v = cceilnf( new Complex64( -0.0, -0.0 ), -2 );
+	t.strictEqual( isNegativeZero( real( v ) ), true, 'returns expected value' );
+	t.strictEqual( isNegativeZero( imag( v ) ), true, 'returns expected value' );
+
+	v = cceilnf( new Complex64( -0.0, -0.0 ), 2 );
+	t.strictEqual( isNegativeZero( real( v ) ), true, 'returns expected value' );
+	t.strictEqual( isNegativeZero( imag( v ) ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `+0` if provided `+0`', opts, function test( t ) {
+	var v;
+
+	v = cceilnf( new Complex64( +0.0, +0.0 ), 0 );
+	t.strictEqual( isPositiveZero( real( v ) ), true, 'returns expected value' );
+	t.strictEqual( isPositiveZero( imag( v ) ), true, 'returns expected value' );
+
+	v = cceilnf( new Complex64( +0.0, +0.0 ), -2 );
+	t.strictEqual( isPositiveZero( real( v ) ), true, 'returns expected value' );
+	t.strictEqual( isPositiveZero( imag( v ) ), true, 'returns expected value' );
+
+	v = cceilnf( new Complex64( +0.0, +0.0 ), 2 );
+	t.strictEqual( isPositiveZero( real( v ) ), true, 'returns expected value' );
+	t.strictEqual( isPositiveZero( imag( v ) ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `+infinity` if provided `+infinity`', opts, function test( t ) {
+	var v = cceilnf( new Complex64( PINF, PINF ), 5 );
+	t.strictEqual( real( v ), PINF, 'returns expected value' );
+	t.strictEqual( imag( v ), PINF, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `-infinity` if provided `-infinity`', opts, function test( t ) {
+	var v = cceilnf( new Complex64( NINF, NINF ), -3 );
+	t.strictEqual( real( v ), NINF, 'returns expected value' );
+	t.strictEqual( imag( v ), NINF, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports rounding real and imaginary components to a desired number of decimals', opts, function test( t ) {
+	var expected;
+	var v;
+
+	v = cceilnf( new Complex64( -PI, PI ), -2 );
+	expected = new Complex64( -3.14, 3.15 );
+	t.strictEqual( real( v ), real( expected ), 'returns expected value' );
+	t.strictEqual( imag( v ), imag( expected ), 'returns expected value' );
+
+	v = cceilnf( new Complex64( PI, -PI ), -2 );
+	expected = new Complex64( 3.15, -3.14 );
+	t.strictEqual( real( v ), real( expected ), 'returns expected value' );
+	t.strictEqual( imag( v ), imag( expected ), 'returns expected value' );
+
+	v = cceilnf( new Complex64( 9.99999, 9.9999 ), -2 );
+	expected = new Complex64( 10.0, 10.0 );
+	t.strictEqual( real( v ), real( expected ), 'returns expected value' );
+	t.strictEqual( imag( v ), imag( expected ), 'returns expected value' );
+
+	v = cceilnf( new Complex64( -9.99999, -9.9999 ), -2 );
+	expected = new Complex64( -9.99, -9.99 );
+	t.strictEqual( real( v ), real( expected ), 'returns expected value' );
+	t.strictEqual( imag( v ), imag( expected ), 'returns expected value' );
+
+	v = cceilnf( new Complex64( 0.0, 0.0 ), -2 );
+	expected = new Complex64( 0.0, 0.0 );
+	t.strictEqual( real( v ), real( expected ), 'returns expected value' );
+	t.strictEqual( imag( v ), imag( expected ), 'returns expected value' );
+
+	v = cceilnf( new Complex64( -12368.0, 12368.0 ), -2 );
+	expected = new Complex64( -12368.0, 12368.0 );
+	t.strictEqual( real( v ), real( expected ), 'returns expected value' );
+	t.strictEqual( imag( v ), imag( expected ), 'returns expected value' );
+	t.end();
+});
+
+tape( 'rounding components to a desired number of decimals can result in unexpected behavior', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = 0.2 + 0.1; // => 0.30000000000000004
+	v = cceilnf( new Complex64( x, x ), -16 );
+
+	t.strictEqual( real( v ), 0.3000000000000001, 'returns 0.3000000000000001 and not 0.3' );
+	t.strictEqual( imag( v ), 0.3000000000000001, 'returns 0.3000000000000001 and not 0.3' );
+	t.end();
+});
+
+tape( 'the function supports rounding components to a desired number of digits', opts, function test( t ) {
+	var expected;
+	var v;
+
+	v = cceilnf( new Complex64( -PI, PI ), 4 );
+	expected = new Complex64( 0.0, 10000.0 );
+	t.strictEqual( real( v ), real( expected ), 'returns expected value' );
+	t.strictEqual( imag( v ), imag( expected ), 'returns expected value' );
+
+	v = cceilnf( new Complex64( -12368.0, 12368.0 ), 3 );
+	expected = new Complex64( -12000.0, 13000.0 );
+	t.strictEqual( real( v ), real( expected ), 'returns expected value' );
+	t.strictEqual( imag( v ), imag( expected ), 'returns expected value' );
+
+	v = cceilnf( new Complex64( 12363.0, -12363.0 ), 1 );
+	expected = new Complex64( 12370.0, -12360.0 );
+	t.strictEqual( real( v ), real( expected ), 'returns expected value' );
+	t.strictEqual( imag( v ), imag( expected ), 'returns expected value' );
+
+	v = cceilnf( new Complex64( PI, -PI ), 3 );
+	t.strictEqual( real( v ), 1000.0, 'returns expected value' );
+	t.strictEqual( isNegativeZero( imag( v ) ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns the components unchanged if provided an `n` which is less than the minimum decimal exponential (-324)', opts, function test( t ) {
+	var exp;
+	var n;
+	var x;
+	var v;
+	var i;
+	for ( i = 0; i < 100; i++ ) {
+		exp = round( randu()*616.0 ) - 308;
+		x = (1.0+randu()) * pow( 10.0, exp );
+		n = -(round( randu()*1000.0 ) + 325);
+		v = cceilnf( new Complex64( x, x ), n );
+		t.strictEqual( real( v ), x, 'returns expected value when provided re='+x+', im='+x+', n='+n+'.' );
+		t.strictEqual( imag( v ), x, 'returns expected value when provided re='+x+', im='+x+', n='+n+'.' );
+	}
+	t.end();
+});
+
+tape( 'if a component is too large a double to have decimals and `n < 0`, the component is returned unchanged', opts, function test( t ) {
+	var sign;
+	var exp;
+	var x;
+	var n;
+	var v;
+	var i;
+	for ( i = 0; i < 100; i++ ) {
+		sign = ( randu()<0.5 ) ? -1.0 : 1.0;
+		exp = 54 + round( randu()*254.0 );
+		x = sign * (1.0+randu()) * pow( 10.0, exp );
+		n = -( round( randu()*324.0) );
+		v = cceilnf( new Complex64( x, x ), n );
+		t.strictEqual( real( v ), x, 'returns expected value when provided re='+x+', im='+x+', n='+n+'.' );
+		t.strictEqual( imag( v ), x, 'returns expected value when provided re='+x+', im='+x+', n='+n+'.' );
+	}
+	t.end();
+});
+
+tape( 'if `n > 308` and a component is greater than zero, the function returns `+infinity`', opts, function test( t ) {
+	var exp;
+	var x;
+	var n;
+	var v;
+	var i;
+	for ( i = 0; i < 100; i++ ) {
+		exp = round( randu()*37.0 );
+		x = (1.0+randu()) * pow( 10.0, exp );
+		n = round( randu()*100.0 ) + 39;
+		v = cceilnf( new Complex64( x, x ), n );
+		t.strictEqual( real( v ), PINF, 'returns expected value when provided re='+x+', im='+x+', n='+n+'.' );
+		t.strictEqual( imag( v ), PINF, 'returns expected value when provided re='+x+', im='+x+', n='+n+'.' );
+	}
+	t.end();
+});
+
+tape( 'if `n > 308` and a component is less than zero, the function returns `-0` (sign preserving)', opts, function test( t ) {
+	var exp;
+	var x;
+	var n;
+	var v;
+	var i;
+	for ( i = 0; i < 100; i++ ) {
+		exp = round( randu()*37.0 );
+		x = -(1.0+randu()) * pow( 10.0, exp );
+		n = round( randu()*100.0 ) + 39;
+		v = cceilnf( new Complex64( x, x ), n );
+		t.strictEqual( isNegativeZero( real( v ) ), true, ' returns -0 when provided re='+x+', n='+n+'.' );
+		t.strictEqual( isNegativeZero( imag( v ) ), true, ' returns -0 when provided im='+x+', n='+n+'.' );
+	}
+	t.end();
+});
+
+tape( 'the function supports rounding very small numbers (including subnormals)', opts, function test( t ) {
+	var expected;
+	var delta;
+	var tol;
+	var x;
+	var n;
+	var v;
+	var i;
+
+	x = 3.1468234 * pow( 10.0, -38 );
+
+	n = [];
+	for ( i = -38; i > -325; i-- ) {
+		n.push( i );
+	}
+	expected = [
+		4e-38,
+		3.2e-38,
+		3.15e-38,
+		3.147e-38,
+		3.1469e-38,
+		3.14683e-38,
+		3.146824e-38,
+		3.1468235e-38,
+		3.14682344e-38,
+		3.146823435e-38,
+		3.1468234344e-38,
+		3.14682343431e-38,
+		3.146823434303e-38,
+		3.1468234343024e-38,
+		3.14682343430234e-38,
+		3.146823434302340e-38,
+		3.1468234343023397e-38
+	];
+
+	for ( i = 0; i < n.length; i++ ) {
+		v = cceilnf( new Complex64( x, x ), n[i] );
+		if ( real( v ) === expected[i] ) {
+			t.strictEqual( real( v ), expected[i], 'returns '+expected[i]+' when provided re='+x+', im='+x+', and n='+n[i]+'.' );
+		} else {
+			delta = abs( real( v ) - expected[i] );
+			tol = EPS * abs( expected[i] );
+			t.strictEqual( delta <= tol, true, 're: '+x+'. n: '+n[i]+'. v: '+v[0]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol );
+
+			delta = abs( imag( v ) - expected[i] );
+			tol = EPS * abs( expected[i] );
+			t.strictEqual( delta <= tol, true, 'im: '+x+'. n: '+n[i]+'. v: '+v[1]+'. expected: '+expected[i]+'. delta: '+delta+'. tol: '+tol );
+		}
+	}
+	t.end();
+});
+
+tape( 'if the function encounters overflow, the function returns the input component', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = 3.1468234343023397;
+	v = cceilnf( new Complex64( x, x ), -314 );
+	t.strictEqual( real( v ), x, 'returns expected value' );
+	t.strictEqual( imag( v ), x, 'returns expected value' );
+
+	x = -3.1468234343023397;
+	v = cceilnf( new Complex64( x, x ), -314 );
+	t.strictEqual( real( v ), x, 'returns expected value' );
+	t.strictEqual( imag( v ), x, 'returns expected value' );
+
+	x = 9007199254740000;
+	v = cceilnf( new Complex64( x, x ), -300 );
+	t.strictEqual( real( v ), x, 'returns expected value' );
+	t.strictEqual( imag( v ), x, 'returns expected value' );
+
+	x = -9007199254740000;
+	v = cceilnf( new Complex64( x, x ), -300 );
+	t.strictEqual( real( v ), x, 'returns expected value' );
+	t.strictEqual( imag( v ), x, 'returns expected value' );
+
+	t.end();
+});


### PR DESCRIPTION
Progresses #649 
Resolves #5419.

## Description

> What is the purpose of this pull request?

This pull request:

-   adds `math/base/special/cceilnf` which is a single-precision version of `cceiln`

## Related Issues

> Does this pull request have any related issues?

This pull request:

- progresses #649

-   resolves #5419.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-  [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
