### PR TITLE
feat: add `stats/incr/nanminabs`

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/minabs/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/incr/minabs/docs/types/index.d.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2019 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/incr/minabs/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/incr/minabs/docs/types/index.d.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2019 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/incr/nanminabs/README.md
+++ b/lib/node_modules/@stdlib/stats/incr/nanminabs/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2018 The Stdlib Authors.
+Copyright (c) 2025 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/incr/nanminabs/README.md
+++ b/lib/node_modules/@stdlib/stats/incr/nanminabs/README.md
@@ -1,0 +1,143 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2018 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# incrnanminabs
+
+> Compute a minimum absolute value incrementally, ignoring NaN values.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var incrnanminabs = require( '@stdlib/stats/incr/nanminabs' );
+```
+
+#### incrnanminabs()
+
+Returns an accumulator `function` which incrementally computes a minimum absolute value, ignoring NaN values.
+
+```javascript
+var accumulator = incrnanminabs();
+```
+
+#### accumulator( \[x] )
+
+If provided an input value `x`, the accumulator function returns an updated minimum absolute value. If not provided an input value `x`, the accumulator function returns the current minimum absolute value.
+
+```javascript
+var accumulator = incrnanminabs();
+
+var min = accumulator( 2.0 );
+// returns 2.0
+
+min = accumulator( 1.0 );
+// returns 1.0
+
+min = accumulator( NaN );
+// returns 1.0
+
+min = accumulator( -3.0 );
+// returns 1.0
+
+min = accumulator();
+// returns 1.0
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   Input values are **not** type checked. If non-numeric inputs are possible, you are advised to type check and handle accordingly **before** passing the value to the accumulator function.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var randu = require( '@stdlib/random/base/randu' );
+var incrnanminabs = require( '@stdlib/stats/incr/nanminabs' );
+
+var accumulator;
+var v;
+var i;
+
+// Initialize an accumulator:
+accumulator = incrnanminabs();
+
+// For each simulated datum, update the minimum absolute value...
+for ( i = 0; i < 100; i++ ) {
+    if ( randu() < 0.2 ) {
+        v = NaN;
+    } else {
+        v = ( randu() * 100.0 ) - 50.0;
+    }
+    accumulator( v );
+}
+console.log( accumulator() );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/stats/incr/minabs`][@stdlib/stats/incr/minabs]</span><span class="delimiter">: </span><span class="description">compute a maximum absolute value incrementally.</span>
+-   <span class="package-name">[`@stdlib/stats/incr/maxabs`][@stdlib/stats/incr/maxabs]</span><span class="delimiter">: </span><span class="description">compute a minimum value incrementally.</span>
+-   <span class="package-name">[`@stdlib/stats/incr/min`][@stdlib/stats/incr/min]</span><span class="delimiter">: </span><span class="description">compute a moving minimum absolute value incrementally.</span>
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+<!-- <related-links> -->
+
+[@stdlib/stats/incr/maxabs]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/maxabs
+
+[@stdlib/stats/incr/min]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/min
+
+[@stdlib/stats/incr/minabs]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/minabs
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/stats/incr/nanminabs/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanminabs/benchmark/benchmark.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/incr/nanminabs/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanminabs/benchmark/benchmark.js
@@ -1,0 +1,69 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var pkg = require( './../package.json' ).name;
+var incrnanminabs = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var f;
+	var i;
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		f = incrnanminabs();
+		if ( typeof f !== 'function' ) {
+			b.fail( 'should return a function' );
+		}
+	}
+	b.toc();
+	if ( typeof f !== 'function' ) {
+		b.fail( 'should return a function' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::accumulator', function benchmark( b ) {
+	var acc;
+	var v;
+	var i;
+
+	acc = incrnanminabs();
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		v = acc( randu()-0.5 );
+		if ( v !== v ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( v !== v ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/stats/incr/nanminabs/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/incr/nanminabs/docs/repl.txt
@@ -1,0 +1,32 @@
+
+{{alias}}()
+    Returns an accumulator function which incrementally computes a minimum
+    absolute value, ignoring `NaN` values.
+
+    If provided a value, the accumulator function returns an updated minimum
+    absolute value. If not provided a value, the accumulator function returns
+    the current minimum absolute value.
+
+    Returns
+    -------
+    acc: Function
+        Accumulator function.
+
+    Examples
+    --------
+    > var accumulator = {{alias}}();
+    > var m = accumulator()
+    null
+    > m = accumulator( 3.14 )
+    3.14
+    > m = accumulator( NaN )
+    3.14
+    > m = accumulator( -5.0 )
+    3.14
+    > m = accumulator( 10.1 )
+    3.14
+    > m = accumulator()
+    3.14
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/stats/incr/nanminabs/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/incr/nanminabs/docs/types/index.d.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2019 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/incr/nanminabs/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/incr/nanminabs/docs/types/index.d.ts
@@ -1,0 +1,62 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2019 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+/**
+* If provided a value, returns an updated minimum absolute value; otherwise, returns the current minimum absolute value.
+*
+* @param x - value
+* @returns minimum absolute value
+*/
+type accumulator = ( x?: number ) => number | null;
+
+/**
+* Returns an accumulator function which incrementally computes a minimum absolute value, ignoring `NaN` values.
+*
+* @returns accumulator function
+*
+* @example
+* var accumulator = incrnanminabs();
+*
+* var v = accumulator();
+* // returns null
+*
+* v = accumulator( 2.0 );
+* // returns 2.0
+*
+* v = accumulator( -3.0 );
+* // returns 2.0
+*
+* v = accumulator( NaN );
+* // returns 2.0
+*
+* v = accumulator( 1.0 );
+* // returns 1.0
+*
+* v = accumulator();
+* // returns 1.0
+*/
+declare function incrnanminabs(): accumulator;
+
+
+// EXPORTS //
+
+export = incrnanminabs;

--- a/lib/node_modules/@stdlib/stats/incr/nanminabs/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/incr/nanminabs/docs/types/test.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2019 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/incr/nanminabs/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/incr/nanminabs/docs/types/test.ts
@@ -1,0 +1,61 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2019 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import incrnanminabs = require( './index' );
+
+
+// TESTS //
+
+// The function returns an accumulator function...
+{
+	incrnanminabs(); // $ExpectType accumulator
+}
+
+// The compiler throws an error if the function is provided arguments...
+{
+	incrnanminabs( '5' ); // $ExpectError
+	incrnanminabs( 5 ); // $ExpectError
+	incrnanminabs( true ); // $ExpectError
+	incrnanminabs( false ); // $ExpectError
+	incrnanminabs( null ); // $ExpectError
+	incrnanminabs( undefined ); // $ExpectError
+	incrnanminabs( [] ); // $ExpectError
+	incrnanminabs( {} ); // $ExpectError
+	incrnanminabs( ( x: number ): number => x ); // $ExpectError
+}
+
+// The function returns an accumulator function which returns an accumulated result...
+{
+	const acc = incrnanminabs();
+
+	acc(); // $ExpectType number | null
+	acc( 3.14 ); // $ExpectType number | null
+}
+
+// The compiler throws an error if the returned accumulator function is provided invalid arguments...
+{
+	const acc = incrnanminabs();
+
+	acc( '5' ); // $ExpectError
+	acc( true ); // $ExpectError
+	acc( false ); // $ExpectError
+	acc( null ); // $ExpectError
+	acc( [] ); // $ExpectError
+	acc( {} ); // $ExpectError
+	acc( ( x: number ): number => x ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/stats/incr/nanminabs/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanminabs/examples/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/incr/nanminabs/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanminabs/examples/index.js
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var randu = require( '@stdlib/random/base/randu' );
+var incrnanminabs = require( './../lib' );
+
+var accumulator;
+var min;
+var v;
+var i;
+
+// Initialize an accumulator:
+accumulator = incrnanminabs();
+
+// For each simulated datum, update the min absolute value...
+console.log( '\nValue\tMinAbs\n' );
+for ( i = 0; i < 100; i++ ) {
+	if ( randu() < 0.2 ) {
+		v = NaN;
+	} else {
+		v = ( randu() * 100.0 ) - 50.0;
+	}
+	min = accumulator( v );
+	console.log( '%d\t%d', v.toFixed( 3 ), ( min === null ) ? NaN : min.toFixed( 3 ) );
+}
+console.log( '\nFinal minimum absolute value: %d\n', accumulator() );

--- a/lib/node_modules/@stdlib/stats/incr/nanminabs/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanminabs/lib/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2020 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/incr/nanminabs/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanminabs/lib/index.js
@@ -1,0 +1,57 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2020 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Compute a minimum absolute value incrementally, ignoring `NaN` values.
+*
+* @module @stdlib/stats/incr/nanminabs
+*
+* @example
+* var incrnanminabs = require( '@stdlib/stats/incr/nanminabs' );
+*
+* var accumulator = incrnanminabs();
+*
+* var min = accumulator();
+* // returns null
+*
+* min = accumulator( 3.14 );
+* // returns 3.14
+*
+* min = accumulator( NaN );
+* // returns 3.14
+*
+* min = accumulator( -5.0 );
+* // returns 3.14
+*
+* min = accumulator( 10.1 );
+* // returns 3.14
+*
+* min = accumulator();
+* // returns 3.14
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/incr/nanminabs/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanminabs/lib/main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/incr/nanminabs/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanminabs/lib/main.js
@@ -1,0 +1,77 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var incrminabs = require( '@stdlib/stats/incr/minabs' );
+
+
+// MAIN //
+
+/**
+* Returns an accumulator function which incrementally computes a minimum absolute value, ignoring `NaN` values.
+*
+* @returns {Function} accumulator function
+*
+* @example
+* var accumulator = incrnanminabs();
+*
+* var min = accumulator();
+* // returns null
+*
+* min = accumulator( 3.14 );
+* // returns 3.14
+*
+* min = accumulator( NaN );
+* // returns 3.14
+*
+* min = accumulator( -5.0 );
+* // returns 3.14
+*
+* min = accumulator( 10.1 );
+* // returns 3.14
+*
+* min = accumulator();
+* // returns 3.14
+*/
+function incrnanminabs() {
+	var minabs = incrminabs();
+	return accumulator;
+
+	/**
+	* If provided a value, the accumulator function returns an updated minimum absolute value. If not provided a value, the accumulator function returns the current minimum absolute value.
+	*
+	* @private
+	* @param {number} [x] - new value
+	* @returns {(number|null)} minimum absolute value or null
+	*/
+	function accumulator( x ) {
+		if ( arguments.length === 0 || isnan( x ) ) {
+			return minabs();
+		}
+		return minabs( x );
+	}
+}
+
+
+// EXPORTS //
+
+module.exports = incrnanminabs;

--- a/lib/node_modules/@stdlib/stats/incr/nanminabs/package.json
+++ b/lib/node_modules/@stdlib/stats/incr/nanminabs/package.json
@@ -1,69 +1,69 @@
 {
-    "name": "@stdlib/stats/incr/nanminabs",
-    "version": "0.0.0",
-    "description": "Compute a minimum absolute value incrementally, ignoring NaN values.",
-    "license": "Apache-2.0",
-    "author": {
-        "name": "The Stdlib Authors",
-        "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
-    },
-    "contributors": [
-        {
-            "name": "The Stdlib Authors",
-            "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
-        }
-    ],
-    "main": "./lib",
-    "directories": {
-        "benchmark": "./benchmark",
-        "doc": "./docs",
-        "example": "./examples",
-        "lib": "./lib",
-        "test": "./test"
-    },
-    "types": "./docs/types",
-    "scripts": {},
-    "homepage": "https://github.com/stdlib-js/stdlib",
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/stdlib-js/stdlib.git"
-    },
-    "bugs": {
-        "url": "https://github.com/stdlib-js/stdlib/issues"
-    },
-    "dependencies": {},
-    "devDependencies": {},
-    "engines": {
-        "node": ">=0.10.0",
-        "npm": ">2.7.0"
-    },
-    "os": [
-        "aix",
-        "darwin",
-        "freebsd",
-        "linux",
-        "macos",
-        "openbsd",
-        "sunos",
-        "win32",
-        "windows"
-    ],
-    "keywords": [
-        "stdlib",
-        "stdmath",
-        "statistics",
-        "stats",
-        "mathematics",
-        "math",
-        "minimum",
-        "min",
-        "abs",
-        "absolute",
-        "range",
-        "extremes",
-        "domain",
-        "extent",
-        "incremental",
-        "accumulator"
-    ]
+  "name": "@stdlib/stats/incr/minabs",
+  "version": "0.0.0",
+  "description": "Compute a minimum absolute value incrementally.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "statistics",
+    "stats",
+    "mathematics",
+    "math",
+    "minimum",
+    "min",
+    "abs",
+    "absolute",
+    "range",
+    "extremes",
+    "domain",
+    "extent",
+    "incremental",
+    "accumulator"
+  ]
 }

--- a/lib/node_modules/@stdlib/stats/incr/nanminabs/package.json
+++ b/lib/node_modules/@stdlib/stats/incr/nanminabs/package.json
@@ -4,66 +4,66 @@
     "description": "Compute a minimum absolute value incrementally, ignoring NaN values.",
     "license": "Apache-2.0",
     "author": {
-      "name": "The Stdlib Authors",
-      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
-    },
-    "contributors": [
-      {
         "name": "The Stdlib Authors",
         "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
-      }
+    },
+    "contributors": [
+        {
+            "name": "The Stdlib Authors",
+            "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+        }
     ],
     "main": "./lib",
     "directories": {
-      "benchmark": "./benchmark",
-      "doc": "./docs",
-      "example": "./examples",
-      "lib": "./lib",
-      "test": "./test"
+        "benchmark": "./benchmark",
+        "doc": "./docs",
+        "example": "./examples",
+        "lib": "./lib",
+        "test": "./test"
     },
     "types": "./docs/types",
     "scripts": {},
     "homepage": "https://github.com/stdlib-js/stdlib",
     "repository": {
-      "type": "git",
-      "url": "git://github.com/stdlib-js/stdlib.git"
+        "type": "git",
+        "url": "git://github.com/stdlib-js/stdlib.git"
     },
     "bugs": {
-      "url": "https://github.com/stdlib-js/stdlib/issues"
+        "url": "https://github.com/stdlib-js/stdlib/issues"
     },
     "dependencies": {},
     "devDependencies": {},
     "engines": {
-      "node": ">=0.10.0",
-      "npm": ">2.7.0"
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
     },
     "os": [
-      "aix",
-      "darwin",
-      "freebsd",
-      "linux",
-      "macos",
-      "openbsd",
-      "sunos",
-      "win32",
-      "windows"
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
     ],
     "keywords": [
-      "stdlib",
-      "stdmath",
-      "statistics",
-      "stats",
-      "mathematics",
-      "math",
-      "minimum",
-      "min",
-      "abs",
-      "absolute",
-      "range",
-      "extremes",
-      "domain",
-      "extent",
-      "incremental",
-      "accumulator"
+        "stdlib",
+        "stdmath",
+        "statistics",
+        "stats",
+        "mathematics",
+        "math",
+        "minimum",
+        "min",
+        "abs",
+        "absolute",
+        "range",
+        "extremes",
+        "domain",
+        "extent",
+        "incremental",
+        "accumulator"
     ]
-  }
+}

--- a/lib/node_modules/@stdlib/stats/incr/nanminabs/package.json
+++ b/lib/node_modules/@stdlib/stats/incr/nanminabs/package.json
@@ -1,0 +1,69 @@
+{
+    "name": "@stdlib/stats/incr/nanminabs",
+    "version": "0.0.0",
+    "description": "Compute a minimum absolute value incrementally, ignoring NaN values.",
+    "license": "Apache-2.0",
+    "author": {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    },
+    "contributors": [
+      {
+        "name": "The Stdlib Authors",
+        "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+      }
+    ],
+    "main": "./lib",
+    "directories": {
+      "benchmark": "./benchmark",
+      "doc": "./docs",
+      "example": "./examples",
+      "lib": "./lib",
+      "test": "./test"
+    },
+    "types": "./docs/types",
+    "scripts": {},
+    "homepage": "https://github.com/stdlib-js/stdlib",
+    "repository": {
+      "type": "git",
+      "url": "git://github.com/stdlib-js/stdlib.git"
+    },
+    "bugs": {
+      "url": "https://github.com/stdlib-js/stdlib/issues"
+    },
+    "dependencies": {},
+    "devDependencies": {},
+    "engines": {
+      "node": ">=0.10.0",
+      "npm": ">2.7.0"
+    },
+    "os": [
+      "aix",
+      "darwin",
+      "freebsd",
+      "linux",
+      "macos",
+      "openbsd",
+      "sunos",
+      "win32",
+      "windows"
+    ],
+    "keywords": [
+      "stdlib",
+      "stdmath",
+      "statistics",
+      "stats",
+      "mathematics",
+      "math",
+      "minimum",
+      "min",
+      "abs",
+      "absolute",
+      "range",
+      "extremes",
+      "domain",
+      "extent",
+      "incremental",
+      "accumulator"
+    ]
+  }

--- a/lib/node_modules/@stdlib/stats/incr/nanminabs/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanminabs/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/incr/nanminabs/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanminabs/test/test.js
@@ -1,0 +1,125 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
+var abs = require( '@stdlib/math/base/special/abs' );
+var incrnanminabs = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof incrnanminabs, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns an accumulator function', function test( t ) {
+	t.equal( typeof incrnanminabs(), 'function', 'returns a function' );
+	t.end();
+});
+
+tape( 'if not provided any values, the initial returned minimum absolute value is `null`', function test( t ) {
+	var acc = incrnanminabs();
+	t.equal( acc(), null, 'returns null' );
+	t.end();
+});
+
+tape( 'the accumulator function incrementally computes a minimum absolute value', function test( t ) {
+	var expected;
+	var actual;
+	var data;
+	var acc;
+	var min;
+	var ad;
+	var N;
+	var d;
+	var i;
+
+	data = [ 2.0, -3.0, 2.0, -4.0, 3.0, 4.0 ];
+	N = data.length;
+
+	expected = [];
+	actual = [];
+
+	acc = incrnanminabs();
+
+	min = data[ 0 ];
+	for ( i = 0; i < N; i++ ) {
+		d = data[ i ];
+		ad = abs( d );
+		if ( ad < min ) {
+			min = ad;
+		}
+		expected.push( min );
+		actual.push( acc( d ) );
+	}
+	t.deepEqual( actual, expected, 'returns expected incremental results' );
+	t.end();
+});
+
+tape( 'if not provided an input value, the accumulator function returns the current minimum absolute value', function test( t ) {
+	var data;
+	var acc;
+	var i;
+
+	data = [ 2.0, -3.0, 1.0 ];
+	acc = incrnanminabs();
+	for ( i = 0; i < data.length; i++ ) {
+		acc( data[ i ] );
+	}
+	t.equal( acc(), 1.0, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the accumulator function correctly handles signed zeros', function test( t ) {
+	var acc;
+	var v;
+
+	acc = incrnanminabs();
+
+	v = acc( -0.0 );
+	t.equal( isPositiveZero( v ), true, 'returns expected value' );
+
+	v = acc( 0.0 );
+	t.equal( isPositiveZero( v ), true, 'returns expected value' );
+
+	v = acc( -0.0 );
+	t.equal( isPositiveZero( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided a `NaN`, the accumulator function ignores `NaN` values and returns current minimum absolute value', function test( t ) {
+	var data;
+	var acc;
+	var i;
+
+	data = [ 2.0, NaN, 1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 1.0, 7.0, NaN ];
+	acc = incrnanminabs();
+	for ( i = 0; i < data.length; i++ ) {
+		acc( data[ i ] );
+	}
+	t.equal( acc(), 1.0, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION

Resolves #5552

## Description

> What is the purpose of this pull request?

-   This PR adds the package `stats/incr/nanminabs` which is a wrapper around `stats/incr/minabs` to handle NaN values

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   Resolves #5552

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
