### PR TITLE
feat(stats/incr): add nanminmax package to handle NaN values

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/nanmin/README.md
+++ b/lib/node_modules/@stdlib/stats/incr/nanmin/README.md
@@ -1,0 +1,142 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2025 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# incrnanmin
+
+> Compute a minimum value incrementally, ignoring `NaN` values.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var incrnanmin = require( '@stdlib/stats/incr/nanmin' );
+```
+
+#### incrnanmin()
+
+Returns an accumulator `function` which incrementally computes a minimum value, ignoring `NaN` values.
+
+```javascript
+var accumulator = incrnanmin();
+```
+
+#### accumulator( \[x] )
+
+If provided an input value `x`, the accumulator function returns an updated minimum value. If not provided an input value `x`, the accumulator function returns the current minimum value.
+
+```javascript
+var accumulator = incrnanmin();
+
+var min = accumulator( 2.0 );
+// returns 2.0
+
+min = accumulator( 1.0 );
+// returns 1.0
+
+min = accumulator( NaN );
+// returns 1.0
+
+min = accumulator( 3.0 );
+// returns 1.0
+
+min = accumulator();
+// returns 1.0
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   Input values are **not** type checked. If non-numeric inputs are possible, you are advised to type check and handle accordingly **before** passing the value to the accumulator function.
+-   If all values provided are `NaN`, the accumulator returns `NaN`.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+```javascript
+var randu = require( '@stdlib/random/base/randu' );
+var incrnanmin = require( '@stdlib/stats/incr/nanmin' );
+
+var accumulator;
+var v;
+var i;
+
+// Initialize an accumulator:
+accumulator = incrnanmin();
+
+// For each simulated datum, update the min...
+for ( i = 0; i < 100; i++ ) {
+    if ( randu() < 0.2 ) {
+        v = NaN;
+    } else {
+        v = randu() * 100.0;
+    }
+    accumulator( v );
+}
+console.log( accumulator() );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/stats/incr/min`][@stdlib/stats/incr/min]</span><span class="delimiter">: </span><span class="description">compute a minimum value incrementally.</span>
+-   <span class="package-name">[`@stdlib/stats/incr/mmin`][@stdlib/stats/incr/mmin]</span><span class="delimiter">: </span><span class="description">compute a moving minimum incrementally.</span>
+-   <span class="package-name">[`@stdlib/stats/incr/nanmax`][@stdlib/stats/incr/nanmax]</span><span class="delimiter">: </span><span class="description">compute a maximum value incrementally, ignoring NaN values.</span>
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+<!-- <related-links> -->
+
+[@stdlib/stats/incr/min]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/min
+
+[@stdlib/stats/incr/mmin]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/mmin
+
+[@stdlib/stats/incr/nanmax]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/nanmax
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/stats/incr/nanmin/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmin/benchmark/benchmark.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/incr/nanmin/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmin/benchmark/benchmark.js
@@ -1,0 +1,69 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var pkg = require( './../package.json' ).name;
+var incrnanmin = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var f;
+	var i;
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		f = incrnanmin();
+		if ( typeof f !== 'function' ) {
+			b.fail( 'should return a function' );
+		}
+	}
+	b.toc();
+	if ( typeof f !== 'function' ) {
+		b.fail( 'should return a function' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::accumulator', function benchmark( b ) {
+	var acc;
+	var v;
+	var i;
+
+	acc = incrnanmin();
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		v = acc( randu() );
+		if ( v !== v ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( v !== v ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/stats/incr/nanmin/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/incr/nanmin/docs/repl.txt
@@ -1,0 +1,37 @@
+{{alias}}()
+    Returns an accumulator function which incrementally computes a minimum
+    value, ignoring NaN values.
+
+    If provided a value, the accumulator function returns an updated minimum
+    value. If not provided a value, the accumulator function returns the current
+    minimum value.
+
+    If no valid numbers have been provided (only NaN values), the accumulator
+    function returns null. Unlike incrmin, NaN values are ignored and do not
+    set the minimum to NaN.
+
+    Returns
+    -------
+    acc: Function
+        Accumulator function.
+
+    Examples
+    --------
+    > var accumulator = {{alias}}();
+    > var m = accumulator()
+    null
+    > m = accumulator( 3.14 )
+    3.14
+    > m = accumulator( NaN )
+    3.14
+    > m = accumulator( -5.0 )
+    -5.0
+    > m = accumulator( 10.1 )
+    -5.0
+    > m = accumulator( NaN )
+    -5.0
+    > m = accumulator()
+    -5.0
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/stats/incr/nanmin/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/incr/nanmin/docs/types/index.d.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2020 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/incr/nanmin/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/incr/nanmin/docs/types/index.d.ts
@@ -1,0 +1,64 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2020 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+/**
+* Returns an accumulator function which incrementally computes a minimum value, ignoring `NaN` values
+* @param x - value
+* @returns minimum value
+*/
+type accumulator = ( x?: number ) => number | null;
+
+/**
+* Returns an accumulator function which incrementally computes a minimum value, ignoring `NaN` values.
+*
+* @returns accumulator function
+*
+* @example
+* var accumulator = incrnanmin();
+*
+* var m = accumulator();
+* // returns null
+*
+* m = accumulator(3.14);
+* // returns 3.14
+*
+* m = accumulator(NaN);
+* // returns 3.14
+*
+* m = accumulator(-5.0);
+* // returns -5.0
+*
+* m = accumulator(10.1);
+* // returns -5.0
+*
+* m = accumulator(NaN);
+* // returns -5.0
+*
+* m = accumulator();
+* // returns -5.0
+*/
+declare function incrnanmin(): accumulator;
+
+
+// EXPORTS //
+
+export = incrnanmin;

--- a/lib/node_modules/@stdlib/stats/incr/nanmin/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/incr/nanmin/docs/types/test.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2019 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/incr/nanmin/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/incr/nanmin/docs/types/test.ts
@@ -1,0 +1,61 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2019 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import incrnanmin = require('./index')
+
+
+// TESTS //
+
+// The function returns an accumulator function...
+{
+	incrnanmin(); // $ExpectType accumulator
+}
+
+// The compiler throws an error if the function is provided arguments...
+{
+	incrnanmin( '5' ); // $ExpectError
+	incrnanmin( 5 ); // $ExpectError
+	incrnanmin( true ); // $ExpectError
+	incrnanmin( false ); // $ExpectError
+	incrnanmin( null ); // $ExpectError
+	incrnanmin( undefined ); // $ExpectError
+	incrnanmin( [] ); // $ExpectError
+	incrnanmin( {} ); // $ExpectError
+	incrnanmin( ( x: number ): number => x ); // $ExpectError
+}
+
+// The function returns an accumulator function which returns an accumulated result...
+{
+	const acc = incrnanmin();
+
+	acc(); // $ExpectType number | null
+	acc( 3.14 ); // $ExpectType number | null
+}
+
+// The compiler throws an error if the returned accumulator function is provided invalid arguments...
+{
+	const acc = incrnanmin();
+
+	acc( '5' ); // $ExpectError
+	acc( true ); // $ExpectError
+	acc( false ); // $ExpectError
+	acc( null ); // $ExpectError
+	acc( [] ); // $ExpectError
+	acc( {} ); // $ExpectError
+	acc( ( x: number ): number => x ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/stats/incr/nanmin/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmin/examples/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/incr/nanmin/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmin/examples/index.js
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var randu = require( '@stdlib/random/base/randu' );
+var incrnanmin = require( './../lib' );
+
+var accumulator;
+var min;
+var v;
+var i;
+
+// Initialize an accumulator:
+accumulator = incrnanmin();
+
+// For each simulated datum, update the min...
+console.log( '\nValue\tMin\n' );
+for ( i = 0; i < 100; i++ ) {
+	if ( randu() < 0.2 ) {
+		v = NaN;
+	} else {
+		v = randu() * 100.0;
+	}
+	min = accumulator( v );
+	console.log( '%d\t%d', v.toFixed( 4 ), ( min === null ) ? NaN : min.toFixed( 4 ) );
+}
+console.log( '\nFinal min: %d\n', accumulator() );

--- a/lib/node_modules/@stdlib/stats/incr/nanmin/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmin/lib/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2020 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/incr/nanmin/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmin/lib/index.js
@@ -1,0 +1,57 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2020 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Compute a minimum value incrementally, ignoring `NaN` values.
+*
+* @module @stdlib/stats/incr/nanmin
+*
+* @example
+* var incrnanmin = require( '@stdlib/stats/incr/nanmin' )
+*
+* var accumulator = incrnanmin();
+*
+* var min = accumulator();
+* // returns null
+*
+* min = accumulator(3.14);
+* // returns 3.14
+*
+* min = accumulator(-5.0);
+* // returns -5.0
+*
+* min = accumulator(NaN);
+* // returns -5.0
+*
+* min = accumulator( 10.1 );
+* returns -5.0
+*
+* min = accumulator();
+* // returns -5.0
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/incr/nanmin/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmin/lib/main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/incr/nanmin/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmin/lib/main.js
@@ -1,0 +1,77 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var incrmin = require( '@stdlib/stats/incr/min' );
+
+
+// MAIN //
+
+/**
+* Returns an accumulator function which incrementally computes a minimum value, ignoring `NaN` values.
+*
+* @returns {Function} accumulator function
+*
+* @example
+* var accumulator = incrnanmin();
+*
+* var min = accumulator();
+* // returns null
+*
+* min = accumulator(3.14);
+* // returns 3.14
+*
+* min = accumulator(-5.0);
+* // returns -5.0
+*
+* min = accumulator(NaN);
+* // returns -5.0
+*
+* min = accumulator( 10.1 );
+* returns -5.0
+*
+* min = accumulator();
+* // returns -5.0
+*/
+function incrnanmin() {
+	var min = incrmin();
+	return accumulator;
+
+	/**
+	* If provided a value, the accumulator function returns an updated minimum value. If not provided a value, the accumulator function returns the current min.
+	*
+	* @private
+	* @param {number} [x] - new value
+	* @returns {(number|null)} min value or null
+	*/
+	function accumulator( x ) {
+		if ( arguments.length === 0 || isnan( x ) ) {
+			return min();
+		}
+		return min( x );
+	}
+}
+
+
+// EXPORTS //
+
+module.exports = incrnanmin;

--- a/lib/node_modules/@stdlib/stats/incr/nanmin/package.json
+++ b/lib/node_modules/@stdlib/stats/incr/nanmin/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@stdlib/stats/incr/nanmin",
+  "version": "0.0.0",
+  "description": "Compute a minimum value incrementally, ignoring NaN values.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "statistics",
+    "stats",
+    "mathematics",
+    "math",
+    "minimum",
+    "min",
+    "range",
+    "extremes",
+    "domain",
+    "extent",
+    "incremental",
+    "accumulator"
+  ]
+}

--- a/lib/node_modules/@stdlib/stats/incr/nanmin/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmin/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2018 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/incr/nanmin/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmin/test/test.js
@@ -1,0 +1,126 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
+var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var incrnanmin = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof incrnanmin, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns an accumulator function', function test( t ) {
+	t.equal( typeof incrnanmin(), 'function', 'returns a function' );
+	t.end();
+});
+
+tape( 'if not provided any values, the initial returned minimum value is `null`', function test( t ) {
+	var acc = incrnanmin();
+	t.equal( acc(), null, 'returns null' );
+	t.end();
+});
+
+tape( 'the accumulator function incrementally computes a minimum value', function test( t ) {
+	var expected;
+	var actual;
+	var data;
+	var acc;
+	var min;
+	var N;
+	var d;
+	var i;
+
+	data = [2.0, 3.0, NaN, 1.0, 4.0, NaN, 3.0, 4.0 ];
+	N = data.length;
+
+	expected = [];
+	actual = [];
+
+	acc = incrnanmin();
+
+	min = data[ 0 ];
+	for ( i = 0; i < N; i++ ) {
+		d = data[ i ];
+		if ( isnan( d ) === false ) {
+			if ( min === null || d < min ) {
+				min = d;
+			}
+		}
+		expected.push( min );
+		actual.push( acc( d ) );
+	}
+	t.deepEqual( actual, expected, 'returns expected incremental results' );
+	t.end();
+});
+
+tape( 'if not provided an input value, the accumulator function returns the current minimum value', function test( t ) {
+	var data;
+	var acc;
+	var i;
+
+	data = [ 2.0, NaN, 1.0, NaN, 3.0 ];
+	acc = incrnanmin();
+	for ( i = 0; i < data.length; i++ ) {
+		acc( data[ i ] );
+	}
+	t.equal( acc(), 1.0, 'returns the current accumulated minimum value' );
+	t.end();
+});
+
+tape( 'the accumulator function correctly handles signed zeros', function test( t ) {
+	var acc;
+	var v;
+
+	acc = incrnanmin();
+
+	v = acc( 0.0 );
+	t.equal( isPositiveZero( v ), true, 'returns expected value' );
+
+	v = acc( -0.0 );
+	t.equal( isNegativeZero( v ), true, 'returns expected value' );
+
+	v = acc( 0.0 );
+	t.equal( isNegativeZero( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided a `NaN`, the accumulator function ignores it and maintains the current minimum', function test( t ) {
+	var data;
+	var acc;
+	var i;
+
+	data = [ 2.0, NaN, 1.0, 2.0, 3.0, NaN, 5.0, 6.0, 7.0 ];
+	acc = incrnanmin();
+	for ( i = 0; i < data.length; i++ ) {
+		acc( data[ i ] );
+	}
+	t.equal( isnan( acc() ), false, 'returns expected value' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/stats/incr/nanminmax/README.md
+++ b/lib/node_modules/@stdlib/stats/incr/nanminmax/README.md
@@ -1,0 +1,157 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2025 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# incrnanminmax
+
+> Compute a minimum and maximum incrementally, ignoring `NaN` values.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var incrnanminmax = require( '@stdlib/stats/incr/nanminmax' );
+```
+
+#### incrnanminmax( \[out] )
+
+Returns an accumulator `function` which incrementally computes a minimum and maximum, ignoring `NaN` values.
+
+```javascript
+var accumulator = incrnanminmax();
+```
+
+By default, the returned accumulator `function` returns the minimum and maximum as a two-element `array`. To avoid unnecessary memory allocation, the function supports providing an output (destination) object.
+
+
+#### accumulator( \[x] )
+
+If provided an input value `x`, the accumulator function returns updated minimum and maximum values. If not provided an input value `x`, the accumulator function returns the current minimum and maximum values.
+
+```javascript
+var accumulator = incrnanminmax();
+
+var mm = accumulator();
+// returns null
+
+mm = accumulator( 2.0 );
+// returns [ 2.0, 2.0 ]
+
+mm = accumulator( 1.0 );
+// returns [ 1.0, 2.0 ]
+
+mm = accumulator( 3.0 );
+// returns [ 1.0, 3.0 ]
+
+mm = accumulator( -7.0 );
+// returns [ -7.0, 3.0 ]
+
+mm = accumulator( NaN );
+// returns [ -7.0, 3.0 ]
+
+mm = accumulator( -5.0 );
+// returns [ -7.0, 3.0 ]
+
+mm = accumulator();
+// returns [ -7.0, 3.0 ]
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   Input values are **not** type checked. If non-numeric inputs are possible, you are advised to type check and handle accordingly **before** passing the value to the accumulator function.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var randu = require( '@stdlib/random/base/randu' );
+var incrnanminmax = require( './../lib' );
+
+var accumulator;
+var v;
+var i;
+
+// Initialize an accumulator:
+accumulator = incrnanminmax();
+
+// For each simulated datum, update the minimum and maximum...
+for ( i = 0; i < 100; i++ ) {
+	if ( randu() < 0.2 ) {
+		v = NaN;
+	} else {
+		v = randu() * 100.0;
+	}
+}
+console.log( accumulator() );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/stats/incr/max`][@stdlib/stats/incr/max]</span><span class="delimiter">: </span><span class="description">compute a maximum value incrementally.</span>
+-   <span class="package-name">[`@stdlib/stats/incr/min`][@stdlib/stats/incr/min]</span><span class="delimiter">: </span><span class="description">compute a minimum value incrementally.</span>
+-   <span class="package-name">[`@stdlib/stats/incr/mminmax`][@stdlib/stats/incr/mminmax]</span><span class="delimiter">: </span><span class="description">compute a moving minimum and maximum incrementally.</span>
+-   <span class="package-name">[`@stdlib/stats/incr/range`][@stdlib/stats/incr/range]</span><span class="delimiter">: </span><span class="description">compute a range incrementally.</span>
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+<!-- <related-links> -->
+
+[@stdlib/stats/incr/max]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/max
+
+[@stdlib/stats/incr/min]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/min
+
+[@stdlib/stats/incr/mminmax]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/mminmax
+
+[@stdlib/stats/incr/range]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/range
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/stats/incr/nanminmax/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanminmax/benchmark/benchmark.js
@@ -1,0 +1,69 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var pkg = require( './../package.json' ).name;
+var incrnanminmax = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var f;
+	var i;
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		f = incrnanminmax();
+		if ( typeof f !== 'function' ) {
+			b.fail( 'should return a function' );
+		}
+	}
+	b.toc();
+	if ( typeof f !== 'function' ) {
+		b.fail( 'should return a function' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::accumulator', function benchmark( b ) {
+	var acc;
+	var v;
+	var i;
+
+	acc = incrnanminmax();
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		v = acc( randu() );
+		if ( v.length !== 2 ) {
+			b.fail( 'should contain two elements' );
+		}
+	}
+	b.toc();
+	if ( v[ 0 ] !== v[ 0 ] || v[ 1 ] !== v[ 1 ] ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/stats/incr/nanminmax/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/incr/nanminmax/docs/repl.txt
@@ -1,0 +1,40 @@
+
+{{alias}}( [out] )
+    Returns an accumulator function which incrementally computes a minimum and
+    maximum, ignoring `NaN` values.
+
+    If provided a value, the accumulator function returns an updated minimum and
+    maximum. If not provided a value, the accumulator function returns the
+    current minimum and maximum.
+
+    Parameters
+    ----------
+    out: Array|TypedArray (optional)
+        Output array.
+
+    Returns
+    -------
+    acc: Function
+        Accumulator function.
+
+    Examples
+    --------
+    > var accumulator = {{alias}}();
+    > var mm = accumulator()
+    null
+    > mm = accumulator( 2.0 )
+    [ 2.0, 2.0 ]
+    > mm = accumulator( -5.0 )
+    [ -5.0, 2.0 ]
+    > mm = accumulator( 3.0 )
+    [ -5.0, 3.0 ]
+    > mm = accumulator( NaN )
+    [ -5.0, 3.0 ]
+    > mm = accumulator( 5.0 )
+    [ -5.0, 5.0 ]
+    > mm = accumulator()
+    [ -5.0, 5.0 ]
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/stats/incr/nanminmax/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/incr/nanminmax/docs/types/index.d.ts
@@ -1,0 +1,68 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { ArrayLike } from '@stdlib/types/array';
+
+/**
+* If provided a value, the accumulator function returns updated minimum and maximum values. If not provided a value, the accumulator function returns the current minimum and maximum values.
+*
+* @param x - input value
+* @returns output array or null
+*/
+type accumulator = ( x?: number ) => ArrayLike<number> | null;
+
+/**
+* Returns an accumulator function which incrementally computes minimum and maximum values.
+*
+* @param out - output array
+* @returns accumulator function
+*
+* @example
+* var accumulator = incrminmax();
+*
+* var mm = accumulator();
+* // returns null
+*
+* mm = accumulator( 2.0 );
+* // returns [ 2.0, 2.0 ]
+*
+* mm = accumulator( -5.0 );
+* // returns [ -5.0, 2.0 ]
+*
+* mm = accumulator( 3.0 );
+* // returns [ -5.0, 3.0 ]
+*
+* mm = accumulator( NaN );
+* // returns [ -5.0, 3.0 ]
+*
+* mm = accumulator( 5.0 );
+* // returns [ -5.0, 5.0 ]
+*
+* mm = accumulator();
+* // returns [ -5.0, 5.0 ]
+*/
+declare function incrnanminmax( out?: ArrayLike<number> ): accumulator;
+
+
+// EXPORTS //
+
+export = incrnanminmax;

--- a/lib/node_modules/@stdlib/stats/incr/nanminmax/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/incr/nanminmax/docs/types/test.ts
@@ -1,0 +1,61 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import incrnanminmax = require( './index' );
+
+
+// TESTS //
+
+// The function returns an accumulator function...
+{
+	incrnanminmax(); // $ExpectType accumulator
+	const out = [ 0.0, 0.0 ];
+	incrnanminmax( out ); // $ExpectType accumulator
+}
+
+// The compiler throws an error if the function is provided an argument that is not an array-like object of numbers...
+{
+	incrnanminmax( '5' ); // $ExpectError
+	incrnanminmax( 5 ); // $ExpectError
+	incrnanminmax( true ); // $ExpectError
+	incrnanminmax( false ); // $ExpectError
+	incrnanminmax( null ); // $ExpectError
+	incrnanminmax( {} ); // $ExpectError
+	incrnanminmax( ( x: number ): number => x ); // $ExpectError
+}
+
+// The function returns an accumulator function which returns an accumulated result...
+{
+	const acc = incrnanminmax();
+
+	acc(); // $ExpectType ArrayLike<number> | null
+	acc( 3.14 ); // $ExpectType ArrayLike<number> | null
+}
+
+// The compiler throws an error if the returned accumulator function is provided invalid arguments...
+{
+	const acc = incrnanminmax();
+
+	acc( '5' ); // $ExpectError
+	acc( true ); // $ExpectError
+	acc( false ); // $ExpectError
+	acc( null ); // $ExpectError
+	acc( [] ); // $ExpectError
+	acc( {} ); // $ExpectError
+	acc( ( x: number ): number => x ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/stats/incr/nanminmax/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanminmax/examples/index.js
@@ -1,0 +1,42 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var randu = require( '@stdlib/random/base/randu' );
+var incrnanminmax = require( './../lib' );
+
+var accumulator;
+var mm;
+var v;
+var i;
+
+// Initialize an accumulator:
+accumulator = incrnanminmax();
+
+// For each simulated datum, update the minimum and maximum...
+console.log( '\nValue\tMin\tMax\n' );
+for ( i = 0; i < 100; i++ ) {
+	if ( randu() < 0.2 ) {
+		v = NaN;
+	} else {
+		v = randu() * 100.0;
+	}
+	mm = accumulator( v );
+	console.log( '%d\t%d\t%d', v.toFixed( 4 ), ( mm === null ) ? NaN : mm[ 0 ].toFixed( 4 ), ( mm === null ) ? NaN : mm[ 1 ].toFixed( 4 ) );
+}

--- a/lib/node_modules/@stdlib/stats/incr/nanminmax/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanminmax/lib/index.js
@@ -1,0 +1,60 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Compute a minimum and maximum incrementally, ignoring `NaN` values.
+*
+* @module @stdlib/stats/incr/nanminmax
+*
+* @example
+* var incrminmax = require( '@stdlib/stats/incr/nanminmax' );
+*
+* var accumulator = incrnanminmax();
+*
+* var mm = accumulator();
+* // returns null
+*
+* mm = accumulator( 2.0 );
+* // returns [ 2.0, 2.0 ]
+*
+* mm = accumulator( -5.0 );
+* // returns [ -5.0, 2.0 ]
+*
+* mm = accumulator( 3.0 );
+* // returns [ -5.0, 3.0 ]
+*
+* mm = accumulator( NaN );
+* // returns [ -5.0, 3.0 ]
+*
+* mm = accumulator( 5.0 );
+* // returns [ -5.0, 5.0 ]
+*
+* mm = accumulator();
+* // returns [ -5.0, 5.0 ]
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/incr/nanminmax/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanminmax/lib/main.js
@@ -1,0 +1,87 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var incrminmax = require( '@stdlib/stats/incr/minmax' );
+
+
+// MAIN //
+
+/**
+* Returns an accumulator function which incrementally computes minimum and maximum values, ignoring `NaN` values.
+*
+* @param {Collection} [out] - output array
+* @returns {Function} accumulator function
+*
+* @example
+* var accumulator = incrminmax();
+*
+* var mm = accumulator();
+* // returns null
+*
+* mm = accumulator( 2.0 );
+* // returns [ 2.0, 2.0 ]
+*
+* mm = accumulator( -5.0 );
+* // returns [ -5.0, 2.0 ]
+*
+* mm = accumulator( 3.0 );
+* // returns [ -5.0, 3.0 ]
+*
+* mm = accumulator( NaN );
+* // returns [ -5.0, 3.0 ]
+*
+* mm = accumulator( 5.0 );
+* // returns [ -5.0, 5.0 ]
+*
+* mm = accumulator();
+* // returns [ -5.0, 5.0 ]
+*/
+function incrnanminmax( out ) {
+	var nanminmax;
+	if ( arguments.length === 0 ) {
+		nanminmax = incrminmax();
+	}
+	else {
+		nanminmax = incrminmax( out );
+	}
+	return accumulator;
+
+	/**
+	* If provided a value, the accumulator function returns updated minimum and maximum values. If not provided a value, the accumulator function returns the current minimum and maximum values.
+	*
+	* @private
+	* @param {number} [x] - input value
+	* @returns {(ArrayLikeObject|null)} output array or null
+	*/
+	function accumulator( x ) {
+		if ( arguments.length === 0 || isnan( x ) ) {
+			return nanminmax();
+		}
+		return nanminmax( x );
+	}
+}
+
+
+// EXPORTS //
+
+module.exports = incrnanminmax;

--- a/lib/node_modules/@stdlib/stats/incr/nanminmax/package.json
+++ b/lib/node_modules/@stdlib/stats/incr/nanminmax/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@stdlib/stats/incr/nanminmax",
+  "version": "0.0.0",
+  "description": "Compute a minimum and maximum incrementally, ignoring NaN values.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "statistics",
+    "stats",
+    "mathematics",
+    "math",
+    "maximum",
+    "max",
+    "minimum",
+    "min",
+    "dispersion",
+    "variance",
+    "range",
+    "extent",
+    "extrema",
+    "incremental",
+    "accumulator"
+  ]
+}

--- a/lib/node_modules/@stdlib/stats/incr/nanminmax/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanminmax/test/test.js
@@ -1,0 +1,223 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
+var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
+var incrnanminmax = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof incrnanminmax, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function throws an error if not provided an array-like object for an output argument', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		-5.0,
+		true,
+		false,
+		null,
+		void 0,
+		NaN,
+		{},
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			incrnanminmax( value );
+		};
+	}
+});
+
+tape( 'the function returns an accumulator function', function test( t ) {
+	t.equal( typeof incrnanminmax(), 'function', 'returns a function' );
+	t.end();
+});
+
+tape( 'the function returns an accumulator function (output)', function test( t ) {
+	t.equal( typeof incrnanminmax( [ 0.0, 0.0 ] ), 'function', 'returns a function' );
+	t.end();
+});
+
+tape( 'the accumulator function computes a minimum and maximum incrementally', function test( t ) {
+	var expected;
+	var actual;
+	var data;
+	var acc;
+	var N;
+	var i;
+
+	data = [ 2.0, 3.0, 2.0, 4.0, NaN, 4.0, 2.0, 2.0, NaN, 1.0, 0.0, 4.0, -1.0 ];
+	N = data.length;
+
+	acc = incrnanminmax();
+
+	actual = [];
+	for ( i = 0; i < N; i++ ) {
+		actual.push( ( acc( data[ i ] ) ).slice() );
+	}
+	expected = [
+		[ 2.0, 2.0 ],
+		[ 2.0, 3.0 ],
+		[ 2.0, 3.0 ],
+		[ 2.0, 4.0 ],
+		[ 2.0, 4.0 ],
+		[ 2.0, 4.0 ],
+		[ 2.0, 4.0 ],
+		[ 2.0, 4.0 ],
+		[ 2.0, 4.0 ],
+		[ 1.0, 4.0 ],
+		[ 0.0, 4.0 ],
+		[ 0.0, 4.0 ],
+		[ -1.0, 4.0 ]
+	];
+
+	t.deepEqual( actual, expected, 'returns expected values' );
+	t.end();
+});
+
+tape( 'the accumulator function computes a minimum and maximum incrementally (output)', function test( t ) {
+	var expected;
+	var actual;
+	var data;
+	var acc;
+	var out;
+	var N;
+	var i;
+
+	data = [ 2.0, 3.0, 2.0, 4.0, NaN, 4.0, 2.0, 2.0, NaN, 1.0, 0.0, 4.0, -1.0 ];
+	N = data.length;
+
+	out = [ 0.0, 0.0 ];
+	acc = incrnanminmax( out );
+
+	actual = [];
+	for ( i = 0; i < N; i++ ) {
+		actual.push( acc( data[ i ] ) );
+		t.equal( actual[ i ], out, 'returns output array' );
+		actual[ i ] = actual[ i ].slice();
+	}
+	expected = [
+		[ 2.0, 2.0 ],
+		[ 2.0, 3.0 ],
+		[ 2.0, 3.0 ],
+		[ 2.0, 4.0 ],
+		[ 2.0, 4.0 ],
+		[ 2.0, 4.0 ],
+		[ 2.0, 4.0 ],
+		[ 2.0, 4.0 ],
+		[ 2.0, 4.0 ],
+		[ 1.0, 4.0 ],
+		[ 0.0, 4.0 ],
+		[ 0.0, 4.0 ],
+		[ -1.0, 4.0 ]
+	];
+
+	t.deepEqual( actual, expected, 'returns expected values' );
+	t.end();
+});
+
+tape( 'if not provided an input value, the accumulator function returns the current minimum and maximum values', function test( t ) {
+	var data;
+	var acc;
+	var i;
+
+	data = [ 2.0, 3.0, 5.0, 4.0 ];
+	acc = incrnanminmax();
+	for ( i = 0; i < data.length; i++ ) {
+		acc( data[ i ] );
+	}
+	t.deepEqual( acc(), [ 2.0, 5.0 ], 'returns expected value' );
+	t.end();
+});
+
+tape( 'if data has yet to be provided, the accumulator function returns `null`', function test( t ) {
+	var acc = incrnanminmax();
+	t.equal( acc(), null, 'returns null' );
+	t.end();
+});
+
+tape( 'the accumulator function correctly handles signed zeros', function test( t ) {
+	var acc;
+	var v;
+
+	acc = incrnanminmax();
+
+	v = acc( 0.0 );
+	t.equal( isPositiveZero( v[ 0 ] ), true, 'returns expected value' );
+	t.equal( isPositiveZero( v[ 1 ] ), true, 'returns expected value' );
+
+	v = acc( -0.0 );
+	t.equal( isNegativeZero( v[ 0 ] ), true, 'returns expected value' );
+	t.equal( isPositiveZero( v[ 1 ] ), true, 'returns expected value' );
+
+	v = acc( 0.0 );
+	t.equal( isNegativeZero( v[ 0 ] ), true, 'returns expected value' );
+	t.equal( isPositiveZero( v[ 1 ] ), true, 'returns expected value' );
+
+	acc = incrnanminmax();
+
+	v = acc( -0.0 );
+	t.equal( isNegativeZero( v[ 0 ] ), true, 'returns expected value' );
+	t.equal( isNegativeZero( v[ 1 ] ), true, 'returns expected value' );
+
+	v = acc( 0.0 );
+	t.equal( isNegativeZero( v[ 0 ] ), true, 'returns expected value' );
+	t.equal( isPositiveZero( v[ 1 ] ), true, 'returns expected value' );
+
+	v = acc( -0.0 );
+	t.equal( isNegativeZero( v[ 0 ] ), true, 'returns expected value' );
+	t.equal( isPositiveZero( v[ 1 ] ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'if provided `NaN`, the accumulated minimum and maximum values remain unchanged', function test( t ) {
+	var data;
+	var acc;
+	var v;
+	var i;
+
+	data = [ 2.0, NaN, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0 ];
+	acc = incrnanminmax();
+	for ( i = 0; i < data.length; i++ ) {
+		acc( data[ i ] );
+	}
+	v = acc();
+	t.equal( v[ 0 ], 1.0, false, 'returns expected value' );
+	t.equal( v[ 1 ], 7.0, false, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
Resolves #5579 

## Description

> What is the purpose of this pull request?

This pull request:

-   introduces the @stdlib/stats/incr/nanminmax package, which incrementally computes minimum and maximum, ignoring `NaN` values.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #5579 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
