### PR TITLE
docs: add examples for `string` and `float` formatting

### DIFF
--- a/lib/node_modules/@stdlib/console/log-each-map/README.md
+++ b/lib/node_modules/@stdlib/console/log-each-map/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # logEachMap
 
-> Insert array element values and the result of a callback function into a format string and print the result.
+> Insert array element values and the result of a callback function into a [format string][@stdlib/string/format] and print the result.
 
 <!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
 
@@ -42,7 +42,7 @@ var logEachMap = require( '@stdlib/console/log-each-map' );
 
 #### logEachMap( str\[, ...args], clbk\[, thisArg] )
 
-Inserts array element values and the result of a callback function into a format string and prints the result.
+Inserts array element values and the result of a callback function into a [format string][@stdlib/string/format] and prints the result.
 
 ```javascript
 function add( a, b ) {
@@ -181,6 +181,8 @@ logEachMap( '%d + %d = %d', x, y, add );
 [@stdlib/array/complex128]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/complex128
 
 [@stdlib/array/complex64]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/complex64
+
+[@stdlib/string/format]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/string/format
 
 </section>
 

--- a/lib/node_modules/@stdlib/console/log-each-map/README.md
+++ b/lib/node_modules/@stdlib/console/log-each-map/README.md
@@ -95,10 +95,10 @@ function multiply( x, y ) {
 }
 
 var x = [ 1, 2, 3 ];
-var y = 2;
+var y = 0.5;
 
-logEachMap( '%d * %d = %d', x, y, multiply );
-// e.g., => '1 * 2 = 2\n2 * 2 = 4\n3 * 2 = 6\n'
+logEachMap( '%0.1f * %0.1f = %0.1f', x, y, multiply );
+// e.g., => '1.0 * 0.5 = 0.5\n2.0 * 0.5 = 1.0\n3.0 * 0.5 = 1.5\n'
 ```
 
 The callback function is provided the following arguments:

--- a/lib/node_modules/@stdlib/console/log-each-map/docs/repl.txt
+++ b/lib/node_modules/@stdlib/console/log-each-map/docs/repl.txt
@@ -27,5 +27,15 @@
     > function f( x, y ) { return x + y; };
     > {{alias}}( '%d + %d = %d', x, y, f );
 
+    > var x = [ 0.5, 1.0, 1.5 ];
+    > var y = [ 0.5, 0.75, 1.0 ];
+    > function f( x, y ) { return x * y; };
+    > {{alias}}( '%0.2f * %0.2f = %0.2f', x, y, f );
+
+    > var x = [ 'foo', 'bar' ];
+    > var y = [ 'baz', 'beep' ];
+    > function f( x, y ) { return x + y; };
+    > {{alias}}( '%s-%s', x, y, f );
+
     See Also
     --------

--- a/lib/node_modules/@stdlib/console/log-each-map/docs/repl.txt
+++ b/lib/node_modules/@stdlib/console/log-each-map/docs/repl.txt
@@ -35,7 +35,7 @@
     > var x = [ 'foo', 'bar' ];
     > var y = [ 'baz', 'beep' ];
     > function f( x, y ) { return x + y; };
-    > {{alias}}( '%s-%s', x, y, f );
+    > {{alias}}( '%s+%s = %s', x, y, f );
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/console/log-each-map/lib/index.js
+++ b/lib/node_modules/@stdlib/console/log-each-map/lib/index.js
@@ -35,6 +35,26 @@
 *
 * logEachMap( '%d + %d = %d', x, y, add );
 * // e.g., => '1 + 4 = 5\n2 + 5 = 7\n3 + 6 = 9\n'
+*
+* function multiply( x, y ) {
+*     return x * y;
+* }
+*
+* var x = [ 0.5, 1.0, 1.5 ];
+* var y = [ 0.5, 0.75, 1.0 ];
+*
+* logEachMap( '%0.2f * %0.2f = %0.2f', x, y, multiply );
+* // e.g., => '0.50 * 0.50 = 0.25\n1.00 * 0.75 = 0.75\n1.50 * 1.00 = 1.50\n'
+*
+* function append( x, y ) {
+*     return x + y;
+* }
+*
+* var x = [ 'foo', 'bar' ];
+* var y = [ 'baz', 'beep' ];
+*
+* logEachMap( '%s-%s', x, y, append );
+* // e.g., => 'foo-baz\nbar-beep\n'
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/console/log-each-map/lib/index.js
+++ b/lib/node_modules/@stdlib/console/log-each-map/lib/index.js
@@ -53,8 +53,8 @@
 * var x = [ 'foo', 'bar' ];
 * var y = [ 'baz', 'beep' ];
 *
-* logEachMap( '%s-%s', x, y, append );
-* // e.g., => 'foo-baz\nbar-beep\n'
+* logEachMap( '%s+%s = %s', x, y, append );
+* // e.g., => 'foo+baz = foobaz\nbar+beep = barbeep\n'
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/console/log-each-map/lib/main.js
+++ b/lib/node_modules/@stdlib/console/log-each-map/lib/main.js
@@ -74,8 +74,8 @@ var logger = require( '@stdlib/console/log' );
 * var x = [ 'foo', 'bar' ];
 * var y = [ 'baz', 'beep' ];
 *
-* logEachMap( '%s-%s', x, y, append );
-* // e.g., => 'foo-baz\nbar-beep\n'
+* logEachMap( '%s+%s = %s', x, y, append );
+* // e.g., => 'foo+baz = foobaz\nbar+beep = barbeep\n'
 */
 function logEachMap( str ) {
 	var strides;

--- a/lib/node_modules/@stdlib/console/log-each-map/lib/main.js
+++ b/lib/node_modules/@stdlib/console/log-each-map/lib/main.js
@@ -54,6 +54,28 @@ var logger = require( '@stdlib/console/log' );
 *
 * logEachMap( '%d + %d = %d', x, y, add );
 * // e.g., => '1 + 4 = 5\n2 + 5 = 7\n3 + 6 = 9\n'
+*
+* @example
+* function multiply( x, y ) {
+*     return x * y;
+* }
+*
+* var x = [ 0.5, 1.0, 1.5 ];
+* var y = [ 0.5, 0.75, 1.0 ];
+*
+* logEachMap( '%0.2f * %0.2f = %0.2f', x, y, multiply );
+* // e.g., => '0.50 * 0.50 = 0.25\n1.00 * 0.75 = 0.75\n1.50 * 1.00 = 1.50\n'
+*
+* @example
+* function append( x, y ) {
+*     return x + y;
+* }
+*
+* var x = [ 'foo', 'bar' ];
+* var y = [ 'baz', 'beep' ];
+*
+* logEachMap( '%s-%s', x, y, append );
+* // e.g., => 'foo-baz\nbar-beep\n'
 */
 function logEachMap( str ) {
 	var strides;


### PR DESCRIPTION
Resolves None

## Description

> What is the purpose of this pull request?

This pull request:

- adds `float` and `string` examples to `@stdlib/console/log-each-map` JSDoc

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves none

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md