### PR TITLE
chore: fix C lint errors #6132

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/smeanors/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/stats/base/smeanors/benchmark/c/benchmark.length.c
@@ -96,7 +96,7 @@ static float rand_float( void ) {
 */
 static double benchmark( int iterations, int len ) {
 	double elapsed;
-	float x[ len ];
+	double x[ len ];
 	float v;
 	double t;
 	int i;

--- a/lib/node_modules/@stdlib/strided/base/dmskmap/examples/c/example.c
+++ b/lib/node_modules/@stdlib/strided/base/dmskmap/examples/c/example.c
@@ -28,10 +28,10 @@ static double scale( const double x ) {
 
 int main( void ) {
 	// Create an input strided array:
-	double X[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
+	const double X[] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
 
 	// Create a mask strided array:
-	uint8_t M[] = { 0, 0, 1, 0, 0, 1 };
+	const uint8_t M[] = { 0, 0, 1, 0, 0, 1 };
 
 	// Create an output strided array:
 	double Y[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };


### PR DESCRIPTION
Resolves a part of #6132 .

## Description

> What is the purpose of this pull request?

This pull request: 

 •   Fixes the linting failures that were detected in the automated lint workflow run.
      > lib/node_modules/@stdlib/strided/base/dmskmap/examples/c/example.c:31:9
      > lib/node_modules/@stdlib/strided/base/dmskmap/examples/c/example.c:34:10
      > lib/node_modules/@stdlib/stats/base/smeanors/benchmark/c/benchmark.length.c:110:37


## Related Issues

> Does this pull request have any related issues?

This pull request:

-   Fixes #6132.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
