### PR TITLE
feat: add `constants/float32/max-safe-nth-tribonacci`

### DIFF
--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/README.md
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/README.md
@@ -1,0 +1,183 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2025 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# FLOAT32_MAX_SAFE_NTH_TRIBONACCI
+
+> Maximum safe nth [Tribonacci number][tribonacci-number] when stored in [single-precision floating-point][ieee754] format.
+
+<section class="usage">
+
+## Usage
+
+<!-- eslint-disable id-length -->
+
+```javascript
+var FLOAT32_MAX_SAFE_NTH_TRIBONACCI = require( '@stdlib/constants/float32/max-safe-nth-tribonacci' );
+```
+
+#### FLOAT32_MAX_SAFE_NTH_TRIBONACCI
+
+Maximum [safe][safe-integers] nth [Tribonacci number][tribonacci-number] when stored in [single-precision floating-point][ieee754] format.
+
+<!-- eslint-disable id-length -->
+
+```javascript
+var bool = ( FLOAT32_MAX_SAFE_NTH_TRIBONACCI === 35 );
+// returns true
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint-disable id-length -->
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var FLOAT32_MAX_SAFE_NTH_TRIBONACCI = require( '@stdlib/constants/float32/max-safe-nth-tribonacci' );
+
+function tribonacci( n ) {
+    var a;
+    var b;
+    var c;
+    var d;
+    var i;
+
+    a = 0;
+    b = 0;
+    c = 1;
+    if ( n === 0 ) {
+        return a;
+    }
+    if ( n === 1 ) {
+        return b;
+    }
+    if ( n === 2 ) {
+        return c;
+    }
+    for ( i = 3; i <= n; i++ ) {
+        d = a + b + c;
+        a = b;
+        b = c;
+        c = d;
+    }
+    return c;
+}
+
+var v;
+var i;
+for ( i = 0; i < 100; i++ ) {
+    v = tribonacci( i );
+    if ( i > FLOAT32_MAX_SAFE_NTH_TRIBONACCI ) {
+        console.log( 'Unsafe: %d', v );
+    } else {
+        console.log( 'Safe:   %d', v );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/constants/float32/max_safe_nth_tribonacci.h"
+```
+
+#### STDLIB_CONSTANT_FLOAT32_MAX_SAFE_NTH_TRIBONACCI
+
+Maximum [safe][safe-integers] nth [Tribonacci number][tribonacci-number] when stored in [single-precision floating-point][ieee754] format.
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[safe-integers]: http://www.2ality.com/2013/10/safe-integers.html
+
+[tribonacci-number]: https://en.wikipedia.org/wiki/Tribonacci_number
+
+[ieee754]: https://en.wikipedia.org/wiki/IEEE_754-1985
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/README.md
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/README.md
@@ -39,7 +39,7 @@ Maximum [safe][safe-integers] nth [Tribonacci number][tribonacci-number] when st
 <!-- eslint-disable id-length -->
 
 ```javascript
-var bool = ( FLOAT32_MAX_SAFE_NTH_TRIBONACCI === 35 );
+var bool = ( FLOAT32_MAX_SAFE_NTH_TRIBONACCI === 30 );
 // returns true
 ```
 

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/docs/repl.txt
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/docs/repl.txt
@@ -6,7 +6,7 @@
     Examples
     --------
     > {{alias}}
-    35
+    30
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/docs/repl.txt
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/docs/repl.txt
@@ -1,0 +1,13 @@
+
+{{alias}}
+    Maximum safe nth Tribonacci number when stored in single-precision
+    floating-point format.
+
+    Examples
+    --------
+    > {{alias}}
+    35
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/docs/types/index.d.ts
@@ -1,0 +1,33 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Maximum safe nth Tribonacci number when stored in single-precision floating-point format.
+*
+* @example
+* var max = FLOAT32_MAX_SAFE_NTH_TRIBONACCI;
+* // returns 35
+*/
+declare const FLOAT32_MAX_SAFE_NTH_TRIBONACCI: number;
+
+
+// EXPORTS //
+
+export = FLOAT32_MAX_SAFE_NTH_TRIBONACCI;

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/docs/types/index.d.ts
@@ -23,7 +23,7 @@
 *
 * @example
 * var max = FLOAT32_MAX_SAFE_NTH_TRIBONACCI;
-* // returns 35
+* // returns 30
 */
 declare const FLOAT32_MAX_SAFE_NTH_TRIBONACCI: number;
 

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/docs/types/test.ts
@@ -1,0 +1,28 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import FLOAT32_MAX_SAFE_NTH_TRIBONACCI = require( './index' );
+
+
+// TESTS //
+
+// The export is a number...
+{
+	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+	FLOAT32_MAX_SAFE_NTH_TRIBONACCI; // $ExpectType number
+}

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/examples/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/examples/index.js
@@ -1,0 +1,60 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var FLOAT32_MAX_SAFE_NTH_TRIBONACCI = require( './../lib' ); // eslint-disable-line id-length
+
+function tribonacci( n ) {
+	var a;
+	var b;
+	var c;
+	var d;
+	var i;
+
+	a = 0;
+	b = 0;
+	c = 1;
+	if ( n === 0 ) {
+		return a;
+	}
+	if ( n === 1 ) {
+		return b;
+	}
+	if ( n === 2 ) {
+		return c;
+	}
+	for ( i = 3; i <= n; i++ ) {
+		d = a + b + c;
+		a = b;
+		b = c;
+		c = d;
+	}
+	return c;
+}
+
+var v;
+var i;
+for ( i = 0; i < 100; i++ ) {
+	v = tribonacci( i );
+	if ( i > FLOAT32_MAX_SAFE_NTH_TRIBONACCI ) {
+		console.log( 'Unsafe: %d', v );
+	} else {
+		console.log( 'Safe:   %d', v );
+	}
+}

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/include/stdlib/constants/float32/max_safe_nth_tribonacci.h
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/include/stdlib/constants/float32/max_safe_nth_tribonacci.h
@@ -22,6 +22,6 @@
 /**
 * Maximum safe nth Tribonacci number when stored in single-precision floating-point format.
 */
-#define STDLIB_CONSTANT_FLOAT32_MAX_SAFE_NTH_TRIBONACCI 35
+#define STDLIB_CONSTANT_FLOAT32_MAX_SAFE_NTH_TRIBONACCI 30
 
 #endif // !STDLIB_CONSTANTS_FLOAT32_MAX_SAFE_NTH_TRIBONACCI_H

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/include/stdlib/constants/float32/max_safe_nth_tribonacci.h
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/include/stdlib/constants/float32/max_safe_nth_tribonacci.h
@@ -1,0 +1,27 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_CONSTANTS_FLOAT32_MAX_SAFE_NTH_TRIBONACCI_H
+#define STDLIB_CONSTANTS_FLOAT32_MAX_SAFE_NTH_TRIBONACCI_H
+
+/**
+* Maximum safe nth Tribonacci number when stored in single-precision floating-point format.
+*/
+#define STDLIB_CONSTANT_FLOAT32_MAX_SAFE_NTH_TRIBONACCI 35
+
+#endif // !STDLIB_CONSTANTS_FLOAT32_MAX_SAFE_NTH_TRIBONACCI_H

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/lib/index.js
@@ -1,0 +1,49 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Maximum safe nth Tribonacci number when stored in single-precision floating-point format.
+*
+* @module @stdlib/constants/float32/max-safe-nth-tribonacci
+* @type {integer}
+*
+* @example
+* var FLOAT32_MAX_SAFE_NTH_TRIBONACCI = require( '@stdlib/constants/float32/max-safe-nth-tribonacci' );
+* // returns 35
+*/
+
+
+// MAIN //
+
+/**
+* Maximum safe nth Tribonacci number when stored in single-precision floating-point format.
+*
+* @constant
+* @type {integer}
+* @default 35
+* @see [Tribonacci number]{@link https://en.wikipedia.org/wiki/Tribonacci_number}
+* @see [IEEE 754]{@link https://en.wikipedia.org/wiki/IEEE_754-1985}
+*/
+var FLOAT32_MAX_SAFE_NTH_TRIBONACCI = 35|0; // eslint-disable-line id-length
+
+
+// EXPORTS //
+
+module.exports = FLOAT32_MAX_SAFE_NTH_TRIBONACCI;

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/lib/index.js
@@ -26,7 +26,7 @@
 *
 * @example
 * var FLOAT32_MAX_SAFE_NTH_TRIBONACCI = require( '@stdlib/constants/float32/max-safe-nth-tribonacci' );
-* // returns 35
+* // returns 30
 */
 
 
@@ -37,11 +37,11 @@
 *
 * @constant
 * @type {integer}
-* @default 35
+* @default 30
 * @see [Tribonacci number]{@link https://en.wikipedia.org/wiki/Tribonacci_number}
 * @see [IEEE 754]{@link https://en.wikipedia.org/wiki/IEEE_754-1985}
 */
-var FLOAT32_MAX_SAFE_NTH_TRIBONACCI = 35|0; // eslint-disable-line id-length
+var FLOAT32_MAX_SAFE_NTH_TRIBONACCI = 30|0; // eslint-disable-line id-length
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/manifest.json
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/manifest.json
@@ -1,0 +1,36 @@
+{
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": []
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/package.json
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/package.json
@@ -60,8 +60,6 @@
     "trib",
     "safe",
     "integer",
-    "double",
-    "dbl",
     "floating",
     "point",
     "floating-point",

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/package.json
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@stdlib/constants/float32/max-safe-nth-tribonacci",
+  "version": "0.0.0",
+  "description": "Maximum safe nth Tribonacci number when stored in single-precision floating-point format.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "constant",
+    "const",
+    "max",
+    "maximum",
+    "tribonacci",
+    "number",
+    "trib",
+    "safe",
+    "integer",
+    "double",
+    "dbl",
+    "floating",
+    "point",
+    "floating-point",
+    "float",
+    "float32",
+    "f32",
+    "ieee754"
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/test/test.js
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/test/test.js
@@ -32,7 +32,7 @@ tape( 'main export is a number', function test( t ) {
 	t.end();
 });
 
-tape( 'the exported value is 35', function test( t ) {
-	t.strictEqual( FLOAT32_MAX_SAFE_NTH_TRIBONACCI, 35, 'returns expected value' );
+tape( 'the exported value is 30', function test( t ) {
+	t.strictEqual( FLOAT32_MAX_SAFE_NTH_TRIBONACCI, 30, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/test/test.js
+++ b/lib/node_modules/@stdlib/constants/float32/max-safe-nth-tribonacci/test/test.js
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var FLOAT32_MAX_SAFE_NTH_TRIBONACCI = require( './../lib' ); // eslint-disable-line id-length
+
+
+// TESTS //
+
+tape( 'main export is a number', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof FLOAT32_MAX_SAFE_NTH_TRIBONACCI, 'number', 'main export is a number' );
+	t.end();
+});
+
+tape( 'the exported value is 35', function test( t ) {
+	t.strictEqual( FLOAT32_MAX_SAFE_NTH_TRIBONACCI, 35, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
Resolves #6050.

## Description

> What is the purpose of this pull request?

This pull request:

-   adds `constants/float32/max-safe-nth-tribonacci` to expand the scope for float32 operations.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #6050 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-  [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
