### PR TITLE
fix: corrected spacing in if condition in geometric quantile implementation

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/quantile/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/quantile/src/main.c
@@ -45,7 +45,7 @@ double stdlib_base_dists_geometric_quantile( const double r, const double p ) {
 	) {
 		return 0.0 / 0.0; // NaN
 	}
-	if( r == 1.0 ) {
+	if ( r == 1.0 ) {
 		return STDLIB_CONSTANT_FLOAT64_PINF;
 	}
 	return stdlib_base_max( 0.0, stdlib_base_floor( stdlib_base_ln( 1.0 - r ) / stdlib_base_ln( 1.0 - p ) ) );

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/quantile/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/quantile/src/main.c
@@ -45,7 +45,7 @@ double stdlib_base_dists_geometric_quantile( const double r, const double p ) {
 	) {
 		return 0.0 / 0.0; // NaN
 	}
-	if( r == 1.0 ){
+	if( r == 1.0 ) {
 		return STDLIB_CONSTANT_FLOAT64_PINF;
 	}
 	return stdlib_base_max( 0.0, stdlib_base_floor( stdlib_base_ln( 1.0 - r ) / stdlib_base_ln( 1.0 - p ) ) );


### PR DESCRIPTION
Resolves #5948

---

## Description

> What is the purpose of this pull request?

This pull request:
- Fixes spacing issues in the `if` condition of the geometric quantile implementation.
- Improves code readability and aligns with project standards.

---

## Related Issues

> Does this pull request have any related issues?

This pull request:
- Resolves #5948

---

## Questions

> Any questions for reviewers of this pull request?

No.

---

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No additional notes.

---

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

---

@stdlib-js/reviewers
