### PR TITLE
chore(array): fix incorrect JSDoc type

### DIFF
--- a/lib/node_modules/@stdlib/array/filled/lib/main.js
+++ b/lib/node_modules/@stdlib/array/filled/lib/main.js
@@ -100,7 +100,7 @@ function filledAccessors( arr, value ) {
 * @throws {TypeError} must provide a recognized data type
 * @throws {TypeError} must provide a length, typed array, array-like object, buffer, or iterable
 * @throws {Error} creating a generic array from an `ArrayBuffer` is not supported
-* @returns {(TypedArray|Array|ComplexArray)} array or typed array
+* @returns {(TypedArray|Array|Complex64Array)} array or typed array
 *
 * @example
 * var arr = filledarray();


### PR DESCRIPTION
Resolves #5836 

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes incorrect jsDoc type from ComplexArray to Complex64Array.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #5836 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
