### PR TITLE
bench: update random value generation

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/csc/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/csc/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var sin = require( '@stdlib/math/base/special/sin' );
 var pkg = require( './../package.json' ).name;
@@ -35,10 +35,11 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -10.0, 10.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = (randu() * 20.0) - 10.0;
-		y = csc( x );
+		y = csc( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -56,10 +57,11 @@ bench( pkg + '::built-in', function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -10.0, 10.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = (randu() * 20.0) - 10.0;
-		y = 1.0 / sin( x );
+		y = 1.0 / sin( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/csc/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/csc/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -43,10 +43,11 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -10.0, 10.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = (randu() * 20.0) - 10.0;
-		y = csc( x );
+		y = csc( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/csc/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/csc/benchmark/c/native/benchmark.c
@@ -91,15 +91,18 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double x[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 20.0 * rand_double() ) - 10.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 20.0 * rand_double() ) - 10.0;
-		y = stdlib_base_csc( x );
+		y = stdlib_base_csc( x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/csc/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/csc/test/test.js
@@ -379,18 +379,18 @@ tape( 'if provided a multiple of `pi`, the function does not return `~-infinity`
 
 tape( 'if provided a `NaN`, the function returns `NaN`', function test( t ) {
 	var v = csc(NaN);
-	t.equal(isnan(v), true, 'returns NaN');
+	t.equal(isnan(v), true, 'returns expected value');
 	t.end();
 });
 
 tape( 'if provided `+infinity`, the function returns `NaN`', function test( t ) {
 	var v = csc(PINF);
-	t.equal(isnan(v), true, 'returns NaN');
+	t.equal(isnan(v), true, 'returns expected value');
 	t.end();
 });
 
 tape( 'if provided `-infinity`, the function returns `NaN`', function test( t ) {
 	var v = csc(NINF);
-	t.equal(isnan(v), true, 'returns NaN');
+	t.equal(isnan(v), true, 'returns expected value');
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/csc/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/csc/test/test.native.js
@@ -388,18 +388,18 @@ tape( 'if provided a multiple of `pi`, the function does not return `~-infinity`
 
 tape( 'if provided a `NaN`, the function returns `expected value`', opts, function test( t ) {
 	var v = csc(NaN);
-	t.equal(isnan(v), true, 'returns NaN');
+	t.equal(isnan(v), true, 'returns expected value');
 	t.end();
 });
 
 tape( 'if provided `+infinity`, the function returns `expected value`', opts, function test( t ) {
 	var v = csc(PINF);
-	t.equal(isnan(v), true, 'returns NaN');
+	t.equal(isnan(v), true, 'returns expected value');
 	t.end();
 });
 
 tape( 'if provided `-infinity`, the function returns `expected value`', opts, function test( t ) {
 	var v = csc(NINF);
-	t.equal(isnan(v), true, 'returns NaN');
+	t.equal(isnan(v), true, 'returns expected value');
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/cscd/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/cscd/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var cscd = require( './../lib' );
@@ -34,10 +34,11 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, 1.0, 3.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*2.0 ) + 1.0;
-		y = cscd( x );
+		y = cscd( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/cscd/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cscd/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -43,10 +43,11 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, 1.0, 3.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu() * 2.0 ) + 1.0;
-		y = cscd( x );
+		y = cscd( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/cscd/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/cscd/benchmark/c/native/benchmark.c
@@ -91,15 +91,18 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double x[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 2.0 * rand_double() ) + 1.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 2.0 * rand_double() ) + 1.0;
-		y = stdlib_base_cscd( x );
+		y = stdlib_base_cscd( x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/csch/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/csch/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/array/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var csch = require( './../lib' );
@@ -34,7 +34,7 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
-	x = randu( 100, -5.0, 5.0 );
+	x = uniform( 100, -5.0, 5.0 );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/math/base/special/csch/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/csch/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/array/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -43,7 +43,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
-	x = randu( 100, -5.0, 5.0 );
+	x = uniform( 100, -5.0, 5.0 );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors random number generation in JS benchmarks for the `math/base/special/csc`, `math/base/special/cscd` and `math/base/special/csch` packages.
-   Replaces `randu()` with `uniform()` from `@stdlib/random/array/uniform` for cleaner and more consistent code.
-   Moves the random number generation outside the benchmarking loops.
-   Updates the test messages to follow code conventions.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
