### PR TITLE
Fixed the readme in lib/node_modules. Now it displays 2.0 instead of 2

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/variance/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/variance/README.md
@@ -154,7 +154,7 @@ Returns the [variance][variance] of a [geometric][geometric-distribution] distri
 
 ```c
 double out = stdlib_base_dists_geometric_variance( 0.5 );
-// returns 2
+// returns 2.0
 ```
 
 The function accepts the following arguments:

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/variance/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/variance/test/test.js
@@ -35,6 +35,11 @@ var data = require( './fixtures/julia/data.json' );
 
 
 // TESTS //
+tape( 'the function returns 2.0 when p = 0.5', function test( t ) {
+    var v = variance( 0.5 );
+    t.equal( v, 2.0, 'returns 2.0' );
+    t.end();
+});
 
 tape( 'main export is a function', function test( t ) {
 	t.ok( true, __filename );


### PR DESCRIPTION
Fixed the readme in lib/node_modules. Now it displays 2.0 instead of 2

---
type: pre_push_report
description: Results of running various checks prior to pushing changes. report:
  - task: run_javascript_examples status: na
  - task: run_c_examples status: na
  - task: run_cpp_examples status: na
  - task: run_javascript_readme_examples status: na
  - task: run_c_benchmarks status: na
  - task: run_cpp_benchmarks status: na
  - task: run_fortran_benchmarks status: na
  - task: run_javascript_benchmarks status: na
  - task: run_julia_benchmarks status: na
  - task: run_python_benchmarks status: na
  - task: run_r_benchmarks status: na
  - task: run_javascript_tests status: na ---

Resolves #5719 .

## Description

Fixed a small minor issue in the stdlib repository. Now the function "double out = stdlib_base_dists_geometric_variance( 0.5 );" returns 2.0 instead of 2, as a double is returned and along with that added a custom test case for it for future checks.
![image](https://github.com/user-attachments/assets/e2f4628c-aeb1-433f-8c61-483d32d4cc0a)
Attached image shows it after testing.

This pull request:

-   resolves #5719 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
