### PR TITLE
chore: fixes C lint errors #5898

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/ccis/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/ccis/benchmark/c/native/benchmark.c
@@ -92,8 +92,8 @@ static double rand_double( void ) {
 * @return elapsed time in seconds
 */
 static double benchmark( void ) {
-	double re[ 100 ];
-	double im[ 100 ];
+	double real_part[ 100 ];
+	double imag_part[ 100 ];
 	double elapsed;
 	double t;
 	int i;
@@ -102,25 +102,23 @@ static double benchmark( void ) {
 	stdlib_complex128_t z2;
 
 	for ( i = 0; i < 100; i++ ) {
-		re[ i ] = ( 1000.0*rand_double() ) - 500.0;
-		im[ i ] = ( 1000.0*rand_double() ) - 500.0;
+		real_part[ i ] = ( 1000.0*rand_double() ) - 500.0;
+		imag_part[ i ] = ( 1000.0*rand_double() ) - 500.0;
 	}
 
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		z1 = stdlib_complex128( re[ i%100 ], im[ i%100 ] );
+		z1 = stdlib_complex128( real_part[ i%100 ], imag_part[ i%100 ] );
 
 		z2 = stdlib_base_ccis( z1 );
-		stdlib_complex128_reim( z2, &re[ i%100 ], &im[ i%100 ] );
-		if ( re != re ) {
+		stdlib_complex128_reim( z2, &real_part[ i%100 ], &imag_part[ i%100 ] );
+		if (isnan(real_part[ i%100 ]) || isnan(imag_part[ i%100 ])) {
 			printf( "should not return NaN\n" );
 			break;
 		}
 	}
 	elapsed = tic() - t;
-	if ( im != im ) {
-		printf( "should not return NaN\n" );
-	}
+	
 	return elapsed;
 }
 


### PR DESCRIPTION
Resolves #5898.

## Description

> What is the purpose of this pull request?

This pull request: 

 •   Fixes the following issue
> https://github.com/stdlib-js/stdlib/commit/73d8eb85e52e10d7928ec64809752baa2b23e4cc#r153449434
   Line 114: @stdlib-bot This is not what is desired based on L115. Instead, L105-6 should be renamed (e.g., are and aim for arrays of reals and imaginaries, respectively). Then the output variables here should be re and im as in the original benchmark.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #5898.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
