### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/etc/eslint/rules/style.js
+++ b/etc/eslint/rules/style.js
@@ -481,7 +481,7 @@ rules[ 'func-style' ] = [ 'error', 'declaration', {
 * // Good...
 * console.log( 1, 2 );
 */
-rules[ 'function-call-argument-newline' ] = [ 'error', 'never' ];
+rules[ 'function-call-argument-newline' ] = [ 'error', 'consistent' ];
 
 /**
 * Never allow linebreaks inside parentheses of function parameters or arguments.

--- a/lib/node_modules/@stdlib/stats/base/mskmax/lib/mskmax.js
+++ b/lib/node_modules/@stdlib/stats/base/mskmax/lib/mskmax.js
@@ -44,7 +44,15 @@ var ndarray = require( './ndarray.js' );
 * // returns 2.0
 */
 function mskmax( N, x, strideX, mask, strideMask ) {
-	return ndarray( N, x, strideX, stride2offset( N, strideX ), mask, strideMask, stride2offset( N, strideMask ) );
+	return ndarray(
+        N,
+        x,
+        strideX,
+        stride2offset( N, strideX ),
+        mask,
+        strideMask,
+        stride2offset( N, strideMask )
+    );
 }
 
 

--- a/lib/node_modules/@stdlib/stats/base/mskmax/lib/mskmax.js
+++ b/lib/node_modules/@stdlib/stats/base/mskmax/lib/mskmax.js
@@ -43,18 +43,12 @@ var ndarray = require( './ndarray.js' );
 * var v = mskmax( x.length, x, 1, mask, 1 );
 * // returns 2.0
 */
-function mskmax( N, x, strideX, mask, strideMask ) {
+function mskmax(N, x, strideX, mask, strideMask) {
 	return ndarray(
-        N,
-        x,
-        strideX,
-        stride2offset( N, strideX ),
-        mask,
-        strideMask,
-        stride2offset( N, strideMask )
-    );
+		N, x, strideX, stride2offset(N, strideX), 
+		mask, strideMask, stride2offset(N, strideMask)
+	);
 }
-
 
 // EXPORTS //
 


### PR DESCRIPTION
Resolve
## Description

> What is the purpose of this pull request?

This pull request: 

 •   Fixes the following issue
> Linting file: lib/node_modules/@stdlib/stats/base/mskmax/lib/mskmax.js
   /home/runner/work/stdlib/stdlib/lib/node_modules/@stdlib/stats/base/mskmax/lib/mskmax.js
   47:1  warning  This line has a length of 115. Maximum allowed is 80  max-len
   ✖ 1 problem (0 errors, 1 warning)
 
## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves
## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
