### PR TITLE
chore: fix C lint errors (issue #6272)

### DIFF
--- a/lib/node_modules/@stdlib/strided/base/cmap/examples/c/example.c
+++ b/lib/node_modules/@stdlib/strided/base/cmap/examples/c/example.c
@@ -34,7 +34,7 @@ int main( void ) {
 	const float complex X[] = { 1.0+1.0*I, 2.0+2.0*I, 3.0+3.0*I, 4.0+4.0*I, 5.0+5.0*I, 6.0+6.0*I };
 
 	// Create an output strided array:
-	const float complex Y[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+	float complex Y[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 
 	// Specify the number of elements:
 	int64_t N = 6;

--- a/lib/node_modules/@stdlib/strided/base/cmap/examples/c/example.c
+++ b/lib/node_modules/@stdlib/strided/base/cmap/examples/c/example.c
@@ -31,10 +31,10 @@ static float complex scale( const float complex x ) {
 
 int main( void ) {
 	// Create an input strided array:
-	float complex X[] = { 1.0+1.0*I, 2.0+2.0*I, 3.0+3.0*I, 4.0+4.0*I, 5.0+5.0*I, 6.0+6.0*I };
+	const float complex X[] = { 1.0+1.0*I, 2.0+2.0*I, 3.0+3.0*I, 4.0+4.0*I, 5.0+5.0*I, 6.0+6.0*I };
 
 	// Create an output strided array:
-	float complex Y[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+	const float complex Y[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 
 	// Specify the number of elements:
 	int64_t N = 6;


### PR DESCRIPTION
Resolves #6272.

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes C lint error by making the float complex X[] and float complex Y[] array as constant.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #6272 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
