### PR TITLE
chore: fix EditorConfig lint errors

### DIFF
--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-nested-require/examples/index.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-nested-require/examples/index.js
@@ -48,5 +48,5 @@ console.log( result );
 			'endLine': 2,
 			'endColumn': 29
 		}
-]
+	]
 */

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-nested-require/examples/index.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-nested-require/examples/index.js
@@ -36,17 +36,17 @@ result = linter.verify( code, {
 });
 console.log( result );
 /* =>
-    [
-        {
-            'ruleId': 'no-nested-require',
-            'severity': 2,
-            'message': 'do not use nested property access for require() expressions',
-            'line': 2,
-            'column': 15,
-            'nodeType': 'CallExpression',
-            'source': 'var special = require( \'@stdlib/math\' ).base.special;',
-            'endLine': 2,
-            'endColumn': 29
-        }
-    ]
+	[
+		{
+			'ruleId': 'no-nested-require',
+			'severity': 2,
+			'message': 'do not use nested property access for require() expressions',
+			'line': 2,
+			'column': 15,
+			'nodeType': 'CallExpression',
+			'source': 'var special = require( \'@stdlib/math\' ).base.special;',
+			'endLine': 2,
+			'endColumn': 29
+		}
+]
 */

--- a/lib/node_modules/@stdlib/_tools/github/user-details/lib/defaults.json
+++ b/lib/node_modules/@stdlib/_tools/github/user-details/lib/defaults.json
@@ -1,13 +1,13 @@
 {
-    "usernames": [],
-    "protocol": "https",
-    "hostname": "api.github.com",
-    "port": 443,
-    "pathname": "/",
-    "page": 1,
-    "last_page": 1,
-    "per_page": 1,
-    "method": "GET",
-    "useragent": "https://github.com/stdlib-js/stdlib/@stdlib/_tools/github/user-details",
-    "accept": "application/vnd.github.v3+json"
+  "usernames": [],
+  "protocol": "https",
+  "hostname": "api.github.com",
+  "port": 443,
+  "pathname": "/",
+  "page": 1,
+  "last_page": 1,
+  "per_page": 1,
+  "method": "GET",
+  "useragent": "https://github.com/stdlib-js/stdlib/@stdlib/_tools/github/user-details",
+  "accept": "application/vnd.github.v3+json"
 }

--- a/lib/node_modules/@stdlib/_tools/github/user-details/lib/defaults.json
+++ b/lib/node_modules/@stdlib/_tools/github/user-details/lib/defaults.json
@@ -1,13 +1,13 @@
 {
-	"usernames": [],
-	"protocol": "https",
-	"hostname": "api.github.com",
-	"port": 443,
-	"pathname": "/",
-	"page": 1,
-	"last_page": 1,
-	"per_page": 1,
-	"method": "GET",
-	"useragent": "https://github.com/stdlib-js/stdlib/@stdlib/_tools/github/user-details",
-	"accept": "application/vnd.github.v3+json"
+    "usernames": [],
+    "protocol": "https",
+    "hostname": "api.github.com",
+    "port": 443,
+    "pathname": "/",
+    "page": 1,
+    "last_page": 1,
+    "per_page": 1,
+    "method": "GET",
+    "useragent": "https://github.com/stdlib-js/stdlib/@stdlib/_tools/github/user-details",
+    "accept": "application/vnd.github.v3+json"
 }

--- a/lib/node_modules/@stdlib/error/reviver/examples/index.js
+++ b/lib/node_modules/@stdlib/error/reviver/examples/index.js
@@ -26,12 +26,12 @@ var err1 = new SyntaxError( 'bad syntax' );
 
 var json = err2json( err1 );
 /* e.g., returns
-    {
-        'type': 'SyntaxError',
-        'name': 'SyntaxError',
-        'message': 'bad syntax',
-        'stack': '...'
-    }
+	{
+		'type': 'SyntaxError',
+		'name': 'SyntaxError',
+		'message': 'bad syntax',
+		'stack': '...'
+	}
 */
 
 var str = JSON.stringify( json );

--- a/lib/node_modules/@stdlib/math/base/special/rsqrt/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/rsqrt/manifest.json
@@ -1,78 +1,78 @@
 {
-	"options": {
-		"task": "build"
-	},
-	"fields": [
-		{
-			"field": "src",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "include",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "libraries",
-			"resolve": false,
-			"relative": false
-		},
-		{
-			"field": "libpath",
-			"resolve": true,
-			"relative": false
-		}
-	],
-	"confs": [
-		{
-			"task": "build",
-			"src": [
-				"./src/rsqrt.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [
-				"-lm"
-			],
-			"libpath": [],
-			"dependencies": [
-				"@stdlib/math/base/napi/unary",
-				"@stdlib/math/base/special/sqrt"
-			]
-		},
-		{
-			"task": "benchmark",
-			"src": [
-				"./src/rsqrt.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [
-				"-lm"
-			],
-			"libpath": [],
-			"dependencies": [
-				"@stdlib/math/base/special/sqrt"
-			]
-		},
-		{
-			"task": "examples",
-			"src": [
-				"./src/rsqrt.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [
-				"-lm"
-			],
-			"libpath": [],
-			"dependencies": [
-				"@stdlib/math/base/special/sqrt"
-			]
-		}
-	]
+    "options": {
+        "task": "build"
+    },
+    "fields": [
+        {
+            "field": "src",
+            "resolve": true,
+            "relative": true
+        },
+        {
+            "field": "include",
+            "resolve": true,
+            "relative": true
+        },
+        {
+            "field": "libraries",
+            "resolve": false,
+            "relative": false
+        },
+        {
+            "field": "libpath",
+            "resolve": true,
+            "relative": false
+        }
+    ],
+    "confs": [
+        {
+            "task": "build",
+            "src": [
+                "./src/rsqrt.c"
+            ],
+            "include": [
+                "./include"
+            ],
+            "libraries": [
+                "-lm"
+            ],
+            "libpath": [],
+            "dependencies": [
+                "@stdlib/math/base/napi/unary",
+                "@stdlib/math/base/special/sqrt"
+            ]
+        },
+        {
+            "task": "benchmark",
+            "src": [
+                "./src/rsqrt.c"
+            ],
+            "include": [
+                "./include"
+            ],
+            "libraries": [
+                "-lm"
+            ],
+            "libpath": [],
+            "dependencies": [
+                "@stdlib/math/base/special/sqrt"
+            ]
+        },
+        {
+            "task": "examples",
+            "src": [
+                "./src/rsqrt.c"
+            ],
+            "include": [
+                "./include"
+            ],
+            "libraries": [
+                "-lm"
+            ],
+            "libpath": [],
+            "dependencies": [
+                "@stdlib/math/base/special/sqrt"
+            ]
+        }
+    ]
 }

--- a/lib/node_modules/@stdlib/ndarray/base/strides2offset/manifest.json
+++ b/lib/node_modules/@stdlib/ndarray/base/strides2offset/manifest.json
@@ -1,38 +1,38 @@
 {
-	"options": {},
-	"fields": [
-		{
-			"field": "src",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "include",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "libraries",
-			"resolve": false,
-			"relative": false
-		},
-		{
-			"field": "libpath",
-			"resolve": true,
-			"relative": false
-		}
-	],
-	"confs": [
-		{
-			"src": [
-				"./src/main.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [],
-			"libpath": [],
-			"dependencies": []
-		}
-	]
+    "options": {},
+    "fields": [
+        {
+            "field": "src",
+            "resolve": true,
+            "relative": true
+        },
+        {
+            "field": "include",
+            "resolve": true,
+            "relative": true
+        },
+        {
+            "field": "libraries",
+            "resolve": false,
+            "relative": false
+        },
+        {
+            "field": "libpath",
+            "resolve": true,
+            "relative": false
+        }
+    ],
+    "confs": [
+        {
+            "src": [
+                "./src/main.c"
+            ],
+            "include": [
+                "./include"
+            ],
+            "libraries": [],
+            "libpath": [],
+            "dependencies": []
+        }
+    ]
 }

--- a/lib/node_modules/@stdlib/strided/napi/smskmap/manifest.json
+++ b/lib/node_modules/@stdlib/strided/napi/smskmap/manifest.json
@@ -1,40 +1,40 @@
 {
-    "options": {},
-    "fields": [
-        {
-            "field": "src",
-            "resolve": true,
-            "relative": true
-        },
-        {
-            "field": "include",
-            "resolve": true,
-            "relative": true
-        },
-        {
-            "field": "libraries",
-            "resolve": false,
-            "relative": false
-        },
-        {
-            "field": "libpath",
-            "resolve": true,
-            "relative": false
-        }
-    ],
-    "confs": [
-        {
-            "src": [
-                "./src/main.c"
-            ],
-            "include": [
-                "./include"
-            ],
-            "libraries": [],
-            "libpath": [],
-            "dependencies": [
-                "@stdlib/strided/base/smskmap"
-            ]
-        }
-    ]
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/strided/base/smskmap"
+      ]
+    }
+  ]
 }

--- a/lib/node_modules/@stdlib/strided/napi/smskmap/manifest.json
+++ b/lib/node_modules/@stdlib/strided/napi/smskmap/manifest.json
@@ -1,40 +1,40 @@
 {
-	"options": {},
-	"fields": [
-		{
-			"field": "src",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "include",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "libraries",
-			"resolve": false,
-			"relative": false
-		},
-		{
-			"field": "libpath",
-			"resolve": true,
-			"relative": false
-		}
-	],
-	"confs": [
-		{
-			"src": [
-				"./src/main.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [],
-			"libpath": [],
-			"dependencies": [
-				"@stdlib/strided/base/smskmap"
-			]
-		}
-	]
+    "options": {},
+    "fields": [
+        {
+            "field": "src",
+            "resolve": true,
+            "relative": true
+        },
+        {
+            "field": "include",
+            "resolve": true,
+            "relative": true
+        },
+        {
+            "field": "libraries",
+            "resolve": false,
+            "relative": false
+        },
+        {
+            "field": "libpath",
+            "resolve": true,
+            "relative": false
+        }
+    ],
+    "confs": [
+        {
+            "src": [
+                "./src/main.c"
+            ],
+            "include": [
+                "./include"
+            ],
+            "libraries": [],
+            "libpath": [],
+            "dependencies": [
+                "@stdlib/strided/base/smskmap"
+            ]
+        }
+    ]
 }

--- a/lint_editorconfig_errors.txt
+++ b/lint_editorconfig_errors.txt
@@ -1,0 +1,3 @@
+Linting files for basic formatting errors...
+Success. No detected EditorConfig lint errors.
+

--- a/lint_editorconfig_errors.txt
+++ b/lint_editorconfig_errors.txt
@@ -1,3 +1,0 @@
-Linting files for basic formatting errors...
-Success. No detected EditorConfig lint errors.
-


### PR DESCRIPTION
Resolves #5526

## Description

> What is the purpose of this pull request?

The purpose of this pull request is to fix EditorConfig linting issues with spaces and indents in the following files:

lib/node_modules/@stdlib/_tools/github/user-details/lib/defaults.json
lib/node_modules/@stdlib/error/reviver/examples/index.js
lib/node_modules/@stdlib/strided/napi/smskmap/manifest.json

## Related Issues

This pull request:

-   resolves #5526

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
