### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/_tools/github/get/lib/cache.js
+++ b/lib/node_modules/@stdlib/_tools/github/get/lib/cache.js
@@ -36,6 +36,7 @@ function create( size ) {
 	return cache;
 }
 
+
 // EXPORTS //
 
 module.exports = create;

--- a/lib/node_modules/@stdlib/_tools/github/get/lib/cache.js
+++ b/lib/node_modules/@stdlib/_tools/github/get/lib/cache.js
@@ -28,9 +28,12 @@
 * @returns {Array} cache
 */
 function create( size ) {
-	return new Array( size );
+	const cache = [];
+    for (let i = 0; i < size; i++) {
+        cache.push(undefined);
+    }
+    return cache;
 }
-
 
 // EXPORTS //
 

--- a/lib/node_modules/@stdlib/_tools/github/get/lib/cache.js
+++ b/lib/node_modules/@stdlib/_tools/github/get/lib/cache.js
@@ -28,11 +28,12 @@
 * @returns {Array} cache
 */
 function create( size ) {
-	const cache = [];
-    for (let i = 0; i < size; i++) {
-        cache.push(undefined);
-    }
-    return cache;
+	var cache = [];
+	var i;
+	for ( i = 0; i < size; i++ ) {
+		cache.push( null );
+	}
+	return cache;
 }
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/_tools/pkgs/browser-entry-points/lib/sync.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/browser-entry-points/lib/sync.js
@@ -55,7 +55,7 @@ var debug = logger( 'browser-entry-points:sync' );
 * var pkgs = [ '/foo/bar/baz' ];
 *
 * var entries = entryPoints( pkgs );
-* // returns [{...}]
+* // throws <Error>
 */
 function entryPoints( pkgs, options ) {
 	var results;

--- a/lib/node_modules/@stdlib/_tools/pkgs/browser-entry-points/lib/sync.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/browser-entry-points/lib/sync.js
@@ -55,7 +55,7 @@ var debug = logger( 'browser-entry-points:sync' );
 * var pkgs = [ '/foo/bar/baz' ];
 *
 * var entries = entryPoints( pkgs );
-* // throws <Error>
+* // e.g., returns [{...}]
 */
 function entryPoints( pkgs, options ) {
 	var results;


### PR DESCRIPTION

Resolves  #5502 

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR make sure that it avoids the javascript linting errors

1. It doesn't use the constructor `new Array()`
2. Fix JSDoc doctest linting issue in sync.js


## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #5502 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
