### PR TITLE
test: fix use of `tape.skip`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cscd/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cscd/test/test.native.js
@@ -85,7 +85,7 @@ tape( 'the function computes the cosecant in degrees (negative values)', opts, f
 	t.end();
 });
 
-tape.skip( 'the function computes the cosecant in degrees (positive values)', opts, function test( t ) {
+tape( 'the function computes the cosecant in degrees (positive values)', opts, function test( t ) {
 	var expected;
 	var delta;
 	var tol;


### PR DESCRIPTION
Resolves None

## Description

> What is the purpose of this pull request?

This pull request:

- Removes `skip` from the test definition in `math/base/special/cscd`

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md