### PR TITLE
fix(buffer): remove unused eslint-disable directives in polyfill.js

### DIFF
--- a/lib/node_modules/@stdlib/buffer/from-string/lib/polyfill.js
+++ b/lib/node_modules/@stdlib/buffer/from-string/lib/polyfill.js
@@ -49,9 +49,9 @@ function fromString( str, encoding ) {
 		if ( !isString( encoding ) ) {
 			throw new TypeError( format( 'invalid argument. Second argument must be a string. Value: `%s`.', encoding ) );
 		}
-		return new Buffer( str, encoding ); // eslint-disable-line no-buffer-constructor
+		return new Buffer( str, encoding );
 	}
-	return new Buffer( str, 'utf8' ); // eslint-disable-line no-buffer-constructor
+	return new Buffer( str, 'utf8' );
 }
 
 


### PR DESCRIPTION
---
type: pre_push_report
description: Results of running various checks prior to pushing changes. report:
  - task: run_javascript_examples status: na
  - task: run_c_examples status: na
  - task: run_cpp_examples status: na
  - task: run_javascript_readme_examples status: na
  - task: run_c_benchmarks status: na
  - task: run_cpp_benchmarks status: na
  - task: run_fortran_benchmarks status: na
  - task: run_javascript_benchmarks status: na
  - task: run_julia_benchmarks status: na
  - task: run_python_benchmarks status: na
  - task: run_r_benchmarks status: na
  - task: run_javascript_tests status: na ---

Resolves #5697.

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes JavaScript lint error of buffer constructor

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #5697  

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
