### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/besselj0/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/besselj0/README.md
@@ -192,14 +192,6 @@ int main( void ) {
 
 <section class="related">
 
-* * *
-
-## See Also
-
--   <span class="package-name">[`@stdlib/math/base/special/besselj1`][@stdlib/math/base/special/besselj1]</span><span class="delimiter">: </span><span class="description">compute the Bessel function of the first kind of order one.</span>
--   <span class="package-name">[`@stdlib/math/base/special/bessely0`][@stdlib/math/base/special/bessely0]</span><span class="delimiter">: </span><span class="description">compute the Bessel function of the second kind of order zero.</span>
--   <span class="package-name">[`@stdlib/math/base/special/bessely1`][@stdlib/math/base/special/bessely1]</span><span class="delimiter">: </span><span class="description">compute the Bessel function of the second kind of order one.</span>
-
 </section>
 
 <!-- /.related -->
@@ -211,12 +203,6 @@ int main( void ) {
 [bessel-first-kind]: https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_first_kind:_J.CE.B1
 
 <!-- <related-links> -->
-
-[@stdlib/math/base/special/besselj1]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/besselj1
-
-[@stdlib/math/base/special/bessely0]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/bessely0
-
-[@stdlib/math/base/special/bessely1]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/bessely1
 
 <!-- </related-links> -->
 

--- a/lib/node_modules/@stdlib/math/base/special/besselj0/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/besselj0/README.md
@@ -83,16 +83,17 @@ v = j0( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var j0 = require( '@stdlib/math/base/special/besselj0' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
+var besselj0 = require( '@stdlib/math/base/special/besselj0' );
 
 var x;
-var i;
 
-for ( i = 0; i < 100; i++ ) {
-    x = randu() * 10.0;
-    console.log( 'j0(%d) = %d', x, j0( x ) );
-}
+x = uniform( 100, 0.0, 100.0, {
+	'dtype': 'float64'
+});
+
+logEachMap( 'besselj0(%0.4f) = %0.4f', x, besselj0 );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/besselj0/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/besselj0/README.md
@@ -87,9 +87,10 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var besselj0 = require( '@stdlib/math/base/special/besselj0' );
 
-var x = uniform( 100, 0.0, 100.0, {
+var opts = {
     'dtype': 'float64'
-});
+};
+var x = uniform( 100, 0.0, 100.0, opts );
 
 logEachMap( 'besselj0(%0.4f) = %0.4f', x, besselj0 );
 ```

--- a/lib/node_modules/@stdlib/math/base/special/besselj0/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/besselj0/README.md
@@ -87,9 +87,7 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var besselj0 = require( '@stdlib/math/base/special/besselj0' );
 
-var x;
-
-x = uniform( 100, 0.0, 100.0, {
+var x = uniform( 100, 0.0, 100.0, {
     'dtype': 'float64'
 });
 
@@ -192,6 +190,14 @@ int main( void ) {
 
 <section class="related">
 
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/math/base/special/besselj1`][@stdlib/math/base/special/besselj1]</span><span class="delimiter">: </span><span class="description">compute the Bessel function of the first kind of order one.</span>
+-   <span class="package-name">[`@stdlib/math/base/special/bessely0`][@stdlib/math/base/special/bessely0]</span><span class="delimiter">: </span><span class="description">compute the Bessel function of the second kind of order zero.</span>
+-   <span class="package-name">[`@stdlib/math/base/special/bessely1`][@stdlib/math/base/special/bessely1]</span><span class="delimiter">: </span><span class="description">compute the Bessel function of the second kind of order one.</span>
+
 </section>
 
 <!-- /.related -->
@@ -203,6 +209,12 @@ int main( void ) {
 [bessel-first-kind]: https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_first_kind:_J.CE.B1
 
 <!-- <related-links> -->
+
+[@stdlib/math/base/special/besselj1]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/besselj1
+
+[@stdlib/math/base/special/bessely0]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/bessely0
+
+[@stdlib/math/base/special/bessely1]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/bessely1
 
 <!-- </related-links> -->
 

--- a/lib/node_modules/@stdlib/math/base/special/besselj0/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/besselj0/README.md
@@ -90,7 +90,7 @@ var besselj0 = require( '@stdlib/math/base/special/besselj0' );
 var x;
 
 x = uniform( 100, 0.0, 100.0, {
-	'dtype': 'float64'
+    'dtype': 'float64'
 });
 
 logEachMap( 'besselj0(%0.4f) = %0.4f', x, besselj0 );

--- a/lib/node_modules/@stdlib/math/base/special/besselj0/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/besselj0/examples/index.js
@@ -22,10 +22,9 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var besselj0 = require( './../lib' );
 
-var x;
-
-x = uniform( 100, 0.0, 100.0, {
-	'dtype': 'float64'
-});
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, 0.0, 100.0, opts );
 
 logEachMap( 'besselj0(%0.4f) = %0.4f', x, besselj0 );

--- a/lib/node_modules/@stdlib/math/base/special/besselj0/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/besselj0/examples/index.js
@@ -18,13 +18,14 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var besselj0 = require( './../lib' );
 
 var x;
-var i;
 
-for ( i = 0; i < 100; i++ ) {
-	x = randu() * 100.0;
-	console.log( 'besselj0(%d) = %d', x, besselj0( x ) );
-}
+x = uniform( 100, 0.0, 100.0, {
+	'dtype': 'float64'
+});
+
+logEachMap( 'besselj0(%0.4f) = %0.4f', x, besselj0 );

--- a/lib/node_modules/@stdlib/math/base/special/besselj0/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/besselj0/examples/index.js
@@ -23,7 +23,7 @@ var logEachMap = require( '@stdlib/console/log-each-map' );
 var besselj0 = require( './../lib' );
 
 var opts = {
-    'dtype': 'float64'
+	'dtype': 'float64'
 };
 var x = uniform( 100, 0.0, 100.0, opts );
 

--- a/lib/node_modules/@stdlib/math/base/special/besselj1/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/besselj1/README.md
@@ -90,7 +90,7 @@ var besselj1 = require( '@stdlib/math/base/special/besselj1' );
 var x;
 
 x = uniform( 100, 0.0, 100.0, {
-	'dtype': 'float64'
+    'dtype': 'float64'
 });
 
 logEachMap( 'besselj1(%0.4f) = %0.4f', x, besselj1 );

--- a/lib/node_modules/@stdlib/math/base/special/besselj1/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/besselj1/README.md
@@ -87,9 +87,10 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var besselj1 = require( '@stdlib/math/base/special/besselj1' );
 
-var x = uniform( 100, 0.0, 100.0, {
+var opts = {
     'dtype': 'float64'
-});
+};
+var x = uniform( 100, 0.0, 100.0, opts );
 
 logEachMap( 'besselj1(%0.4f) = %0.4f', x, besselj1 );
 ```

--- a/lib/node_modules/@stdlib/math/base/special/besselj1/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/besselj1/README.md
@@ -87,9 +87,7 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var besselj1 = require( '@stdlib/math/base/special/besselj1' );
 
-var x;
-
-x = uniform( 100, 0.0, 100.0, {
+var x = uniform( 100, 0.0, 100.0, {
     'dtype': 'float64'
 });
 
@@ -192,6 +190,14 @@ int main( void ) {
 
 <section class="related">
 
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/math/base/special/besselj0`][@stdlib/math/base/special/besselj0]</span><span class="delimiter">: </span><span class="description">compute the Bessel function of the first kind of order zero.</span>
+-   <span class="package-name">[`@stdlib/math/base/special/bessely0`][@stdlib/math/base/special/bessely0]</span><span class="delimiter">: </span><span class="description">compute the Bessel function of the second kind of order zero.</span>
+-   <span class="package-name">[`@stdlib/math/base/special/bessely1`][@stdlib/math/base/special/bessely1]</span><span class="delimiter">: </span><span class="description">compute the Bessel function of the second kind of order one.</span>
+
 </section>
 
 <!-- /.related -->
@@ -203,6 +209,12 @@ int main( void ) {
 [bessel-first-kind]: https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_first_kind:_J.CE.B1
 
 <!-- <related-links> -->
+
+[@stdlib/math/base/special/besselj0]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/besselj0
+
+[@stdlib/math/base/special/bessely0]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/bessely0
+
+[@stdlib/math/base/special/bessely1]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/bessely1
 
 <!-- </related-links> -->
 

--- a/lib/node_modules/@stdlib/math/base/special/besselj1/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/besselj1/README.md
@@ -192,14 +192,6 @@ int main( void ) {
 
 <section class="related">
 
-* * *
-
-## See Also
-
--   <span class="package-name">[`@stdlib/math/base/special/besselj0`][@stdlib/math/base/special/besselj0]</span><span class="delimiter">: </span><span class="description">compute the Bessel function of the first kind of order zero.</span>
--   <span class="package-name">[`@stdlib/math/base/special/bessely0`][@stdlib/math/base/special/bessely0]</span><span class="delimiter">: </span><span class="description">compute the Bessel function of the second kind of order zero.</span>
--   <span class="package-name">[`@stdlib/math/base/special/bessely1`][@stdlib/math/base/special/bessely1]</span><span class="delimiter">: </span><span class="description">compute the Bessel function of the second kind of order one.</span>
-
 </section>
 
 <!-- /.related -->
@@ -211,12 +203,6 @@ int main( void ) {
 [bessel-first-kind]: https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_first_kind:_J.CE.B1
 
 <!-- <related-links> -->
-
-[@stdlib/math/base/special/besselj0]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/besselj0
-
-[@stdlib/math/base/special/bessely0]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/bessely0
-
-[@stdlib/math/base/special/bessely1]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/bessely1
 
 <!-- </related-links> -->
 

--- a/lib/node_modules/@stdlib/math/base/special/besselj1/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/besselj1/README.md
@@ -83,16 +83,17 @@ v = j1( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var j1 = require( '@stdlib/math/base/special/besselj1' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
+var besselj1 = require( '@stdlib/math/base/special/besselj1' );
 
 var x;
-var i;
 
-for ( i = 0; i < 100; i++ ) {
-    x = randu() * 10.0;
-    console.log( 'j1(%d) = %d', x, j1( x ) );
-}
+x = uniform( 100, 0.0, 100.0, {
+	'dtype': 'float64'
+});
+
+logEachMap( 'besselj1(%0.4f) = %0.4f', x, besselj1 );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/besselj1/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/besselj1/examples/index.js
@@ -18,13 +18,14 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var besselj1 = require( './../lib' );
 
 var x;
-var i;
 
-for ( i = 0; i < 100; i++ ) {
-	x = randu() * 100.0;
-	console.log( 'besselj1(%d) = %d', x, besselj1( x ) );
-}
+x = uniform( 100, 0.0, 100.0, {
+	'dtype': 'float64'
+});
+
+logEachMap( 'besselj1(%0.4f) = %0.4f', x, besselj1 );

--- a/lib/node_modules/@stdlib/math/base/special/besselj1/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/besselj1/examples/index.js
@@ -22,10 +22,9 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var besselj1 = require( './../lib' );
 
-var x;
-
-x = uniform( 100, 0.0, 100.0, {
+var opts = {
 	'dtype': 'float64'
-});
+};
+var x = uniform( 100, 0.0, 100.0, opts );
 
 logEachMap( 'besselj1(%0.4f) = %0.4f', x, besselj1 );

--- a/lib/node_modules/@stdlib/math/base/special/bessely0/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/bessely0/README.md
@@ -199,14 +199,6 @@ int main( void ) {
 
 <section class="related">
 
-* * *
-
-## See Also
-
--   <span class="package-name">[`@stdlib/math/base/special/besselj0`][@stdlib/math/base/special/besselj0]</span><span class="delimiter">: </span><span class="description">compute the Bessel function of the first kind of order zero.</span>
--   <span class="package-name">[`@stdlib/math/base/special/besselj1`][@stdlib/math/base/special/besselj1]</span><span class="delimiter">: </span><span class="description">compute the Bessel function of the first kind of order one.</span>
--   <span class="package-name">[`@stdlib/math/base/special/bessely1`][@stdlib/math/base/special/bessely1]</span><span class="delimiter">: </span><span class="description">compute the Bessel function of the second kind of order one.</span>
-
 </section>
 
 <!-- /.related -->
@@ -218,12 +210,6 @@ int main( void ) {
 [bessel-second-kind]: https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_second_kind:_Y.CE.B1
 
 <!-- <related-links> -->
-
-[@stdlib/math/base/special/besselj0]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/besselj0
-
-[@stdlib/math/base/special/besselj1]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/besselj1
-
-[@stdlib/math/base/special/bessely1]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/bessely1
 
 <!-- </related-links> -->
 

--- a/lib/node_modules/@stdlib/math/base/special/bessely0/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/bessely0/README.md
@@ -94,9 +94,7 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var bessely0 = require( '@stdlib/math/base/special/bessely0' );
 
-var x;
-
-x = uniform( 100, 0.0, 100.0, {
+var x = uniform( 100, 0.0, 100.0, {
     'dtype': 'float64'
 });
 
@@ -199,6 +197,14 @@ int main( void ) {
 
 <section class="related">
 
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/math/base/special/besselj0`][@stdlib/math/base/special/besselj0]</span><span class="delimiter">: </span><span class="description">compute the Bessel function of the first kind of order zero.</span>
+-   <span class="package-name">[`@stdlib/math/base/special/besselj1`][@stdlib/math/base/special/besselj1]</span><span class="delimiter">: </span><span class="description">compute the Bessel function of the first kind of order one.</span>
+-   <span class="package-name">[`@stdlib/math/base/special/bessely1`][@stdlib/math/base/special/bessely1]</span><span class="delimiter">: </span><span class="description">compute the Bessel function of the second kind of order one.</span>
+
 </section>
 
 <!-- /.related -->
@@ -210,6 +216,12 @@ int main( void ) {
 [bessel-second-kind]: https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_second_kind:_Y.CE.B1
 
 <!-- <related-links> -->
+
+[@stdlib/math/base/special/besselj0]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/besselj0
+
+[@stdlib/math/base/special/besselj1]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/besselj1
+
+[@stdlib/math/base/special/bessely1]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/bessely1
 
 <!-- </related-links> -->
 

--- a/lib/node_modules/@stdlib/math/base/special/bessely0/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/bessely0/README.md
@@ -90,16 +90,17 @@ v = y0( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var y0 = require( '@stdlib/math/base/special/bessely0' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
+var bessely0 = require( '@stdlib/math/base/special/bessely0' );
 
 var x;
-var i;
 
-for ( i = 0; i < 100; i++ ) {
-    x = randu() * 10.0;
-    console.log( 'y0(%d) = %d', x, y0( x ) );
-}
+x = uniform( 100, 0.0, 100.0, {
+	'dtype': 'float64'
+});
+
+logEachMap( 'bessely0(%0.4f) = %0.4f', x, bessely0 );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/bessely0/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/bessely0/README.md
@@ -97,7 +97,7 @@ var bessely0 = require( '@stdlib/math/base/special/bessely0' );
 var x;
 
 x = uniform( 100, 0.0, 100.0, {
-	'dtype': 'float64'
+    'dtype': 'float64'
 });
 
 logEachMap( 'bessely0(%0.4f) = %0.4f', x, bessely0 );

--- a/lib/node_modules/@stdlib/math/base/special/bessely0/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/bessely0/README.md
@@ -94,9 +94,10 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var bessely0 = require( '@stdlib/math/base/special/bessely0' );
 
-var x = uniform( 100, 0.0, 100.0, {
+var opts = {
     'dtype': 'float64'
-});
+};
+var x = uniform( 100, 0.0, 100.0, opts );
 
 logEachMap( 'bessely0(%0.4f) = %0.4f', x, bessely0 );
 ```

--- a/lib/node_modules/@stdlib/math/base/special/bessely0/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/bessely0/examples/index.js
@@ -18,13 +18,14 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var bessely0 = require( './../lib' );
 
 var x;
-var i;
 
-for ( i = 0; i < 100; i++ ) {
-	x = randu() * 100.0;
-	console.log( 'bessely0(%d) = %d', x, bessely0( x ) );
-}
+x = uniform( 100, 0.0, 100.0, {
+	'dtype': 'float64'
+});
+
+logEachMap( 'bessely0(%0.4f) = %0.4f', x, bessely0 );

--- a/lib/node_modules/@stdlib/math/base/special/bessely0/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/bessely0/examples/index.js
@@ -22,10 +22,9 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var bessely0 = require( './../lib' );
 
-var x;
-
-x = uniform( 100, 0.0, 100.0, {
+var opts = {
 	'dtype': 'float64'
-});
+};
+var x = uniform( 100, 0.0, 100.0, opts );
 
 logEachMap( 'bessely0(%0.4f) = %0.4f', x, bessely0 );

--- a/lib/node_modules/@stdlib/math/base/special/bessely1/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/bessely1/README.md
@@ -112,14 +112,6 @@ logEachMap( 'bessely1(%0.4f) = %0.4f', x, bessely1 );
 
 <section class="related">
 
-* * *
-
-## See Also
-
--   <span class="package-name">[`@stdlib/math/base/special/besselj0`][@stdlib/math/base/special/besselj0]</span><span class="delimiter">: </span><span class="description">compute the Bessel function of the first kind of order zero.</span>
--   <span class="package-name">[`@stdlib/math/base/special/besselj1`][@stdlib/math/base/special/besselj1]</span><span class="delimiter">: </span><span class="description">compute the Bessel function of the first kind of order one.</span>
--   <span class="package-name">[`@stdlib/math/base/special/bessely0`][@stdlib/math/base/special/bessely0]</span><span class="delimiter">: </span><span class="description">compute the Bessel function of the second kind of order zero.</span>
-
 </section>
 
 <!-- /.related -->
@@ -131,12 +123,6 @@ logEachMap( 'bessely1(%0.4f) = %0.4f', x, bessely1 );
 [bessel-second-kind]: https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_second_kind:_Y.CE.B1
 
 <!-- <related-links> -->
-
-[@stdlib/math/base/special/besselj0]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/besselj0
-
-[@stdlib/math/base/special/besselj1]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/besselj1
-
-[@stdlib/math/base/special/bessely0]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/bessely0
 
 <!-- </related-links> -->
 

--- a/lib/node_modules/@stdlib/math/base/special/bessely1/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/bessely1/README.md
@@ -98,7 +98,7 @@ var bessely1 = require( '@stdlib/math/base/special/bessely1' );
 var x;
 
 x = uniform( 100, 0.0, 100.0, {
-	'dtype': 'float64'
+    'dtype': 'float64'
 });
 
 logEachMap( 'bessely1(%0.4f) = %0.4f', x, bessely1 );

--- a/lib/node_modules/@stdlib/math/base/special/bessely1/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/bessely1/README.md
@@ -112,6 +112,14 @@ logEachMap( 'bessely1(%0.4f) = %0.4f', x, bessely1 );
 
 <section class="related">
 
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/math/base/special/besselj0`][@stdlib/math/base/special/besselj0]</span><span class="delimiter">: </span><span class="description">compute the Bessel function of the first kind of order zero.</span>
+-   <span class="package-name">[`@stdlib/math/base/special/besselj1`][@stdlib/math/base/special/besselj1]</span><span class="delimiter">: </span><span class="description">compute the Bessel function of the first kind of order one.</span>
+-   <span class="package-name">[`@stdlib/math/base/special/bessely0`][@stdlib/math/base/special/bessely0]</span><span class="delimiter">: </span><span class="description">compute the Bessel function of the second kind of order zero.</span>
+
 </section>
 
 <!-- /.related -->
@@ -123,6 +131,12 @@ logEachMap( 'bessely1(%0.4f) = %0.4f', x, bessely1 );
 [bessel-second-kind]: https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_second_kind:_Y.CE.B1
 
 <!-- <related-links> -->
+
+[@stdlib/math/base/special/besselj0]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/besselj0
+
+[@stdlib/math/base/special/besselj1]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/besselj1
+
+[@stdlib/math/base/special/bessely0]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/bessely0
 
 <!-- </related-links> -->
 

--- a/lib/node_modules/@stdlib/math/base/special/bessely1/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/bessely1/README.md
@@ -91,16 +91,17 @@ v = y1( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var y1 = require( '@stdlib/math/base/special/bessely1' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
+var bessely1 = require( '@stdlib/math/base/special/bessely1' );
 
 var x;
-var i;
 
-for ( i = 0; i < 100; i++ ) {
-    x = randu() * 10.0;
-    console.log( 'y1(%d) = %d', x, y1( x ) );
-}
+x = uniform( 100, 0.0, 100.0, {
+	'dtype': 'float64'
+});
+
+logEachMap( 'bessely1(%0.4f) = %0.4f', x, bessely1 );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/bessely1/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/bessely1/README.md
@@ -95,11 +95,10 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var bessely1 = require( '@stdlib/math/base/special/bessely1' );
 
-var x;
-
-x = uniform( 100, 0.0, 100.0, {
+var opts = {
     'dtype': 'float64'
-});
+};
+var x = uniform( 100, 0.0, 100.0, opts );
 
 logEachMap( 'bessely1(%0.4f) = %0.4f', x, bessely1 );
 ```

--- a/lib/node_modules/@stdlib/math/base/special/bessely1/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/bessely1/examples/index.js
@@ -22,10 +22,9 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var bessely1 = require( './../lib' );
 
-var x;
-
-x = uniform( 100, 0.0, 100.0, {
-	'dtype': 'float64'
-});
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, 0.0, 100.0, opts );
 
 logEachMap( 'bessely1(%0.4f) = %0.4f', x, bessely1 );

--- a/lib/node_modules/@stdlib/math/base/special/bessely1/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/bessely1/examples/index.js
@@ -18,13 +18,14 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var bessely1 = require( './../lib' );
 
 var x;
-var i;
 
-for ( i = 0; i < 100; i++ ) {
-	x = randu() * 100.0;
-	console.log( 'bessely1(%d) = %d', x, bessely1( x ) );
-}
+x = uniform( 100, 0.0, 100.0, {
+	'dtype': 'float64'
+});
+
+logEachMap( 'bessely1(%0.4f) = %0.4f', x, bessely1 );

--- a/lib/node_modules/@stdlib/math/base/special/bessely1/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/bessely1/examples/index.js
@@ -23,7 +23,7 @@ var logEachMap = require( '@stdlib/console/log-each-map' );
 var bessely1 = require( './../lib' );
 
 var opts = {
-    'dtype': 'float64'
+	'dtype': 'float64'
 };
 var x = uniform( 100, 0.0, 100.0, opts );
 

--- a/lib/node_modules/@stdlib/math/base/special/betainc/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/betainc/README.md
@@ -131,6 +131,14 @@ logEachMap( 'x: %0.4f, \t a: %0.4f, \t b: %0.4f, \t f(x,a,b): %0.4f', x, a, b, b
 
 <section class="related">
 
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/math/base/special/beta`][@stdlib/math/base/special/beta]</span><span class="delimiter">: </span><span class="description">beta function.</span>
+-   <span class="package-name">[`@stdlib/math/base/special/betaincinv`][@stdlib/math/base/special/betaincinv]</span><span class="delimiter">: </span><span class="description">inverse incomplete beta function.</span>
+-   <span class="package-name">[`@stdlib/math/base/special/betaln`][@stdlib/math/base/special/betaln]</span><span class="delimiter">: </span><span class="description">natural logarithm of the beta function.</span>
+
 </section>
 
 <!-- /.related -->
@@ -142,6 +150,12 @@ logEachMap( 'x: %0.4f, \t a: %0.4f, \t b: %0.4f, \t f(x,a,b): %0.4f', x, a, b, b
 [incomplete-beta-function]: https://en.wikipedia.org/wiki/Incomplete_beta_function
 
 <!-- <related-links> -->
+
+[@stdlib/math/base/special/beta]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/beta
+
+[@stdlib/math/base/special/betaincinv]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/betaincinv
+
+[@stdlib/math/base/special/betaln]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/betaln
 
 <!-- </related-links> -->
 

--- a/lib/node_modules/@stdlib/math/base/special/betainc/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/betainc/README.md
@@ -131,14 +131,6 @@ logEachMap( 'x: %0.4f, \t a: %0.4f, \t b: %0.4f, \t f(x,a,b): %0.4f', x, a, b, b
 
 <section class="related">
 
-* * *
-
-## See Also
-
--   <span class="package-name">[`@stdlib/math/base/special/beta`][@stdlib/math/base/special/beta]</span><span class="delimiter">: </span><span class="description">beta function.</span>
--   <span class="package-name">[`@stdlib/math/base/special/betaincinv`][@stdlib/math/base/special/betaincinv]</span><span class="delimiter">: </span><span class="description">inverse incomplete beta function.</span>
--   <span class="package-name">[`@stdlib/math/base/special/betaln`][@stdlib/math/base/special/betaln]</span><span class="delimiter">: </span><span class="description">natural logarithm of the beta function.</span>
-
 </section>
 
 <!-- /.related -->
@@ -150,12 +142,6 @@ logEachMap( 'x: %0.4f, \t a: %0.4f, \t b: %0.4f, \t f(x,a,b): %0.4f', x, a, b, b
 [incomplete-beta-function]: https://en.wikipedia.org/wiki/Incomplete_beta_function
 
 <!-- <related-links> -->
-
-[@stdlib/math/base/special/beta]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/beta
-
-[@stdlib/math/base/special/betaincinv]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/betaincinv
-
-[@stdlib/math/base/special/betaln]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/betaln
 
 <!-- </related-links> -->
 

--- a/lib/node_modules/@stdlib/math/base/special/betainc/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/betainc/README.md
@@ -102,20 +102,25 @@ var y = betainc( 0.5, 2.0, -2.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var betainc = require( '@stdlib/math/base/special/betainc' );
 
-var i;
 var x;
 var a;
 var b;
 
-for ( i = 0; i < 100; i++ ) {
-    x = randu();
-    a = randu() * 10.0;
-    b = randu() * 10.0;
-    console.log( 'x: %d, \t a: %d, \t b: %d, \t f(x,a,b): %d', x.toFixed( 4 ), a.toFixed( 4 ), b.toFixed( 4 ), betainc( x, a, b ).toFixed( 4 ) );
-}
+x = uniform( 100, 0.0, 1.0, {
+	'dtype': 'float64'
+});
+a = uniform( 100, 0.0, 10.0, {
+	'dtype': 'float64'
+});
+b = uniform( 100, 0.0, 10.0, {
+	'dtype': 'float64'
+});
+
+logEachMap( 'x: %0.4f, \t a: %0.4f, \t b: %0.4f, \t f(x,a,b): %0.4f', x, a, b, betainc );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/betainc/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/betainc/README.md
@@ -111,13 +111,13 @@ var a;
 var b;
 
 x = uniform( 100, 0.0, 1.0, {
-	'dtype': 'float64'
+    'dtype': 'float64'
 });
 a = uniform( 100, 0.0, 10.0, {
-	'dtype': 'float64'
+    'dtype': 'float64'
 });
 b = uniform( 100, 0.0, 10.0, {
-	'dtype': 'float64'
+    'dtype': 'float64'
 });
 
 logEachMap( 'x: %0.4f, \t a: %0.4f, \t b: %0.4f, \t f(x,a,b): %0.4f', x, a, b, betainc );

--- a/lib/node_modules/@stdlib/math/base/special/betainc/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/betainc/README.md
@@ -106,19 +106,12 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var betainc = require( '@stdlib/math/base/special/betainc' );
 
-var x;
-var a;
-var b;
-
-x = uniform( 100, 0.0, 1.0, {
+var opts = {
     'dtype': 'float64'
-});
-a = uniform( 100, 0.0, 10.0, {
-    'dtype': 'float64'
-});
-b = uniform( 100, 0.0, 10.0, {
-    'dtype': 'float64'
-});
+};
+var x = uniform( 100, 0.0, 1.0, opts );
+var a = uniform( 100, 0.0, 10.0, opts );
+var b = uniform( 100, 0.0, 10.0, opts );
 
 logEachMap( 'x: %0.4f, \t a: %0.4f, \t b: %0.4f, \t f(x,a,b): %0.4f', x, a, b, betainc );
 ```

--- a/lib/node_modules/@stdlib/math/base/special/betainc/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/betainc/examples/index.js
@@ -23,7 +23,7 @@ var logEachMap = require( '@stdlib/console/log-each-map' );
 var betainc = require( './../lib' );
 
 var opts = {
-    'dtype': 'float64'
+	'dtype': 'float64'
 };
 var x = uniform( 100, 0.0, 1.0, opts );
 var a = uniform( 100, 0.0, 10.0, opts );

--- a/lib/node_modules/@stdlib/math/base/special/betainc/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/betainc/examples/index.js
@@ -18,17 +18,22 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var betainc = require( './../lib' );
 
-var i;
 var x;
 var a;
 var b;
 
-for ( i = 0; i < 100; i++ ) {
-	x = randu();
-	a = randu() * 10.0;
-	b = randu() * 10.0;
-	console.log( 'x: %d, \t a: %d, \t b: %d, \t f(x,a,b): %d', x.toFixed( 4 ), a.toFixed( 4 ), b.toFixed( 4 ), betainc( x, a, b ).toFixed( 4 ) );
-}
+x = uniform( 100, 0.0, 1.0, {
+	'dtype': 'float64'
+});
+a = uniform( 100, 0.0, 10.0, {
+	'dtype': 'float64'
+});
+b = uniform( 100, 0.0, 10.0, {
+	'dtype': 'float64'
+});
+
+logEachMap( 'x: %0.4f, \t a: %0.4f, \t b: %0.4f, \t f(x,a,b): %0.4f', x, a, b, betainc );

--- a/lib/node_modules/@stdlib/math/base/special/betainc/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/betainc/examples/index.js
@@ -22,18 +22,11 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var betainc = require( './../lib' );
 
-var x;
-var a;
-var b;
-
-x = uniform( 100, 0.0, 1.0, {
-	'dtype': 'float64'
-});
-a = uniform( 100, 0.0, 10.0, {
-	'dtype': 'float64'
-});
-b = uniform( 100, 0.0, 10.0, {
-	'dtype': 'float64'
-});
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, 0.0, 1.0, opts );
+var a = uniform( 100, 0.0, 10.0, opts );
+var b = uniform( 100, 0.0, 10.0, opts );
 
 logEachMap( 'x: %0.4f, \t a: %0.4f, \t b: %0.4f, \t f(x,a,b): %0.4f', x, a, b, betainc );

--- a/lib/node_modules/@stdlib/math/base/special/betaincinv/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/betaincinv/README.md
@@ -120,13 +120,13 @@ var a;
 var b;
 
 p = uniform( 100, 0.0, 1.0, {
-	'dtype': 'float64'
+    'dtype': 'float64'
 });
 a = uniform( 100, 0.0, 10.0, {
-	'dtype': 'float64'
+    'dtype': 'float64'
 });
 b = uniform( 100, 0.0, 10.0, {
-	'dtype': 'float64'
+    'dtype': 'float64'
 });
 
 logEachMap( 'p: %0.4f, \t a: %0.4f, \t b: %0.4f, \t f(p,a,b): %0.4f', p, a, b, betaincinv );

--- a/lib/node_modules/@stdlib/math/base/special/betaincinv/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/betaincinv/README.md
@@ -140,6 +140,14 @@ logEachMap( 'p: %0.4f, \t a: %0.4f, \t b: %0.4f, \t f(p,a,b): %0.4f', p, a, b, b
 
 <section class="related">
 
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/math/base/special/beta`][@stdlib/math/base/special/beta]</span><span class="delimiter">: </span><span class="description">beta function.</span>
+-   <span class="package-name">[`@stdlib/math/base/special/betainc`][@stdlib/math/base/special/betainc]</span><span class="delimiter">: </span><span class="description">incomplete beta function.</span>
+-   <span class="package-name">[`@stdlib/math/base/special/betaln`][@stdlib/math/base/special/betaln]</span><span class="delimiter">: </span><span class="description">natural logarithm of the beta function.</span>
+
 </section>
 
 <!-- /.related -->
@@ -151,6 +159,12 @@ logEachMap( 'p: %0.4f, \t a: %0.4f, \t b: %0.4f, \t f(p,a,b): %0.4f', p, a, b, b
 [incomplete-beta-function]: https://en.wikipedia.org/wiki/Incomplete_beta_function
 
 <!-- <related-links> -->
+
+[@stdlib/math/base/special/beta]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/beta
+
+[@stdlib/math/base/special/betainc]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/betainc
+
+[@stdlib/math/base/special/betaln]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/betaln
 
 <!-- </related-links> -->
 

--- a/lib/node_modules/@stdlib/math/base/special/betaincinv/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/betaincinv/README.md
@@ -140,14 +140,6 @@ logEachMap( 'p: %0.4f, \t a: %0.4f, \t b: %0.4f, \t f(p,a,b): %0.4f', p, a, b, b
 
 <section class="related">
 
-* * *
-
-## See Also
-
--   <span class="package-name">[`@stdlib/math/base/special/beta`][@stdlib/math/base/special/beta]</span><span class="delimiter">: </span><span class="description">beta function.</span>
--   <span class="package-name">[`@stdlib/math/base/special/betainc`][@stdlib/math/base/special/betainc]</span><span class="delimiter">: </span><span class="description">incomplete beta function.</span>
--   <span class="package-name">[`@stdlib/math/base/special/betaln`][@stdlib/math/base/special/betaln]</span><span class="delimiter">: </span><span class="description">natural logarithm of the beta function.</span>
-
 </section>
 
 <!-- /.related -->
@@ -159,12 +151,6 @@ logEachMap( 'p: %0.4f, \t a: %0.4f, \t b: %0.4f, \t f(p,a,b): %0.4f', p, a, b, b
 [incomplete-beta-function]: https://en.wikipedia.org/wiki/Incomplete_beta_function
 
 <!-- <related-links> -->
-
-[@stdlib/math/base/special/beta]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/beta
-
-[@stdlib/math/base/special/betainc]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/betainc
-
-[@stdlib/math/base/special/betaln]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/betaln
 
 <!-- </related-links> -->
 

--- a/lib/node_modules/@stdlib/math/base/special/betaincinv/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/betaincinv/README.md
@@ -111,20 +111,25 @@ y = betaincinv( 0.5, 2.0, 0.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var betaincinv = require( '@stdlib/math/base/special/betaincinv' );
 
-var i;
 var p;
 var a;
 var b;
 
-for ( i = 0; i < 100; i++ ) {
-    p = randu();
-    a = randu() * 10.0;
-    b = randu() * 10.0;
-    console.log( 'p: %d, \t a: %d, \t b: %d, \t f(p,a,b): %d', p.toFixed( 4 ), a.toFixed( 4 ), b.toFixed( 4 ), betaincinv( p, a, b ) );
-}
+p = uniform( 100, 0.0, 1.0, {
+	'dtype': 'float64'
+});
+a = uniform( 100, 0.0, 10.0, {
+	'dtype': 'float64'
+});
+b = uniform( 100, 0.0, 10.0, {
+	'dtype': 'float64'
+});
+
+logEachMap( 'p: %0.4f, \t a: %0.4f, \t b: %0.4f, \t f(p,a,b): %0.4f', p, a, b, betaincinv );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/betaincinv/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/betaincinv/README.md
@@ -115,19 +115,12 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var betaincinv = require( '@stdlib/math/base/special/betaincinv' );
 
-var p;
-var a;
-var b;
-
-p = uniform( 100, 0.0, 1.0, {
+var opts = {
     'dtype': 'float64'
-});
-a = uniform( 100, 0.0, 10.0, {
-    'dtype': 'float64'
-});
-b = uniform( 100, 0.0, 10.0, {
-    'dtype': 'float64'
-});
+};
+var p = uniform( 100, 0.0, 1.0, opts );
+var a = uniform( 100, 0.0, 10.0, opts );
+var b = uniform( 100, 0.0, 10.0, opts );
 
 logEachMap( 'p: %0.4f, \t a: %0.4f, \t b: %0.4f, \t f(p,a,b): %0.4f', p, a, b, betaincinv );
 ```

--- a/lib/node_modules/@stdlib/math/base/special/betaincinv/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/betaincinv/examples/index.js
@@ -22,18 +22,11 @@ var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var betaincinv = require( './../lib' );
 
-var p;
-var a;
-var b;
-
-p = uniform( 100, 0.0, 1.0, {
-	'dtype': 'float64'
-});
-a = uniform( 100, 0.0, 10.0, {
-	'dtype': 'float64'
-});
-b = uniform( 100, 0.0, 10.0, {
-	'dtype': 'float64'
-});
+var opts = {
+    'dtype': 'float64'
+};
+var p = uniform( 100, 0.0, 1.0, opts );
+var a = uniform( 100, 0.0, 10.0, opts );
+var b = uniform( 100, 0.0, 10.0, opts );
 
 logEachMap( 'p: %0.4f, \t a: %0.4f, \t b: %0.4f, \t f(p,a,b): %0.4f', p, a, b, betaincinv );

--- a/lib/node_modules/@stdlib/math/base/special/betaincinv/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/betaincinv/examples/index.js
@@ -23,7 +23,7 @@ var logEachMap = require( '@stdlib/console/log-each-map' );
 var betaincinv = require( './../lib' );
 
 var opts = {
-    'dtype': 'float64'
+	'dtype': 'float64'
 };
 var p = uniform( 100, 0.0, 1.0, opts );
 var a = uniform( 100, 0.0, 10.0, opts );

--- a/lib/node_modules/@stdlib/math/base/special/betaincinv/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/betaincinv/examples/index.js
@@ -18,17 +18,22 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var betaincinv = require( './../lib' );
 
-var i;
 var p;
 var a;
 var b;
 
-for ( i = 0; i < 100; i++ ) {
-	p = randu();
-	a = randu() * 10.0;
-	b = randu() * 10.0;
-	console.log( 'p: %d, \t a: %d, \t b: %d, \t f(p,a,b): %d', p.toFixed( 4 ), a.toFixed( 4 ), b.toFixed( 4 ), betaincinv( p, a, b ) );
-}
+p = uniform( 100, 0.0, 1.0, {
+	'dtype': 'float64'
+});
+a = uniform( 100, 0.0, 10.0, {
+	'dtype': 'float64'
+});
+b = uniform( 100, 0.0, 10.0, {
+	'dtype': 'float64'
+});
+
+logEachMap( 'p: %0.4f, \t a: %0.4f, \t b: %0.4f, \t f(p,a,b): %0.4f', p, a, b, betaincinv );

--- a/lib/node_modules/@stdlib/math/base/special/binomcoef/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoef/README.md
@@ -128,11 +128,11 @@ var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var binomcoef = require( '@stdlib/math/base/special/binomcoef' );
 
-var n;
-var k;
-
-n = discreteUniform( 100, -10, 30 );
-k = discreteUniform( 100, 0, 20 );
+var opts = {
+    'dtype': 'float64'
+};
+var n = discreteUniform( 100, -10, 30, opts );
+var k = discreteUniform( 100, 0, 20, opts );
 
 logEachMap( '%d choose %d = %d', n, k, binomcoef );
 ```

--- a/lib/node_modules/@stdlib/math/base/special/binomcoef/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoef/README.md
@@ -124,19 +124,17 @@ v = binomcoef( 5.5, 2 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var binomcoef = require( '@stdlib/math/base/special/binomcoef' );
 
 var n;
 var k;
-var i;
 
-for ( i = 0; i < 100; i++ ) {
-    n = round( (randu()*30.0) - 10.0 );
-    k = round( randu()*20.0 );
-    console.log( '%d choose %d = %d', n, k, binomcoef( n, k ) );
-}
+n = discreteUniform( 100, -10, 30 );
+k = discreteUniform( 100, 0, 20 );
+
+logEachMap( '%d choose %d = %d', n, k, binomcoef );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/binomcoef/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoef/examples/index.js
@@ -22,10 +22,10 @@ var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var binomcoef = require( './../lib' );
 
-var n;
-var k;
-
-n = discreteUniform( 100, -10, 30 );
-k = discreteUniform( 100, 0, 20 );
+var opts = {
+    'dtype': 'float64'
+};
+var n = discreteUniform( 100, -10, 30, opts );
+var k = discreteUniform( 100, 0, 20, opts );
 
 logEachMap( '%d choose %d = %d', n, k, binomcoef );

--- a/lib/node_modules/@stdlib/math/base/special/binomcoef/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoef/examples/index.js
@@ -23,7 +23,7 @@ var logEachMap = require( '@stdlib/console/log-each-map' );
 var binomcoef = require( './../lib' );
 
 var opts = {
-    'dtype': 'float64'
+	'dtype': 'float64'
 };
 var n = discreteUniform( 100, -10, 30, opts );
 var k = discreteUniform( 100, 0, 20, opts );

--- a/lib/node_modules/@stdlib/math/base/special/binomcoef/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoef/examples/index.js
@@ -18,16 +18,14 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var binomcoef = require( './../lib' );
 
 var n;
 var k;
-var i;
 
-for ( i = 0; i < 100; i++ ) {
-	n = round( (randu()*40.0) - 10.0 );
-	k = round( randu()*20.0 );
-	console.log( '%d choose %d = %d', n, k, binomcoef( n, k ) );
-}
+n = discreteUniform( 100, -10, 30 );
+k = discreteUniform( 100, 0, 20 );
+
+logEachMap( '%d choose %d = %d', n, k, binomcoef );

--- a/lib/node_modules/@stdlib/math/base/special/binomcoefln/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoefln/README.md
@@ -143,11 +143,11 @@ var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var binomcoefln = require( '@stdlib/math/base/special/binomcoefln' );
 
-var n;
-var k;
-
-n = discreteUniform( 100, -10, 30 );
-k = discreteUniform( 100, 0, 20 );
+var opts = {
+    'dtype': 'float64'
+};
+var n = discreteUniform( 100, -10, 30, opts );
+var k = discreteUniform( 100, 0, 20, opts );
 
 logEachMap( 'ln( %d choose %d ) = %d', n, k, binomcoefln );
 ```

--- a/lib/node_modules/@stdlib/math/base/special/binomcoefln/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoefln/README.md
@@ -139,19 +139,17 @@ v = binomcoefln( 5.5, 2 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var binomcoefln = require( '@stdlib/math/base/special/binomcoefln' );
 
 var n;
 var k;
-var i;
 
-for ( i = 0; i < 100; i++ ) {
-    n = round( (randu()*40.0) - 10.0 );
-    k = round( randu()*20.0 );
-    console.log( 'ln( %d choose %d ) = %d', n, k, binomcoefln( n, k ) );
-}
+n = discreteUniform( 100, -10, 30 );
+k = discreteUniform( 100, 0, 20 );
+
+logEachMap( 'ln( %d choose %d ) = %d', n, k, binomcoefln );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/binomcoefln/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoefln/examples/index.js
@@ -18,16 +18,14 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var binomcoefln = require( './../lib' );
 
 var n;
 var k;
-var i;
 
-for ( i = 0; i < 100; i++ ) {
-	n = round( (randu()*40.0) - 10.0 );
-	k = round( randu()*20.0 );
-	console.log( 'ln( %d choose %d ) = %d', n, k, binomcoefln( n, k ) );
-}
+n = discreteUniform( 100, -10, 30 );
+k = discreteUniform( 100, 0, 20 );
+
+logEachMap( 'ln( %d choose %d ) = %d', n, k, binomcoefln );

--- a/lib/node_modules/@stdlib/math/base/special/binomcoefln/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoefln/examples/index.js
@@ -23,7 +23,7 @@ var logEachMap = require( '@stdlib/console/log-each-map' );
 var binomcoefln = require( './../lib' );
 
 var opts = {
-    'dtype': 'float64'
+	'dtype': 'float64'
 };
 var n = discreteUniform( 100, -10, 30, opts );
 var k = discreteUniform( 100, 0, 20, opts );

--- a/lib/node_modules/@stdlib/math/base/special/binomcoefln/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/binomcoefln/examples/index.js
@@ -22,10 +22,10 @@ var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var binomcoefln = require( './../lib' );
 
-var n;
-var k;
-
-n = discreteUniform( 100, -10, 30 );
-k = discreteUniform( 100, 0, 20 );
+var opts = {
+    'dtype': 'float64'
+};
+var n = discreteUniform( 100, -10, 30, opts );
+var k = discreteUniform( 100, 0, 20, opts );
 
 logEachMap( 'ln( %d choose %d ) = %d', n, k, binomcoefln );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `math/base/special/besselj0`, `math/base/special/besselj1`, `math/base/special/bessely0`, `math/base/special/bessely1`, `math/base/special/betainc`, `math/base/special/betaincinv`, `math/base/special/binomcoef`, and `math/base/special/binomcoefln` packages

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
