### PR TITLE
Fix JavaScript lint error

### DIFF
--- a/lib/node_modules/@stdlib/_tools/github/get/lib/cache.js
+++ b/lib/node_modules/@stdlib/_tools/github/get/lib/cache.js
@@ -27,8 +27,8 @@
 * @param {NonNegativeInteger} size - cache size
 * @returns {Array} cache
 */
-function create( size ) {
-	return new Array( size );
+function create(size) {
+    return Array.from({ length: size });
 }
 
 


### PR DESCRIPTION
Resolves #5502

## Description 

### Purpose of this pull request
This pull request:  
- Fixes JavaScript lint errors in `lib/node_modules/@stdlib/_tools/github/get/lib/cache.js`.  
- Replaces the `new Array(size)` constructor with `Array.from({ length: size })` to comply with `stdlib/no-new-array`.  

## Related Issues
This pull request:  
- Resolves #5502.  

## Questions 
> Any questions for reviewers of this pull request?  

No.  

## Other
> Any other information relevant to this pull request?  

No.  

## Checklist
> Please ensure the following tasks are completed before submitting this pull request.  

- Read, understood, and followed the [contributing guidelines][contributing].  

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

---  

@stdlib-js/reviewers  

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md  
