### PR TITLE
chore: fix EditorConfig lint error #6130

### DIFF
--- a/lib/node_modules/@stdlib/_tools/pkgs/clis/lib/config.json
+++ b/lib/node_modules/@stdlib/_tools/pkgs/clis/lib/config.json
@@ -1,4 +1,4 @@
 {
-    "pattern": "**/package.json",
-    "ignore": []
+  "pattern": "**/package.json",
+  "ignore": []
 }

--- a/lib/node_modules/@stdlib/_tools/pkgs/clis/lib/config.json
+++ b/lib/node_modules/@stdlib/_tools/pkgs/clis/lib/config.json
@@ -1,4 +1,4 @@
 {
-	"pattern": "**/package.json",
-	"ignore": []
+    "pattern": "**/package.json",
+    "ignore": []
 }


### PR DESCRIPTION
Resolves a part of #6130 .

## Description

> What is the purpose of this pull request?

This pull request: 

 •   Fixes EditorConfig linting issues by converting tabs to spaces in the following files:
         > lib/node_modules/@stdlib/_tools/pkgs/clis/lib/config.json
         > lib/node_modules/@stdlib/ndarray/base/minmax-view-buffer-index/manifest.json
 •   Ensures consistency with .editorconfig rules for indentation (spaces instead of tabs).
 •   Updates affected JSON files without modifying their structure or content.


## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves a part of #6130

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
