### PR TITLE
feat: add `toSorted` method to `array/fixed-endian-factory`

### DIFF
--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/README.md
@@ -903,6 +903,73 @@ var str = arr.toString();
 // returns '1,2,3'
 ```
 
+<a name="method-to-sorted"></a>
+
+#### TypedArrayFE.prototype.toSorted( \[compareFn] )
+
+Returns a new array with the elements sorted.
+
+```javascript
+var Float64ArrayFE = fixedEndianFactory( 'float64' );
+
+var arr = new Float64ArrayFE( 'little-endian', [ 3.0, 1.0, 2.0 ] );
+// returns <Float64ArrayFE>
+
+var out = arr.toSorted();
+// returns <Float64ArrayFE>
+
+var len = out.length;
+// returns 3
+
+var v = out.get( 0 );
+// returns 1.0
+
+v = out.get( 1 );
+// returns 2.0
+
+v = out.get( 2 );
+// returns 3.0
+```
+
+By default, the method sorts array elements in ascending order. To specify a custom sort order, provide a `compareFn`.
+
+```javascript
+function descending( a, b ) {
+    return b - a;
+}
+
+var Float64ArrayFE = fixedEndianFactory( 'float64' );
+
+var arr = new Float64ArrayFE( 'little-endian', [ 3.0, 1.0, 2.0 ] );
+// returns <Float64ArrayFE>
+
+var out = arr.toSorted( descending );
+// returns <Float64ArrayFE>
+
+var len = out.length;
+// returns 3
+
+var v = out.get( 0 );
+// returns 3.0
+
+v = out.get( 1 );
+// returns 2.0
+
+v = out.get( 2 );
+// returns 1.0
+```
+
+The comparison function is provided two arguments:
+
+-   **a**: first element for comparison.
+-   **b**: second element for comparison.
+
+The function should return a number where:
+
+-   a negative value indicates that `a` should come before `b`.
+-   a positive value indicates that `a` should come after `b`.
+-   zero or `NaN` indicates that `a` and `b` are considered equal.
+
 <a name="method-join"></a>
 
 #### TypedArrayFE.prototype.join( \[separator] )

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.to_sorted.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.to_sorted.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.to_sorted.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.to_sorted.js
@@ -1,0 +1,59 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isTypedArrayLike = require( '@stdlib/assert/is-typed-array-like' );
+var pkg = require( './../package.json' ).name;
+var factory = require( './../lib' );
+
+
+// VARIABLES //
+
+var Float64ArrayFE = factory( 'float64' );
+
+
+// MAIN //
+
+bench( pkg+':toSorted', function benchmark( b ) {
+	var arr;
+	var out;
+	var i;
+
+	arr = new Float64ArrayFE( 'little-endian', [ 3.0, 1.0, 2.0 ] );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		out = arr.toSorted();
+		if ( typeof out !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+	if ( !isTypedArrayLike( out ) ) {
+		b.fail( 'should return a typed array' );
+	}
+	if ( out.length !== 3 ) {
+		b.fail( 'should have expected length' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.to_sorted.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.to_sorted.length.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.to_sorted.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.to_sorted.length.js
@@ -1,0 +1,103 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var zeroTo = require( '@stdlib/array/zero-to' );
+var isTypedArrayLike = require( '@stdlib/assert/is-typed-array-like' );
+var pkg = require( './../package.json' ).name;
+var factory = require( './../lib' );
+
+
+// VARIABLES //
+
+var Float64ArrayFE = factory( 'float64' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var arr = new Float64ArrayFE( 'little-endian', zeroTo( len ) );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var out;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			out = arr.toSorted();
+			if ( typeof out !== 'object' ) {
+				b.fail( 'should return an object' );
+			}
+		}
+		b.toc();
+		if ( !isTypedArrayLike( out ) ) {
+			b.fail( 'should return a typed array' );
+		}
+		if ( out.length !== len ) {
+			b.fail( 'should have expected length' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':toSorted:len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/lib/main.js
@@ -1096,6 +1096,51 @@ function factory( dtype ) { // eslint-disable-line max-lines-per-function, stdli
 	});
 
 	/**
+	* Returns a new array with the elements sorted in ascending order.
+	*
+	* @private
+	* @name toSorted
+	* @memberof TypedArray.prototype
+	* @type {Function}
+	* @param {Function} [comparefn] - function that defines the sort order
+	* @throws {TypeError} `this` must be a typed array instance
+	* @throws {TypeError} callback argument must be a function
+	* @returns {TypedArray} new typed array
+	*/
+	setReadOnly( TypedArray.prototype, 'toSorted', function toSorted( comparefn ) {
+		var obuf;
+		var temp;
+		var buf;
+		var len;
+		var out;
+		var i;
+
+		if ( !isTypedArray( this ) ) {
+			throw new TypeError( format( 'invalid invocation. `this` is not %s %s.', CHAR2ARTICLE[ dtype[0] ], CTOR_NAME ) );
+		}
+		if ( arguments.length > 0 && !isFunction( comparefn ) ) {
+			throw new TypeError( format( 'invalid argument. Comparison function must be a function. Value: `%s`.', comparefn ) );
+		}
+		buf = this._buffer;
+		len = this._length;
+		temp = [];
+		for ( i = 0; i < len; i++ ) {
+			temp.push( buf[ GETTER ]( i * BYTES_PER_ELEMENT, this._isLE ) );
+		}
+		if ( arguments.length === 0 ) {
+			temp.sort();
+		} else {
+			temp.sort( comparefn );
+		}
+		out = new this.constructor( flag2byteOrder( this._isLE ), len );
+		obuf = out._buffer;  // eslint-disable-line no-underscore-dangle
+		for ( i = 0; i < len; i++ ) {
+			obuf[ SETTER ]( i * BYTES_PER_ELEMENT, temp[i], obuf );
+		}
+		return out;
+	});
+
+	/**
 	* Serializes an array as a string.
 	*
 	* @private

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/test/test.to_sorted.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/test/test.to_sorted.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/test/test.to_sorted.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/test/test.to_sorted.js
@@ -1,0 +1,170 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var factory = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof factory, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns a function', function test( t ) {
+	var ctor = factory( 'float64' );
+	t.strictEqual( isFunction( ctor ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'attached to the prototype of the returned function is a `toSorted` method', function test( t ) {
+	var ctor = factory( 'float64' );
+	t.strictEqual( hasOwnProp( ctor.prototype, 'toSorted' ), true, 'returns expected value' );
+	t.strictEqual( isFunction( ctor.prototype.toSorted ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a typed array instance', function test( t ) {
+	var values;
+	var ctor;
+	var i;
+
+	ctor = factory( 'float64' );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided ' + values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return ctor.prototype.toSorted.call( value );
+		};
+	}
+});
+
+tape( 'the method throws an error if provided a first argument which is not a function', function test( t ) {
+	var values;
+	var ctor;
+	var arr;
+	var i;
+
+	ctor = factory( 'float64' );
+	arr = new ctor( 'little-endian', [ 1.0, 2.0, 3.0 ] );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[]
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided ' + values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return arr.toSorted( value );
+		};
+	}
+});
+
+tape( 'the method returns an empty array if operating on an empty array', function test( t ) {
+	var expected;
+	var actual;
+	var ctor;
+	var arr;
+
+	ctor = factory( 'float64' );
+
+	arr = new ctor( 'little-endian' );
+	expected = new ctor( 'little-endian' );
+	actual = arr.toSorted();
+
+	t.strictEqual( actual.length, 0, 'returns expected value' );
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method sorts an array (default)', function test( t ) {
+	var expected;
+	var actual;
+	var ctor;
+	var arr;
+
+	ctor = factory( 'float64' );
+
+	arr = new ctor( 'little-endian', [ 3.0, 1.0, 2.0 ] );
+	expected = new ctor( 'little-endian', [ 1.0, 2.0, 3.0 ] );
+	actual = arr.toSorted();
+
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.notEqual( actual, arr, 'returns a new array' );
+	t.deepEqual( arr, new ctor( 'little-endian', [ 3.0, 1.0, 2.0 ] ), 'does not modify original array' );
+	t.end();
+});
+
+tape( 'the method sorts an array (custom comparison function)', function test( t ) {
+	var expected;
+	var actual;
+	var ctor;
+	var arr;
+
+	ctor = factory( 'float64' );
+
+	arr = new ctor( 'little-endian', [ 3.0, 1.0, 2.0 ] );
+	expected = new ctor( 'little-endian', [ 3.0, 2.0, 1.0 ] );
+	actual = arr.toSorted( descending );
+
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.notEqual( actual, arr, 'returns a new array' );
+	t.deepEqual( arr, new ctor( 'little-endian', [ 3.0, 1.0, 2.0 ] ), 'does not modify original array' );
+	t.end();
+
+	function descending( a, b ) {
+		return b - a;
+	}
+});


### PR DESCRIPTION
Ref #3160

## Description

> What is the purpose of this pull request?

This pull request:

-   adds support for a toSorted method to [@stdlib/array/fixed-endian-factory](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/fixed-endian-factory).

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   ref https://github.com/stdlib-js/stdlib/issues/3160

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
