### PR TITLE
build: add an `ESLint` rule to disallow global `BigInt` literal and constructor

### DIFF
--- a/etc/eslint/rules/stdlib.js
+++ b/etc/eslint/rules/stdlib.js
@@ -4230,6 +4230,30 @@ rules[ 'stdlib/no-internal-require' ] = 'error';
 rules[ 'stdlib/no-multiple-empty-lines' ] = 'error';
 
 /**
+* Disallow usage of the built-in global `BigInt` literal syntax and constructor.
+*
+* @name no-builtin-big-int
+* @memberof rules
+* @type {string}
+* @default 'error'
+*
+* @example
+* // Bad...
+* var x = BigInt( 123 );
+* console.log( typeof x );
+* // => 'bigint'
+*
+* @example
+* // Good...
+* var BigInt = require( '@stdlib/bigint/ctor' );
+*
+* var x = BigInt( 123 );
+* console.log( typeof x );
+* // => 'bigint'
+*/
+rules[ 'stdlib/no-builtin-big-int' ] = 'error';
+
+/**
 * Disallow usage of the built-in global `Math` object.
 *
 * @name no-builtin-math

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/lib/index.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/lib/index.js
@@ -838,6 +838,15 @@ setReadOnly( rules, 'new-cap-error', require( '@stdlib/_tools/eslint/rules/new-c
 setReadOnly( rules, 'new-cap-regexp', require( '@stdlib/_tools/eslint/rules/new-cap-regexp' ) );
 
 /**
+* @name no-builtin-big-int
+* @memberof rules
+* @readonly
+* @type {Function}
+* @see {@link module:@stdlib/_tools/eslint/rules/no-builtin-big-int}
+*/
+setReadOnly( rules, 'no-builtin-big-int', require( '@stdlib/_tools/eslint/rules/no-builtin-big-int' ) );
+
+/**
 * @name no-builtin-math
 * @memberof rules
 * @readonly

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-builtin-big-int/README.md
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-builtin-big-int/README.md
@@ -1,0 +1,125 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2025 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# no-builtin-big-int
+
+> [ESLint rule][eslint-rules] disallowing the use of the built-in global `BigInt` literal syntax and constructor.
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var rule = require( '@stdlib/_tools/eslint/rules/no-builtin-big-int' );
+```
+
+#### rule
+
+[ESLint rule][eslint-rules] disallowing the use of the built-in global `BigInt` literal syntax and constructor.
+
+**Bad**:
+
+<!-- eslint-disable stdlib/no-builtin-big-int -->
+
+<!-- eslint-disable stdlib/require-globals -->
+
+```javascript
+var x = BigInt( 123 );
+console.log( typeof x );
+// => 'bigint'
+```
+
+<!-- eslint-enable stdlib/require-globals -->
+
+**Good**:
+
+```javascript
+var BigInt = require( '@stdlib/bigint/ctor' );
+
+var x = BigInt( 123 );
+console.log( typeof x );
+// => 'bigint'
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+```javascript
+var Linter = require( 'eslint' ).Linter;
+var rule = require( '@stdlib/_tools/eslint/rules/no-builtin-big-int' );
+
+var linter = new Linter();
+
+var code = 'var x = 123n;';
+
+linter.defineRule( 'no-builtin-big-int', rule );
+
+var result = linter.verify( code, {
+    'rules': {
+        'no-builtin-big-int': 'error'
+    }
+});
+/* returns
+    [
+        {
+            'ruleId': 'no-builtin-big-int',
+            'severity': 2,
+            'message': 'Using the built-in global `BigInt` literal syntax is not allowed; use `@stdlib/bigint/ctor` instead.',
+            'line': 1,
+            'column': 9,
+            'nodeType': 'Literal',
+            'source': 'var x = 123n;',
+            'endLine': 1,
+            'endColumn': 13
+        }
+    ]
+*/
+```
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[eslint-rules]: https://eslint.org/docs/developer-guide/working-with-rules
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-builtin-big-int/examples/index.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-builtin-big-int/examples/index.js
@@ -1,0 +1,53 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var Linter = require( 'eslint' ).Linter;
+var rule = require( './../lib' );
+
+var linter = new Linter();
+var code = 'var x = 123n;';
+
+linter.defineRule( 'no-builtin-big-int', rule );
+
+var results = linter.verify( code, {
+	'rules': {
+		'no-builtin-big-int': 'error'
+	},
+	'parserOptions': {
+		'ecmaVersion': 2020
+	}
+});
+console.log( results );
+
+/*
+	[
+		{
+			'ruleId': 'no-builtin-big-int',
+			'severity': 2,
+			'message': 'Using the built-in global `BigInt` literal syntax is not allowed; use `@stdlib/bigint/ctor` instead.',
+			'line': 1,
+			'column': 9,
+			'nodeType': 'Literal',
+			'source': 'var x = 123n;',
+			'endLine': 1,
+			'endColumn': 13
+		}
+	]
+*/

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-builtin-big-int/lib/index.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-builtin-big-int/lib/index.js
@@ -1,0 +1,39 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* ESLint rule disallowing the use of the built-in global `BigInt` literal syntax and constructor.
+*
+* @module @stdlib/_tools/eslint/rules/no-builtin-big-int
+*
+* @example
+* var rule = require( '@stdlib/_tools/eslint/rules/no-builtin-big-int' );
+*
+* console.log( rule );
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-builtin-big-int/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-builtin-big-int/lib/main.js
@@ -26,11 +26,11 @@ var rule;
 // FUNCTIONS //
 
 /**
-* Checks whether using the built-in BigInt or `@stdlib/bigint/ctor`.
+* Checks whether using imported constructor from `@stdlib/bigint/ctor`.
 *
 * @private
 * @param {Object} scope - scope
-* @returns {boolean} boolean indicating if using the built-in BigInt or `@stdlib/bigint/ctor`
+* @returns {boolean} boolean indicating if using imported constructor from `@stdlib/bigint/ctor`
 */
 function isImportedBigInt( scope ) {
 	var isNotBuiltIn;
@@ -60,9 +60,7 @@ function isImportedBigInt( scope ) {
 * @returns {Object} validators
 */
 function main( context ) {
-	var scope;
-
-	scope = context.getScope();
+	var scope = context.getScope();
 
 	/**
 	* Reports the error message.

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-builtin-big-int/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-builtin-big-int/lib/main.js
@@ -127,8 +127,7 @@ rule = {
 	'meta': {
 		'type': 'problem',
 		'docs': {
-			'description': 'disallow the use of the built-in global `BigInt` literal syntax and constructor',
-			'category': 'ES2020'
+			'description': 'disallow the use of the built-in global `BigInt` literal syntax and constructor'
 		},
 		'schema': []
 	},

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-builtin-big-int/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-builtin-big-int/lib/main.js
@@ -1,0 +1,143 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// VARIABLES //
+
+var rule;
+
+
+// FUNCTIONS //
+
+/**
+* Checks whether using the built-in BigInt or `@stdlib/bigint/ctor`.
+*
+* @private
+* @param {Object} scope - scope
+* @returns {boolean} boolean indicating if using the built-in BigInt or `@stdlib/bigint/ctor`
+*/
+function isImportedBigInt( scope ) {
+	var isNotBuiltIn;
+	var v;
+
+	isNotBuiltIn = scope.set.has( 'BigInt' );
+	if ( isNotBuiltIn ) {
+		v = scope.set.get( 'BigInt' );
+		if (
+			v.defs.length > 0 &&
+			v.defs[ 0 ].node.type === 'VariableDeclarator' &&
+			v.defs[ 0 ].node.init &&
+			v.defs[ 0 ].node.init.type === 'CallExpression' &&
+			v.defs[ 0 ].node.init.callee.name === 'require' &&
+			v.defs[ 0 ].node.init.arguments[ 0 ].value === '@stdlib/bigint/ctor'
+		) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+* Rule for disallowing the use of the built-in global `BigInt` literal syntax and constructor.
+*
+* @param {Object} context - ESLint context
+* @returns {Object} validators
+*/
+function main( context ) {
+	var scope;
+
+	scope = context.getScope();
+
+	/**
+	* Reports the error message.
+	*
+	* @private
+	* @param {ASTNode} node - node to report
+	* @param {string} type - node type
+	*/
+	function report( node, type ) {
+		var message;
+
+		if ( type === 'Literal' ) {
+			message = 'Using the built-in global `BigInt` literal syntax is not allowed; use `@stdlib/bigint/ctor` instead.';
+		} else if ( type === 'CallExpression' ) {
+			message = 'Using the built-in global `BigInt` constructor is not allowed; use `@stdlib/bigint/ctor` instead.';
+		}
+		context.report({
+			'node': node,
+			'message': message
+		});
+	}
+
+	/**
+	* Validates a BigInt literal.
+	*
+	* @private
+	* @param {ASTNode} node - node to examine
+	*/
+	function validateBigIntLiteral( node ) {
+		if ( node.bigint ) {
+			report( node, 'Literal' );
+		}
+	}
+
+	/**
+	* Validates a BigInt constructor.
+	*
+	* @private
+	* @param {ASTNode} node - node to examine
+	*/
+	function validateBigIntConstructor( node ) {
+		if (
+			node.callee &&
+			node.callee.type === 'Identifier' &&
+			node.callee.name === 'BigInt'
+		) {
+			if ( isImportedBigInt( scope ) ) {
+				return;
+			}
+			report( node, 'CallExpression' );
+		}
+	}
+
+	return {
+		'Literal': validateBigIntLiteral,
+		'CallExpression': validateBigIntConstructor
+	};
+}
+
+
+// MAIN //
+
+rule = {
+	'meta': {
+		'type': 'problem',
+		'docs': {
+			'description': 'disallow the use of the built-in global `BigInt` literal syntax and constructor',
+			'category': 'ES2020'
+		},
+		'schema': []
+	},
+	'create': main
+};
+
+
+// EXPORTS //
+
+module.exports = rule;

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-builtin-big-int/package.json
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-builtin-big-int/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@stdlib/_tools/eslint/rules/no-builtin-big-int",
+  "version": "0.0.0",
+  "description": "ESLint rule disallowing the use of the built-in global `BigInt` literal syntax and constructor.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "bin": {},
+  "main": "./lib",
+  "directories": {
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "keywords": [
+    "stdlib",
+    "tools",
+    "tool",
+    "eslint",
+    "lint",
+    "custom",
+    "rules",
+    "rule",
+    "plugin",
+    "bigint",
+    "big",
+    "int",
+    "integer",
+    "literal",
+    "constructor"
+  ]
+}

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-builtin-big-int/test/fixtures/invalid.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-builtin-big-int/test/fixtures/invalid.js
@@ -1,0 +1,94 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var invalid = [];
+var test;
+
+test = {
+	'code': [
+		'var x = 123n;'
+	].join( '\n' ),
+	'errors': [
+		{
+			'message': 'Using the built-in global `BigInt` literal syntax is not allowed; use `@stdlib/bigint/ctor` instead.',
+			'type': 'Literal'
+		}
+	]
+};
+invalid.push( test );
+
+test = {
+	'code': [
+		'var x = { a: 123n }'
+	].join( '\n' ),
+	'errors': [
+		{
+			'message': 'Using the built-in global `BigInt` literal syntax is not allowed; use `@stdlib/bigint/ctor` instead.',
+			'type': 'Literal'
+		}
+	]
+};
+invalid.push( test );
+
+test = {
+	'code': [
+		'var x = { a: BigInt( 123 ) }'
+	].join( '\n' ),
+	'errors': [
+		{
+			'message': 'Using the built-in global `BigInt` constructor is not allowed; use `@stdlib/bigint/ctor` instead.',
+			'type': 'CallExpression'
+		}
+	]
+};
+invalid.push( test );
+
+test = {
+	'code': [
+		'var x = BigInt( 123 );'
+	].join( '\n' ),
+	'errors': [
+		{
+			'message': 'Using the built-in global `BigInt` constructor is not allowed; use `@stdlib/bigint/ctor` instead.',
+			'type': 'CallExpression'
+		}
+	]
+};
+invalid.push( test );
+
+test = {
+	'code': [
+		'function createBigInt() {',
+		'  return BigInt( 123 );',
+		'}'
+	].join( '\n' ),
+	'errors': [
+		{
+			'message': 'Using the built-in global `BigInt` constructor is not allowed; use `@stdlib/bigint/ctor` instead.',
+			'type': 'CallExpression'
+		}
+	]
+};
+invalid.push( test );
+
+
+// EXPORTS //
+
+module.exports = invalid;

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-builtin-big-int/test/fixtures/unvalidated.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-builtin-big-int/test/fixtures/unvalidated.js
@@ -1,0 +1,55 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var unvalidated = [];
+var test;
+
+test = {
+	'code': [
+		'var x = 123;'
+	].join( '\n' )
+};
+unvalidated.push( test );
+
+test = {
+	'code': [
+		'var x = "123";'
+	].join( '\n' )
+};
+unvalidated.push( test );
+
+test = {
+	'code': [
+		'var x = [];'
+	].join( '\n' )
+};
+unvalidated.push( test );
+
+test = {
+	'code': [
+		'var x = {};'
+	].join( '\n' )
+};
+unvalidated.push( test );
+
+
+// EXPORTS //
+
+module.exports = unvalidated;

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-builtin-big-int/test/fixtures/valid.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-builtin-big-int/test/fixtures/valid.js
@@ -1,0 +1,65 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var valid = [];
+var test;
+
+test = {
+	'code': [
+		'var BigInt = require( \'@stdlib/bigint/ctor\' );',
+		'',
+		'var x = BigInt( 123 );'
+	].join( '\n' )
+};
+valid.push( test );
+
+test = {
+	'code': [
+		'var BigInt = require( \'@stdlib/bigint/ctor\' );',
+		'',
+		'function createBigInt() {',
+		'  return BigInt( 123 );',
+		'}'
+	].join( '\n' )
+};
+valid.push( test );
+
+test = {
+	'code': [
+		'var BigInt = require( \'@stdlib/bigint/ctor\' );',
+		'',
+		'var x = BigInt( 123 );'
+	].join( '\n' )
+};
+valid.push( test );
+
+test = {
+	'code': [
+		'var BigInt = require( \'@stdlib/bigint/ctor\' );',
+		'',
+		'var x = { a: BigInt( 123 ) };'
+	].join( '\n' )
+};
+valid.push( test );
+
+
+// EXPORTS //
+
+module.exports = valid;

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-builtin-big-int/test/test.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-builtin-big-int/test/test.js
@@ -1,0 +1,98 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var RuleTester = require( 'eslint' ).RuleTester;
+var rule = require( './../lib' );
+
+
+// FIXTURES //
+
+var valid = require( './fixtures/valid.js' );
+var invalid = require( './fixtures/invalid.js' );
+var unvalidated = require( './fixtures/unvalidated.js' );
+
+
+// TESTS //
+
+tape( 'main export is an object', function test( t ) {
+	t.ok( true, __filename );
+	t.equal( typeof rule, 'object', 'main export is an object' );
+	t.end();
+});
+
+tape( 'the function positively validates code without the built-in global `BigInt` constructor or the BigInt literal syntax', function test( t ) {
+	var tester = new RuleTester({
+		'parserOptions': {
+			'ecmaVersion': 2020
+		}
+	});
+
+	try {
+		tester.run( 'no-builtin-big-int', rule, {
+			'valid': valid,
+			'invalid': []
+		});
+		t.pass( 'passed without errors' );
+	} catch ( err ) {
+		t.fail( 'encountered an error: ' + err.message );
+	}
+	t.end();
+});
+
+tape( 'the function negatively validates code with the built-in global `BigInt` constructor or the BigInt literal syntax', function test( t ) {
+	var tester = new RuleTester({
+		'parserOptions': {
+			'ecmaVersion': 2020
+		}
+	});
+
+	try {
+		tester.run( 'no-builtin-big-int', rule, {
+			'valid': [],
+			'invalid': invalid
+		});
+		t.pass( 'passed without errors' );
+	} catch ( err ) {
+		t.fail( 'encountered an error: ' + err.message );
+	}
+	t.end();
+});
+
+tape( 'the function does not validate code without global `BigInt`s', function test( t ) {
+	var tester = new RuleTester({
+		'parserOptions': {
+			'ecmaVersion': 2020
+		}
+	});
+
+	try {
+		tester.run( 'no-builtin-big-int', rule, {
+			'valid': unvalidated,
+			'invalid': []
+		});
+		t.pass( 'passed without errors' );
+	} catch ( err ) {
+		t.fail( 'encountered an error: ' + err.message );
+	}
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   add an `ESLint` rule to disallow global `BigInt` literal and constructor.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves https://github.com/stdlib-js/metr-issue-tracker/issues/29

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
