### PR TITLE
chore: fix EditorConfig lint errors by replacing tabs with spaces

### DIFF
--- a/lib/node_modules/@stdlib/datasets/sotu/lib/party.json
+++ b/lib/node_modules/@stdlib/datasets/sotu/lib/party.json
@@ -1,10 +1,10 @@
 {
-	"d": "Democratic",
-	"dr": "Democratic-Republican",
-	"f": "Federalist",
-	"n": "none",
-	"nu": "National Union",
-	"r": "Republican",
-	"w": "Whig",
-	"wd": "Whig & Democratic"
+  "d": "Democratic",
+  "dr": "Democratic-Republican",
+  "f": "Federalist",
+  "n": "none",
+  "nu": "National Union",
+  "r": "Republican",
+  "w": "Whig",
+  "wd": "Whig & Democratic"
 }

--- a/lib/node_modules/@stdlib/math/strided/special/dmskabs2/manifest.json
+++ b/lib/node_modules/@stdlib/math/strided/special/dmskabs2/manifest.json
@@ -1,75 +1,75 @@
 {
-	"options": {
-		"task": "build"
-	},
-	"fields": [
-		{
-			"field": "src",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "include",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "libraries",
-			"resolve": false,
-			"relative": false
-		},
-		{
-			"field": "libpath",
-			"resolve": true,
-			"relative": false
-		}
-	],
-	"confs": [
-		{
-			"task": "build",
-			"src": [
-				"./src/dmskabs2.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [],
-			"libpath": [],
-			"dependencies": [
-				"@stdlib/math/base/special/abs2",
-				"@stdlib/strided/base/dmskmap",
-				"@stdlib/strided/napi/dmskmap"
-			]
-		},
-		{
-			"task": "examples",
-			"src": [
-				"./src/dmskabs2.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [],
-			"libpath": [],
-			"dependencies": [
-				"@stdlib/math/base/special/abs2",
-				"@stdlib/strided/base/dmskmap"
-			]
-		},
-		{
-			"task": "benchmark",
-			"src": [
-				"./src/dmskabs2.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [],
-			"libpath": [],
-			"dependencies": [
-				"@stdlib/math/base/special/abs2",
-				"@stdlib/strided/base/dmskmap"
-			]
-		}
-	]
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/dmskabs2.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/abs2",
+        "@stdlib/strided/base/dmskmap",
+        "@stdlib/strided/napi/dmskmap"
+      ]
+    },
+    {
+      "task": "examples",
+      "src": [
+        "./src/dmskabs2.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/abs2",
+        "@stdlib/strided/base/dmskmap"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/dmskabs2.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/abs2",
+        "@stdlib/strided/base/dmskmap"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
This pull request resolves EditorConfig linting issues by replacing tabs with spaces in the following files:

lib/node_modules/@stdlib/datasets/sotu/lib/party.json
lib/node_modules/@stdlib/math/strided/special/dmskabs2/manifest.json
These changes ensure consistency with the project's coding standards and improve readability. No functionality was affected.

Let me know if you need any modifications! 🚀.        
- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
