### PR TITLE
chore: fix C lint errors (issue #6238)

### DIFF
--- a/lib/node_modules/@stdlib/math/base/napi/unary/include/stdlib/math/base/napi/unary/d_d.h
+++ b/lib/node_modules/@stdlib/math/base/napi/unary/include/stdlib/math/base/napi/unary/d_d.h
@@ -48,17 +48,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value fcn_val;                                                   \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_d_d_wrapper,                                 \
 			NULL,                                                              \
-			&fcn                                                               \
+			&fcn_val                                                           \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return fcn_val;                                                        \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_d_d_init )
 


### PR DESCRIPTION
Resolves #6238.

## Description

> What is the purpose of this pull request?

This pull request: 

 •   Fixes the following issue
> lib/node_modules/@stdlib/math/base/special/floor10/src/addon.c:22:1: style: Local variable 'stdlib_base_floor10' shadows 
    outer function [shadowFunction]
    STDLIB_MATH_BASE_NAPI_MODULE_D_D( stdlib_base_floor10 )
 
## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #6238.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
