### PR TITLE
feat: add protocol support to stats/base/varianceyc

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/varianceyc/README.md
+++ b/lib/node_modules/@stdlib/stats/base/varianceyc/README.md
@@ -98,7 +98,7 @@ The use of the term `n-1` is commonly referred to as Bessel's correction. Note, 
 var varianceyc = require( '@stdlib/stats/base/varianceyc' );
 ```
 
-#### varianceyc( N, correction, x, stride )
+#### varianceyc( N, correction, x, strideX )
 
 Computes the [variance][variance] of a strided array `x` using a one-pass algorithm proposed by Youngs and Cramer.
 
@@ -114,17 +114,16 @@ The function has the following parameters:
 -   **N**: number of indexed elements.
 -   **correction**: degrees of freedom adjustment. Setting this parameter to a value other than `0` has the effect of adjusting the divisor during the calculation of the [variance][variance] according to `N-c` where `c` corresponds to the provided degrees of freedom adjustment. When computing the [variance][variance] of a population, setting this parameter to `0` is the standard choice (i.e., the provided array contains data constituting an entire population). When computing the unbiased sample [variance][variance], setting this parameter to `1` is the standard choice (i.e., the provided array contains data sampled from a larger population; this is commonly referred to as Bessel's correction).
 -   **x**: input [`Array`][mdn-array] or [`typed array`][mdn-typed-array].
--   **stride**: index increment for `x`.
+-   **strideX**: stride length for `x`.
 
-The `N` and `stride` parameters determine which elements in `x` are accessed at runtime. For example, to compute the [variance][variance] of every other element in `x`,
+The `N` and `stride` parameters determine which elements in the strided array are accessed at runtime. For example, to compute the [variance][variance] of every other element in `x`,
 
 ```javascript
 var floor = require( '@stdlib/math/base/special/floor' );
 
 var x = [ 1.0, 2.0, 2.0, -7.0, -2.0, 3.0, 4.0, 2.0 ];
-var N = floor( x.length / 2 );
 
-var v = varianceyc( N, 1, x, 2 );
+var v = varianceyc( 4, 1, x, 2 );
 // returns 6.25
 ```
 
@@ -139,13 +138,11 @@ var floor = require( '@stdlib/math/base/special/floor' );
 var x0 = new Float64Array( [ 2.0, 1.0, 2.0, -2.0, -2.0, 2.0, 3.0, 4.0 ] );
 var x1 = new Float64Array( x0.buffer, x0.BYTES_PER_ELEMENT*1 ); // start at 2nd element
 
-var N = floor( x0.length / 2 );
-
-var v = varianceyc( N, 1, x1, 2 );
+var v = varianceyc( 4, 1, x1, 2 );
 // returns 6.25
 ```
 
-#### varianceyc.ndarray( N, correction, x, stride, offset )
+#### varianceyc.ndarray( N, correction, x, strideX, offsetX )
 
 Computes the [variance][variance] of a strided array using a one-pass algorithm proposed by Youngs and Cramer and alternative indexing semantics.
 
@@ -158,17 +155,14 @@ var v = varianceyc.ndarray( x.length, 1, x, 1, 0 );
 
 The function has the following additional parameters:
 
--   **offset**: starting index for `x`.
+-   **offsetX**: starting index for `x`.
 
-While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying `buffer`, the `offset` parameter supports indexing semantics based on a starting index. For example, to calculate the [variance][variance] for every other value in `x` starting from the second value
+While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying buffer, the offset parameter supports indexing semantics based on a starting index. For example, to calculate the [variance][variance] for every other value in `x` starting from the second value
 
 ```javascript
-var floor = require( '@stdlib/math/base/special/floor' );
-
 var x = [ 2.0, 1.0, 2.0, -2.0, -2.0, 2.0, 3.0, 4.0 ];
-var N = floor( x.length / 2 );
 
-var v = varianceyc.ndarray( N, 1, x, 2, 1 );
+var v = varianceyc.ndarray( 4, 1, x, 2, 1 );
 // returns 6.25
 ```
 
@@ -183,6 +177,7 @@ var v = varianceyc.ndarray( N, 1, x, 2, 1 );
 -   If `N <= 0`, both functions return `NaN`.
 -   If `N - c` is less than or equal to `0` (where `c` corresponds to the provided degrees of freedom adjustment), both functions return `NaN`.
 -   Depending on the environment, the typed versions ([`dvarianceyc`][@stdlib/stats/base/dvarianceyc], [`svarianceyc`][@stdlib/stats/base/svarianceyc], etc.) are likely to be significantly more performant.
+-   Both functions support array-like objects having getter and setter accessors for array element access (e.g., [`@stdlib/array/base/accessor`][@stdlib/array/base/accessor]).
 
 </section>
 
@@ -195,18 +190,13 @@ var v = varianceyc.ndarray( N, 1, x, 2, 1 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var Float64Array = require( '@stdlib/array/float64' );
 var varianceyc = require( '@stdlib/stats/base/varianceyc' );
 
-var x;
-var i;
-
-x = new Float64Array( 10 );
-for ( i = 0; i < x.length; i++ ) {
-    x[ i ] = round( (randu()*100.0) - 50.0 );
-}
+var x = uniform( 10, -50.0, 50.0, {
+    'dtype': 'float64'
+});
 console.log( x );
 
 var v = varianceyc( x.length, 1, x, 1 );
@@ -255,6 +245,8 @@ console.log( v );
 [mdn-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array
 
 [mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
+
+[@stdlib/array/base/accessor]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/base/accessor
 
 [@stdlib/stats/base/svarianceyc]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/base/svarianceyc
 

--- a/lib/node_modules/@stdlib/stats/base/varianceyc/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/varianceyc/benchmark/benchmark.js
@@ -21,11 +21,18 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var pkg = require( './../package.json' ).name;
 var varianceyc = require( './../lib/varianceyc.js' );
+
+
+// VARIABLES //
+
+var options = {
+	'dtype': 'generic'
+};
 
 
 // FUNCTIONS //
@@ -38,13 +45,7 @@ var varianceyc = require( './../lib/varianceyc.js' );
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x;
-	var i;
-
-	x = [];
-	for ( i = 0; i < len; i++ ) {
-		x.push( ( randu()*20.0 ) - 10.0 );
-	}
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	function benchmark( b ) {

--- a/lib/node_modules/@stdlib/stats/base/varianceyc/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/base/varianceyc/benchmark/benchmark.ndarray.js
@@ -21,11 +21,18 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var pkg = require( './../package.json' ).name;
 var varianceyc = require( './../lib/ndarray.js' );
+
+
+// VARIABLES //
+
+var options = {
+	'dtype': 'generic'
+};
 
 
 // FUNCTIONS //
@@ -38,13 +45,7 @@ var varianceyc = require( './../lib/ndarray.js' );
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x;
-	var i;
-
-	x = [];
-	for ( i = 0; i < len; i++ ) {
-		x.push( ( randu()*20.0 ) - 10.0 );
-	}
+	var x = uniform( len, -10.0, 10.0, options );
 	return benchmark;
 
 	function benchmark( b ) {

--- a/lib/node_modules/@stdlib/stats/base/varianceyc/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/base/varianceyc/docs/repl.txt
@@ -1,10 +1,10 @@
 
-{{alias}}( N, correction, x, stride )
+{{alias}}( N, correction, x, strideX )
     Computes the variance of a strided array using a one-pass algorithm proposed
     by Youngs and Cramer.
 
-    The `N` and `stride` parameters determine which elements in `x` are accessed
-    at runtime.
+    The `N` and stride parameters determine which elements in the strided array
+    are accessed at runtime.
 
     Indexing is relative to the first index. To introduce an offset, use a typed
     array view.
@@ -31,8 +31,8 @@
     x: Array<number>|TypedArray
         Input array.
 
-    stride: integer
-        Index increment.
+    strideX: integer
+        Stride length.
 
     Returns
     -------
@@ -46,27 +46,24 @@
     > {{alias}}( x.length, 1, x, 1 )
     ~4.3333
 
-    // Using `N` and `stride` parameters:
+    // Using `N` and stride parameters:
     > x = [ -2.0, 1.0, 1.0, -5.0, 2.0, -1.0 ];
-    > var N = {{alias:@stdlib/math/base/special/floor}}( x.length / 2 );
-    > var stride = 2;
-    > {{alias}}( N, 1, x, stride )
+    > {{alias}}( 3, 1, x, 2 )
     ~4.3333
 
     // Using view offsets:
     > var x0 = new {{alias:@stdlib/array/float64}}( [ 1.0, -2.0, 3.0, 2.0, 5.0, -1.0 ] );
     > var x1 = new {{alias:@stdlib/array/float64}}( x0.buffer, x0.BYTES_PER_ELEMENT*1 );
-    > N = {{alias:@stdlib/math/base/special/floor}}( x0.length / 2 );
-    > stride = 2;
-    > {{alias}}( N, 1, x1, stride )
+    > {{alias}}( 3, 1, x1, 2 )
     ~4.3333
 
-{{alias}}.ndarray( N, correction, x, stride, offset )
+
+{{alias}}.ndarray( N, correction, x, strideX, offsetX )
     Computes the variance of a strided array using a one-pass algorithm proposed
     by Youngs and Cramer and alternative indexing semantics.
 
     While typed array views mandate a view offset based on the underlying
-    buffer, the `offset` parameter supports indexing semantics based on a
+    buffer, the offset parameter supports indexing semantics based on a
     starting index.
 
     Parameters
@@ -89,10 +86,10 @@
     x: Array<number>|TypedArray
         Input array.
 
-    stride: integer
-        Index increment.
+    strideX: integer
+        Stride length.
 
-    offset: integer
+    offsetX: integer
         Starting index.
 
     Returns
@@ -109,8 +106,7 @@
 
     // Using offset parameter:
     > var x = [ 1.0, -2.0, 3.0, 2.0, 5.0, -1.0 ];
-    > var N = {{alias:@stdlib/math/base/special/floor}}( x.length / 2 );
-    > {{alias}}.ndarray( N, 1, x, 2, 1 )
+    > {{alias}}.ndarray( 3, 1, x, 2, 1 )
     ~4.3333
 
     See Also

--- a/lib/node_modules/@stdlib/stats/base/varianceyc/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/varianceyc/docs/types/index.d.ts
@@ -20,7 +20,14 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { NumericArray } from '@stdlib/types/array';
+import { NumericArray, Collection, AccessorArrayLike } from '@stdlib/types/array';
+
+
+/**
+* Input array.
+*/
+type InputArray = NumericArray | Collection<number> | AccessorArrayLike<number>;
+
 
 /**
 * Interface describing `varianceyc`.
@@ -32,7 +39,7 @@ interface Routine {
 	* @param N - number of indexed elements
 	* @param correction - degrees of freedom adjustment
 	* @param x - input array
-	* @param stride - stride length
+	* @param strideX - stride length for `x`
 	* @returns variance
 	*
 	* @example
@@ -41,7 +48,7 @@ interface Routine {
 	* var v = varianceyc( x.length, 1, x, 1 );
 	* // returns ~4.3333
 	*/
-	( N: number, correction: number, x: NumericArray, stride: number ): number;
+	( N: number, correction: number, x: InputArray, stride: number ): number;
 
 	/**
 	* Computes the variance of a strided array using a one-pass algorithm proposed by Youngs and Cramer and alternative indexing semantics.
@@ -49,8 +56,8 @@ interface Routine {
 	* @param N - number of indexed elements
 	* @param correction - degrees of freedom adjustment
 	* @param x - input array
-	* @param stride - stride length
-	* @param offset - starting index
+	* @param strideX - stride length for `x`
+	* @param offsetX - starting index
 	* @returns variance
 	*
 	* @example
@@ -59,7 +66,7 @@ interface Routine {
 	* var v = varianceyc.ndarray( x.length, 1, x, 1, 0 );
 	* // returns ~4.3333
 	*/
-	ndarray( N: number, correction: number, x: NumericArray, stride: number, offset: number ): number;
+	ndarray( N: number, correction: number, x: InputArray, stride: number, offset: number ): number;
 }
 
 /**
@@ -68,7 +75,7 @@ interface Routine {
 * @param N - number of indexed elements
 * @param correction - degrees of freedom adjustment
 * @param x - input array
-* @param stride - stride length
+* @param strideX - stride length
 * @returns variance
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/varianceyc/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/base/varianceyc/docs/types/test.ts
@@ -16,6 +16,7 @@
 * limitations under the License.
 */
 
+import AccessorArray = require( '@stdlib/array/base/accessor' );
 import varianceyc = require( './index' );
 
 
@@ -26,6 +27,7 @@ import varianceyc = require( './index' );
 	const x = new Float64Array( 10 );
 
 	varianceyc( x.length, 1, x, 1 ); // $ExpectType number
+	varianceyc( x.length, 1, new AccessorArray( x ), 1 ); // $ExpectType number
 }
 
 // The compiler throws an error if the function is provided a first argument which is not a number...
@@ -101,6 +103,7 @@ import varianceyc = require( './index' );
 	const x = new Float64Array( 10 );
 
 	varianceyc.ndarray( x.length, 1, x, 1, 0 ); // $ExpectType number
+	varianceyc.ndarray( x.length, 1, new AccessorArray( x ), 1, 0 ); // $ExpectType number
 }
 
 // The compiler throws an error if the `ndarray` method is provided a first argument which is not a number...

--- a/lib/node_modules/@stdlib/stats/base/varianceyc/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/varianceyc/examples/index.js
@@ -18,18 +18,12 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
-var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var varianceyc = require( './../lib' );
 
-var x;
-var i;
-
-x = new Float64Array( 10 );
-for ( i = 0; i < x.length; i++ ) {
-	x[ i ] = round( (randu()*100.0) - 50.0 );
-}
+var x = uniform( 10, -50.0, 50.0, {
+	'dtype': 'float64'
+});
 console.log( x );
 
 var v = varianceyc( x.length, 1, x, 1 );

--- a/lib/node_modules/@stdlib/stats/base/varianceyc/lib/accessors.js
+++ b/lib/node_modules/@stdlib/stats/base/varianceyc/lib/accessors.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2020 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,12 +18,6 @@
 
 'use strict';
 
-// MODULES //
-
-var stride2offset = require( '@stdlib/strided/base/stride2offset' );
-var ndarray = require( './ndarray.js' );
-
-
 // MAIN //
 
 /**
@@ -37,20 +31,61 @@ var ndarray = require( './ndarray.js' );
 *
 * -   Youngs, Edward A., and Elliot M. Cramer. 1971. "Some Results Relevant to Choice of Sum and Sum-of-Product Algorithms." _Technometrics_ 13 (3): 657–65. doi:[10.1080/00401706.1971.10488826](https://doi.org/10.1080/00401706.1971.10488826).
 *
+* @private
 * @param {PositiveInteger} N - number of indexed elements
 * @param {number} correction - degrees of freedom adjustment
-* @param {NumericArray} x - input array
+* @param {Object} x - input array object
+* @param {Collection} x.data - input array data
+* @param {Array<Function>} x.accessors - array element accessors
 * @param {integer} strideX - stride length for `x`
+* @param {NonNegativeInteger} offsetX - starting index
 * @returns {number} variance
 *
 * @example
-* var x = [ 1.0, -2.0, 2.0 ];
+* var toAccessorArray = require( '@stdlib/array/base/to-accessor-array' );
+* var arraylike2object = require( '@stdlib/array/base/arraylike2object' );
 *
-* var v = varianceyc( x.length, 1, x, 1 );
+* var x = toAccessorArray( [ 1.0, -2.0, 2.0 ] );
+*
+* var v = varianceyc( x.length, 1, arraylike2object( x ), 1, 0 );
 * // returns ~4.3333
 */
-function varianceyc( N, correction, x, strideX ) {
-	return ndarray( N, correction, x, strideX, stride2offset( N, strideX ) );
+function varianceyc( N, correction, x, strideX, offsetX ) {
+	var xbuf;
+	var xget;
+	var sum;
+	var ix;
+	var S;
+	var v;
+	var d;
+	var n;
+	var i;
+
+	n = N - correction;
+	if ( N <= 0 || n <= 0.0 ) {
+		return NaN;
+	}
+	if ( N === 1 || strideX === 0 ) {
+		return 0.0;
+	}
+
+	// Cache references to array data:
+	xbuf = x.data;
+
+	// Cache references to element accessors:
+	xget = x.accessors[ 0 ];
+
+	sum = xget( xbuf, offsetX );
+	ix = offsetX + strideX;
+	S = 0.0;
+	for ( i = 2; i <= N; i++ ) {
+		v = xget( xbuf, ix );
+		sum += v;
+		d = (i*v) - sum;
+		S += (1.0/(i*(i-1))) * d * d;
+		ix += strideX;
+	}
+	return S / n;
 }
 
 

--- a/lib/node_modules/@stdlib/stats/base/varianceyc/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/varianceyc/lib/index.js
@@ -33,13 +33,11 @@
 * // returns ~4.3333
 *
 * @example
-* var floor = require( '@stdlib/math/base/special/floor' );
 * var varianceyc = require( '@stdlib/stats/base/varianceyc' );
 *
 * var x = [ 2.0, 1.0, 2.0, -2.0, -2.0, 2.0, 3.0, 4.0 ];
-* var N = floor( x.length / 2 );
 *
-* var v = varianceyc.ndarray( N, 1, x, 2, 1 );
+* var v = varianceyc.ndarray( 4, 1, x, 2, 1 );
 * // returns 6.25
 */
 

--- a/lib/node_modules/@stdlib/stats/base/varianceyc/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/stats/base/varianceyc/lib/ndarray.js
@@ -18,6 +18,12 @@
 
 'use strict';
 
+// MODULES //
+
+var arraylike2object = require( '@stdlib/array/base/arraylike2object' );
+var accessors = require( './accessors.js' );
+
+
 // MAIN //
 
 /**
@@ -34,8 +40,8 @@
 * @param {PositiveInteger} N - number of indexed elements
 * @param {number} correction - degrees of freedom adjustment
 * @param {NumericArray} x - input array
-* @param {integer} stride - stride length
-* @param {NonNegativeInteger} offset - starting index
+* @param {integer} strideX - stride length for `x`
+* @param {NonNegativeInteger} offsetX - starting index
 * @returns {number} variance
 *
 * @example
@@ -47,7 +53,7 @@
 * var v = varianceyc( N, 1, x, 2, 1 );
 * // returns 6.25
 */
-function varianceyc( N, correction, x, stride, offset ) {
+function varianceyc( N, correction, x, strideX, offsetX ) {
 	var sum;
 	var ix;
 	var S;
@@ -55,23 +61,30 @@ function varianceyc( N, correction, x, stride, offset ) {
 	var d;
 	var n;
 	var i;
+	var o;
 
 	n = N - correction;
 	if ( N <= 0 || n <= 0.0 ) {
 		return NaN;
 	}
-	if ( N === 1 || stride === 0 ) {
+	if ( N === 1 || strideX === 0 ) {
 		return 0.0;
 	}
-	sum = x[ offset ];
-	ix = offset + stride;
+
+	o = arraylike2object( x );
+	if ( o.accessorProtocol ) {
+		return accessors( N, correction, o, strideX, offsetX );
+	}
+
+	sum = x[ offsetX ];
+	ix = offsetX + strideX;
 	S = 0.0;
 	for ( i = 2; i <= N; i++ ) {
 		v = x[ ix ];
 		sum += v;
 		d = (i*v) - sum;
 		S += (1.0/(i*(i-1))) * d * d;
-		ix += stride;
+		ix += strideX;
 	}
 	return S / n;
 }

--- a/lib/node_modules/@stdlib/stats/base/varianceyc/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/base/varianceyc/test/test.ndarray.js
@@ -130,6 +130,21 @@ tape( 'if provided an `N` parameter less than or equal to `0`, the function retu
 	t.end();
 });
 
+tape( 'if provided an `N` parameter less than or equal to `0`, the function returns `NaN` (accessor)', function test( t ) {
+	var x;
+	var v;
+
+	x = toAccessorArray([ 1.0, -2.0, -4.0, 5.0, 3.0 ]);
+
+	v = varianceyc( 0, 1, x, 1, 0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	v = varianceyc( -1, 1, x, 1, 0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'if provided an `N` parameter equal to `1`, the function returns a population variance of `0`', function test( t ) {
 	var x;
 	var v;
@@ -142,11 +157,38 @@ tape( 'if provided an `N` parameter equal to `1`, the function returns a populat
 	t.end();
 });
 
+tape( 'if provided an `N` parameter equal to `1`, the function returns a population variance of `0` (accessor)', function test( t ) {
+	var x;
+	var v;
+
+	x = toAccessorArray([ 1.0, -2.0, -4.0, 5.0, 3.0 ]);
+
+	v = varianceyc( 1, 0, x, 1, 0 );
+	t.strictEqual( v, 0.0, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'if provided a `correction` parameter yielding `N-correction` less than or equal to `0`, the function returns `NaN`', function test( t ) {
 	var x;
 	var v;
 
 	x = [ 1.0, -2.0, -4.0, 5.0, 3.0 ];
+
+	v = varianceyc( x.length, x.length, x, 1, 0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	v = varianceyc( x.length, x.length+1, x, 1, 0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided a `correction` parameter yielding `N-correction` less than or equal to `0`, the function returns `NaN (accessor)`', function test( t ) {
+	var x;
+	var v;
+
+	x = toAccessorArray([ 1.0, -2.0, -4.0, 5.0, 3.0 ]);
 
 	v = varianceyc( x.length, x.length, x, 1, 0 );
 	t.strictEqual( isnan( v ), true, 'returns expected value' );

--- a/lib/node_modules/@stdlib/stats/base/varianceyc/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/base/varianceyc/test/test.ndarray.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var floor = require( '@stdlib/math/base/special/floor' );
+var toAccessorArray = require( '@stdlib/array/base/to-accessor-array' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var varianceyc = require( './../lib/ndarray.js' );
 
@@ -58,6 +58,25 @@ tape( 'the function calculates the population variance of a strided array', func
 	t.end();
 });
 
+tape( 'the function calculates the population variance of a strided array (accessor)', function test( t ) {
+	var x;
+	var v;
+
+	x = [ 1.0, -2.0, -4.0, 5.0, 0.0, 3.0 ];
+	v = varianceyc( x.length, 0, toAccessorArray( x ), 1, 0 );
+	t.strictEqual( v, 53.5/x.length, 'returns expected value' );
+
+	x = [ -4.0, -4.0 ];
+	v = varianceyc( x.length, 0, toAccessorArray( x ), 1, 0 );
+	t.strictEqual( v, 0.0, 'returns expected value' );
+
+	x = [ NaN, 4.0 ];
+	v = varianceyc( x.length, 0, toAccessorArray( x ), 1, 0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function calculates the sample variance of a strided array', function test( t ) {
 	var x;
 	var v;
@@ -72,6 +91,25 @@ tape( 'the function calculates the sample variance of a strided array', function
 
 	x = [ NaN, 4.0 ];
 	v = varianceyc( x.length, 1, x, 1, 0 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function calculates the sample variance of a strided array (accessor)', function test( t ) {
+	var x;
+	var v;
+
+	x = [ 1.0, -2.0, -4.0, 5.0, 0.0, 3.0 ];
+	v = varianceyc( x.length, 1, toAccessorArray( x ), 1, 0 );
+	t.strictEqual( v, 53.5/(x.length-1), 'returns expected value' );
+
+	x = [ -4.0, -4.0 ];
+	v = varianceyc( x.length, 1, toAccessorArray( x ), 1, 0 );
+	t.strictEqual( v, 0.0, 'returns expected value' );
+
+	x = [ NaN, 4.0 ];
+	v = varianceyc( x.length, 1, toAccessorArray( x ), 1, 0 );
 	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	t.end();
@@ -120,7 +158,6 @@ tape( 'if provided a `correction` parameter yielding `N-correction` less than or
 });
 
 tape( 'the function supports a `stride` parameter', function test( t ) {
-	var N;
 	var x;
 	var v;
 
@@ -135,15 +172,34 @@ tape( 'the function supports a `stride` parameter', function test( t ) {
 		2.0
 	];
 
-	N = floor( x.length / 2 );
-	v = varianceyc( N, 1, x, 2, 0 );
+	v = varianceyc( 4, 1, x, 2, 0 );
+
+	t.strictEqual( v, 6.25, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports a `stride` parameter (accessor)', function test( t ) {
+	var x;
+	var v;
+
+	x = [
+		1.0,  // 0
+		2.0,
+		2.0,  // 1
+		-7.0,
+		-2.0, // 2
+		3.0,
+		4.0,  // 3
+		2.0
+	];
+
+	v = varianceyc( 4, 1, toAccessorArray( x ), 2, 0 );
 
 	t.strictEqual( v, 6.25, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function supports a negative `stride` parameter', function test( t ) {
-	var N;
 	var x;
 	var v;
 
@@ -158,8 +214,28 @@ tape( 'the function supports a negative `stride` parameter', function test( t ) 
 		2.0
 	];
 
-	N = floor( x.length / 2 );
-	v = varianceyc( N, 1, x, -2, 6 );
+	v = varianceyc( 4, 1, x, -2, 6 );
+
+	t.strictEqual( v, 6.25, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports a negative `stride` parameter (accessor)', function test( t ) {
+	var x;
+	var v;
+
+	x = [
+		1.0,  // 3
+		2.0,
+		2.0,  // 2
+		-7.0,
+		-2.0, // 1
+		3.0,
+		4.0,  // 0
+		2.0
+	];
+
+	v = varianceyc( 4, 1, toAccessorArray( x ), -2, 6 );
 
 	t.strictEqual( v, 6.25, 'returns expected value' );
 	t.end();
@@ -177,8 +253,19 @@ tape( 'if provided a `stride` parameter equal to `0`, the function returns `0`',
 	t.end();
 });
 
+tape( 'if provided a `stride` parameter equal to `0`, the function returns `0` (accessor)', function test( t ) {
+	var x;
+	var v;
+
+	x = [ 1.0, -2.0, -4.0, 5.0, 3.0 ];
+
+	v = varianceyc( x.length, 1, toAccessorArray( x ), 0, 0 );
+	t.strictEqual( v, 0.0, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function supports an `offset` parameter', function test( t ) {
-	var N;
 	var x;
 	var v;
 
@@ -192,10 +279,27 @@ tape( 'the function supports an `offset` parameter', function test( t ) {
 		3.0,
 		4.0   // 3
 	];
-	N = floor( x.length / 2 );
 
-	v = varianceyc( N, 1, x, 2, 1 );
+	v = varianceyc( 4, 1, x, 2, 1 );
 	t.strictEqual( v, 6.25, 'returns expected value' );
 
+	t.end();
+});
+
+tape( 'the function supports an `offset` parameter (accessor)', function test( t ) {
+	var x;
+	var v;
+	x = [
+		2.0,
+		1.0,  // 0
+		2.0,
+		-2.0, // 1
+		-2.0,
+		2.0,  // 2
+		3.0,
+		4.0   // 3
+	];
+	v = varianceyc( 4, 1, toAccessorArray( x ), 2, 1 );
+	t.strictEqual( v, 6.25, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/varianceyc/test/test.varianceyc.js
+++ b/lib/node_modules/@stdlib/stats/base/varianceyc/test/test.varianceyc.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var floor = require( '@stdlib/math/base/special/floor' );
+var toAccessorArray = require( '@stdlib/array/base/to-accessor-array' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
 var varianceyc = require( './../lib/varianceyc.js' );
@@ -59,6 +59,25 @@ tape( 'the function calculates the population variance of a strided array', func
 	t.end();
 });
 
+tape( 'the function calculates the population variance of a strided array (accessor)', function test( t ) {
+	var x;
+	var v;
+
+	x = [ 1.0, -2.0, -4.0, 5.0, 0.0, 3.0 ];
+	v = varianceyc( x.length, 0, toAccessorArray( x ), 1 );
+	t.strictEqual( v, 53.5/x.length, 'returns expected value' );
+
+	x = [ -4.0, -4.0 ];
+	v = varianceyc( x.length, 0, toAccessorArray( x ), 1 );
+	t.strictEqual( v, 0.0, 'returns expected value' );
+
+	x = [ NaN, 4.0 ];
+	v = varianceyc( x.length, 0, toAccessorArray( x ), 1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function calculates the sample variance of a strided array', function test( t ) {
 	var x;
 	var v;
@@ -73,6 +92,25 @@ tape( 'the function calculates the sample variance of a strided array', function
 
 	x = [ NaN, 4.0 ];
 	v = varianceyc( x.length, 1, x, 1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function calculates the sample variance of a strided array (accessor)', function test( t ) {
+	var x;
+	var v;
+
+	x = [ 1.0, -2.0, -4.0, 5.0, 0.0, 3.0 ];
+	v = varianceyc( x.length, 1, toAccessorArray( x ), 1 );
+	t.strictEqual( v, 53.5/(x.length-1), 'returns expected value' );
+
+	x = [ -4.0, -4.0 ];
+	v = varianceyc( x.length, 1, toAccessorArray( x ), 1 );
+	t.strictEqual( v, 0.0, 'returns expected value' );
+
+	x = [ NaN, 4.0 ];
+	v = varianceyc( x.length, 1, toAccessorArray( x ), 1 );
 	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	t.end();
@@ -121,7 +159,6 @@ tape( 'if provided a `correction` parameter yielding `N-correction` less than or
 });
 
 tape( 'the function supports a `stride` parameter', function test( t ) {
-	var N;
 	var x;
 	var v;
 
@@ -136,15 +173,34 @@ tape( 'the function supports a `stride` parameter', function test( t ) {
 		2.0
 	];
 
-	N = floor( x.length / 2 );
-	v = varianceyc( N, 1, x, 2 );
+	v = varianceyc( 4, 1, x, 2 );
+
+	t.strictEqual( v, 6.25, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports a `stride` parameter (accessor)', function test( t ) {
+	var x;
+	var v;
+
+	x = [
+		1.0,  // 0
+		2.0,
+		2.0,  // 1
+		-7.0,
+		-2.0, // 2
+		3.0,
+		4.0,  // 3
+		2.0
+	];
+
+	v = varianceyc( 4, 1, toAccessorArray( x ), 2 );
 
 	t.strictEqual( v, 6.25, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function supports a negative `stride` parameter', function test( t ) {
-	var N;
 	var x;
 	var v;
 
@@ -159,8 +215,28 @@ tape( 'the function supports a negative `stride` parameter', function test( t ) 
 		2.0
 	];
 
-	N = floor( x.length / 2 );
-	v = varianceyc( N, 1, x, -2 );
+	v = varianceyc( 4, 1, x, -2 );
+
+	t.strictEqual( v, 6.25, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports a negative `stride` parameter (accessor)', function test( t ) {
+	var x;
+	var v;
+
+	x = [
+		1.0,  // 3
+		2.0,
+		2.0,  // 2
+		-7.0,
+		-2.0, // 1
+		3.0,
+		4.0,  // 0
+		2.0
+	];
+
+	v = varianceyc( 4, 1, toAccessorArray( x ), -2 );
 
 	t.strictEqual( v, 6.25, 'returns expected value' );
 	t.end();
@@ -178,10 +254,21 @@ tape( 'if provided a `stride` parameter equal to `0`, the function returns `0`',
 	t.end();
 });
 
+tape( 'if provided a `stride` parameter equal to `0`, the function returns `0` (accessor)', function test( t ) {
+	var x;
+	var v;
+
+	x = [ 1.0, -2.0, -4.0, 5.0, 3.0 ];
+
+	v = varianceyc( x.length, 1, toAccessorArray( x ), 0 );
+	t.strictEqual( v, 0.0, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function supports view offsets', function test( t ) {
 	var x0;
 	var x1;
-	var N;
 	var v;
 
 	x0 = new Float64Array([
@@ -197,9 +284,33 @@ tape( 'the function supports view offsets', function test( t ) {
 	]);
 
 	x1 = new Float64Array( x0.buffer, x0.BYTES_PER_ELEMENT*1 ); // start at 2nd element
-	N = floor(x1.length / 2);
 
-	v = varianceyc( N, 1, x1, 2 );
+	v = varianceyc( 4, 1, x1, 2 );
+	t.strictEqual( v, 6.25, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports view offsets (accessor)', function test( t ) {
+	var x0;
+	var x1;
+	var v;
+
+	x0 = new Float64Array([
+		2.0,
+		1.0,  // 0
+		2.0,
+		-2.0, // 1
+		-2.0,
+		2.0,  // 2
+		3.0,
+		4.0,  // 3
+		6.0
+	]);
+
+	x1 = new Float64Array( x0.buffer, x0.BYTES_PER_ELEMENT*1 ); // start at 2nd element
+
+	v = varianceyc( 4, 1, toAccessorArray( x1 ), 2 );
 	t.strictEqual( v, 6.25, 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/stats/base/varianceyc/test/test.varianceyc.js
+++ b/lib/node_modules/@stdlib/stats/base/varianceyc/test/test.varianceyc.js
@@ -131,6 +131,21 @@ tape( 'if provided an `N` parameter less than or equal to `0`, the function retu
 	t.end();
 });
 
+tape( 'if provided an `N` parameter less than or equal to `0`, the function returns `NaN (accessor)`', function test( t ) {
+	var x;
+	var v;
+
+	x = toAccessorArray([ 1.0, -2.0, -4.0, 5.0, 3.0 ]);
+
+	v = varianceyc( 0, 1, x, 1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	v = varianceyc( -1, 1, x, 1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'if provided an `N` parameter equal to `1`, the function returns a population variance of `0`', function test( t ) {
 	var x;
 	var v;
@@ -143,11 +158,38 @@ tape( 'if provided an `N` parameter equal to `1`, the function returns a populat
 	t.end();
 });
 
+tape( 'if provided an `N` parameter equal to `1`, the function returns a population variance of `0` (accessor)', function test( t ) {
+	var x;
+	var v;
+
+	x = toAccessorArray([ 1.0, -2.0, -4.0, 5.0, 3.0 ]);
+
+	v = varianceyc( 1, 0, x, 1 );
+	t.strictEqual( v, 0.0, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'if provided a `correction` parameter yielding `N-correction` less than or equal to `0`, the function returns `NaN`', function test( t ) {
 	var x;
 	var v;
 
 	x = [ 1.0, -2.0, -4.0, 5.0, 3.0 ];
+
+	v = varianceyc( x.length, x.length, x, 1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	v = varianceyc( x.length, x.length+1, x, 1 );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided a `correction` parameter yielding `N-correction` less than or equal to `0`, the function returns `NaN` (accessor)', function test( t ) {
+	var x;
+	var v;
+
+	x = toAccessorArray([ 1.0, -2.0, -4.0, 5.0, 3.0 ]);
 
 	v = varianceyc( x.length, x.length, x, 1 );
 	t.strictEqual( isnan( v ), true, 'returns expected value' );


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: passed
  - task: lint_package_json status: na
  - task: lint_repl_help status: passed
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: passed
  - task: lint_javascript_tests status: passed
  - task: lint_javascript_benchmarks status: passed
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: passed
  - task: lint_license_headers status: passed ---

Resolves #5692 .

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors and adds accessor protocol support to `@stdlib/stats/base/varianceyc`

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #5692 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Upon reviewing the issue, I noted it references refactoring `@stats/base/varianceyv`, but this package doesn't exist in the repository. I've assumed this was a typographical error, and the intended target is `@stats/base/varianceyc` based on the context and references in the issue. I've proceeded with implementing the changes for `@stats/base/varianceyc` accordingly.


## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
