### PR TITLE
chore: fix C lint errors

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/assign/src/t_u.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assign/src/t_u.c
@@ -206,7 +206,7 @@ int8_t stdlib_ndarray_assign_t_u_0d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_1d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_1D_LOOP_CAST( const uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_1D_LOOP_CAST( const uint16_t *, uint32_t )
 	return 0;
 }
 
@@ -293,7 +293,7 @@ int8_t stdlib_ndarray_assign_t_u_1d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_2d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_2D_LOOP_CAST( const uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_2D_LOOP_CAST( const uint16_t *, uint32_t )
 	return 0;
 }
 
@@ -380,7 +380,7 @@ int8_t stdlib_ndarray_assign_t_u_2d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_2d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_2D_BLOCKED_LOOP_CAST( const uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_2D_BLOCKED_LOOP_CAST( const uint16_t *, uint32_t )
 	return 0;
 }
 
@@ -467,7 +467,7 @@ int8_t stdlib_ndarray_assign_t_u_2d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_3d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_3D_LOOP_CAST( const uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_3D_LOOP_CAST( const uint16_t *, uint32_t )
 	return 0;
 }
 
@@ -554,7 +554,7 @@ int8_t stdlib_ndarray_assign_t_u_3d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_3d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_3D_BLOCKED_LOOP_CAST( const uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_3D_BLOCKED_LOOP_CAST( const uint16_t *, uint32_t )
 	return 0;
 }
 
@@ -641,7 +641,7 @@ int8_t stdlib_ndarray_assign_t_u_3d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_4d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_4D_LOOP_CAST( const uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_4D_LOOP_CAST( const uint16_t *, uint32_t )
 	return 0;
 }
 
@@ -728,7 +728,7 @@ int8_t stdlib_ndarray_assign_t_u_4d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_4d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_4D_BLOCKED_LOOP_CAST( const uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_4D_BLOCKED_LOOP_CAST( const uint16_t *, uint32_t )
 	return 0;
 }
 
@@ -815,7 +815,7 @@ int8_t stdlib_ndarray_assign_t_u_4d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_5d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_5D_LOOP_CAST( const uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_5D_LOOP_CAST( const uint16_t *, uint32_t )
 	return 0;
 }
 
@@ -902,7 +902,7 @@ int8_t stdlib_ndarray_assign_t_u_5d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_5d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_5D_BLOCKED_LOOP_CAST( const uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_5D_BLOCKED_LOOP_CAST( const uint16_t *, uint32_t )
 	return 0;
 }
 
@@ -989,7 +989,7 @@ int8_t stdlib_ndarray_assign_t_u_5d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_6d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_6D_LOOP_CAST( const uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_6D_LOOP_CAST( const uint16_t *, uint32_t )
 	return 0;
 }
 
@@ -1076,7 +1076,7 @@ int8_t stdlib_ndarray_assign_t_u_6d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_6d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_6D_BLOCKED_LOOP_CAST( const uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_6D_BLOCKED_LOOP_CAST( const uint16_t *, uint32_t )
 	return 0;
 }
 
@@ -1163,7 +1163,7 @@ int8_t stdlib_ndarray_assign_t_u_6d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_7d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_7D_LOOP_CAST( const uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_7D_LOOP_CAST( const uint16_t *, uint32_t )
 	return 0;
 }
 
@@ -1250,7 +1250,7 @@ int8_t stdlib_ndarray_assign_t_u_7d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_7d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_7D_BLOCKED_LOOP_CAST( const uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_7D_BLOCKED_LOOP_CAST( const uint16_t *, uint32_t )
 	return 0;
 }
 
@@ -1337,7 +1337,7 @@ int8_t stdlib_ndarray_assign_t_u_7d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_8d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_8D_LOOP_CAST( const uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_8D_LOOP_CAST( const uint16_t *, uint32_t )
 	return 0;
 }
 
@@ -1424,7 +1424,7 @@ int8_t stdlib_ndarray_assign_t_u_8d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_8d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_8D_BLOCKED_LOOP_CAST( const uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_8D_BLOCKED_LOOP_CAST( const uint16_t *, uint32_t )
 	return 0;
 }
 
@@ -1511,7 +1511,7 @@ int8_t stdlib_ndarray_assign_t_u_8d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_9d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_9D_LOOP_CAST( const uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_9D_LOOP_CAST( const uint16_t *, uint32_t )
 	return 0;
 }
 
@@ -1598,7 +1598,7 @@ int8_t stdlib_ndarray_assign_t_u_9d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_9d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_9D_BLOCKED_LOOP_CAST( const uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_9D_BLOCKED_LOOP_CAST( const uint16_t *, uint32_t )
 	return 0;
 }
 
@@ -1685,7 +1685,7 @@ int8_t stdlib_ndarray_assign_t_u_9d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_10d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_10D_LOOP_CAST( const uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_10D_LOOP_CAST( const uint16_t *, uint32_t )
 	return 0;
 }
 
@@ -1772,7 +1772,7 @@ int8_t stdlib_ndarray_assign_t_u_10d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_10d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_10D_BLOCKED_LOOP_CAST( const uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_10D_BLOCKED_LOOP_CAST( const uint16_t *, uint32_t )
 	return 0;
 }
 
@@ -1859,7 +1859,7 @@ int8_t stdlib_ndarray_assign_t_u_10d_blocked( struct ndarray *arrays[], void *da
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_nd( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_ND_LOOP_CAST( const uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_ND_LOOP_CAST( const uint16_t *, uint32_t )
 	return 0;
 }
 

--- a/lib/node_modules/@stdlib/ndarray/base/assign/src/t_u.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assign/src/t_u.c
@@ -206,7 +206,7 @@ int8_t stdlib_ndarray_assign_t_u_0d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_1d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_1D_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_1D_LOOP_CAST( uint16_t * const, uint32_t )
 	return 0;
 }
 
@@ -293,7 +293,7 @@ int8_t stdlib_ndarray_assign_t_u_1d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_2d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_2D_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_2D_LOOP_CAST( uint16_t * const, uint32_t )
 	return 0;
 }
 

--- a/lib/node_modules/@stdlib/ndarray/base/assign/src/t_u.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assign/src/t_u.c
@@ -206,7 +206,7 @@ int8_t stdlib_ndarray_assign_t_u_0d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_1d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_1D_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_1D_LOOP_CAST( const uint16_t, uint32_t )
 	return 0;
 }
 
@@ -293,7 +293,7 @@ int8_t stdlib_ndarray_assign_t_u_1d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_2d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_2D_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_2D_LOOP_CAST( const uint16_t, uint32_t )
 	return 0;
 }
 
@@ -380,7 +380,7 @@ int8_t stdlib_ndarray_assign_t_u_2d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_2d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_2D_BLOCKED_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_2D_BLOCKED_LOOP_CAST( const uint16_t, uint32_t )
 	return 0;
 }
 
@@ -467,7 +467,7 @@ int8_t stdlib_ndarray_assign_t_u_2d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_3d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_3D_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_3D_LOOP_CAST( const uint16_t, uint32_t )
 	return 0;
 }
 
@@ -554,7 +554,7 @@ int8_t stdlib_ndarray_assign_t_u_3d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_3d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_3D_BLOCKED_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_3D_BLOCKED_LOOP_CAST( const uint16_t, uint32_t )
 	return 0;
 }
 
@@ -641,7 +641,7 @@ int8_t stdlib_ndarray_assign_t_u_3d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_4d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_4D_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_4D_LOOP_CAST( const uint16_t, uint32_t )
 	return 0;
 }
 
@@ -728,7 +728,7 @@ int8_t stdlib_ndarray_assign_t_u_4d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_4d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_4D_BLOCKED_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_4D_BLOCKED_LOOP_CAST( const uint16_t, uint32_t )
 	return 0;
 }
 
@@ -815,7 +815,7 @@ int8_t stdlib_ndarray_assign_t_u_4d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_5d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_5D_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_5D_LOOP_CAST( const uint16_t, uint32_t )
 	return 0;
 }
 
@@ -902,7 +902,7 @@ int8_t stdlib_ndarray_assign_t_u_5d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_5d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_5D_BLOCKED_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_5D_BLOCKED_LOOP_CAST( const uint16_t, uint32_t )
 	return 0;
 }
 
@@ -989,7 +989,7 @@ int8_t stdlib_ndarray_assign_t_u_5d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_6d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_6D_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_6D_LOOP_CAST( const uint16_t, uint32_t )
 	return 0;
 }
 
@@ -1076,7 +1076,7 @@ int8_t stdlib_ndarray_assign_t_u_6d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_6d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_6D_BLOCKED_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_6D_BLOCKED_LOOP_CAST( const uint16_t, uint32_t )
 	return 0;
 }
 
@@ -1163,7 +1163,7 @@ int8_t stdlib_ndarray_assign_t_u_6d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_7d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_7D_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_7D_LOOP_CAST( const uint16_t, uint32_t )
 	return 0;
 }
 
@@ -1250,7 +1250,7 @@ int8_t stdlib_ndarray_assign_t_u_7d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_7d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_7D_BLOCKED_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_7D_BLOCKED_LOOP_CAST( const uint16_t, uint32_t )
 	return 0;
 }
 
@@ -1337,7 +1337,7 @@ int8_t stdlib_ndarray_assign_t_u_7d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_8d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_8D_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_8D_LOOP_CAST( const uint16_t, uint32_t )
 	return 0;
 }
 
@@ -1424,7 +1424,7 @@ int8_t stdlib_ndarray_assign_t_u_8d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_8d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_8D_BLOCKED_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_8D_BLOCKED_LOOP_CAST( const uint16_t, uint32_t )
 	return 0;
 }
 
@@ -1511,7 +1511,7 @@ int8_t stdlib_ndarray_assign_t_u_8d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_9d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_9D_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_9D_LOOP_CAST( const uint16_t, uint32_t )
 	return 0;
 }
 
@@ -1598,7 +1598,7 @@ int8_t stdlib_ndarray_assign_t_u_9d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_9d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_9D_BLOCKED_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_9D_BLOCKED_LOOP_CAST( const uint16_t, uint32_t )
 	return 0;
 }
 
@@ -1685,7 +1685,7 @@ int8_t stdlib_ndarray_assign_t_u_9d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_10d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_10D_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_10D_LOOP_CAST( const uint16_t, uint32_t )
 	return 0;
 }
 
@@ -1772,7 +1772,7 @@ int8_t stdlib_ndarray_assign_t_u_10d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_10d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_10D_BLOCKED_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_10D_BLOCKED_LOOP_CAST( const uint16_t, uint32_t )
 	return 0;
 }
 
@@ -1859,7 +1859,7 @@ int8_t stdlib_ndarray_assign_t_u_10d_blocked( struct ndarray *arrays[], void *da
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_nd( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_ND_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_ND_LOOP_CAST( const uint16_t, uint32_t )
 	return 0;
 }
 

--- a/lib/node_modules/@stdlib/ndarray/base/assign/src/t_u.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assign/src/t_u.c
@@ -380,7 +380,7 @@ int8_t stdlib_ndarray_assign_t_u_2d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_2d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_2D_BLOCKED_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_2D_BLOCKED_LOOP_CAST( uint16_t * const, uint32_t )
 	return 0;
 }
 
@@ -467,7 +467,7 @@ int8_t stdlib_ndarray_assign_t_u_2d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_3d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_3D_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_3D_LOOP_CAST( uint16_t * const, uint32_t )
 	return 0;
 }
 
@@ -554,7 +554,7 @@ int8_t stdlib_ndarray_assign_t_u_3d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_3d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_3D_BLOCKED_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_3D_BLOCKED_LOOP_CAST( uint16_t * const, uint32_t )
 	return 0;
 }
 
@@ -641,7 +641,7 @@ int8_t stdlib_ndarray_assign_t_u_3d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_4d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_4D_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_4D_LOOP_CAST( uint16_t * const, uint32_t )
 	return 0;
 }
 
@@ -728,7 +728,7 @@ int8_t stdlib_ndarray_assign_t_u_4d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_4d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_4D_BLOCKED_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_4D_BLOCKED_LOOP_CAST( uint16_t * const, uint32_t )
 	return 0;
 }
 
@@ -815,7 +815,7 @@ int8_t stdlib_ndarray_assign_t_u_4d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_5d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_5D_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_5D_LOOP_CAST( uint16_t * const, uint32_t )
 	return 0;
 }
 
@@ -902,7 +902,7 @@ int8_t stdlib_ndarray_assign_t_u_5d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_5d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_5D_BLOCKED_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_5D_BLOCKED_LOOP_CAST( uint16_t * const, uint32_t )
 	return 0;
 }
 
@@ -989,7 +989,7 @@ int8_t stdlib_ndarray_assign_t_u_5d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_6d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_6D_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_6D_LOOP_CAST( uint16_t * const, uint32_t )
 	return 0;
 }
 
@@ -1076,7 +1076,7 @@ int8_t stdlib_ndarray_assign_t_u_6d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_6d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_6D_BLOCKED_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_6D_BLOCKED_LOOP_CAST( uint16_t * const, uint32_t )
 	return 0;
 }
 
@@ -1163,7 +1163,7 @@ int8_t stdlib_ndarray_assign_t_u_6d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_7d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_7D_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_7D_LOOP_CAST( uint16_t * const, uint32_t )
 	return 0;
 }
 
@@ -1250,7 +1250,7 @@ int8_t stdlib_ndarray_assign_t_u_7d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_7d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_7D_BLOCKED_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_7D_BLOCKED_LOOP_CAST( uint16_t * const, uint32_t )
 	return 0;
 }
 
@@ -1337,7 +1337,7 @@ int8_t stdlib_ndarray_assign_t_u_7d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_8d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_8D_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_8D_LOOP_CAST( uint16_t * const, uint32_t )
 	return 0;
 }
 
@@ -1424,7 +1424,7 @@ int8_t stdlib_ndarray_assign_t_u_8d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_8d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_8D_BLOCKED_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_8D_BLOCKED_LOOP_CAST( uint16_t * const, uint32_t )
 	return 0;
 }
 
@@ -1511,7 +1511,7 @@ int8_t stdlib_ndarray_assign_t_u_8d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_9d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_9D_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_9D_LOOP_CAST( uint16_t * const, uint32_t )
 	return 0;
 }
 
@@ -1598,7 +1598,7 @@ int8_t stdlib_ndarray_assign_t_u_9d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_9d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_9D_BLOCKED_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_9D_BLOCKED_LOOP_CAST( uint16_t * const, uint32_t )
 	return 0;
 }
 
@@ -1685,7 +1685,7 @@ int8_t stdlib_ndarray_assign_t_u_9d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_10d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_10D_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_10D_LOOP_CAST( uint16_t * const, uint32_t )
 	return 0;
 }
 
@@ -1772,7 +1772,7 @@ int8_t stdlib_ndarray_assign_t_u_10d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_10d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_10D_BLOCKED_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_10D_BLOCKED_LOOP_CAST( uint16_t * const, uint32_t )
 	return 0;
 }
 
@@ -1859,7 +1859,7 @@ int8_t stdlib_ndarray_assign_t_u_10d_blocked( struct ndarray *arrays[], void *da
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_nd( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_ND_LOOP_CAST( uint16_t, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_ND_LOOP_CAST( uint16_t * const, uint32_t )
 	return 0;
 }
 

--- a/lib/node_modules/@stdlib/ndarray/base/assign/src/t_u.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assign/src/t_u.c
@@ -206,7 +206,7 @@ int8_t stdlib_ndarray_assign_t_u_0d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_1d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_1D_LOOP_CAST( const uint16_t *, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_1D_LOOP_CAST( uint16_t, uint32_t )
 	return 0;
 }
 
@@ -293,7 +293,7 @@ int8_t stdlib_ndarray_assign_t_u_1d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_2d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_2D_LOOP_CAST( const uint16_t *, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_2D_LOOP_CAST( uint16_t, uint32_t )
 	return 0;
 }
 
@@ -380,7 +380,7 @@ int8_t stdlib_ndarray_assign_t_u_2d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_2d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_2D_BLOCKED_LOOP_CAST( const uint16_t *, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_2D_BLOCKED_LOOP_CAST( uint16_t, uint32_t )
 	return 0;
 }
 
@@ -467,7 +467,7 @@ int8_t stdlib_ndarray_assign_t_u_2d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_3d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_3D_LOOP_CAST( const uint16_t *, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_3D_LOOP_CAST( uint16_t, uint32_t )
 	return 0;
 }
 
@@ -554,7 +554,7 @@ int8_t stdlib_ndarray_assign_t_u_3d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_3d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_3D_BLOCKED_LOOP_CAST( const uint16_t *, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_3D_BLOCKED_LOOP_CAST( uint16_t, uint32_t )
 	return 0;
 }
 
@@ -641,7 +641,7 @@ int8_t stdlib_ndarray_assign_t_u_3d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_4d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_4D_LOOP_CAST( const uint16_t *, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_4D_LOOP_CAST( uint16_t, uint32_t )
 	return 0;
 }
 
@@ -728,7 +728,7 @@ int8_t stdlib_ndarray_assign_t_u_4d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_4d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_4D_BLOCKED_LOOP_CAST( const uint16_t *, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_4D_BLOCKED_LOOP_CAST( uint16_t, uint32_t )
 	return 0;
 }
 
@@ -815,7 +815,7 @@ int8_t stdlib_ndarray_assign_t_u_4d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_5d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_5D_LOOP_CAST( const uint16_t *, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_5D_LOOP_CAST( uint16_t, uint32_t )
 	return 0;
 }
 
@@ -902,7 +902,7 @@ int8_t stdlib_ndarray_assign_t_u_5d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_5d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_5D_BLOCKED_LOOP_CAST( const uint16_t *, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_5D_BLOCKED_LOOP_CAST( uint16_t, uint32_t )
 	return 0;
 }
 
@@ -989,7 +989,7 @@ int8_t stdlib_ndarray_assign_t_u_5d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_6d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_6D_LOOP_CAST( const uint16_t *, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_6D_LOOP_CAST( uint16_t, uint32_t )
 	return 0;
 }
 
@@ -1076,7 +1076,7 @@ int8_t stdlib_ndarray_assign_t_u_6d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_6d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_6D_BLOCKED_LOOP_CAST( const uint16_t *, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_6D_BLOCKED_LOOP_CAST( uint16_t, uint32_t )
 	return 0;
 }
 
@@ -1163,7 +1163,7 @@ int8_t stdlib_ndarray_assign_t_u_6d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_7d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_7D_LOOP_CAST( const uint16_t *, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_7D_LOOP_CAST( uint16_t, uint32_t )
 	return 0;
 }
 
@@ -1250,7 +1250,7 @@ int8_t stdlib_ndarray_assign_t_u_7d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_7d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_7D_BLOCKED_LOOP_CAST( const uint16_t *, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_7D_BLOCKED_LOOP_CAST( uint16_t, uint32_t )
 	return 0;
 }
 
@@ -1337,7 +1337,7 @@ int8_t stdlib_ndarray_assign_t_u_7d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_8d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_8D_LOOP_CAST( const uint16_t *, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_8D_LOOP_CAST( uint16_t, uint32_t )
 	return 0;
 }
 
@@ -1424,7 +1424,7 @@ int8_t stdlib_ndarray_assign_t_u_8d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_8d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_8D_BLOCKED_LOOP_CAST( const uint16_t *, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_8D_BLOCKED_LOOP_CAST( uint16_t, uint32_t )
 	return 0;
 }
 
@@ -1511,7 +1511,7 @@ int8_t stdlib_ndarray_assign_t_u_8d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_9d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_9D_LOOP_CAST( const uint16_t *, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_9D_LOOP_CAST( uint16_t, uint32_t )
 	return 0;
 }
 
@@ -1598,7 +1598,7 @@ int8_t stdlib_ndarray_assign_t_u_9d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_9d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_9D_BLOCKED_LOOP_CAST( const uint16_t *, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_9D_BLOCKED_LOOP_CAST( uint16_t, uint32_t )
 	return 0;
 }
 
@@ -1685,7 +1685,7 @@ int8_t stdlib_ndarray_assign_t_u_9d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_10d( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_10D_LOOP_CAST( const uint16_t *, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_10D_LOOP_CAST( uint16_t, uint32_t )
 	return 0;
 }
 
@@ -1772,7 +1772,7 @@ int8_t stdlib_ndarray_assign_t_u_10d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_10d_blocked( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_10D_BLOCKED_LOOP_CAST( const uint16_t *, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_10D_BLOCKED_LOOP_CAST( uint16_t, uint32_t )
 	return 0;
 }
 
@@ -1859,7 +1859,7 @@ int8_t stdlib_ndarray_assign_t_u_10d_blocked( struct ndarray *arrays[], void *da
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_t_u_nd( struct ndarray *arrays[], void *data ) {
-	STDLIB_NDARRAY_ASSIGN_ND_LOOP_CAST( const uint16_t *, uint32_t )
+	STDLIB_NDARRAY_ASSIGN_ND_LOOP_CAST( uint16_t, uint32_t )
 	return 0;
 }
 


### PR DESCRIPTION
Resolves #6105 

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes a coding style issue where the variable x1 was not declared as a pointer to const in t_u.c.
-   Updates all occurrences where x1 can be declared as const, improving code safety and reducing unintended modifications.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #6105 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

-   The changes were applied to the following lines in t_u.c: 
     -   209, 296, 383, 470, 557, 644, 731, 818, 905, 992, 1079, 1166, 1253, 1340, 1427, 1514, 1601, 1688, 1775, 1862
-   Ensured the changes follow the required coding style guidelines.


## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [X] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
