### PR TITLE
chore: fix EditorConfig lint error

### DIFF
--- a/lib/node_modules/@stdlib/strided/napi/README.md
+++ b/lib/node_modules/@stdlib/strided/napi/README.md
@@ -109,7 +109,7 @@ This package exposes various C APIs to facilitate the creation of Node-API strid
 -   [`@stdlib/strided/base/smap2`][@stdlib/strided/base/smap2]: single-precision floating-point strided array interface for applying a binary callback to two input strided arrays.
 -   [`@stdlib/strided/base/smskmap`][@stdlib/strided/base/smskmap]: single-precision floating-point strided array interface for applying a unary callback to a single input strided array according to a mask strided array.
 -   [`@stdlib/strided/base/smskmap2`][@stdlib/strided/base/smskmap2]: single-precision floating-point strided array interface for applying a unary callback to two input strided arrays according to a mask strided array.
--   [`@stdlib/strided/base/unary`][@stdlib/strided/base/unary]: strided array loops for operating on a single input strided array and one or more output strided arrays. 
+-   [`@stdlib/strided/base/unary`][@stdlib/strided/base/unary]: strided array loops for operating on a single input strided array and one or more output strided arrays.
 -   [`@stdlib/strided/base/zmap`][@stdlib/strided/base/zmap]: double-precision complex floating-point strided array interface for applying a unary callback to a single input strided array.
 -   [`@stdlib/strided/dtypes`][@stdlib/strided/dtypes]: supported strided array data types.
 -   [`@stdlib/strided/napi/binary`][@stdlib/strided/napi/binary]: Node-API interfaces and macros for registering one or more [`@stdlib/strided/base/binary`][@stdlib/strided/base/binary] interfaces with support for multiple dispatch.


### PR DESCRIPTION
Resolves #5981

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes EditorConfig linting errors in the @stdlib/strided/napi package documentation
-   Removes trailing whitespace identified in the EditorConfig lint workflow

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #5981 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

The linting failure was detected in the automated EditorConfig lint workflow run on 2025-03-12.
Workflow Details:

-  Run: https://github.com/stdlib-js/stdlib/actions/runs/13800596635
-  Type: EditorConfig Linting
-  Date: 2025-03-12 00:04:06 UTC

The specific error was:
![image](https://github.com/user-attachments/assets/792ae713-3ef2-4ffc-9380-bde0723e964f)


## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [X] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
