### PR TITLE
refactor(stats/base/cuminabs): add accessor protocol support

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/cuminabs/README.md
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/README.md
@@ -135,7 +135,6 @@ cuminabs.ndarray( 4, x, 2, 1, y, -1, y.length-1 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var Float64Array = require( '@stdlib/array/float64' );
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var cuminabs = require( '@stdlib/stats/base/cuminabs' );
 
@@ -144,15 +143,6 @@ var x = discreteUniform( 10, 0, 100, {
 });
 var y = new Float64Array( x.length );
 
-var y;
-var x;
-var i;
-
-x = new Float64Array( 10 );
-y = new Float64Array( x.length );
-for ( i = 0; i < x.length; i++ ) {
-    x[ i ] = round( randu()*100.0 );
-}
 console.log( x );
 console.log( y );
 

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/README.md
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/README.md
@@ -52,11 +52,11 @@ The function has the following parameters:
 
 -   **N**: number of indexed elements.
 -   **x**: input [`Array`][mdn-array] or [`typed array`][mdn-typed-array].
--   **strideX**: index increment for `x`.
+-   **strideX**: stride length for `x`.
 -   **y**: output [`Array`][mdn-array] or [`typed array`][mdn-typed-array].
--   **strideY**: index increment for `y`.
+-   **strideY**: stride length for `y`.
 
-The `N` and `stride` parameters determine which elements in `x` and `y` are accessed at runtime. For example, to compute the cumulative minimum absolute value of every other element in `x`,
+The `N` and stride parameters determine which elements in the strided arrays are accessed at runtime. For example, to compute the cumulative minimum absolute value of every other element in `x`,
 
 ```javascript
 var x = [ 1.0, 2.0, 2.0, -7.0, -2.0, 3.0, 4.0, 2.0 ];
@@ -102,7 +102,7 @@ The function has the following additional parameters:
 -   **offsetX**: starting index for `x`.
 -   **offsetY**: starting index for `y`.
 
-While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying `buffer`, `offsetX` and `offsetY` parameters support indexing semantics based on a starting indices. For example, to calculate the cumulative minimum absolute value of every other value in `x` starting from the second value and to store in the last `N` elements of `y` starting from the last element
+While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying buffer, offset parameters support indexing semantics based on a starting indices. For example, to calculate the cumulative minimum absolute value of every other value in `x` starting from the second value and to store in the last `N` elements of `y` starting from the last element
 
 ```javascript
 var x = [ 2.0, 1.0, 2.0, -2.0, -2.0, 2.0, 3.0, 4.0 ];
@@ -122,6 +122,7 @@ cuminabs.ndarray( 4, x, 2, 1, y, -1, y.length-1 );
 
 -   If `N <= 0`, both functions return `y` unchanged.
 -   Depending on the environment, the typed versions ([`dcuminabs`][@stdlib/stats/strided/dcuminabs], [`scuminabs`][@stdlib/stats/base/scuminabs], etc.) are likely to be significantly more performant.
+-   Both functions support array-like objects having getter and setter accessors for array element access (e.g., [`@stdlib/array/base/accessor`][@stdlib/array/base/accessor]).
 
 </section>
 
@@ -134,10 +135,14 @@ cuminabs.ndarray( 4, x, 2, 1, y, -1, y.length-1 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
 var Float64Array = require( '@stdlib/array/float64' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var cuminabs = require( '@stdlib/stats/base/cuminabs' );
+
+var x = discreteUniform( 10, 0, 100, {
+    'dtype': 'float64'
+});
+var y = new Float64Array( x.length );
 
 var y;
 var x;
@@ -188,7 +193,10 @@ console.log( y );
 
 [mdn-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array
 
+[@stdlib/array/base/accessor]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/base/accessor
+
 [mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
+
 
 <!-- <related-links> -->
 

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/README.md
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/README.md
@@ -102,7 +102,7 @@ The function has the following additional parameters:
 -   **offsetX**: starting index for `x`.
 -   **offsetY**: starting index for `y`.
 
-While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying buffer, offset parameters support indexing semantics based on a starting indices. For example, to calculate the cumulative minimum absolute value of every other value in `x` starting from the second value and to store in the last `N` elements of `y` starting from the last element
+While [`typed array`][mdn-typed-array] views mandate a view offset based on the underlying buffer, offset parameters support indexing semantics based on a starting indices. For example, to calculate the cumulative minimum absolute value of every other element in `x` starting from the second element and to store in the last `N` elements of `y` starting from the last element
 
 ```javascript
 var x = [ 2.0, 1.0, 2.0, -2.0, -2.0, 2.0, 3.0, 4.0 ];
@@ -142,9 +142,9 @@ var Float64Array = require( '@stdlib/array/float64' );
 var x = discreteUniform( 10, 0, 100, {
     'dtype': 'float64'
 });
-var y = new Float64Array( x.length );
-
 console.log( x );
+
+var y = new Float64Array( x.length );
 console.log( y );
 
 cuminabs( x.length, x, 1, y, -1 );

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/README.md
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/README.md
@@ -137,6 +137,7 @@ cuminabs.ndarray( 4, x, 2, 1, y, -1, y.length-1 );
 ```javascript
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var cuminabs = require( '@stdlib/stats/base/cuminabs' );
+var Float64Array = require( '@stdlib/array/float64' );
 
 var x = discreteUniform( 10, 0, 100, {
     'dtype': 'float64'

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/README.md
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/README.md
@@ -188,7 +188,6 @@ console.log( y );
 
 [mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
 
-
 <!-- <related-links> -->
 
 [@stdlib/stats/base/cumaxabs]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/base/cumaxabs

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/benchmark/benchmark.js
@@ -21,11 +21,20 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var zeros = require( '@stdlib/array/zeros' );
+var gfill = require( '@stdlib/blas/ext/base/gfill' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var pkg = require( './../package.json' ).name;
 var cuminabs = require( './../lib/cuminabs.js' );
+
+
+// VARIABLES //
+
+var options = {
+	'dtype': 'generic'
+};
 
 
 // FUNCTIONS //
@@ -38,35 +47,25 @@ var cuminabs = require( './../lib/cuminabs.js' );
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var y;
-	var x;
-	var i;
-
-	x = [];
-	y = [];
-	for ( i = 0; i < len; i++ ) {
-		x.push( ( randu()*20.0 ) - 10.0 );
-		y.push( 0.0 );
-	}
+	var x = uniform( len, -10, 10, options );
+	var y = zeros( len, options.dtype );
 	return benchmark;
 
 	function benchmark( b ) {
 		var v;
 		var i;
 
-		for ( i = 0; i < len; i++ ) {
-			y[ i ] = 0.0;
-		}
+		gfill( len, 0.0, y, 1 );
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			x[ 0 ] += 1.0;
 			v = cuminabs( x.length, x, 1, y, 1 );
-			if ( isnan( v[ i%len ] ) ) {
+			if ( isnan( v[ i % len ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( v[ i%len ] ) ) {
+		if ( isnan( v[ i % len ] ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/benchmark/benchmark.ndarray.js
@@ -21,12 +21,20 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var zeros = require( '@stdlib/array/zeros' );
+var gfill = require( '@stdlib/blas/ext/base/gfill' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var pkg = require( './../package.json' ).name;
 var cuminabs = require( './../lib/ndarray.js' );
 
+
+// VARIABLES //
+
+var options = {
+	'dtype': 'generic'
+};
 
 // FUNCTIONS //
 
@@ -38,35 +46,25 @@ var cuminabs = require( './../lib/ndarray.js' );
 * @returns {Function} benchmark function
 */
 function createBenchmark( len ) {
-	var x;
-	var y;
-	var i;
-
-	x = [];
-	y = [];
-	for ( i = 0; i < len; i++ ) {
-		x.push( ( randu()*20.0 ) - 10.0 );
-		y.push( 0.0 );
-	}
+	var x = uniform( len, -10, 10, options );
+	var y = zeros( len, options.dtype );
 	return benchmark;
 
 	function benchmark( b ) {
 		var v;
 		var i;
 
-		for ( i = 0; i < len; i++ ) {
-			y[ i ] = 0.0;
-		}
+		gfill( len, 0.0, y, 1 );
 		b.tic();
 		for ( i = 0; i < b.iterations; i++ ) {
 			x[ 0 ] += 1.0;
 			v = cuminabs( x.length, x, 1, 0, y, 1, 0 );
-			if ( isnan( v[ i%len ] ) ) {
+			if ( isnan( v[ i % len ] ) ) {
 				b.fail( 'should not return NaN' );
 			}
 		}
 		b.toc();
-		if ( isnan( v[ i%len ] ) ) {
+		if ( isnan( v[ i % len ] ) ) {
 			b.fail( 'should not return NaN' );
 		}
 		b.pass( 'benchmark finished' );

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/benchmark/benchmark.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/benchmark/benchmark.ndarray.js
@@ -36,6 +36,7 @@ var options = {
 	'dtype': 'generic'
 };
 
+
 // FUNCTIONS //
 
 /**

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/docs/repl.txt
@@ -2,8 +2,8 @@
 {{alias}}( N, x, strideX, y, strideY )
     Computes the cumulative minimum absolute value of a strided array.
 
-    The `N` and stride parameters determine which elements in the strided arrays are
-    accessed at runtime.
+    The `N` and stride parameters determine which elements in the strided
+    arrays are accessed at runtime.
 
     Indexing is relative to the first index. To introduce an offset, use a typed
     array view.
@@ -55,6 +55,7 @@
     <Float64Array>[ 2.0, 2.0, 1.0 ]
     > y0
     <Float64Array>[ 0.0, 0.0, 0.0, 2.0, 2.0, 1.0 ]
+
 
 {{alias}}.ndarray( N, x, strideX, offsetX, y, strideY, offsetY )
     Computes the cumulative minimum absolute value of a strided array using

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/docs/repl.txt
@@ -2,7 +2,7 @@
 {{alias}}( N, x, strideX, y, strideY )
     Computes the cumulative minimum absolute value of a strided array.
 
-    The `N` and `stride` parameters determine which elements in `x` and `y` are
+    The `N` and stride parameters determine which elements in the strided arrays are
     accessed at runtime.
 
     Indexing is relative to the first index. To introduce an offset, use a typed
@@ -19,13 +19,13 @@
         Input array.
 
     strideX: integer
-        Index increment for `x`.
+        Stride length for `x`.
 
     y: Array<number>|TypedArray
         Output array.
 
     strideY: integer
-        Index increment for `y`.
+        Stride length for `y`.
 
     Returns
     -------
@@ -40,11 +40,10 @@
     > {{alias}}( x.length, x, 1, y, 1 )
     [ 1.0, 1.0, 1.0 ]
 
-    // Using `N` and `stride` parameters:
+    // Using `N` and stride parameters:
     > x = [ -2.0, 1.0, 1.0, -5.0, 2.0, -1.0 ];
     > y = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
-    > var N = {{alias:@stdlib/math/base/special/floor}}( x.length / 2 );
-    > {{alias}}( N, x, 2, y, 2 )
+    > {{alias}}( 3, x, 2, y, 2 )
     [ 2.0, 0.0, 1.0, 0.0, 1.0, 0.0 ]
 
     // Using view offsets:
@@ -52,8 +51,7 @@
     > var y0 = new {{alias:@stdlib/array/float64}}( x0.length );
     > var x1 = new {{alias:@stdlib/array/float64}}( x0.buffer, x0.BYTES_PER_ELEMENT*1 );
     > var y1 = new {{alias:@stdlib/array/float64}}( y0.buffer, y0.BYTES_PER_ELEMENT*3 );
-    > N = {{alias:@stdlib/math/base/special/floor}}( x0.length / 2 );
-    > {{alias}}( N, x1, 2, y1, 1 )
+    > {{alias}}( 3, x1, 2, y1, 1 )
     <Float64Array>[ 2.0, 2.0, 1.0 ]
     > y0
     <Float64Array>[ 0.0, 0.0, 0.0, 2.0, 2.0, 1.0 ]
@@ -75,7 +73,7 @@
         Input array.
 
     strideX: integer
-        Index increment for `x`.
+        Stride length for `x`.
 
     offsetX: integer
         Starting index for `x`.
@@ -84,7 +82,7 @@
         Output array.
 
     strideY: integer
-        Index increment for `y`.
+        Stride length for `y`.
 
     offsetY: integer
         Starting index for `y`.
@@ -105,8 +103,7 @@
     // Advanced indexing:
     > x = [ 1.0, -2.0, 3.0, 2.0, 5.0, -1.0 ];
     > y = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
-    > var N = {{alias:@stdlib/math/base/special/floor}}( x.length / 2 );
-    > {{alias}}.ndarray( N, x, 2, 1, y, -1, y.length-1 )
+    > {{alias}}.ndarray( 3, x, 2, 1, y, -1, y.length-1 )
     [ 0.0, 0.0, 0.0, 1.0, 2.0, 2.0 ]
 
     See Also

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/docs/types/index.d.ts
@@ -20,7 +20,17 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { NumericArray } from '@stdlib/types/array';
+import { NumericArray, Collection, AccessorArrayLike } from '@stdlib/types/array';
+
+/**
+* Input array.
+*/
+type InputArray = NumericArray | Collection<number> | AccessorArrayLike<number>;
+
+/**
+* Output array.
+*/
+type OutputArray = NumericArray | Collection<number> | AccessorArrayLike<number>;
 
 /**
 * Interface describing `cuminabs`.
@@ -31,9 +41,9 @@ interface Routine {
 	*
 	* @param N - number of indexed elements
 	* @param x - input array
-	* @param strideX - `x` stride length
+	* @param strideX - stride length for `x`
 	* @param y - output array
-	* @param strideY - `y` stride length
+	* @param strideY - stride length for `y`
 	* @returns output array
 	*
 	* @example
@@ -43,17 +53,17 @@ interface Routine {
 	* cuminabs( x.length, x, 1, y, 1 );
 	* // y => [ 1.0, 1.0, 1.0 ]
 	*/
-	( N: number, x: NumericArray, strideX: number, y: NumericArray, strideY: number ): NumericArray;
+	<T extends OutputArray>( N: number, x: InputArray, strideX: number, y: T, strideY: number ): T;
 
 	/**
 	* Computes the cumulative minimum absolute value of a strided array using alternative indexing semantics.
 	*
 	* @param N - number of indexed elements
 	* @param x - input array
-	* @param strideX - `x` stride length
+	* @param strideX - stride length for `x`
 	* @param offsetX - starting index for `x`
 	* @param y - output array
-	* @param strideY - `y` stride length
+	* @param strideY - stride length for `y`
 	* @param offsetY - starting index for `y`
 	* @returns output array
 	*
@@ -64,7 +74,7 @@ interface Routine {
 	* cuminabs.ndarray( x.length, x, 1, 0, y, 1, 0 );
 	* // y => [ 1.0, 1.0, 1.0 ]
 	*/
-	ndarray( N: number, x: NumericArray, strideX: number, offsetX: number, y: NumericArray, strideY: number, offsetY: number ): NumericArray;
+	ndarray<T extends OutputArray>( N: number, x: InputArray, strideX: number, offsetX: number, y: T, strideY: number, offsetY: number ): T;
 }
 
 /**
@@ -72,9 +82,9 @@ interface Routine {
 *
 * @param N - number of indexed elements
 * @param x - input array
-* @param strideX - `x` stride length
+* @param strideX - stride length for `x`
 * @param y - output array
-* @param strideY - `y` stride length
+* @param strideY - stride length for `y`
 * @returns output array
 *
 * @example

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/docs/types/test.ts
@@ -16,6 +16,7 @@
 * limitations under the License.
 */
 
+import AccessorArray = require( '@stdlib/array/base/accessor' );
 import cuminabs = require( './index' );
 
 
@@ -27,6 +28,7 @@ import cuminabs = require( './index' );
 	const y = new Float64Array( 10 );
 
 	cuminabs( x.length, x, 1, y, 1 ); // $ExpectType NumericArray
+	cuminabs( x.length, new AccessorArray( x ), 1, new AccessorArray( y ), 1 ); // $ExpectType AccessorArray<number>
 }
 
 // The compiler throws an error if the function is provided a first argument which is not a number...
@@ -124,6 +126,8 @@ import cuminabs = require( './index' );
 	const y = new Float64Array( 10 );
 
 	cuminabs.ndarray( x.length, x, 1, 0, y, 1, 0 ); // $ExpectType NumericArray
+	cuminabs.ndarray( x.length, new AccessorArray( x ), 1, 0, new AccessorArray( y ), 1, 0 ); // $ExpectType AccessorArray<number>
+
 }
 
 // The compiler throws an error if the `ndarray` method is provided a first argument which is not a number...

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/docs/types/test.ts
@@ -27,7 +27,7 @@ import cuminabs = require( './index' );
 	const x = new Float64Array( 10 );
 	const y = new Float64Array( 10 );
 
-	cuminabs( x.length, x, 1, y, 1 ); // $ExpectType NumericArray
+	cuminabs( x.length, x, 1, y, 1 ); // $ExpectType Float64Array
 	cuminabs( x.length, new AccessorArray( x ), 1, new AccessorArray( y ), 1 ); // $ExpectType AccessorArray<number>
 }
 
@@ -125,7 +125,7 @@ import cuminabs = require( './index' );
 	const x = new Float64Array( 10 );
 	const y = new Float64Array( 10 );
 
-	cuminabs.ndarray( x.length, x, 1, 0, y, 1, 0 ); // $ExpectType NumericArray
+	cuminabs.ndarray( x.length, x, 1, 0, y, 1, 0 ); // $ExpectType Float64Array
 	cuminabs.ndarray( x.length, new AccessorArray( x ), 1, 0, new AccessorArray( y ), 1, 0 ); // $ExpectType AccessorArray<number>
 
 }

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/examples/index.js
@@ -25,9 +25,9 @@ var cuminabs = require( './../lib' );
 var x = discreteUniform(10, -50, 50, {
 	'dtype': 'float64'
 });
-var y = new Float64Array( x.length );
-
 console.log( x );
+
+var y = new Float64Array( x.length );
 console.log( y );
 
 cuminabs( x.length, x, 1, y, -1 );

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/examples/index.js
@@ -22,9 +22,9 @@ var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var Float64Array = require( '@stdlib/array/float64' );
 var cuminabs = require( './../lib' );
 
-var x = discreteUniform(10, -50, 50, { 
-		'dtype': 'float64' 
-});  
+var x = discreteUniform(10, -50, 50, {
+	'dtype': 'float64'
+});
 var y = new Float64Array( x.length );
 
 console.log( x );

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/examples/index.js
@@ -18,20 +18,15 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var Float64Array = require( '@stdlib/array/float64' );
 var cuminabs = require( './../lib' );
 
-var y;
-var x;
-var i;
+var x = discreteUniform(10, -50, 50, { 
+		'dtype': 'float64' 
+});  
+var y = new Float64Array( x.length );
 
-x = new Float64Array( 10 );
-y = new Float64Array( x.length );
-for ( i = 0; i < x.length; i++ ) {
-	x[ i ] = round( (randu()*100.0) - 50.0 );
-}
 console.log( x );
 console.log( y );
 

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/lib/accessors.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/lib/accessors.js
@@ -23,6 +23,7 @@
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var abs = require( '@stdlib/math/base/special/abs' );
 
+
 // MAIN //
 
 /**
@@ -43,6 +44,7 @@ var abs = require( '@stdlib/math/base/special/abs' );
 * @returns {Object} output array object
 *
 * @example
+* var toAccessorArray = require( '@stdlib/array/base/to-accessor-array' );
 * var arraylike2object = require( '@stdlib/array/base/arraylike2object' );
 * var accessors = require( './accessors.js' );
 *

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/lib/accessors.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/lib/accessors.js
@@ -52,7 +52,7 @@ var abs = require( '@stdlib/math/base/special/abs' );
 * var y = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
 *
 * var v = cuminabs( 4, arraylike2object( toAccessorArray( x ) ), 2, 1, arraylike2object( toAccessorArray( y ) ), 1, 0 );
-* // returns [ 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0 ]
+* // y => [ 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0 ]
 */
 function cuminabs( N, x, strideX, offsetX, y, strideY, offsetY ) {
 	var xbuf;

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/lib/accessors.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/lib/accessors.js
@@ -43,8 +43,8 @@ var abs = require( '@stdlib/math/base/special/abs' );
 * @returns {Object} output array object
 *
 * @example
-var arraylike2object = require( '@stdlib/array/base/arraylike2object' );
-var accessors = require( './accessors.js' );
+* var arraylike2object = require( '@stdlib/array/base/arraylike2object' );
+* var accessors = require( './accessors.js' );
 *
 * var x = [ 2.0, 1.0, 2.0, -2.0, -2.0, 2.0, 3.0, 4.0 ];
 * var y = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
@@ -72,24 +72,18 @@ function cuminabs( N, x, strideX, offsetX, y, strideY, offsetY ) {
 	xget = x.accessors[0];
 	yset = y.accessors[1];
 	
-
-
 	ix = offsetX;
-
 	iy = offsetY;
   
-	min = abs(xget(xbuf, ix));
-  
-	yset(ybuf, iy, min);
+	min = abs( xget( xbuf, ix ));
+	yset( ybuf, iy, min );
   
 	iy += strideY;
-  
 	i = 1;
-  
 	if ( isnan( min ) === false ) {
 		for ( i; i < N; i++ ) {
 			ix += strideX;
-			v = abs(xget( xbuf, ix) );
+			v = abs( xget( xbuf, ix ) );
 			if ( isnan( v ) ) {
 				min = v;
 				break;
@@ -97,13 +91,13 @@ function cuminabs( N, x, strideX, offsetX, y, strideY, offsetY ) {
 			if ( v < min ) {
 				min = v;
 			}
-			yset(ybuf, iy, min);
+			yset( ybuf, iy, min );
 			iy += strideY;
 		}
 	}
 	if ( isnan( min ) ) {
 		for ( i; i < N; i++ ) {
-			yset(ybuf, iy, min);
+			yset( ybuf, iy, min );
 			iy += strideY;
 		}
 	}

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/lib/accessors.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/lib/accessors.js
@@ -76,7 +76,7 @@ function cuminabs( N, x, strideX, offsetX, y, strideY, offsetY ) {
 	ix = offsetX;
 	iy = offsetY;
 
-	min = abs( xget( xbuf, ix ));
+	min = abs( xget( xbuf, ix ) );
 	yset( ybuf, iy, min );
 
 	iy += strideY;

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/lib/accessors.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/lib/accessors.js
@@ -71,7 +71,7 @@ function cuminabs( N, x, strideX, offsetX, y, strideY, offsetY ) {
 
 	// Cache references to element accessors:
 	xget = x.accessors[ 0 ];
-	yset = y.accessors[1];
+	yset = y.accessors[ 1 ];
 
 	ix = offsetX;
 	iy = offsetY;

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/lib/accessors.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/lib/accessors.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2020 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -22,62 +22,74 @@
 
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var abs = require( '@stdlib/math/base/special/abs' );
-var arraylike2object = require( '@stdlib/array/base/arraylike2object' );
-var accessors = require( './accessors.js' );
 
 // MAIN //
 
 /**
-* Computes the cumulative minimum absolute value of a strided array.
+* Computes the cumulative minimum of a strided array.
 *
+* @private
 * @param {PositiveInteger} N - number of indexed elements
-* @param {NumericArray} x - input array
+* @param {Object} x - input array object
+* @param {Collection} x.data - input array data
+* @param {Array<Function>} x.accessors - array element accessors
 * @param {integer} strideX - stride length for `x`
 * @param {NonNegativeInteger} offsetX - starting index for `x`
-* @param {NumericArray} y - output array
+* @param {Object} y - output array object
+* @param {Collection} y.data - output array data
+* @param {Array<Function>} y.accessors - array element accessors
 * @param {integer} strideY - stride length for `y`
 * @param {NonNegativeInteger} offsetY - starting index for `y`
-* @returns {NumericArray} output array
+* @returns {Object} output array object
 *
 * @example
-* var floor = require( '@stdlib/math/base/special/floor' );
+var arraylike2object = require( '@stdlib/array/base/arraylike2object' );
+var accessors = require( './accessors.js' );
 *
 * var x = [ 2.0, 1.0, 2.0, -2.0, -2.0, 2.0, 3.0, 4.0 ];
 * var y = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
 *
-* var v = cuminabs( 4, x, 2, 1, y, 1, 0 );
+* var v = cuminabs( 4, arraylike2object( toAccessorArray( x ) ), 2, 1, arraylike2object( toAccessorArray( y ) ), 1, 0 );
 * // returns [ 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0 ]
 */
+
 function cuminabs( N, x, strideX, offsetX, y, strideY, offsetY ) {
+	var xbuf;
+	var ybuf;
+	var xget;
+	var yset;
 	var min;
 	var ix;
 	var iy;
-	var ox;
-	var oy;
 	var v;
 	var i;
 
-	if ( N <= 0 ) {
-		return y;
-	}
-	ox = arraylike2object( x );
-	oy = arraylike2object( y );
-	if ( ox.accessorProtocol || oy.accessorProtocol ) {
-		accessors( N, ox, strideX, offsetX, oy, strideY, offsetY );
-		return y;
-	}
+	// Cache references to array data:
+	xbuf = x.data;
+	ybuf = y.data;
+
+	// Cache references to element accessors:
+	xget = x.accessors[0];
+	yset = y.accessors[1];
+	
+
+
 	ix = offsetX;
+
 	iy = offsetY;
-
-	min = abs( x[ ix ] );
-	y[ iy ] = min;
-
+  
+	min = abs(xget(xbuf, ix));
+  
+	yset(ybuf, iy, min);
+  
 	iy += strideY;
+  
 	i = 1;
+  
 	if ( isnan( min ) === false ) {
 		for ( i; i < N; i++ ) {
 			ix += strideX;
-			v = abs( x[ ix ] );
+			v = abs(xget( xbuf, ix) );
 			if ( isnan( v ) ) {
 				min = v;
 				break;
@@ -85,13 +97,13 @@ function cuminabs( N, x, strideX, offsetX, y, strideY, offsetY ) {
 			if ( v < min ) {
 				min = v;
 			}
-			y[ iy ] = min;
+			yset(ybuf, iy, min);
 			iy += strideY;
 		}
 	}
 	if ( isnan( min ) ) {
 		for ( i; i < N; i++ ) {
-			y[ iy ] = min;
+			yset(ybuf, iy, min);
 			iy += strideY;
 		}
 	}

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/lib/accessors.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/lib/accessors.js
@@ -70,7 +70,7 @@ function cuminabs( N, x, strideX, offsetX, y, strideY, offsetY ) {
 	ybuf = y.data;
 
 	// Cache references to element accessors:
-	xget = x.accessors[0];
+	xget = x.accessors[ 0 ];
 	yset = y.accessors[1];
 
 	ix = offsetX;

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/lib/accessors.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/lib/accessors.js
@@ -52,7 +52,6 @@ var abs = require( '@stdlib/math/base/special/abs' );
 * var v = cuminabs( 4, arraylike2object( toAccessorArray( x ) ), 2, 1, arraylike2object( toAccessorArray( y ) ), 1, 0 );
 * // returns [ 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0 ]
 */
-
 function cuminabs( N, x, strideX, offsetX, y, strideY, offsetY ) {
 	var xbuf;
 	var ybuf;
@@ -71,13 +70,13 @@ function cuminabs( N, x, strideX, offsetX, y, strideY, offsetY ) {
 	// Cache references to element accessors:
 	xget = x.accessors[0];
 	yset = y.accessors[1];
-	
+
 	ix = offsetX;
 	iy = offsetY;
-  
+
 	min = abs( xget( xbuf, ix ));
 	yset( ybuf, iy, min );
-  
+
 	iy += strideY;
 	i = 1;
 	if ( isnan( min ) === false ) {

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/lib/cuminabs.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/lib/cuminabs.js
@@ -21,7 +21,8 @@
 // MODULES //
 
 var stride2offset = require( '@stdlib/strided/base/stride2offset' );
-var ndarray = require( './ndarray' );
+var ndarray = require( './ndarray.js' );
+
 
 // MAIN //
 
@@ -44,10 +45,9 @@ var ndarray = require( './ndarray' );
 * // returns [ 1.0, 1.0, 1.0 ]
 */
 function cuminabs( N, x, strideX, y, strideY ) {
-	
 	var ix = stride2offset( N, strideX );
 	var iy = stride2offset( N, strideY );
-	
+
 	return ndarray( N, x, strideX, ix, y, strideY, iy );
 }
 

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/lib/cuminabs.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/lib/cuminabs.js
@@ -20,9 +20,8 @@
 
 // MODULES //
 
-var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
-
+var stride2offset = require( '@stdlib/strided/base/stride2offset' );
+var ndarray = require( './ndarray' );
 
 // MAIN //
 
@@ -45,52 +44,11 @@ var abs = require( '@stdlib/math/base/special/abs' );
 * // returns [ 1.0, 1.0, 1.0 ]
 */
 function cuminabs( N, x, strideX, y, strideY ) {
-	var min;
-	var ix;
-	var iy;
-	var v;
-	var i;
-
-	if ( N <= 0 ) {
-		return y;
-	}
-	if ( strideX < 0 ) {
-		ix = (1-N) * strideX;
-	} else {
-		ix = 0;
-	}
-	if ( strideY < 0 ) {
-		iy = (1-N) * strideY;
-	} else {
-		iy = 0;
-	}
-	min = abs( x[ ix ] );
-	y[ iy ] = min;
-
-	iy += strideY;
-	i = 1;
-	if ( isnan( min ) === false ) {
-		for ( i; i < N; i++ ) {
-			ix += strideX;
-			v = abs( x[ ix ] );
-			if ( isnan( v ) ) {
-				min = v;
-				break;
-			}
-			if ( v < min ) {
-				min = v;
-			}
-			y[ iy ] = min;
-			iy += strideY;
-		}
-	}
-	if ( isnan( min ) ) {
-		for ( i; i < N; i++ ) {
-			y[ iy ] = min;
-			iy += strideY;
-		}
-	}
-	return y;
+	
+	var ix = stride2offset( N, strideX );
+	var iy = stride2offset( N, strideY );
+	
+	return ndarray( N, x, strideX, ix, y, strideY, iy );
 }
 
 

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/lib/ndarray.js
@@ -25,6 +25,7 @@ var abs = require( '@stdlib/math/base/special/abs' );
 var arraylike2object = require( '@stdlib/array/base/arraylike2object' );
 var accessors = require( './accessors.js' );
 
+
 // MAIN //
 
 /**

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/lib/ndarray.js
@@ -41,8 +41,6 @@ var accessors = require( './accessors.js' );
 * @returns {NumericArray} output array
 *
 * @example
-* var floor = require( '@stdlib/math/base/special/floor' );
-*
 * var x = [ 2.0, 1.0, 2.0, -2.0, -2.0, 2.0, 3.0, 4.0 ];
 * var y = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ];
 *

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/test/test.cuminabs.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/test/test.cuminabs.js
@@ -21,9 +21,9 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var floor = require( '@stdlib/math/base/special/floor' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
+var toAccessorArray = require( '@stdlib/array/base/to-accessor-array' );
 var Float64Array = require( '@stdlib/array/float64' );
 var cuminabs = require( './../lib/cuminabs.js' );
 
@@ -109,6 +109,74 @@ tape( 'the function computes the cumulative minimum absolute value', function te
 	t.end();
 });
 
+tape( 'the function computes the cumulative minimum absolute value (accessor)', function test( t ) {
+	var expected;
+	var x;
+	var y;
+	var i;
+
+	x = [ 1.0, -2.0, 3.0, -4.0, 5.0 ];
+	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
+	cuminabs( x.length, toAccessorArray( x ), 1, toAccessorArray( y ), 1 );
+
+	expected = [
+		1.0,
+		1.0,
+		1.0,
+		1.0,
+		1.0
+	];
+	t.deepEqual( y, expected, 'returns expected value' );
+
+	x = [ -0.0, 0.0, -0.0 ];
+	y = [ -0.0, -0.0, -0.0 ];
+	cuminabs( x.length, toAccessorArray( x ), 1, toAccessorArray( y ), 1 );
+
+	expected = [
+		0.0,
+		0.0,
+		0.0
+	];
+	for ( i = 0; i < y.length; i++ ) {
+		t.strictEqual( isPositiveZero( y[ i ] ), true, 'returns expected value. i: ' + i );
+	}
+
+	x = [ NaN ];
+	y = [ 0.0 ];
+	cuminabs( x.length, toAccessorArray( x ), 1, toAccessorArray( y ), 1 );
+
+	for ( i = 0; i < y.length; i++ ) {
+		t.strictEqual( isnan( y[ i ] ), true, 'returns expected value. i: ' + i );
+	}
+
+	x = [ NaN, NaN ];
+	y = [ 0.0, 0.0 ];
+	cuminabs( x.length, toAccessorArray( x ), 1, toAccessorArray( y ), 1 );
+
+	for ( i = 0; i < y.length; i++ ) {
+		t.strictEqual( isnan( y[ i ] ), true, 'returns expected value. i: ' + i );
+	}
+
+	x = [ 1.0, NaN, 3.0, NaN ];
+	y = [ 0.0, 0.0, 0.0, 0.0 ];
+	cuminabs( x.length, toAccessorArray( x ), 1, toAccessorArray( y ), 1 );
+
+	expected = [
+		1.0,
+		NaN,
+		NaN,
+		NaN
+	];
+	for ( i = 0; i < y.length; i++ ) {
+		if ( isnan( expected[ i ] ) ) {
+			t.strictEqual( isnan( y[ i ] ), true, 'returns expected value. i: ' + i );
+		} else {
+			t.strictEqual( y[ i ], expected[ i ], true, 'returns expected value. i: ' + i );
+		}
+	}
+	t.end();
+});
+
 tape( 'the function returns a reference to the output array', function test( t ) {
 	var out;
 	var x;
@@ -116,6 +184,20 @@ tape( 'the function returns a reference to the output array', function test( t )
 
 	x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
+
+	out = cuminabs( x.length, x, 1, y, 1 );
+	t.strictEqual( out, y, 'same reference' );
+
+	t.end();
+});
+
+tape( 'the function returns a reference to the output array (accessor)', function test( t ) {
+	var out;
+	var x;
+	var y;
+
+	x = toAccessorArray([ 1.0, 2.0, 3.0, 4.0, 5.0 ]);
+	y = toAccessorArray([ 0.0, 0.0, 0.0, 0.0, 0.0 ]);
 
 	out = cuminabs( x.length, x, 1, y, 1 );
 	t.strictEqual( out, y, 'same reference' );
@@ -172,6 +254,36 @@ tape( 'the function supports an `x` stride', function test( t ) {
 	t.end();
 });
 
+tape( 'the function supports an `x` stride (accessor)', function test( t ) {
+	var expected;
+	var x;
+	var y;
+	var N;
+
+	x = [
+		1.0,  // 0
+		-2.0,
+		3.0,  // 1
+		4.0,
+		-5.0  // 2
+	];
+	y = [
+		0.0, // 0
+		0.0, // 1
+		0.0, // 2
+		0.0,
+		0.0
+	];
+	N = 3;
+
+	cuminabs( N, toAccessorArray( x ), 2, toAccessorArray( y ), 1 );
+
+	expected = [ 1.0, 1.0, 1.0, 0.0, 0.0 ];
+	t.deepEqual( y, expected, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function supports a `y` stride', function test( t ) {
 	var expected;
 	var x;
@@ -202,6 +314,36 @@ tape( 'the function supports a `y` stride', function test( t ) {
 	t.end();
 });
 
+tape( 'the function supports a `y` stride (accessor)', function test( t ) {
+	var expected;
+	var x;
+	var y;
+	var N;
+
+	x = [
+		1.0,  // 0
+		-2.0, // 1
+		3.0,  // 2
+		4.0,
+		5.0
+	];
+	y = [
+		0.0, // 0
+		0.0,
+		0.0, // 1
+		0.0,
+		0.0  // 2
+	];
+	N = 3;
+
+	cuminabs( N, toAccessorArray( x ), 1, toAccessorArray( y ), 2 );
+
+	expected = [ 1.0, 0.0, 1.0, 0.0, 1.0 ];
+	t.deepEqual( y, expected, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function supports negative strides', function test( t ) {
 	var expected;
 	var x;
@@ -225,6 +367,36 @@ tape( 'the function supports negative strides', function test( t ) {
 	N = 3;
 
 	cuminabs( N, x, -2, y, -1 );
+
+	expected = [ 1.0, 3.0, 5.0, 0.0, 0.0 ];
+	t.deepEqual( y, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports negative strides (accessor)', function test( t ) {
+	var expected;
+	var x;
+	var y;
+	var N;
+
+	x = [
+		1.0,  // 2
+		-2.0,
+		3.0,  // 1
+		4.0,
+		-5.0  // 0
+	];
+	y = [
+		0.0, // 2
+		0.0, // 1
+		0.0, // 0
+		0.0,
+		0.0
+	];
+	N = 3;
+
+	cuminabs( N, toAccessorArray( x ), -2, toAccessorArray( y ), -1 );
 
 	expected = [ 1.0, 3.0, 5.0, 0.0, 0.0 ];
 	t.deepEqual( y, expected, 'returns expected value' );
@@ -264,6 +436,38 @@ tape( 'the function supports complex access patterns', function test( t ) {
 	t.end();
 });
 
+tape( 'the function supports complex access patterns (accessor)', function test( t ) {
+	var expected;
+	var x;
+	var y;
+	var N;
+
+	x = [
+		1.0,  // 0
+		2.0,
+		-3.0, // 1
+		4.0,
+		5.0,  // 2
+		6.0
+	];
+	y = [
+		0.0,  // 2
+		0.0,  // 1
+		0.0,  // 0
+		0.0,
+		0.0,
+		0.0
+	];
+	N = 3;
+
+	cuminabs( N, toAccessorArray( x ), 2, toAccessorArray( y ), -1 );
+
+	expected = [ 1.0, 1.0, 1.0, 0.0, 0.0, 0.0 ];
+	t.deepEqual( y, expected, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function supports view offsets', function test( t ) {
 	var expected;
 	var x0;
@@ -294,9 +498,44 @@ tape( 'the function supports view offsets', function test( t ) {
 	x1 = new Float64Array( x0.buffer, x0.BYTES_PER_ELEMENT*1 ); // begin at 2nd element
 	y1 = new Float64Array( y0.buffer, y0.BYTES_PER_ELEMENT*3 ); // begin at the 4th element
 
-	N = floor( x0.length / 2 );
+	cuminabs( 3, x1, -2, y1, 1 );
+	expected = new Float64Array( [ 0.0, 0.0, 0.0, 6.0, 4.0, 2.0 ] );
 
-	cuminabs( N, x1, -2, y1, 1 );
+	t.deepEqual( y0, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports view offsets (accessor)', function test( t ) {
+	var expected;
+	var x0;
+	var y0;
+	var x1;
+	var y1;
+	var N;
+
+	// Initial arrays...
+	x0 = new Float64Array([
+		1.0,
+		2.0, // 2
+		3.0,
+		4.0, // 1
+		5.0,
+		6.0  // 0
+	]);
+	y0 = new Float64Array([
+		0.0,
+		0.0,
+		0.0,
+		0.0, // 0
+		0.0, // 1
+		0.0  // 2
+	]);
+
+	// Create offset views...
+	x1 = new Float64Array( x0.buffer, x0.BYTES_PER_ELEMENT*1 ); // begin at 2nd element
+	y1 = new Float64Array( y0.buffer, y0.BYTES_PER_ELEMENT*3 ); // begin at the 4th element
+
+	cuminabs( 3, toAccessorArray( x1 ), -2, toAccessorArray( y1 ), 1 );
 	expected = new Float64Array( [ 0.0, 0.0, 0.0, 6.0, 4.0, 2.0 ] );
 
 	t.deepEqual( y0, expected, 'returns expected value' );

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/test/test.cuminabs.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/test/test.cuminabs.js
@@ -196,8 +196,8 @@ tape( 'the function returns a reference to the output array (accessor)', functio
 	var x;
 	var y;
 
-	x = toAccessorArray([ 1.0, 2.0, 3.0, 4.0, 5.0 ]);
-	y = toAccessorArray([ 0.0, 0.0, 0.0, 0.0, 0.0 ]);
+	x = toAccessorArray( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+	y = toAccessorArray( [ 0.0, 0.0, 0.0, 0.0, 0.0 ] );
 
 	out = cuminabs( x.length, x, 1, y, 1 );
 	t.strictEqual( out, y, 'same reference' );

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/test/test.cuminabs.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/test/test.cuminabs.js
@@ -474,7 +474,6 @@ tape( 'the function supports view offsets', function test( t ) {
 	var y0;
 	var x1;
 	var y1;
-	var N;
 
 	// Initial arrays...
 	x0 = new Float64Array([
@@ -511,7 +510,6 @@ tape( 'the function supports view offsets (accessor)', function test( t ) {
 	var y0;
 	var x1;
 	var y1;
-	var N;
 
 	// Initial arrays...
 	x0 = new Float64Array([

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/test/test.ndarray.js
@@ -195,8 +195,8 @@ tape( 'the function returns a reference to the output array (accessor)', functio
 	var x;
 	var y;
 
-	x = toAccessorArray([ 1.0, 2.0, 3.0, 4.0, 5.0 ]);
-	y = toAccessorArray([ 0.0, 0.0, 0.0, 0.0, 0.0 ]);
+	x = toAccessorArray( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+	y = toAccessorArray( [ 0.0, 0.0, 0.0, 0.0, 0.0 ] );
 
 	out = cuminabs( x.length, x, 1, 0, y, 1, 0 );
 	t.strictEqual( out, y, 'same reference' );

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/test/test.ndarray.js
@@ -579,7 +579,6 @@ tape( 'the function supports complex access patterns', function test( t ) {
 	t.end();
 });
 
-
 tape( 'the function supports complex access patterns (accessor', function test( t ) {
 	var expected;
 	var x;

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/test/test.ndarray.js
@@ -116,7 +116,7 @@ tape( 'the function calculates the cumulative minimum absolute value (accessor)'
 
 	x = [ 1.0, -2.0, 3.0, -4.0, 5.0 ];
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
-	cuminabs( x.length, toAccessorArray( x ), 1, 0, toAccessorArray( y ), 1, 0 );
+	cuminabs(x.length, toAccessorArray( x ), 1, 0, toAccessorArray( y ), 1, 0);
 
 	expected = [
 		1.0,
@@ -129,7 +129,7 @@ tape( 'the function calculates the cumulative minimum absolute value (accessor)'
 
 	x = [ -0.0, 0.0, -0.0 ];
 	y = [ -0.0, -0.0, -0.0 ];
-	cuminabs( x.length, toAccessorArray( x ), 1, 0, toAccessorArray( y ), 1, 0 );
+	cuminabs(x.length, toAccessorArray( x ), 1, 0, toAccessorArray( y ), 1, 0);
 
 	expected = [
 		0.0,
@@ -142,7 +142,7 @@ tape( 'the function calculates the cumulative minimum absolute value (accessor)'
 
 	x = [ NaN ];
 	y = [ 0.0 ];
-	cuminabs( x.length, toAccessorArray( x ), 1, 0, toAccessorArray( y ), 1, 0 );
+	cuminabs(x.length, toAccessorArray( x ), 1, 0, toAccessorArray( y ), 1, 0);
 
 	for ( i = 0; i < y.length; i++ ) {
 		t.strictEqual( isnan( y[ i ] ), true, 'returns expected value. i: ' + i );
@@ -150,7 +150,7 @@ tape( 'the function calculates the cumulative minimum absolute value (accessor)'
 
 	x = [ NaN, NaN ];
 	y = [ 0.0, 0.0 ];
-	cuminabs( x.length, toAccessorArray( x ), 1, 0, toAccessorArray( y ), 1, 0 );
+	cuminabs(x.length, toAccessorArray( x ), 1, 0, toAccessorArray( y ), 1, 0);
 
 	for ( i = 0; i < y.length; i++ ) {
 		t.strictEqual( isnan( y[ i ] ), true, 'returns expected value. i: ' + i );
@@ -158,7 +158,7 @@ tape( 'the function calculates the cumulative minimum absolute value (accessor)'
 
 	x = [ 1.0, NaN, 3.0, NaN ];
 	y = [ 0.0, 0.0, 0.0, 0.0 ];
-	cuminabs( x.length, toAccessorArray( x ), 1, 0, toAccessorArray( y ), 1, 0 );
+	cuminabs(x.length, toAccessorArray( x ), 1, 0, toAccessorArray( y ), 1, 0);
 
 	expected = [
 		1.0,
@@ -275,7 +275,7 @@ tape( 'the function supports an `x` stride (accessor)', function test( t ) {
 	];
 	N = 3;
 
-	cuminabs( N, toAccessorArray( x ), 2, 0, toAccessorArray( y ), 1, 0 );
+	cuminabs(N, toAccessorArray( x ), 2, 0, toAccessorArray( y ), 1, 0);
 
 	expected = [ 1.0, 1.0, 1.0, 0.0, 0.0 ];
 	t.deepEqual( y, expected, 'returns expected value' );
@@ -395,7 +395,7 @@ tape( 'the function supports negative strides (accessor)', function test( t ) {
 	];
 	N = 3;
 
-	cuminabs( N, toAccessorArray( x ), -2, x.length-1, toAccessorArray( y ), -1, 2 );
+	cuminabs( N, toAccessorArray( x ), -2, x.length-1, toAccessorArray( y ), -1, 2);
 
 	expected = [ 1.0, 3.0, 5.0, 0.0, 0.0 ];
 	t.deepEqual( y, expected, 'returns expected value' );

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/test/test.ndarray.js
@@ -116,7 +116,7 @@ tape( 'the function calculates the cumulative minimum absolute value (accessor)'
 
 	x = [ 1.0, -2.0, 3.0, -4.0, 5.0 ];
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
-	cuminabs(x.length, toAccessorArray( x ), 1, 0, toAccessorArray( y ), 1, 0);
+	cuminabs( x.length, toAccessorArray( x ), 1, 0, toAccessorArray( y ), 1, 0 );
 
 	expected = [
 		1.0,

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/test/test.ndarray.js
@@ -395,7 +395,7 @@ tape( 'the function supports negative strides (accessor)', function test( t ) {
 	];
 	N = 3;
 
-	cuminabs( N, toAccessorArray( x ), -2, x.length-1, toAccessorArray( y ), -1, 2);
+	cuminabs(N, toAccessorArray( x ), -2, x.length-1, toAccessorArray( y ), -1, 2);
 
 	expected = [ 1.0, 3.0, 5.0, 0.0, 0.0 ];
 	t.deepEqual( y, expected, 'returns expected value' );

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/test/test.ndarray.js
@@ -395,7 +395,7 @@ tape( 'the function supports negative strides (accessor)', function test( t ) {
 	];
 	N = 3;
 
-	cuminabs(N, toAccessorArray( x ), -2, x.length-1, toAccessorArray( y ), -1, 2);
+	cuminabs(N, toAccessorArray(x), -2, x.length - 1, toAccessorArray(y), -1, 2);
 
 	expected = [ 1.0, 3.0, 5.0, 0.0, 0.0 ];
 	t.deepEqual( y, expected, 'returns expected value' );

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/test/test.ndarray.js
@@ -21,8 +21,8 @@
 // MODULES //
 
 var tape = require( 'tape' );
-var floor = require( '@stdlib/math/base/special/floor' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var toAccessorArray = require( '@stdlib/array/base/to-accessor-array' );
 var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
 var cuminabs = require( './../lib/ndarray.js' );
 
@@ -108,6 +108,74 @@ tape( 'the function calculates the cumulative minimum absolute value', function 
 	t.end();
 });
 
+tape( 'the function calculates the cumulative minimum absolute value (accessor)', function test( t ) {
+	var expected;
+	var x;
+	var y;
+	var i;
+
+	x = [ 1.0, -2.0, 3.0, -4.0, 5.0 ];
+	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
+	cuminabs( x.length, toAccessorArray( x ), 1, 0, toAccessorArray( y ), 1, 0 );
+
+	expected = [
+		1.0,
+		1.0,
+		1.0,
+		1.0,
+		1.0
+	];
+	t.deepEqual( y, expected, 'returns expected value' );
+
+	x = [ -0.0, 0.0, -0.0 ];
+	y = [ -0.0, -0.0, -0.0 ];
+	cuminabs( x.length, toAccessorArray( x ), 1, 0, toAccessorArray( y ), 1, 0 );
+
+	expected = [
+		0.0,
+		0.0,
+		0.0
+	];
+	for ( i = 0; i < y.length; i++ ) {
+		t.strictEqual( isPositiveZero( y[ i ] ), true, 'returns expected value. i: ' + i );
+	}
+
+	x = [ NaN ];
+	y = [ 0.0 ];
+	cuminabs( x.length, toAccessorArray( x ), 1, 0, toAccessorArray( y ), 1, 0 );
+
+	for ( i = 0; i < y.length; i++ ) {
+		t.strictEqual( isnan( y[ i ] ), true, 'returns expected value. i: ' + i );
+	}
+
+	x = [ NaN, NaN ];
+	y = [ 0.0, 0.0 ];
+	cuminabs( x.length, toAccessorArray( x ), 1, 0, toAccessorArray( y ), 1, 0 );
+
+	for ( i = 0; i < y.length; i++ ) {
+		t.strictEqual( isnan( y[ i ] ), true, 'returns expected value. i: ' + i );
+	}
+
+	x = [ 1.0, NaN, 3.0, NaN ];
+	y = [ 0.0, 0.0, 0.0, 0.0 ];
+	cuminabs( x.length, toAccessorArray( x ), 1, 0, toAccessorArray( y ), 1, 0 );
+
+	expected = [
+		1.0,
+		NaN,
+		NaN,
+		NaN
+	];
+	for ( i = 0; i < y.length; i++ ) {
+		if ( isnan( expected[ i ] ) ) {
+			t.strictEqual( isnan( y[ i ] ), true, 'returns expected value. i: ' + i );
+		} else {
+			t.strictEqual( y[ i ], expected[ i ], true, 'returns expected value. i: ' + i );
+		}
+	}
+	t.end();
+});
+
 tape( 'the function returns a reference to the output array', function test( t ) {
 	var out;
 	var x;
@@ -115,6 +183,20 @@ tape( 'the function returns a reference to the output array', function test( t )
 
 	x = [ 1.0, 2.0, 3.0, 4.0, 5.0 ];
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
+
+	out = cuminabs( x.length, x, 1, 0, y, 1, 0 );
+	t.strictEqual( out, y, 'same reference' );
+
+	t.end();
+});
+
+tape( 'the function returns a reference to the output array (accessor)', function test( t ) {
+	var out;
+	var x;
+	var y;
+
+	x = toAccessorArray([ 1.0, 2.0, 3.0, 4.0, 5.0 ]);
+	y = toAccessorArray([ 0.0, 0.0, 0.0, 0.0, 0.0 ]);
 
 	out = cuminabs( x.length, x, 1, 0, y, 1, 0 );
 	t.strictEqual( out, y, 'same reference' );
@@ -171,6 +253,36 @@ tape( 'the function supports an `x` stride', function test( t ) {
 	t.end();
 });
 
+tape( 'the function supports an `x` stride (accessor)', function test( t ) {
+	var expected;
+	var x;
+	var y;
+	var N;
+
+	x = [
+		1.0,  // 0
+		-2.0,
+		3.0,  // 1
+		4.0,
+		-5.0  // 2
+	];
+	y = [
+		0.0, // 0
+		0.0, // 1
+		0.0, // 2
+		0.0,
+		0.0
+	];
+	N = 3;
+
+	cuminabs( N, toAccessorArray( x ), 2, 0, toAccessorArray( y ), 1, 0 );
+
+	expected = [ 1.0, 1.0, 1.0, 0.0, 0.0 ];
+	t.deepEqual( y, expected, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function supports a `y` stride', function test( t ) {
 	var expected;
 	var x;
@@ -194,6 +306,36 @@ tape( 'the function supports a `y` stride', function test( t ) {
 	N = 3;
 
 	cuminabs( N, x, 1, 0, y, 2, 0 );
+
+	expected = [ 1.0, 0.0, 1.0, 0.0, 1.0 ];
+	t.deepEqual( y, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a `y` stride (accessor)', function test( t ) {
+	var expected;
+	var x;
+	var y;
+	var N;
+
+	x = [
+		1.0,  // 0
+		-2.0, // 1
+		3.0,  // 2
+		4.0,
+		5.0
+	];
+	y = [
+		0.0, // 0
+		0.0,
+		0.0, // 1
+		0.0,
+		0.0  // 2
+	];
+	N = 3;
+
+	cuminabs( N, toAccessorArray( x ), 1, 0, toAccessorArray( y ), 2, 0 );
 
 	expected = [ 1.0, 0.0, 1.0, 0.0, 1.0 ];
 	t.deepEqual( y, expected, 'returns expected value' );
@@ -231,6 +373,36 @@ tape( 'the function supports negative strides', function test( t ) {
 	t.end();
 });
 
+tape( 'the function supports negative strides (accessor)', function test( t ) {
+	var expected;
+	var x;
+	var y;
+	var N;
+
+	x = [
+		1.0,  // 2
+		-2.0,
+		3.0,  // 1
+		4.0,
+		-5.0  // 0
+	];
+	y = [
+		0.0, // 2
+		0.0, // 1
+		0.0, // 0
+		0.0,
+		0.0
+	];
+	N = 3;
+
+	cuminabs( N, toAccessorArray( x ), -2, x.length-1, toAccessorArray( y ), -1, 2 );
+
+	expected = [ 1.0, 3.0, 5.0, 0.0, 0.0 ];
+	t.deepEqual( y, expected, 'returns expected value' );
+
+	t.end();
+});
+
 tape( 'the function supports an `x` offset', function test( t ) {
 	var expected;
 	var N;
@@ -257,9 +429,45 @@ tape( 'the function supports an `x` offset', function test( t ) {
 		0.0,
 		0.0
 	];
-	N = floor( x.length / 2 );
+	N = 4;
 
 	cuminabs( N, x, 2, 1, y, 1, 0 );
+
+	expected = [ 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0 ];
+	t.deepEqual( y, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports an `x` offset (accessor)', function test( t ) {
+	var expected;
+	var N;
+	var x;
+	var y;
+
+	x = [
+		2.0,
+		1.0,  // 0
+		2.0,
+		-2.0, // 1
+		-2.0,
+		2.0,  // 2
+		3.0,
+		4.0   // 3
+	];
+	y = [
+		0.0, // 0
+		0.0, // 1
+		0.0, // 2
+		0.0, // 3
+		0.0,
+		0.0,
+		0.0,
+		0.0
+	];
+	N = 4;
+
+	cuminabs( N, toAccessorArray( x ), 2, 1, toAccessorArray( y ), 1, 0 );
 
 	expected = [ 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0 ];
 	t.deepEqual( y, expected, 'returns expected value' );
@@ -293,9 +501,45 @@ tape( 'the function supports a `y` offset', function test( t ) {
 		0.0,
 		0.0  // 3
 	];
-	N = floor( x.length / 2 );
+	N = 4;
 
 	cuminabs( N, x, 1, 0, y, 2, 1 );
+
+	expected = [ 0.0, 2.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0 ];
+	t.deepEqual( y, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports a `y` offset (accessor)', function test( t ) {
+	var expected;
+	var N;
+	var x;
+	var y;
+
+	x = [
+		2.0,  // 0
+		1.0,  // 1
+		2.0,  // 2
+		-2.0, // 3
+		-2.0,
+		2.0,
+		3.0,
+		4.0
+	];
+	y = [
+		0.0,
+		0.0, // 0
+		0.0,
+		0.0, // 1
+		0.0,
+		0.0, // 2
+		0.0,
+		0.0  // 3
+	];
+	N = 4;
+
+	cuminabs( N, toAccessorArray( x ), 1, 0, toAccessorArray( y ), 2, 1 );
 
 	expected = [ 0.0, 2.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0 ];
 	t.deepEqual( y, expected, 'returns expected value' );
@@ -328,6 +572,39 @@ tape( 'the function supports complex access patterns', function test( t ) {
 	N = 3;
 
 	cuminabs( N, x, 2, 0, y, -1, 2 );
+
+	expected = [ 1.0, 1.0, 1.0, 0.0, 0.0, 0.0 ];
+	t.deepEqual( y, expected, 'returns expected value' );
+
+	t.end();
+});
+
+
+tape( 'the function supports complex access patterns (accessor', function test( t ) {
+	var expected;
+	var x;
+	var y;
+	var N;
+
+	x = [
+		1.0,  // 0
+		2.0,
+		-3.0, // 1
+		4.0,
+		5.0,  // 2
+		6.0
+	];
+	y = [
+		0.0,  // 2
+		0.0,  // 1
+		0.0,  // 0
+		0.0,
+		0.0,
+		0.0
+	];
+	N = 3;
+
+	cuminabs( N, toAccessorArray( x ), 2, 0, toAccessorArray( y ), -1, 2 );
 
 	expected = [ 1.0, 1.0, 1.0, 0.0, 0.0, 0.0 ];
 	t.deepEqual( y, expected, 'returns expected value' );

--- a/lib/node_modules/@stdlib/stats/base/cuminabs/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/base/cuminabs/test/test.ndarray.js
@@ -275,7 +275,7 @@ tape( 'the function supports an `x` stride (accessor)', function test( t ) {
 	];
 	N = 3;
 
-	cuminabs(N, toAccessorArray( x ), 2, 0, toAccessorArray( y ), 1, 0);
+	cuminabs( N, toAccessorArray( x ), 2, 0, toAccessorArray( y ), 1, 0 );
 
 	expected = [ 1.0, 1.0, 1.0, 0.0, 0.0 ];
 	t.deepEqual( y, expected, 'returns expected value' );
@@ -395,7 +395,7 @@ tape( 'the function supports negative strides (accessor)', function test( t ) {
 	];
 	N = 3;
 
-	cuminabs(N, toAccessorArray(x), -2, x.length - 1, toAccessorArray(y), -1, 2);
+	cuminabs( N, toAccessorArray(x), -2, x.length - 1, toAccessorArray(y), -1, 2 );
 
 	expected = [ 1.0, 3.0, 5.0, 0.0, 0.0 ];
 	t.deepEqual( y, expected, 'returns expected value' );


### PR DESCRIPTION
- Refactored cuminabs implementation to support accessor protocol.
- Standardized descriptions and parameter documentation.
- Updated examples and benchmarks to align with stdlib conventions.
- Reduced code duplication by delegating main entry point to ndarray API.
- Added explicit tests for accessor arrays.
- Ensured compatibility with strided array dependencies.

Resolves #5645.

## Description

> What is the purpose of this pull request?

This pull request:

-   {{TODO: add description describing what this pull request does}}
-   Refactors stats/base/cuminabs to support the accessor protocol.
-   Standardizes descriptions and parameter documentation.
-   Updates examples and benchmarks to align with stdlib conventions.
-   Reduces code duplication by delegating the main entry point to the ndarray API.
-   Adds explicit tests for accessor arrays.
-   Ensures compatibility with strided array dependencies.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #5645

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Benchmark:
![benchmarks](https://github.com/user-attachments/assets/d336dd36-8ce5-4397-9832-e0594892b943)

tests:
![tests](https://github.com/user-attachments/assets/92159b31-f5f2-4b09-a16c-6ac707be7ffe)

examples:
![examples](https://github.com/user-attachments/assets/368f7c46-edfe-469c-8259-4ee854adbb52)



## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
