### PR TITLE
Fix Address commit comments of #5431

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/cauchy/cdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/cauchy/cdf/README.md
@@ -170,8 +170,8 @@ for ( i = 0; i < 10; i++ ) {
 Evaluates the [cumulative distribution function][cdf] (CDF) for a [Cauchy][cauchy-distribution] distribution with parameters `x0` (location parameter) and `gamma > 0` (scale parameter).
 
 ```c
-double out = stdlib_base_dists_cauchy_cdf( 0.5, 0.0, 2.0 );
-// returns ~0.333
+double out = stdlib_base_dists_cauchy_cdf( 4.0, 0.0, 2.0 );
+// returns ~0.852
 ```
 
 The function accepts the following arguments:
@@ -213,11 +213,11 @@ static double random_uniform( const double min, const double max ) {
 }
 
 int main( void ) {
-    double gamma;
-    double x;
-    double x0;
-    double y;
     int i;
+    double x;
+    double y;
+    double x0;
+    double gamma;
 
     for ( i = 0; i < 25; i++ ) {
         x = random_uniform( 0.0, 10.0 );


### PR DESCRIPTION
Resolves a part of #5431.

## Description

> What is the purpose of this pull request?

This pull request: 

 •   Fixes the linting failures that were detected in the automated lint workflow run
> https://github.com/stdlib-js/stdlib/commit/8fa382766ef9fac1355c9ad98cf3e81f47387016#r152950715.
    Line 174: @stdlib-bot This return value is incorrect. The example should be updated to use similar values as L61 and the return value should be updated accordingly.

> https://github.com/stdlib-js/stdlib/commit/8fa382766ef9fac1355c9ad98cf3e81f47387016#r152950726
    Line 218: @stdlib-bot Variables should be ordered based on length.


## Related Issues

> Does this pull request have any related issues?

This pull request:

-   Resolves a part of #5431.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
