### PR TITLE
fix(lint): resolve JavaScript lint error-5697

### DIFF
--- a/lib/node_modules/@stdlib/buffer/from-string/lib/polyfill.js
+++ b/lib/node_modules/@stdlib/buffer/from-string/lib/polyfill.js
@@ -49,9 +49,9 @@ function fromString( str, encoding ) {
 		if ( !isString( encoding ) ) {
 			throw new TypeError( format( 'invalid argument. Second argument must be a string. Value: `%s`.', encoding ) );
 		}
-		return new Buffer( str, encoding ); // eslint-disable-line no-buffer-constructor
+		return Buffer.from( str, encoding );
 	}
-	return new Buffer( str, 'utf8' ); // eslint-disable-line no-buffer-constructor
+	return Buffer.from( str, 'utf8' );
 }
 
 


### PR DESCRIPTION
Resolves #5697 

## Description

> What is the purpose of this pull request?

This pull request:

-  Fixes JavaScript lint error of buffer constructor

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #5697  

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Updated the fromString function to use Buffer.from() instead of the deprecated new Buffer() constructor. This change follows Node.js best practices and addresses the ESLint no-buffer-constructor warning.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
