### PR TITLE
fix: use STDLIB_CONSTANT_FLOAT64_SQRT_TWO instead of recomputing sqrt(2)

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/README.md
@@ -152,10 +152,6 @@ for ( i = 0; i < 10; i++ ) {
 
 <!-- /.examples -->
 
-<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
-
-<section class="references">
-
 <!-- C interface documentation. -->
 
 * * *
@@ -249,7 +245,13 @@ int main( void ) {
 
 </section>
 
+<!-- /.c -->
+
 <!-- /.references -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
 
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/benchmark/c/benchmark.c
@@ -93,10 +93,10 @@ static double random_uniform( const double min, const double max ) {
 * @return elapsed time in seconds
 */
 static double benchmark( void ) {
-	double elapsed;
 	double p[ 100 ];
 	double mu[ 100 ];
 	double sigma[ 100 ];
+	double elapsed;
 	double y;
 	double t;
 	int i;

--- a/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/normal/quantile/src/main.c
@@ -18,8 +18,10 @@
 
 #include "stdlib/stats/base/dists/normal/quantile.h"
 #include "stdlib/math/base/assert/is_nan.h"
-#include "stdlib/math/base/special/sqrt.h"
 #include "stdlib/math/base/special/erfinv.h"
+#include "stdlib/constants/float64/sqrt_two.h" 
+
+
 
 /**
 * Evaluates the quantile function for a normal distribution with mean `mu` and standard deviation `sigma` at a probability `p`.
@@ -47,5 +49,5 @@ double stdlib_base_dists_normal_quantile( const double p, const double mu, const
 	if ( sigma == 0.0 ) {
 		return mu;
 	}
-	return mu + ( ( sigma * stdlib_base_sqrt( 2.0 ) ) * stdlib_base_erfinv( ( 2.0 * p ) - 1.0 ) );
+	return mu + ( ( sigma * STDLIB_CONSTANT_FLOAT64_SQRT_TWO ) * stdlib_base_erfinv( ( 2.0 * p ) - 1.0 ) );
 }


### PR DESCRIPTION
Resolves #5712.

## Description

> What is the purpose of this pull request?

This pull request:
- updates the normal quantile implementation to use `STDLIB_CONSTANT_FLOAT64_SQRT_TWO` instead of recalculating `sqrt(2)` each time. This improves efficiency and maintains consistency with similar implementations.

## Related Issues

-   {{TODO: add description describing what this pull request does}}

## Related Issues

> Does this pull request have any related issues?

This pull request:

- Resolves #5712

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [X] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
