### PR TITLE
feat: add `stats/incr/nanhmean`

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/nanhmean/README.md
+++ b/lib/node_modules/@stdlib/stats/incr/nanhmean/README.md
@@ -103,7 +103,8 @@ v = accumulator();
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var bernoulli = require( '@stdlib/random/base/bernoulli' );
 var incrnanhmean = require( '@stdlib/stats/incr/nanhmean' );
 
 var accumulator;
@@ -115,10 +116,10 @@ accumulator = incrnanhmean();
 
 // For each simulated datum, update the harmonic mean...
 for ( i = 0; i < 100; i++ ) {
-    if ( randu() < 0.2 ) {
+    if ( bernoulli( 0.2 ) ) {
         v = NaN;
     } else {
-        v = ( randu()*100.0 );
+        v = uniform( 1.0, 100.0 );
     }
     accumulator( v );
 }

--- a/lib/node_modules/@stdlib/stats/incr/nanhmean/README.md
+++ b/lib/node_modules/@stdlib/stats/incr/nanhmean/README.md
@@ -32,10 +32,6 @@ The [harmonic mean][harmonic-mean] of positive real numbers `x_0, x_1, ..., x_{n
 \begin{align}H &= \frac{n}{\frac{1}{x_0} + \frac{1}{x_1} + \cdots + \frac{1}{x_{n-1}}} \\ &= \frac{\displaystyle n}{\displaystyle\sum_{i=0}^{n-1} \frac{1}{x_i}} \\ &= \biggl( \frac{\displaystyle\sum_{i=0}^{n-1} \frac{1}{x_i}}{\displaystyle n} \biggr)^{-1}\end{align}
 ```
 
-<!-- <div class="equation" align="center" data-raw-text="\begin{align}H &amp;= \frac{n}{\frac{1}{x_0} + \frac{1}{x_1} + \cdots + \frac{1}{x_{n-1}}} \\ &amp;= \frac{\displaystyle n}{\displaystyle\sum_{i=0}^{n-1} \frac{1}{x_i}} \\ &amp;= \biggl( \frac{\displaystyle\sum_{i=0}^{n-1} \frac{1}{x_i}}{\displaystyle n} \biggr)^{-1}\end{align}" data-equation="eq:harmonic_mean">
-    <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@2b632747053b9e357a4663369528fe62b29a6d55/lib/node_modules/@stdlib/stats/incr/nanhmean/docs/img/equation_harmonic_mean.svg" alt="Equation for the harmonic mean.">
-    <br>
-</div> -->
 
 <!-- </equation> -->
 
@@ -134,15 +130,6 @@ console.log( accumulator() );
 
 <section class="related">
 
-* * *
-
-## See Also
-
--   <span class="package-name">[`@stdlib/stats/incr/gmean`][@stdlib/stats/incr/gmean]</span><span class="delimiter">: </span><span class="description">compute a geometric mean incrementally.</span>
--   <span class="package-name">[`@stdlib/stats/incr/mean`][@stdlib/stats/incr/mean]</span><span class="delimiter">: </span><span class="description">compute an arithmetic mean incrementally.</span>
--   <span class="package-name">[`@stdlib/stats/incr/mnanhmean`][@stdlib/stats/incr/mnanhmean]</span><span class="delimiter">: </span><span class="description">compute a moving harmonic mean incrementally.</span>
--   <span class="package-name">[`@stdlib/stats/incr/summary`][@stdlib/stats/incr/summary]</span><span class="delimiter">: </span><span class="description">compute a statistical summary incrementally.</span>
-
 </section>
 
 <!-- /.related -->
@@ -154,14 +141,6 @@ console.log( accumulator() );
 [harmonic-mean]: https://en.wikipedia.org/wiki/Harmonic_mean
 
 <!-- <related-links> -->
-
-[@stdlib/stats/incr/gmean]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/gmean
-
-[@stdlib/stats/incr/mean]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/mean
-
-[@stdlib/stats/incr/mnanhmean]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/mnanhmean
-
-[@stdlib/stats/incr/summary]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/summary
 
 <!-- </related-links> -->
 

--- a/lib/node_modules/@stdlib/stats/incr/nanhmean/README.md
+++ b/lib/node_modules/@stdlib/stats/incr/nanhmean/README.md
@@ -1,0 +1,169 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2025 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# incrnanhmean
+
+> Compute a [harmonic mean][harmonic-mean] incrementally, ignoring `NaN` values.
+
+<section class="intro">
+
+The [harmonic mean][harmonic-mean] of positive real numbers `x_0, x_1, ..., x_{n-1}` is defined as
+
+<!-- <equation class="equation" label="eq:harmonic_mean" align="center" raw="\begin{align}H &= \frac{n}{\frac{1}{x_0} + \frac{1}{x_1} + \cdots + \frac{1}{x_{n-1}}} \\ &= \frac{\displaystyle n}{\displaystyle\sum_{i=0}^{n-1} \frac{1}{x_i}} \\ &= \biggl( \frac{\displaystyle\sum_{i=0}^{n-1} \frac{1}{x_i}}{\displaystyle n} \biggr)^{-1}\end{align}" alt="Equation for the harmonic mean."> -->
+
+```math
+\begin{align}H &= \frac{n}{\frac{1}{x_0} + \frac{1}{x_1} + \cdots + \frac{1}{x_{n-1}}} \\ &= \frac{\displaystyle n}{\displaystyle\sum_{i=0}^{n-1} \frac{1}{x_i}} \\ &= \biggl( \frac{\displaystyle\sum_{i=0}^{n-1} \frac{1}{x_i}}{\displaystyle n} \biggr)^{-1}\end{align}
+```
+
+<!-- <div class="equation" align="center" data-raw-text="\begin{align}H &amp;= \frac{n}{\frac{1}{x_0} + \frac{1}{x_1} + \cdots + \frac{1}{x_{n-1}}} \\ &amp;= \frac{\displaystyle n}{\displaystyle\sum_{i=0}^{n-1} \frac{1}{x_i}} \\ &amp;= \biggl( \frac{\displaystyle\sum_{i=0}^{n-1} \frac{1}{x_i}}{\displaystyle n} \biggr)^{-1}\end{align}" data-equation="eq:harmonic_mean">
+    <img src="https://cdn.jsdelivr.net/gh/stdlib-js/stdlib@2b632747053b9e357a4663369528fe62b29a6d55/lib/node_modules/@stdlib/stats/incr/nanhmean/docs/img/equation_harmonic_mean.svg" alt="Equation for the harmonic mean.">
+    <br>
+</div> -->
+
+<!-- </equation> -->
+
+</section>
+
+<!-- /.intro -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var incrnanhmean = require( '@stdlib/stats/incr/nanhmean' );
+```
+
+#### incrnanhmean()
+
+Returns an accumulator `function` which incrementally computes a [harmonic mean][harmonic-mean], ignoring `NaN` values.
+
+```javascript
+var accumulator = incrnanhmean();
+```
+
+#### accumulator( \[x] )
+
+If provided an input value `x`, the accumulator function returns an updated [harmonic mean][harmonic-mean]. If not provided an input value `x`, the accumulator function returns the current [harmonic mean][harmonic-mean].
+
+```javascript
+var accumulator = incrnanhmean();
+
+var v = accumulator( 2.0 );
+// returns 2.0
+
+v = accumulator( 1.0 );
+// returns ~1.33
+
+v = accumulator( NaN );
+// returns ~1.33
+
+v = accumulator( 3.0 );
+// returns ~1.64
+
+v = accumulator();
+// returns ~1.64
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   Input values are **not** type checked. If non-numeric inputs are possible, you are advised to type check and handle accordingly **before** passing the value to the accumulator function.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var randu = require( '@stdlib/random/base/randu' );
+var incrnanhmean = require( '@stdlib/stats/incr/nanhmean' );
+
+var accumulator;
+var v;
+var i;
+
+// Initialize an accumulator:
+accumulator = incrnanhmean();
+
+// For each simulated datum, update the harmonic mean...
+for ( i = 0; i < 100; i++ ) {
+    if ( randu() < 0.2 ) {
+        v = NaN;
+    } else {
+        v = ( randu()*100.0 );
+    }
+    accumulator( v );
+}
+console.log( accumulator() );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/stats/incr/gmean`][@stdlib/stats/incr/gmean]</span><span class="delimiter">: </span><span class="description">compute a geometric mean incrementally.</span>
+-   <span class="package-name">[`@stdlib/stats/incr/mean`][@stdlib/stats/incr/mean]</span><span class="delimiter">: </span><span class="description">compute an arithmetic mean incrementally.</span>
+-   <span class="package-name">[`@stdlib/stats/incr/mnanhmean`][@stdlib/stats/incr/mnanhmean]</span><span class="delimiter">: </span><span class="description">compute a moving harmonic mean incrementally.</span>
+-   <span class="package-name">[`@stdlib/stats/incr/summary`][@stdlib/stats/incr/summary]</span><span class="delimiter">: </span><span class="description">compute a statistical summary incrementally.</span>
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[harmonic-mean]: https://en.wikipedia.org/wiki/Harmonic_mean
+
+<!-- <related-links> -->
+
+[@stdlib/stats/incr/gmean]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/gmean
+
+[@stdlib/stats/incr/mean]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/mean
+
+[@stdlib/stats/incr/mnanhmean]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/mnanhmean
+
+[@stdlib/stats/incr/summary]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/summary
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/stats/incr/nanhmean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanhmean/benchmark/benchmark.js
@@ -1,0 +1,69 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var pkg = require( './../package.json' ).name;
+var incrnanhmean = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var f;
+	var i;
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		f = incrnanhmean();
+		if ( typeof f !== 'function' ) {
+			b.fail( 'should return a function' );
+		}
+	}
+	b.toc();
+	if ( typeof f !== 'function' ) {
+		b.fail( 'should return a function' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::accumulator', function benchmark( b ) {
+	var acc;
+	var v;
+	var i;
+
+	acc = incrnanhmean();
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		v = acc( randu() );
+		if ( v !== v ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( v !== v ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/stats/incr/nanhmean/docs/img/equation_harmonic_mean.svg
+++ b/lib/node_modules/@stdlib/stats/incr/nanhmean/docs/img/equation_harmonic_mean.svg
@@ -1,0 +1,148 @@
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="27.657ex" height="20.509ex" style="vertical-align: -9.671ex;" viewBox="0 -4666.3 11907.6 8830.4" role="img" focusable="false" xmlns="http://www.w3.org/2000/svg" aria-labelledby="MathJax-SVG-1-Title">
+<title id="MathJax-SVG-1-Title">StartLayout 1st Row 1st Column upper H 2nd Column equals StartStartFraction n OverOver StartFraction 1 Over x 0 EndFraction plus StartFraction 1 Over x 1 EndFraction plus midline-horizontal-ellipsis plus StartFraction 1 Over x Subscript n minus 1 Baseline EndFraction EndEndFraction 2nd Row 1st Column Blank 2nd Column equals StartStartFraction n OverOver sigma-summation Underscript i equals 0 Overscript n minus 1 Endscripts StartFraction 1 Over x Subscript i Baseline EndFraction EndEndFraction 3rd Row 1st Column Blank 2nd Column equals left-parenthesis StartStartFraction sigma-summation Underscript i equals 0 Overscript n minus 1 Endscripts StartFraction 1 Over x Subscript i Baseline EndFraction OverOver n EndEndFraction right-parenthesis Superscript negative 1 EndLayout</title>
+<defs aria-hidden="true">
+<path stroke-width="1" id="E1-MJMATHI-48" d="M228 637Q194 637 192 641Q191 643 191 649Q191 673 202 682Q204 683 219 683Q260 681 355 681Q389 681 418 681T463 682T483 682Q499 682 499 672Q499 670 497 658Q492 641 487 638H485Q483 638 480 638T473 638T464 637T455 637Q416 636 405 634T387 623Q384 619 355 500Q348 474 340 442T328 395L324 380Q324 378 469 378H614L615 381Q615 384 646 504Q674 619 674 627T617 637Q594 637 587 639T580 648Q580 650 582 660Q586 677 588 679T604 682Q609 682 646 681T740 680Q802 680 835 681T871 682Q888 682 888 672Q888 645 876 638H874Q872 638 869 638T862 638T853 637T844 637Q805 636 794 634T776 623Q773 618 704 340T634 58Q634 51 638 51Q646 48 692 46H723Q729 38 729 37T726 19Q722 6 716 0H701Q664 2 567 2Q533 2 504 2T458 2T437 1Q420 1 420 10Q420 15 423 24Q428 43 433 45Q437 46 448 46H454Q481 46 514 49Q520 50 522 50T528 55T534 64T540 82T547 110T558 153Q565 181 569 198Q602 330 602 331T457 332H312L279 197Q245 63 245 58Q245 51 253 49T303 46H334Q340 38 340 37T337 19Q333 6 327 0H312Q275 2 178 2Q144 2 115 2T69 2T48 1Q31 1 31 10Q31 12 34 24Q39 43 44 45Q48 46 59 46H65Q92 46 125 49Q139 52 144 61Q147 65 216 339T285 628Q285 635 228 637Z"></path>
+<path stroke-width="1" id="E1-MJMAIN-3D" d="M56 347Q56 360 70 367H707Q722 359 722 347Q722 336 708 328L390 327H72Q56 332 56 347ZM56 153Q56 168 72 173H708Q722 163 722 153Q722 140 707 133H70Q56 140 56 153Z"></path>
+<path stroke-width="1" id="E1-MJMATHI-6E" d="M21 287Q22 293 24 303T36 341T56 388T89 425T135 442Q171 442 195 424T225 390T231 369Q231 367 232 367L243 378Q304 442 382 442Q436 442 469 415T503 336T465 179T427 52Q427 26 444 26Q450 26 453 27Q482 32 505 65T540 145Q542 153 560 153Q580 153 580 145Q580 144 576 130Q568 101 554 73T508 17T439 -10Q392 -10 371 17T350 73Q350 92 386 193T423 345Q423 404 379 404H374Q288 404 229 303L222 291L189 157Q156 26 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 112 180T152 343Q153 348 153 366Q153 405 129 405Q91 405 66 305Q60 285 60 284Q58 278 41 278H27Q21 284 21 287Z"></path>
+<path stroke-width="1" id="E1-MJMAIN-31" d="M213 578L200 573Q186 568 160 563T102 556H83V602H102Q149 604 189 617T245 641T273 663Q275 666 285 666Q294 666 302 660V361L303 61Q310 54 315 52T339 48T401 46H427V0H416Q395 3 257 3Q121 3 100 0H88V46H114Q136 46 152 46T177 47T193 50T201 52T207 57T213 61V578Z"></path>
+<path stroke-width="1" id="E1-MJMATHI-78" d="M52 289Q59 331 106 386T222 442Q257 442 286 424T329 379Q371 442 430 442Q467 442 494 420T522 361Q522 332 508 314T481 292T458 288Q439 288 427 299T415 328Q415 374 465 391Q454 404 425 404Q412 404 406 402Q368 386 350 336Q290 115 290 78Q290 50 306 38T341 26Q378 26 414 59T463 140Q466 150 469 151T485 153H489Q504 153 504 145Q504 144 502 134Q486 77 440 33T333 -11Q263 -11 227 52Q186 -10 133 -10H127Q78 -10 57 16T35 71Q35 103 54 123T99 143Q142 143 142 101Q142 81 130 66T107 46T94 41L91 40Q91 39 97 36T113 29T132 26Q168 26 194 71Q203 87 217 139T245 247T261 313Q266 340 266 352Q266 380 251 392T217 404Q177 404 142 372T93 290Q91 281 88 280T72 278H58Q52 284 52 289Z"></path>
+<path stroke-width="1" id="E1-MJMAIN-30" d="M96 585Q152 666 249 666Q297 666 345 640T423 548Q460 465 460 320Q460 165 417 83Q397 41 362 16T301 -15T250 -22Q224 -22 198 -16T137 16T82 83Q39 165 39 320Q39 494 96 585ZM321 597Q291 629 250 629Q208 629 178 597Q153 571 145 525T137 333Q137 175 145 125T181 46Q209 16 250 16Q290 16 318 46Q347 76 354 130T362 333Q362 478 354 524T321 597Z"></path>
+<path stroke-width="1" id="E1-MJMAIN-2B" d="M56 237T56 250T70 270H369V420L370 570Q380 583 389 583Q402 583 409 568V270H707Q722 262 722 250T707 230H409V-68Q401 -82 391 -82H389H387Q375 -82 369 -68V230H70Q56 237 56 250Z"></path>
+<path stroke-width="1" id="E1-MJMAIN-22EF" d="M78 250Q78 274 95 292T138 310Q162 310 180 294T199 251Q199 226 182 208T139 190T96 207T78 250ZM525 250Q525 274 542 292T585 310Q609 310 627 294T646 251Q646 226 629 208T586 190T543 207T525 250ZM972 250Q972 274 989 292T1032 310Q1056 310 1074 294T1093 251Q1093 226 1076 208T1033 190T990 207T972 250Z"></path>
+<path stroke-width="1" id="E1-MJMAIN-2212" d="M84 237T84 250T98 270H679Q694 262 694 250T679 230H98Q84 237 84 250Z"></path>
+<path stroke-width="1" id="E1-MJSZ1-2211" d="M61 748Q64 750 489 750H913L954 640Q965 609 976 579T993 533T999 516H979L959 517Q936 579 886 621T777 682Q724 700 655 705T436 710H319Q183 710 183 709Q186 706 348 484T511 259Q517 250 513 244L490 216Q466 188 420 134T330 27L149 -187Q149 -188 362 -188Q388 -188 436 -188T506 -189Q679 -189 778 -162T936 -43Q946 -27 959 6H999L913 -249L489 -250Q65 -250 62 -248Q56 -246 56 -239Q56 -234 118 -161Q186 -81 245 -11L428 206Q428 207 242 462L57 717L56 728Q56 744 61 748Z"></path>
+<path stroke-width="1" id="E1-MJMATHI-69" d="M184 600Q184 624 203 642T247 661Q265 661 277 649T290 619Q290 596 270 577T226 557Q211 557 198 567T184 600ZM21 287Q21 295 30 318T54 369T98 420T158 442Q197 442 223 419T250 357Q250 340 236 301T196 196T154 83Q149 61 149 51Q149 26 166 26Q175 26 185 29T208 43T235 78T260 137Q263 149 265 151T282 153Q302 153 302 143Q302 135 293 112T268 61T223 11T161 -11Q129 -11 102 10T74 74Q74 91 79 106T122 220Q160 321 166 341T173 380Q173 404 156 404H154Q124 404 99 371T61 287Q60 286 59 284T58 281T56 279T53 278T49 278T41 278H27Q21 284 21 287Z"></path>
+<path stroke-width="1" id="E1-MJMAIN-28" d="M94 250Q94 319 104 381T127 488T164 576T202 643T244 695T277 729T302 750H315H319Q333 750 333 741Q333 738 316 720T275 667T226 581T184 443T167 250T184 58T225 -81T274 -167T316 -220T333 -241Q333 -250 318 -250H315H302L274 -226Q180 -141 137 -14T94 250Z"></path>
+<path stroke-width="1" id="E1-MJSZ3-28" d="M701 -940Q701 -943 695 -949H664Q662 -947 636 -922T591 -879T537 -818T475 -737T412 -636T350 -511T295 -362T250 -186T221 17T209 251Q209 962 573 1361Q596 1386 616 1405T649 1437T664 1450H695Q701 1444 701 1441Q701 1436 681 1415T629 1356T557 1261T476 1118T400 927T340 675T308 359Q306 321 306 250Q306 -139 400 -430T690 -924Q701 -936 701 -940Z"></path>
+<path stroke-width="1" id="E1-MJMAIN-29" d="M60 749L64 750Q69 750 74 750H86L114 726Q208 641 251 514T294 250Q294 182 284 119T261 12T224 -76T186 -143T145 -194T113 -227T90 -246Q87 -249 86 -250H74Q66 -250 63 -250T58 -247T55 -238Q56 -237 66 -225Q221 -64 221 250T66 725Q56 737 55 738Q55 746 60 749Z"></path>
+<path stroke-width="1" id="E1-MJSZ3-29" d="M34 1438Q34 1446 37 1448T50 1450H56H71Q73 1448 99 1423T144 1380T198 1319T260 1238T323 1137T385 1013T440 864T485 688T514 485T526 251Q526 134 519 53Q472 -519 162 -860Q139 -885 119 -904T86 -936T71 -949H56Q43 -949 39 -947T34 -937Q88 -883 140 -813Q428 -430 428 251Q428 453 402 628T338 922T245 1146T145 1309T46 1425Q44 1427 42 1429T39 1433T36 1436L34 1438Z"></path>
+</defs>
+<g stroke="currentColor" fill="currentColor" stroke-width="0" transform="matrix(1 0 0 -1 0 0)" aria-hidden="true">
+<g transform="translate(167,0)">
+<g transform="translate(-11,0)">
+ <use xlink:href="#E1-MJMATHI-48" x="0" y="3466"></use>
+</g>
+<g transform="translate(878,0)">
+<g transform="translate(0,3466)">
+ <use xlink:href="#E1-MJMAIN-3D" x="277" y="0"></use>
+<g transform="translate(1056,0)">
+<g transform="translate(397,0)">
+<rect stroke="none" width="9121" height="60" x="0" y="220"></rect>
+ <use xlink:href="#E1-MJMATHI-6E" x="4260" y="676"></use>
+<g transform="translate(60,-937)">
+<g transform="translate(120,0)">
+<rect stroke="none" width="882" height="60" x="0" y="220"></rect>
+ <use transform="scale(0.707)" xlink:href="#E1-MJMAIN-31" x="374" y="629"></use>
+<g transform="translate(60,-345)">
+ <use transform="scale(0.707)" xlink:href="#E1-MJMATHI-78" x="0" y="0"></use>
+ <use transform="scale(0.574)" xlink:href="#E1-MJMAIN-30" x="705" y="-243"></use>
+</g>
+</g>
+ <use xlink:href="#E1-MJMAIN-2B" x="1345" y="0"></use>
+<g transform="translate(2123,0)">
+<g transform="translate(342,0)">
+<rect stroke="none" width="882" height="60" x="0" y="220"></rect>
+ <use transform="scale(0.707)" xlink:href="#E1-MJMAIN-31" x="374" y="629"></use>
+<g transform="translate(60,-345)">
+ <use transform="scale(0.707)" xlink:href="#E1-MJMATHI-78" x="0" y="0"></use>
+ <use transform="scale(0.574)" xlink:href="#E1-MJMAIN-31" x="705" y="-243"></use>
+</g>
+</g>
+</g>
+ <use xlink:href="#E1-MJMAIN-2B" x="3690" y="0"></use>
+ <use xlink:href="#E1-MJMAIN-22EF" x="4691" y="0"></use>
+ <use xlink:href="#E1-MJMAIN-2B" x="6086" y="0"></use>
+<g transform="translate(6864,0)">
+<g transform="translate(342,0)">
+<rect stroke="none" width="1674" height="60" x="0" y="220"></rect>
+ <use transform="scale(0.707)" xlink:href="#E1-MJMAIN-31" x="933" y="629"></use>
+<g transform="translate(60,-345)">
+ <use transform="scale(0.707)" xlink:href="#E1-MJMATHI-78" x="0" y="0"></use>
+<g transform="translate(404,-140)">
+ <use transform="scale(0.574)" xlink:href="#E1-MJMATHI-6E" x="0" y="0"></use>
+ <use transform="scale(0.574)" xlink:href="#E1-MJMAIN-2212" x="600" y="0"></use>
+ <use transform="scale(0.574)" xlink:href="#E1-MJMAIN-31" x="1379" y="0"></use>
+</g>
+</g>
+</g>
+</g>
+</g>
+</g>
+</g>
+</g>
+<g transform="translate(0,577)">
+ <use xlink:href="#E1-MJMAIN-3D" x="277" y="0"></use>
+<g transform="translate(1056,0)">
+<g transform="translate(397,0)">
+<rect stroke="none" width="3806" height="60" x="0" y="220"></rect>
+ <use xlink:href="#E1-MJMATHI-6E" x="1602" y="676"></use>
+<g transform="translate(60,-970)">
+ <use xlink:href="#E1-MJSZ1-2211" x="0" y="0"></use>
+<g transform="translate(1056,477)">
+ <use transform="scale(0.707)" xlink:href="#E1-MJMATHI-6E" x="0" y="0"></use>
+ <use transform="scale(0.707)" xlink:href="#E1-MJMAIN-2212" x="600" y="0"></use>
+ <use transform="scale(0.707)" xlink:href="#E1-MJMAIN-31" x="1379" y="0"></use>
+</g>
+<g transform="translate(1056,-287)">
+ <use transform="scale(0.707)" xlink:href="#E1-MJMATHI-69" x="0" y="0"></use>
+ <use transform="scale(0.707)" xlink:href="#E1-MJMAIN-3D" x="345" y="0"></use>
+ <use transform="scale(0.707)" xlink:href="#E1-MJMAIN-30" x="1124" y="0"></use>
+</g>
+<g transform="translate(2485,0)">
+<g transform="translate(286,0)">
+<rect stroke="none" width="793" height="60" x="0" y="220"></rect>
+ <use transform="scale(0.707)" xlink:href="#E1-MJMAIN-31" x="311" y="629"></use>
+<g transform="translate(60,-345)">
+ <use transform="scale(0.707)" xlink:href="#E1-MJMATHI-78" x="0" y="0"></use>
+ <use transform="scale(0.574)" xlink:href="#E1-MJMATHI-69" x="705" y="-238"></use>
+</g>
+</g>
+</g>
+</g>
+</g>
+</g>
+</g>
+<g transform="translate(0,-3137)">
+ <use xlink:href="#E1-MJMAIN-3D" x="277" y="0"></use>
+ <use xlink:href="#E1-MJSZ3-28" x="1056" y="-1"></use>
+<g transform="translate(1792,0)">
+<g transform="translate(120,0)">
+<rect stroke="none" width="3806" height="60" x="0" y="220"></rect>
+<g transform="translate(60,1007)">
+ <use xlink:href="#E1-MJSZ1-2211" x="0" y="0"></use>
+<g transform="translate(1056,477)">
+ <use transform="scale(0.707)" xlink:href="#E1-MJMATHI-6E" x="0" y="0"></use>
+ <use transform="scale(0.707)" xlink:href="#E1-MJMAIN-2212" x="600" y="0"></use>
+ <use transform="scale(0.707)" xlink:href="#E1-MJMAIN-31" x="1379" y="0"></use>
+</g>
+<g transform="translate(1056,-287)">
+ <use transform="scale(0.707)" xlink:href="#E1-MJMATHI-69" x="0" y="0"></use>
+ <use transform="scale(0.707)" xlink:href="#E1-MJMAIN-3D" x="345" y="0"></use>
+ <use transform="scale(0.707)" xlink:href="#E1-MJMAIN-30" x="1124" y="0"></use>
+</g>
+<g transform="translate(2485,0)">
+<g transform="translate(286,0)">
+<rect stroke="none" width="793" height="60" x="0" y="220"></rect>
+ <use transform="scale(0.707)" xlink:href="#E1-MJMAIN-31" x="311" y="629"></use>
+<g transform="translate(60,-345)">
+ <use transform="scale(0.707)" xlink:href="#E1-MJMATHI-78" x="0" y="0"></use>
+ <use transform="scale(0.574)" xlink:href="#E1-MJMATHI-69" x="705" y="-238"></use>
+</g>
+</g>
+</g>
+</g>
+ <use xlink:href="#E1-MJMATHI-6E" x="1602" y="-686"></use>
+</g>
+</g>
+<g transform="translate(5838,0)">
+ <use xlink:href="#E1-MJSZ3-29" x="0" y="-1"></use>
+<g transform="translate(736,1177)">
+ <use transform="scale(0.707)" xlink:href="#E1-MJMAIN-2212" x="0" y="0"></use>
+ <use transform="scale(0.707)" xlink:href="#E1-MJMAIN-31" x="778" y="0"></use>
+</g>
+</g>
+</g>
+</g>
+</g>
+</g>
+</svg>

--- a/lib/node_modules/@stdlib/stats/incr/nanhmean/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/incr/nanhmean/docs/repl.txt
@@ -1,0 +1,31 @@
+
+{{alias}}()
+    Returns an accumulator function which incrementally computes a harmonic
+    mean, ignoring NaN values.
+
+    If provided a value, the accumulator function returns an updated harmonic
+    mean. If not provided a value, the accumulator function returns the current
+    harmonic mean.
+
+    Returns
+    -------
+    acc: Function
+        Accumulator function.
+
+    Examples
+    --------
+    > var accumulator = {{alias}}();
+    > var v = accumulator()
+    null
+    > v = accumulator( 2.0 )
+    2.0
+    > v = accumulator( NaN )
+    2.0
+    > v = accumulator( 5.0 )
+    ~2.86
+    > v = accumulator()
+    ~2.86
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/stats/incr/nanhmean/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/incr/nanhmean/docs/types/index.d.ts
@@ -1,0 +1,59 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+/**
+* If provided a value, returns an updated harmonic mean; otherwise, returns the current harmonic mean.
+*
+* @param x - value
+* @returns harmonic mean
+*/
+type accumulator = ( x?: number ) => number | null;
+
+/**
+* Returns an accumulator function which incrementally computes a harmonic mean, ignoring `NaN` values.
+*
+* @returns accumulator function
+*
+* @example
+* var accumulator = incrnanhmean();
+*
+* var v = accumulator();
+* // returns null
+*
+* v = accumulator( 2.0 );
+* // returns 2.0
+*
+* v = accumulator( NaN );
+* // returns 2.0
+*
+* v = accumulator( 5.0 );
+* // returns ~2.86
+*
+* v = accumulator();
+* // returns ~2.86
+*/
+declare function incrnanhmean(): accumulator;
+
+
+// EXPORTS //
+
+export = incrnanhmean;

--- a/lib/node_modules/@stdlib/stats/incr/nanhmean/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/incr/nanhmean/docs/types/test.ts
@@ -1,0 +1,61 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import incrnanhmean = require( './index' );
+
+
+// TESTS //
+
+// The function returns an accumulator function...
+{
+	incrnanhmean(); // $ExpectType accumulator
+}
+
+// The compiler throws an error if the function is provided arguments...
+{
+	incrnanhmean( '5' ); // $ExpectError
+	incrnanhmean( 5 ); // $ExpectError
+	incrnanhmean( true ); // $ExpectError
+	incrnanhmean( false ); // $ExpectError
+	incrnanhmean( null ); // $ExpectError
+	incrnanhmean( undefined ); // $ExpectError
+	incrnanhmean( [] ); // $ExpectError
+	incrnanhmean( {} ); // $ExpectError
+	incrnanhmean( ( x: number ): number => x ); // $ExpectError
+}
+
+// The function returns an accumulator function which returns an accumulated result...
+{
+	const acc = incrnanhmean();
+
+	acc(); // $ExpectType number | null
+	acc( 3.14 ); // $ExpectType number | null
+}
+
+// The compiler throws an error if the returned accumulator function is provided invalid arguments...
+{
+	const acc = incrnanhmean();
+
+	acc( '5' ); // $ExpectError
+	acc( true ); // $ExpectError
+	acc( false ); // $ExpectError
+	acc( null ); // $ExpectError
+	acc( [] ); // $ExpectError
+	acc( {} ); // $ExpectError
+	acc( ( x: number ): number => x ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/stats/incr/nanhmean/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanhmean/examples/index.js
@@ -18,26 +18,21 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/base/uniform' );
+var bernoulli = require( '@stdlib/random/base/bernoulli' );
 var incrnanhmean = require( './../lib' );
 
-var accumulator;
-var mu;
-var v;
-var i;
-
 // Initialize an accumulator:
-accumulator = incrnanhmean();
+var accumulator = incrnanhmean();
 
 // For each simulated datum, update the harmonic mean...
 console.log( '\nValue\tHarmonic Mean\n' );
+var mu;
+var v;
+var i;
 for ( i = 0; i < 100; i++ ) {
-	if ( randu() < 0.2 ) {
-		v = NaN;
-	} else {
-		v = ( randu()*100.0 );
-	}
+	v = ( bernoulli( 0.2 ) ) ? NaN : uniform( 1.0, 100.0 );
 	mu = accumulator( v );
-	console.log( '%d\t%d', ( v === null) ? NaN : v.toFixed( 4 ), ( mu === null) ? NaN : mu.toFixed( 4 ) );
+	console.log( '%d\t%d', v.toFixed( 4 ), ( mu === null ) ? NaN : mu.toFixed( 4 ) );
 }
 console.log( '\nFinal harmonic mean: %d\n', accumulator() );

--- a/lib/node_modules/@stdlib/stats/incr/nanhmean/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanhmean/examples/index.js
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var randu = require( '@stdlib/random/base/randu' );
+var incrnanhmean = require( './../lib' );
+
+var accumulator;
+var mu;
+var v;
+var i;
+
+// Initialize an accumulator:
+accumulator = incrnanhmean();
+
+// For each simulated datum, update the harmonic mean...
+console.log( '\nValue\tHarmonic Mean\n' );
+for ( i = 0; i < 100; i++ ) {
+	if ( randu() < 0.2 ) {
+		v = NaN;
+	} else {
+		v = ( randu()*100.0 );
+	}
+	mu = accumulator( v );
+	console.log( '%d\t%d', ( v === null) ? NaN : v.toFixed( 4 ), ( mu === null) ? NaN : mu.toFixed( 4 ) );
+}
+console.log( '\nFinal harmonic mean: %d\n', accumulator() );

--- a/lib/node_modules/@stdlib/stats/incr/nanhmean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanhmean/lib/index.js
@@ -1,0 +1,54 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Compute a harmonic mean incrementally, ignoring `NaN` values.
+*
+* @module @stdlib/stats/incr/nanhmean
+*
+* @example
+* var incrnanhmean = require( '@stdlib/stats/incr/nanhmean' );
+*
+* var accumulator = incrnanhmean();
+*
+* var v = accumulator();
+* // returns null
+*
+* v = accumulator( 2.0 );
+* // returns 2.0
+*
+* v = accumulator( NaN );
+* // returns 2.0
+*
+* v = accumulator( 5.0 );
+* // returns ~2.86
+*
+* v = accumulator();
+* // returns ~2.86
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/incr/nanhmean/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanhmean/lib/main.js
@@ -80,10 +80,10 @@ function incrnanhmean() {
 	* @returns {(number|null)} harmonic mean or null
 	*/
 	function accumulator( x ) {
-		if ( arguments.length === 0 || isnan( x )) {
+		if ( arguments.length === 0 || isnan( x ) ) {
 			return hmean();
 		}
-		return hmean(x);
+		return hmean( x );
 	}
 }
 

--- a/lib/node_modules/@stdlib/stats/incr/nanhmean/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanhmean/lib/main.js
@@ -1,0 +1,93 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var incrhmean = require( '@stdlib/stats/incr/hmean' );
+
+
+// MAIN //
+
+/**
+* Returns an accumulator function which incrementally computes a harmonic mean, ignoring `NaN` values.
+*
+* ## Method
+*
+* -   The harmonic mean of positive real numbers \\(x_0, x_1, \ldots, x_{n-1}\\) is defined as
+*
+*     ```tex
+*     \begin{align*}
+*     H &= \frac{n}{\frac{1}{x_0} + \frac{1}{x_1} + \cdots + \frac{1}{x_{n-1}}} \\
+*       &= \frac{n}{\sum_{i=0}^{n-1} \frac{1}{x_i}}
+*     \end{align*}
+*     ```
+*
+*     which may be expressed
+*
+*     ```tex
+*     H = \biggl( \frac{\sum_{i=0}^{n-1} \frac{1}{x_i}}{n} \biggr)^{-1}
+*     ```
+*
+* -   Accordingly, to compute the harmonic mean incrementally, we can simply compute the arithmetic mean of reciprocal values and then compute the reciprocal of the result.
+*
+* @returns {Function} accumulator function
+*
+* @example
+* var accumulator = incrnanhmean();
+*
+* var v = accumulator();
+* // returns null
+*
+* v = accumulator( 2.0 );
+* // returns 2.0
+*
+* v = accumulator( NaN );
+* // returns 2.0
+*
+* v = accumulator( 5.0 );
+* // returns ~2.86
+*
+* v = accumulator();
+* // returns ~2.86
+*/
+function incrnanhmean() {
+	var hmean = incrhmean();
+	return accumulator;
+
+	/**
+	* If provided a value, the accumulator function returns an updated harmonic mean. If not provided a value, the accumulator function returns the current harmonic mean.
+	*
+	* @private
+	* @param {number} [x] - new value
+	* @returns {(number|null)} harmonic mean or null
+	*/
+	function accumulator( x ) {
+		if ( arguments.length === 0 || isnan( x )) {
+			return hmean();
+		}
+		return hmean(x);
+	}
+}
+
+
+// EXPORTS //
+
+module.exports = incrnanhmean;

--- a/lib/node_modules/@stdlib/stats/incr/nanhmean/package.json
+++ b/lib/node_modules/@stdlib/stats/incr/nanhmean/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stdlib/stats/incr/nanhmean",
   "version": "0.0.0",
-  "description": "Compute a harmonic mean incrementally.",
+  "description": "Compute a harmonic mean incrementally, ignoring NaN values.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",
@@ -62,6 +62,8 @@
     "harmonic mean",
     "central tendency",
     "incremental",
-    "accumulator"
+    "accumulator",
+    "nan",
+    "ignore"
   ]
 }

--- a/lib/node_modules/@stdlib/stats/incr/nanhmean/package.json
+++ b/lib/node_modules/@stdlib/stats/incr/nanhmean/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@stdlib/stats/incr/nanhmean",
+  "version": "0.0.0",
+  "description": "Compute a harmonic mean incrementally.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "statistics",
+    "stats",
+    "mathematics",
+    "math",
+    "average",
+    "avg",
+    "harmonic",
+    "mean",
+    "harmonic mean",
+    "central tendency",
+    "incremental",
+    "accumulator"
+  ]
+}

--- a/lib/node_modules/@stdlib/stats/incr/nanhmean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanhmean/test/test.js
@@ -24,7 +24,7 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var abs = require( '@stdlib/math/base/special/abs' );
 var EPSILON = require( '@stdlib/constants/float64/eps' );
-var incrnanhmean = require( '@stdlib/stats/incr/nanhmean/lib' );
+var incrnanhmean = require( './../lib' );
 
 
 // TESTS //
@@ -68,10 +68,10 @@ tape( 'the accumulator function incrementally computes a harmonic mean', functio
 	j = 0;
 	for ( i = 0; i < N; i++ ) {
 		d = data[ i ];
-		if ( !isnan(d) ) {
+		if ( !isnan( d ) ) {
 			sum += 1.0 / d;
 			expected = (j+1) / sum;
-			j+=1;
+			j += 1;
 		}
 		actual = acc( d );
 		if ( actual === expected ) {

--- a/lib/node_modules/@stdlib/stats/incr/nanhmean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanhmean/test/test.js
@@ -1,0 +1,100 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var abs = require( '@stdlib/math/base/special/abs' );
+var EPSILON = require( '@stdlib/constants/float64/eps' );
+var incrnanhmean = require( '@stdlib/stats/incr/nanhmean/lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof incrnanhmean, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns an accumulator function', function test( t ) {
+	t.equal( typeof incrnanhmean(), 'function', 'returns a function' );
+	t.end();
+});
+
+tape( 'the initial accumulated value is null', function test( t ) {
+	var acc = incrnanhmean();
+	t.equal( acc(), null, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the accumulator function incrementally computes a harmonic mean', function test( t ) {
+	var expected;
+	var actual;
+	var delta;
+	var data;
+	var tol;
+	var acc;
+	var sum;
+	var N;
+	var d;
+	var i;
+	var j;
+
+	data = [ 2.0, 3.0, NaN, 2.0, 4.0, NaN, 3.0, 4.0 ];
+	N = data.length;
+
+	acc = incrnanhmean();
+
+	sum = 0;
+	j = 0;
+	for ( i = 0; i < N; i++ ) {
+		d = data[ i ];
+		if ( !isnan(d) ) {
+			sum += 1.0 / d;
+			expected = (j+1) / sum;
+			j+=1;
+		}
+		actual = acc( d );
+		if ( actual === expected ) {
+			t.strictEqual( actual, expected, 'returns expected result' );
+		} else {
+			delta = abs( expected - actual );
+			tol = EPSILON * expected;
+			t.strictEqual( delta <= tol, true, 'within tolerance. Expected: '+expected+'. Actual: '+actual+'. Delta: '+delta+'. Tol: '+tol+'.' );
+		}
+	}
+	t.end();
+});
+
+tape( 'if not provided an input value, the accumulator function returns the current harmonic mean', function test( t ) {
+	var data;
+	var acc;
+	var i;
+
+	data = [ 2.0, 3.0, 1.0 ];
+	acc = incrnanhmean();
+	for ( i = 0; i < data.length; i++ ) {
+		acc( data[ i ] );
+	}
+	t.equal( acc(), 1.6363636363636365, 'returns the current accumulated harmonic mean' );
+	t.end();
+});


### PR DESCRIPTION
Resolves #5560 

## Description

> What is the purpose of this pull request?

This pull request:

-   introduces the @stdlib/stats/incr/nanhmean package, which incrementally computes a harmonic mean, ignoring `NaN` values.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #5560 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
