### PR TITLE
bench: update random value generation

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cbrt/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/cbrt/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var cbrt = require( './../lib' );
@@ -41,10 +41,11 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -500.0, 500.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 500.0;
-		y = cbrt( x );
+		y = cbrt( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -62,10 +63,11 @@ bench( pkg+'::built-in', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -500.0, 500.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 500.0;
-		y = Math.cbrt( x ); // eslint-disable-line stdlib/no-builtin-math
+		y = Math.cbrt( x[ i%x.length ] ); // eslint-disable-line stdlib/no-builtin-math
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/cbrt/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cbrt/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -43,10 +43,11 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -500.0, 500.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( 1000.0*randu() ) - 500.0;
-		y = cbrt( x );
+		y = cbrt( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/cbrt/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/cbrt/benchmark/c/benchmark.c
@@ -90,15 +90,18 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double x[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0*rand_double() ) - 500.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) - 500.0;
-		y = cbrt( x );
+		y = cbrt( x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/cbrt/benchmark/c/cephes/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/cbrt/benchmark/c/cephes/benchmark.c
@@ -95,15 +95,18 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double x[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0*rand_double() ) - 500.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) - 500.0;
-		y = cbrt( x );
+		y = cbrt( x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/cbrt/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/cbrt/benchmark/c/native/benchmark.c
@@ -91,15 +91,18 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double x[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0*rand_double() ) - 500.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) - 500.0;
-		y = stdlib_base_cbrt( x );
+		y = stdlib_base_cbrt( x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/cbrt/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/cbrt/test/test.js
@@ -383,30 +383,30 @@ tape( 'the function evaluates the cubic root of `x` (huge positive)', function t
 
 tape( 'the function returns `NaN` if provided `NaN`', function test( t ) {
 	var v = cbrt( NaN );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-infinity` if provided `-infinity`', function test( t ) {
 	var v = cbrt( NINF );
-	t.equal( v, NINF, 'returns -infinity' );
+	t.equal( v, NINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+infinity` if provided `+infinity`', function test( t ) {
 	var v = cbrt( PINF );
-	t.equal( v, PINF, 'returns +infinity' );
+	t.equal( v, PINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+0` if provided `+0`', function test( t ) {
 	var v = cbrt( +0.0 );
-	t.equal( isPositiveZero( v ), true, 'returns 0' );
+	t.equal( isPositiveZero( v ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-0` if provided `-0`', function test( t ) {
 	var v = cbrt( -0.0 );
-	t.equal( isNegativeZero( v ), true, 'returns -0' );
+	t.equal( isNegativeZero( v ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/cbrt/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cbrt/test/test.native.js
@@ -392,30 +392,30 @@ tape( 'the function evaluates the cubic root of `x` (huge positive)', opts, func
 
 tape( 'the function returns `NaN` if provided `NaN`', opts, function test( t ) {
 	var v = cbrt( NaN );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-infinity` if provided `-infinity`', opts, function test( t ) {
 	var v = cbrt( NINF );
-	t.equal( v, NINF, 'returns -infinity' );
+	t.equal( v, NINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+infinity` if provided `+infinity`', opts, function test( t ) {
 	var v = cbrt( PINF );
-	t.equal( v, PINF, 'returns +infinity' );
+	t.equal( v, PINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+0` if provided `+0`', opts, function test( t ) {
 	var v = cbrt( +0.0 );
-	t.equal( isPositiveZero( v ), true, 'returns 0' );
+	t.equal( isPositiveZero( v ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-0` if provided `-0`', opts, function test( t ) {
 	var v = cbrt( -0.0 );
-	t.equal( isNegativeZero( v ), true, 'returns -0' );
+	t.equal( isNegativeZero( v ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/cbrtf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/cbrtf/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pkg = require( './../package.json' ).name;
 var cbrtf = require( './../lib' );
@@ -41,10 +41,13 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -500.0, 500.0, {
+		'dtype': 'float32'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 500.0;
-		y = cbrtf( x );
+		y = cbrtf( x[ i%x.length ] );
 		if ( isnanf( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -62,10 +65,13 @@ bench( pkg+'::built-in', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -500.0, 500.0, {
+		'dtype': 'float32'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 500.0;
-		y = Math.cbrt( x ); // eslint-disable-line stdlib/no-builtin-math
+		y = Math.cbrt( x[ i%x.length ] ); // eslint-disable-line stdlib/no-builtin-math
 		if ( isnanf( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/cbrtf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cbrtf/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -43,10 +43,13 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -500.0, 500.0, {
+		'dtype': 'float32'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( 1000.0*randu() ) - 500.0;
-		y = cbrtf( x );
+		y = cbrtf( x[ i%x.length ] );
 		if ( isnanf( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/cbrtf/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/cbrtf/benchmark/c/benchmark.c
@@ -90,15 +90,18 @@ static float rand_float( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	float x;
+	float x[ 100 ];
 	float y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0f*rand_float() ) - 500.0f;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0f*rand_float() ) - 500.0f;
-		y = cbrtf( x );
+		y = cbrtf( x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/cbrtf/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/cbrtf/benchmark/c/native/benchmark.c
@@ -91,15 +91,18 @@ static float rand_float( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	float x;
+	float x[ 100 ];
 	float y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0f*rand_float() ) - 500.0f;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0f*rand_float() ) - 500.0f;
-		y = stdlib_base_cbrtf( x );
+		y = stdlib_base_cbrtf( x[ i%x.length ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/cbrtf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/cbrtf/test/test.js
@@ -383,30 +383,30 @@ tape( 'the function evaluates the cubic root of `x` (huge positive)', function t
 
 tape( 'the function returns `NaN` if provided `NaN`', function test( t ) {
 	var v = cbrtf( NaN );
-	t.equal( isnanf( v ), true, 'returns NaN' );
+	t.equal( isnanf( v ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-infinity` if provided `-infinity`', function test( t ) {
 	var v = cbrtf( NINF );
-	t.equal( v, NINF, 'returns -infinity' );
+	t.equal( v, NINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+infinity` if provided `+infinity`', function test( t ) {
 	var v = cbrtf( PINF );
-	t.equal( v, PINF, 'returns +infinity' );
+	t.equal( v, PINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+0` if provided `+0`', function test( t ) {
 	var v = cbrtf( +0.0 );
-	t.equal( isPositiveZerof( v ), true, 'returns 0' );
+	t.equal( isPositiveZerof( v ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-0` if provided `-0`', function test( t ) {
 	var v = cbrtf( -0.0 );
-	t.equal( isNegativeZerof( v ), true, 'returns -0' );
+	t.equal( isNegativeZerof( v ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/cbrtf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cbrtf/test/test.native.js
@@ -392,30 +392,30 @@ tape( 'the function evaluates the cubic root of `x` (huge positive)', opts, func
 
 tape( 'the function returns `NaN` if provided `NaN`', opts, function test( t ) {
 	var v = cbrtf( NaN );
-	t.equal( isnanf( v ), true, 'returns NaN' );
+	t.equal( isnanf( v ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-infinity` if provided `-infinity`', opts, function test( t ) {
 	var v = cbrtf( NINF );
-	t.equal( v, NINF, 'returns -infinity' );
+	t.equal( v, NINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+infinity` if provided `+infinity`', opts, function test( t ) {
 	var v = cbrtf( PINF );
-	t.equal( v, PINF, 'returns +infinity' );
+	t.equal( v, PINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+0` if provided `+0`', opts, function test( t ) {
 	var v = cbrtf( +0.0 );
-	t.equal( isPositiveZerof( v ), true, 'returns 0' );
+	t.equal( isPositiveZerof( v ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-0` if provided `-0`', opts, function test( t ) {
 	var v = cbrtf( -0.0 );
-	t.equal( isNegativeZerof( v ), true, 'returns -0' );
+	t.equal( isNegativeZerof( v ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/clamp/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/clamp/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var clamp = require( './../lib' );
@@ -34,10 +34,11 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -10.0, 10.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*20.0 ) - 10.0;
-		y = clamp( x, -5.0, 5.0 );
+		y = clamp( x[ i%x.length ], -5.0, 5.0 );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/clamp/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/clamp/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -43,10 +43,11 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -10.0, 10.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*20.0 ) - 10.0;
-		y = clamp( x, -5.0, 5.0 );
+		y = clamp( x[ i%x.length ], -5.0, 5.0 );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/clamp/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/clamp/benchmark/c/benchmark.c
@@ -108,15 +108,18 @@ double clamp( double v, double min, double max ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double x[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 20.0*rand_double() ) - 10.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 20.0*rand_double() ) - 10.0;
-		y = clamp( x, -5.0, 5.0 );
+		y = clamp( x[ i%100 ], -5.0, 5.0 );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/clamp/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/clamp/benchmark/c/native/benchmark.c
@@ -91,15 +91,18 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double x[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 20.0*rand_double() ) - 10.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 20.0*rand_double() ) - 10.0;
-		y = stdlib_base_clamp( x, -5.0, 5.0 );
+		y = stdlib_base_clamp( x[ i%100 ], -5.0, 5.0 );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/clamp/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/clamp/test/test.js
@@ -39,25 +39,25 @@ tape( 'if provided `NaN` for any argument, the function returns `NaN`', function
 	var v;
 
 	v = clamp( NaN, 0.0, 5.0 );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = clamp( 0.0, NaN, 5.0 );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = clamp( 3.14, 0.0, NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = clamp( NaN, NaN, 5.0 );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = clamp( NaN, 0.0, NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = clamp( 3.14, NaN, NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = clamp( NaN, NaN, NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/clamp/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/clamp/test/test.native.js
@@ -48,25 +48,25 @@ tape( 'if provided `NaN` for any argument, the function returns `NaN`', opts, fu
 	var v;
 
 	v = clamp( NaN, 0.0, 5.0 );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = clamp( 0.0, NaN, 5.0 );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = clamp( 3.14, 0.0, NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = clamp( NaN, NaN, 5.0 );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = clamp( NaN, 0.0, NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = clamp( 3.14, NaN, NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = clamp( NaN, NaN, NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/clampf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/clampf/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pkg = require( './../package.json' ).name;
 var clampf = require( './../lib' );
@@ -34,10 +34,13 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -10.0, 10.0, {
+		'dtype': 'float32'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*20.0 ) - 10.0;
-		y = clampf( x, -5.0, 5.0 );
+		y = clampf( x[ i%x.length ], -5.0, 5.0 );
 		if ( isnanf( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/clampf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/clampf/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -43,10 +43,13 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -10.0, 10.0, {
+		'dtype': 'float32'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*20.0 ) - 10.0;
-		y = clampf( x, -5.0, 5.0 );
+		y = clampf( x[ i%x.length ], -5.0, 5.0 );
 		if ( isnanf( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/clampf/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/clampf/benchmark/c/benchmark.c
@@ -109,14 +109,17 @@ float clampf( float v, float min, float max ) {
 static double benchmark( void ) {
 	double elapsed;
 	double t;
-	float x;
+	float x[ 100 ];
 	float y;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 20.0f*rand_float() ) - 10.0f;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 20.0f*rand_float() ) - 10.0f;
-		y = clampf( x, -5.0f, 5.0f );
+		y = clampf( x[ i%100 ], -5.0f, 5.0f );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/clampf/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/clampf/benchmark/c/native/benchmark.c
@@ -92,14 +92,17 @@ static float rand_float( void ) {
 static double benchmark( void ) {
 	double elapsed;
 	double t;
-	float x;
+	float x[ 100 ];
 	float y;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 20.0f*rand_float() ) - 10.0f;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 20.0f*rand_float() ) - 10.0f;
-		y = stdlib_base_clampf( x, -5.0f, 5.0f );
+		y = stdlib_base_clampf( x[ i%100 ], -5.0f, 5.0f );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/clampf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/clampf/test/test.js
@@ -39,25 +39,25 @@ tape( 'if provided `NaN` for any argument, the function returns `NaN`', function
 	var v;
 
 	v = clampf( NaN, 0.0, 5.0 );
-	t.strictEqual( isnanf( v ), true, 'returns NaN' );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
 
 	v = clampf( 0.0, NaN, 5.0 );
-	t.strictEqual( isnanf( v ), true, 'returns NaN' );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
 
 	v = clampf( 3.14, 0.0, NaN );
-	t.strictEqual( isnanf( v ), true, 'returns NaN' );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
 
 	v = clampf( NaN, NaN, 5.0 );
-	t.strictEqual( isnanf( v ), true, 'returns NaN' );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
 
 	v = clampf( NaN, 0.0, NaN );
-	t.strictEqual( isnanf( v ), true, 'returns NaN' );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
 
 	v = clampf( 3.14, NaN, NaN );
-	t.strictEqual( isnanf( v ), true, 'returns NaN' );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
 
 	v = clampf( NaN, NaN, NaN );
-	t.strictEqual( isnanf( v ), true, 'returns NaN' );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/clampf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/clampf/test/test.native.js
@@ -48,25 +48,25 @@ tape( 'if provided `NaN` for any argument, the function returns `NaN`', opts, fu
 	var v;
 
 	v = clampf( NaN, 0.0, 5.0 );
-	t.strictEqual( isnanf( v ), true, 'returns NaN' );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
 
 	v = clampf( 0.0, NaN, 5.0 );
-	t.strictEqual( isnanf( v ), true, 'returns NaN' );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
 
 	v = clampf( 3.14, 0.0, NaN );
-	t.strictEqual( isnanf( v ), true, 'returns NaN' );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
 
 	v = clampf( NaN, NaN, 5.0 );
-	t.strictEqual( isnanf( v ), true, 'returns NaN' );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
 
 	v = clampf( NaN, 0.0, NaN );
-	t.strictEqual( isnanf( v ), true, 'returns NaN' );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
 
 	v = clampf( 3.14, NaN, NaN );
-	t.strictEqual( isnanf( v ), true, 'returns NaN' );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
 
 	v = clampf( NaN, NaN, NaN );
-	t.strictEqual( isnanf( v ), true, 'returns NaN' );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
 
 	t.end();
 });


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors random number generation in JS benchmarks for the `math/base/special/cbrt`, `math/base/special/cbrtf`, `math/base/special/clamp` and `math/base/special/clampf` packages.
-   Replaces `randu()` with `uniform()` from `@stdlib/random/array/uniform` for cleaner and more consistent code.
-   Moves the random number generation outside the benchmarking loops.
-   Updates the test messages to follow code conventions.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
