### PR TITLE
 Fix: Correctly Apply 2-Space Indentation in manifest.json Files

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/rsqrt/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/rsqrt/manifest.json
@@ -1,78 +1,57 @@
 {
     "options": {
-        "task": "build"
+      "task": "build"
     },
     "fields": [
-        {
-            "field": "src",
-            "resolve": true,
-            "relative": true
-        },
-        {
-            "field": "include",
-            "resolve": true,
-            "relative": true
-        },
-        {
-            "field": "libraries",
-            "resolve": false,
-            "relative": false
-        },
-        {
-            "field": "libpath",
-            "resolve": true,
-            "relative": false
-        }
+      {
+        "field": "src",
+        "resolve": true,
+        "relative": true
+      },
+      {
+        "field": "include",
+        "resolve": true,
+        "relative": true
+      },
+      {
+        "field": "libraries",
+        "resolve": false,
+        "relative": false
+      },
+      {
+        "field": "libpath",
+        "resolve": true,
+        "relative": false
+      }
     ],
     "confs": [
-        {
-            "task": "build",
-            "src": [
-                "./src/rsqrt.c"
-            ],
-            "include": [
-                "./include"
-            ],
-            "libraries": [
-                "-lm"
-            ],
-            "libpath": [],
-            "dependencies": [
-                "@stdlib/math/base/napi/unary",
-                "@stdlib/math/base/special/sqrt"
-            ]
-        },
-        {
-            "task": "benchmark",
-            "src": [
-                "./src/rsqrt.c"
-            ],
-            "include": [
-                "./include"
-            ],
-            "libraries": [
-                "-lm"
-            ],
-            "libpath": [],
-            "dependencies": [
-                "@stdlib/math/base/special/sqrt"
-            ]
-        },
-        {
-            "task": "examples",
-            "src": [
-                "./src/rsqrt.c"
-            ],
-            "include": [
-                "./include"
-            ],
-            "libraries": [
-                "-lm"
-            ],
-            "libpath": [],
-            "dependencies": [
-                "@stdlib/math/base/special/sqrt"
-            ]
-        }
+      {
+        "task": "build",
+        "src": ["./src/rsqrt.c"],
+        "include": ["./include"],
+        "libraries": ["-lm"],
+        "libpath": [],
+        "dependencies": [
+          "@stdlib/math/base/napi/unary",
+          "@stdlib/math/base/special/sqrt"
+        ]
+      },
+      {
+        "task": "benchmark",
+        "src": ["./src/rsqrt.c"],
+        "include": ["./include"],
+        "libraries": ["-lm"],
+        "libpath": [],
+        "dependencies": ["@stdlib/math/base/special/sqrt"]
+      },
+      {
+        "task": "examples",
+        "src": ["./src/rsqrt.c"],
+        "include": ["./include"],
+        "libraries": ["-lm"],
+        "libpath": [],
+        "dependencies": ["@stdlib/math/base/special/sqrt"]
+      }
     ]
-}
+  }
+  

--- a/lib/node_modules/@stdlib/ndarray/base/strides2offset/manifest.json
+++ b/lib/node_modules/@stdlib/ndarray/base/strides2offset/manifest.json
@@ -1,38 +1,35 @@
 {
     "options": {},
     "fields": [
-        {
-            "field": "src",
-            "resolve": true,
-            "relative": true
-        },
-        {
-            "field": "include",
-            "resolve": true,
-            "relative": true
-        },
-        {
-            "field": "libraries",
-            "resolve": false,
-            "relative": false
-        },
-        {
-            "field": "libpath",
-            "resolve": true,
-            "relative": false
-        }
+      {
+        "field": "src",
+        "resolve": true,
+        "relative": true
+      },
+      {
+        "field": "include",
+        "resolve": true,
+        "relative": true
+      },
+      {
+        "field": "libraries",
+        "resolve": false,
+        "relative": false
+      },
+      {
+        "field": "libpath",
+        "resolve": true,
+        "relative": false
+      }
     ],
     "confs": [
-        {
-            "src": [
-                "./src/main.c"
-            ],
-            "include": [
-                "./include"
-            ],
-            "libraries": [],
-            "libpath": [],
-            "dependencies": []
-        }
+      {
+        "src": ["./src/main.c"],
+        "include": ["./include"],
+        "libraries": [],
+        "libpath": [],
+        "dependencies": []
+      }
     ]
-}
+  }
+  


### PR DESCRIPTION
Resolves #5788 .

## Description

> This PR addresses an indentation issue in the following manifest.json files:

lib/node_modules/@stdlib/math/base/special/rsqrt/manifest.json
lib/node_modules/@stdlib/ndarray/base/strides2offset/manifest.json

This pull request:

-  Corrects inconsistent indentation by applying 2-space formatting across both JSON files
- Ensures there are no tab characters or mixed indentation
- Improves readability and consistency with the project's formatting guidelines

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #5788 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
