### PR TITLE
fix: escape % symbol when processing LaTeX equations in `remark-img-equations` plugin

### DIFF
--- a/lib/node_modules/@stdlib/_tools/remark/plugins/remark-img-equations/lib/insert_equations.js
+++ b/lib/node_modules/@stdlib/_tools/remark/plugins/remark-img-equations/lib/insert_equations.js
@@ -46,6 +46,7 @@ var RAW = /raw="([^"]*)"/;
 * @returns {string} substituted equation
 */
 function substitute( tex ) {
+	tex = replace( tex, /%/g, '\\%' );
 	return replace( tex, /\\operatorname{([^}]*)}/g, '\\mathop{\\mathrm{$1}}' );
 }
 


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

- Updates the remark-img-equations plugin to ensure that `%` is properly escaped as `\%` to prevent formatting issues.
- Fixes the incorrect equation rendering in [fmod](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/fmod#modulus-function)

## Related Issues

> Does this pull request have any related issues?

This pull request:

- resolves none

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md