### PR TITLE
fix: correct formatting in dnanvariancech README

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dnanvariancech/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dnanvariancech/README.md
@@ -133,9 +133,9 @@ var v = dnanvariancech( 5, 1, x, 2 );
 
 Note that indexing is relative to the first index. To introduce an offset, use [`typed array`][mdn-typed-array] views.
 
-<!-- eslint-disable stdlib/capitalized-comments, max-len -->
 
 ```javascript
+
 var Float64Array = require( '@stdlib/array/float64' );
 var x0 = new Float64Array( [ 2.0, 1.0, 2.0, -2.0, -2.0, 2.0, 3.0, 4.0, NaN, NaN ] ); // eslint-disable-line max-len
 var x1 = new Float64Array( x0.buffer, x0.BYTES_PER_ELEMENT*1 ); // start at 2nd element


### PR DESCRIPTION
Resolves #5718.

## Description

> What is the purpose of this pull request?

This pull request reinstates a missing empty line in the `dnanvariancech` README file.  
It ensures consistency with the formatting guidelines used in the stdlib project.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #5718 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
