### PR TITLE
bench: suppress uninitialized variable warning

### DIFF
--- a/lib/node_modules/@stdlib/math/strided/special/smskceil/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/math/strided/special/smskceil/benchmark/c/benchmark.length.c
@@ -128,6 +128,7 @@ static double benchmark( int iterations, int len ) {
 	}
 	t = tic();
 	for ( i = 0; i < iterations; i++ ) {
+		// cppcheck-suppress uninitvar
 		stdlib_strided_smskceil( len, x, 1, m, 1, y, 1 );
 		if ( y[ 0 ] != y[ 0 ] ) {
 			printf( "should not return NaN\n" );


### PR DESCRIPTION
Resolves #5503.

## Description

> This pull request fixes uninitialized variable warnings in the `benchmark.length.c` file for `stdlib_strided_smskceil`.

- Ensures `x` and `m` arrays are properly initialized before use.

## Related Issues

> Does this pull request have any related issues?

This pull request:

- Resolves #5503 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
