### PR TITLE
Fix Order of Variables According to Length # 5431

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/cauchy/cdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/cauchy/cdf/examples/c/example.c
@@ -26,11 +26,11 @@ static double random_uniform( const double min, const double max ) {
 }
 
 int main( void ) {
-	double gamma;
-	double x;
-	double x0;
-	double y;
 	int i;
+	double x;
+	double y;
+	double x0;
+	double gamma;
 
 	for ( i = 0; i < 25; i++ ) {
 		x = random_uniform( 0.0, 10.0 );


### PR DESCRIPTION
Resolves a part of #5431.

## Description

> What is the purpose of this pull request?

This pull request: 

 •   Fixes the linting failures that were detected in the automated lint workflow run
> https://github.com/stdlib-js/stdlib/commit/8fa382766ef9fac1355c9ad98cf3e81f47387016#r152950802
    Line 31: @stdlib-bot These variables should be ordered by length.


## Related Issues

> Does this pull request have any related issues?

This pull request:

-   Resolves a part of #5431.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
