### PR TITLE
Fixed some indent style errors and updated manifest.json

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/bytes-per-element/manifest.json
+++ b/lib/node_modules/@stdlib/ndarray/base/bytes-per-element/manifest.json
@@ -1,40 +1,40 @@
 {
-	"options": {},
-	"fields": [
-		{
-			"field": "src",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "include",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "libraries",
-			"resolve": false,
-			"relative": false
-		},
-		{
-			"field": "libpath",
-			"resolve": true,
-			"relative": false
-		}
-	],
-	"confs": [
-		{
-			"src": [
-				"./src/main.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [],
-			"libpath": [],
-			"dependencies": [
-				"@stdlib/ndarray/dtypes"
-			]
-		}
-	]
+    "options": {},
+    "fields": [
+        {
+            "field": "src",
+            "resolve": true,
+            "relative": true
+        },
+        {
+            "field": "include",
+            "resolve": true,
+            "relative": true
+        },
+        {
+            "field": "libraries",
+            "resolve": false,
+            "relative": false
+        },
+        {
+            "field": "libpath",
+            "resolve": true,
+            "relative": false
+        }
+    ],
+    "confs": [
+        {
+            "src": [
+                "./src/main.c"
+            ],
+            "include": [
+                "./include"
+            ],
+            "libraries": [],
+            "libpath": [],
+            "dependencies": [
+                "@stdlib/ndarray/dtypes"
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
Resolves #6053.

## Description

> What is the purpose of this pull request?

This pull request: 

 •   Fixes EditorConfig linting issues by converting tabs to spaces in the following files:
         > lib/node_modules/@stdlib/ndarray/base/bytes-per-element/manifest.json
         > lib/node_modules/@stdlib/strided/ndapi/addon-arguments/manifest.json
 •   Ensures consistency with .editorconfig rules for indentation (spaces instead of tabs).
 •   Updates affected JSON files without modifying their structure or content.


## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves [#6053]

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
