### PR TITLE
chore: fix EditorConfig lint errors #5453

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-allowed-data-type-cast/manifest.json
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-allowed-data-type-cast/manifest.json
@@ -1,44 +1,44 @@
 {
-	"options": {},
-	"fields": [
-		{
-			"field": "src",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "include",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "libraries",
-			"resolve": false,
-			"relative": false
-		},
-		{
-			"field": "libpath",
-			"resolve": true,
-			"relative": false
-		}
-	],
-	"confs": [
-		{
-			"src": [
-				"./src/main.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [],
-			"libpath": [],
-			"dependencies": [
-				"@stdlib/ndarray/base/assert/is-safe-data-type-cast",
-				"@stdlib/ndarray/base/assert/is-mostly-safe-data-type-cast",
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/ndarray/base/assert/is-safe-data-type-cast",
+        "@stdlib/ndarray/base/assert/is-mostly-safe-data-type-cast",
         "@stdlib/ndarray/base/assert/is-same-kind-data-type-cast",
-				"@stdlib/ndarray/casting-modes",
-				"@stdlib/ndarray/dtypes"
-			]
-		}
-	]
+        "@stdlib/ndarray/casting-modes",
+        "@stdlib/ndarray/dtypes"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Resolves a part of #5453.

## Description

> What is the purpose of this pull request?

This pull request: 

 •   Fixes the linting failures that were detected in the automated lint workflow run.
> lib/node_modules/@stdlib/ndarray/base/assert/is-allowed-data-type-cast/manifest.json:
	2-37: Wrong indent style found (tabs instead of spaces)


## Related Issues

> Does this pull request have any related issues?

This pull request:

-   Resolves a part of #5453.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
