### PR TITLE
fix: remove unused headers and move misplaced sections

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/logcdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/logcdf/README.md
@@ -139,10 +139,6 @@ for ( i = 0; i < 10; i++ ) {
 
 <!-- /.examples -->
 
-<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
-
-<section class="references">
-
 <!-- C interface documentation. -->
 
 * * *
@@ -209,7 +205,6 @@ double stdlib_base_dists_geometric_logcdf( const double x, const double p );
 #include "stdlib/stats/base/dists/geometric/logcdf.h"
 #include <stdlib.h>
 #include <stdio.h>
-#include <math.h>
 
 static double random_uniform( const double min, const double max ) {
     double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
@@ -233,7 +228,13 @@ int main( void ) {
 
 </section>
 
+<!-- /.c -->
+
 <!-- /.references -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
 
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/logcdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/logcdf/README.md
@@ -226,15 +226,18 @@ int main( void ) {
 }
 ```
 
-</section>
+
 
 <!-- /.c -->
 
-<!-- /.references -->
 
 <!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 
 <section class="references">
+</section>
+
+
+<!-- /.references -->
 
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/logcdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/logcdf/examples/c/example.c
@@ -19,7 +19,6 @@
 #include "stdlib/stats/base/dists/geometric/logcdf.h"
 #include <stdlib.h>
 #include <stdio.h>
-#include <math.h>
 
 static double random_uniform( const double min, const double max ) {
 	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/logpmf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/logpmf/README.md
@@ -143,10 +143,6 @@ for ( i = 0; i < 10; i++ ) {
 
 <!-- /.examples -->
 
-<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
-
-<section class="references">
-
 <!-- C interface documentation. -->
 
 * * *
@@ -211,7 +207,6 @@ double stdlib_base_dists_geometric_logpmf( const double x, const double p );
 
 ```c
 #include "stdlib/stats/base/dists/geometric/logpmf.h"
-#include "stdlib/math/base/special/round.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>
@@ -238,7 +233,13 @@ int main( void ) {
 
 </section>
 
+<!-- /.c -->
+
 <!-- /.references -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
 
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/logpmf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/logpmf/examples/c/example.c
@@ -17,6 +17,7 @@
 */
 
 #include "stdlib/stats/base/dists/geometric/logpmf.h"
+#include "stdlib/math/base/special/round.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/logpmf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/logpmf/examples/c/example.c
@@ -17,7 +17,6 @@
 */
 
 #include "stdlib/stats/base/dists/geometric/logpmf.h"
-#include "stdlib/math/base/special/round.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/logpmf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/logpmf/src/main.c
@@ -21,7 +21,6 @@
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/special/ln.h"
 #include "stdlib/constants/float64/ninf.h"
-#include <math.h>
 
 /**
 * Evaluates the logarithm of the probability mass function (PMF) for a geometric distribution with success probability `p` at a value `x`.


### PR DESCRIPTION
Resolves #5714.

## Description

> What is the purpose of this pull request?

This pull request:

-Removes unused <math.h> headers from example.c and main.c
-Moves the misplaced references section to the correct position
-Adds a missing closing </section> tag

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #5714

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
