### PR TITLE
chore: address commit comments in README, benchmark, and main.c

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/README.md
@@ -152,9 +152,6 @@ for ( i = 0; i < 10; i++ ) {
 
 <!-- /.examples -->
 
-<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
-
-<section class="references">
 
 <!-- C interface documentation. -->
 
@@ -246,6 +243,18 @@ int main( void ) {
     }
 }
 ```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
 
 </section>
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/benchmark/c/benchmark.c
@@ -93,13 +93,13 @@ static double random_uniform( const double min, const double max ) {
 * @return elapsed time in seconds
 */
 static double benchmark( void ) {
-	int i;	
-	double y;
-	double t;
-	double elapsed;
-	double p[100];
-	double mu[100];
 	double sigma[100];
+	double mu[100];
+	double p[100];
+	double elapsed;
+	double t;
+	double y;
+	int i;	
 
 	for ( i = 0; i < 100; i++ ) {
 		p[ i ] = random_uniform( 0.0, 1.0 );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/benchmark/c/benchmark.c
@@ -93,9 +93,9 @@ static double random_uniform( const double min, const double max ) {
 * @return elapsed time in seconds
 */
 static double benchmark( void ) {
-	double sigma[100];
-	double mu[100];
-	double p[100];
+	double sigma[ 100 ];
+	double mu[ 100 ];
+	double p[ 100 ];
 	double elapsed;
 	double t;
 	double y;

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/benchmark/c/benchmark.c
@@ -99,7 +99,7 @@ static double benchmark( void ) {
 	double elapsed;
 	double t;
 	double y;
-	int i;	
+	int i;
 
 	for ( i = 0; i < 100; i++ ) {
 		p[ i ] = random_uniform( 0.0, 1.0 );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/benchmark/c/benchmark.c
@@ -93,13 +93,13 @@ static double random_uniform( const double min, const double max ) {
 * @return elapsed time in seconds
 */
 static double benchmark( void ) {
-	double elapsed;
-	double p[ 100 ];
-	double mu[ 100 ];
-	double sigma[ 100 ];
+	int i;	
 	double y;
 	double t;
-	int i;
+	double elapsed;
+	double p[100];
+	double mu[100];
+	double sigma[100];
 
 	for ( i = 0; i < 100; i++ ) {
 		p[ i ] = random_uniform( 0.0, 1.0 );

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/manifest.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/manifest.json
@@ -41,7 +41,8 @@
         "@stdlib/math/base/napi/ternary",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/sqrt",
-        "@stdlib/math/base/special/erfinv"
+        "@stdlib/math/base/special/erfinv",
+        "@stdlib/constants/float64/sqrt_two"
       ]
     },
     {
@@ -59,7 +60,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/sqrt",
         "@stdlib/math/base/special/erfinv",
-        "@stdlib/constants/float64/eps"
+        "@stdlib/constants/float64/eps",
+        "@stdlib/constants/float64/sqrt_two"
       ]
     },
     {
@@ -77,7 +79,8 @@
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/sqrt",
         "@stdlib/math/base/special/erfinv",
-        "@stdlib/constants/float64/eps"
+        "@stdlib/constants/float64/eps",
+        "@stdlib/constants/float64/sqrt_two"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/manifest.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/manifest.json
@@ -60,7 +60,7 @@
         "@stdlib/math/base/special/sqrt",
         "@stdlib/math/base/special/erfinv",
         "@stdlib/constants/float64/eps",
-        "@stdlib/constants/float64/sqrt_two"
+        "@stdlib/constants/float64/sqrt-two"
       ]
     },
     {
@@ -79,7 +79,7 @@
         "@stdlib/math/base/special/sqrt",
         "@stdlib/math/base/special/erfinv",
         "@stdlib/constants/float64/eps",
-        "@stdlib/constants/float64/sqrt_two"
+        "@stdlib/constants/float64/sqrt-two"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/manifest.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/manifest.json
@@ -41,7 +41,8 @@
         "@stdlib/math/base/napi/ternary",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/sqrt",
-        "@stdlib/math/base/special/erfinv"
+        "@stdlib/math/base/special/erfinv",
+        "@stdlib/constants/float64/sqrt-two"
       ]
     },
     {

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/manifest.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/manifest.json
@@ -41,8 +41,7 @@
         "@stdlib/math/base/napi/ternary",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/special/sqrt",
-        "@stdlib/math/base/special/erfinv",
-        "@stdlib/constants/float64/sqrt_two"
+        "@stdlib/math/base/special/erfinv"
       ]
     },
     {

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/src/main.c
@@ -20,7 +20,7 @@
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/special/sqrt.h"
 #include "stdlib/math/base/special/erfinv.h"
-#include "@stdlib/constants/float64/sqrt-two.h"
+#include "@stdlib\constants\float64\sqrt-two\include\stdlib\constants\float64\sqrt_two.h"
 
 /**
 * Evaluates the quantile function for a normal distribution with mean `mu` and standard deviation `sigma` at a probability `p`.
@@ -48,5 +48,5 @@ double stdlib_base_dists_normal_quantile( const double p, const double mu, const
 	if ( sigma == 0.0 ) {
 		return mu;
 	}
-	return mu + ( ( sigma * SQRT2 ) * stdlib_base_erfinv( ( 2.0 * p ) - 1.0 ) );
+	return mu + ( ( sigma * STDLIB_CONSTANT_FLOAT64_SQRT2 ) * stdlib_base_erfinv( ( 2.0 * p ) - 1.0 ) );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/src/main.c
@@ -20,7 +20,7 @@
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/special/sqrt.h"
 #include "stdlib/math/base/special/erfinv.h"
-#include "@stdlib\constants\float64\sqrt-two\include\stdlib\constants\float64\sqrt_two.h"
+#include "lib/node_modules/@stdlib/constants/float64/sqrt-two/include/stdlib/constants/float64/sqrt_two.h"
 
 /**
 * Evaluates the quantile function for a normal distribution with mean `mu` and standard deviation `sigma` at a probability `p`.

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/src/main.c
@@ -20,6 +20,7 @@
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/special/sqrt.h"
 #include "stdlib/math/base/special/erfinv.h"
+#include "@stdlib/constants/float64/sqrt-two.h"
 
 /**
 * Evaluates the quantile function for a normal distribution with mean `mu` and standard deviation `sigma` at a probability `p`.
@@ -47,5 +48,5 @@ double stdlib_base_dists_normal_quantile( const double p, const double mu, const
 	if ( sigma == 0.0 ) {
 		return mu;
 	}
-	return mu + ( ( sigma * stdlib_base_sqrt( 2.0 ) ) * stdlib_base_erfinv( ( 2.0 * p ) - 1.0 ) );
+	return mu + ( ( sigma * SQRT2 ) * stdlib_base_erfinv( ( 2.0 * p ) - 1.0 ) );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/src/main.c
@@ -20,7 +20,7 @@
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/special/sqrt.h"
 #include "stdlib/math/base/special/erfinv.h"
-#include "stdlib\constants\float64\sqrt-two\include\stdlib\constants\float64\sqrt_two.h"
+#include "stdlib/constants/float64/sqrt_two.h"
 
 /**
 * Evaluates the quantile function for a normal distribution with mean `mu` and standard deviation `sigma` at a probability `p`.

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/src/main.c
@@ -20,7 +20,7 @@
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/special/sqrt.h"
 #include "stdlib/math/base/special/erfinv.h"
-#include "../../../../../constants/float64/sqrt-two/include/stdlib/constants/float64/sqrt_two.h"
+#include "stdlib/constants/float64/sqrt_two.h"
 
 /**
 * Evaluates the quantile function for a normal distribution with mean `mu` and standard deviation `sigma` at a probability `p`.

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/src/main.c
@@ -20,7 +20,7 @@
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/special/sqrt.h"
 #include "stdlib/math/base/special/erfinv.h"
-#include "lib/node_modules/@stdlib/constants/float64/sqrt-two/include/stdlib/constants/float64/sqrt_two.h"
+#include "../../../../../constants/float64/sqrt-two/include/stdlib/constants/float64/sqrt_two.h"
 
 /**
 * Evaluates the quantile function for a normal distribution with mean `mu` and standard deviation `sigma` at a probability `p`.

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/src/main.c
@@ -20,7 +20,7 @@
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/special/sqrt.h"
 #include "stdlib/math/base/special/erfinv.h"
-#include "@stdlib\constants\float64\sqrt-two\include\stdlib\constants\float64\sqrt_two.h"
+#include "stdlib\constants\float64\sqrt-two\include\stdlib\constants\float64\sqrt_two.h"
 
 /**
 * Evaluates the quantile function for a normal distribution with mean `mu` and standard deviation `sigma` at a probability `p`.


### PR DESCRIPTION
Resolves #5712 

## Description

> What is the purpose of this pull request?

This pull request:

-  Addresses review comments on commit 1f5d85a, which was part of PR #5712.
- Moves lines L155-158 to L250 in README.md.
- Adds a missing closing </section> and trailing comment in README.md.
- Reorders variable declarations by length in benchmark.c.
- Replaces stdlib_base_sqrt(2.0) with @stdlib/constants/float64/sqrt-two in C and JavaScript implementations.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #5712 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
