### PR TITLE
docs: add examples for `string` and `float` formatting

### DIFF
--- a/lib/node_modules/@stdlib/console/log-each/README.md
+++ b/lib/node_modules/@stdlib/console/log-each/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # logEach
 
-> Insert array element values into a format string and print the result.
+> Insert array element values into a [format string][@stdlib/string/format] and print the result.
 
 <!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
 
@@ -42,7 +42,7 @@ var logEach = require( '@stdlib/console/log-each' );
 
 #### logEach( str\[, ...args] )
 
-Inserts array element values into a format string and prints the result.
+Inserts array element values into a [format string][@stdlib/string/format] and prints the result.
 
 ```javascript
 var x = [ 1, 2, 3 ];
@@ -56,10 +56,10 @@ If an interpolated argument is not an array-like object, the argument is broadca
 
 ```javascript
 var x = [ 1, 2, 3 ];
-var y = 4;
+var y = 0.5;
 
-logEach( '%d < %d', x, y );
-// e.g., => '1 < 4\n2 < 4\n3 < 4\n'
+logEach( '%0.1f > %0.1f', x, y );
+// e.g., => '1.0 > 0.5\n2.0 > 0.5\n3.0 > 0.5\n'
 ```
 
 </section>
@@ -129,6 +129,8 @@ logEach( 'abs(%d) = %d', x, y );
 [@stdlib/array/complex128]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/complex128
 
 [@stdlib/array/complex64]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/complex64
+
+[@stdlib/string/format]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/string/format
 
 </section>
 

--- a/lib/node_modules/@stdlib/console/log-each/docs/repl.txt
+++ b/lib/node_modules/@stdlib/console/log-each/docs/repl.txt
@@ -19,6 +19,14 @@
     > var y = [ 4, 5, 6 ];
     > {{alias}}( '%d < %d ', x, y );
 
+    > var x = [ 0.5, 1.0, 1.5 ];
+    > var y = [ 0.25, 0.5, 0.75 ];
+    > {{alias}}( '%0.2f > %0.2f', x, y );
+
+    > var x = [ 'foo', 'bar' ];
+    > var y = [ 'beep', 'boop' ];
+    > {{alias}}( 'x: %s, y: %s', x, y );
+
     See Also
     --------
 

--- a/lib/node_modules/@stdlib/console/log-each/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/console/log-each/docs/types/index.d.ts
@@ -35,6 +35,20 @@
 *
 * logEach( '%d < %d ', x, y );
 * // e.g., => '1 < 4\n2 < 5\n3 < 6\n'
+*
+* @example
+* var x = [ 0.5, 1.0, 1.5 ];
+* var y = [ 0.25, 0.5, 0.75 ];
+*
+* logEach( '%0.2f > %0.2f', x, y );
+* // e.g., => '0.50 > 0.25\n1.00 > 0.50\n1.50 > 0.75\n'
+*
+* @example
+* var x = [ 'foo', 'bar' ];
+* var y = [ 'beep', 'boop' ];
+*
+* logEach( 'x: %s, y: %s', x, y );
+* // e.g., => 'x: foo, y: beep\nx: bar, y: boop\n'
 */
 declare function logEach( str: string, ...args: any ): void;
 

--- a/lib/node_modules/@stdlib/console/log-each/lib/index.js
+++ b/lib/node_modules/@stdlib/console/log-each/lib/index.js
@@ -31,6 +31,18 @@
 *
 * logEach( '%d < %d ', x, y );
 * // e.g., => '1 < 4\n2 < 5\n3 < 6\n'
+*
+* var x = [ 0.5, 1.0, 1.5 ];
+* var y = [ 0.25, 0.5, 0.75 ];
+*
+* logEach( '%0.2f > %0.2f', x, y );
+* // e.g., => '0.50 > 0.25\n1.00 > 0.50\n1.50 > 0.75\n'
+*
+* var x = [ 'foo', 'bar' ];
+* var y = [ 'beep', 'boop' ];
+*
+* logEach( 'x: %s, y: %s', x, y );
+* // e.g., => 'x: foo, y: beep\nx: bar, y: boop\n'
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/console/log-each/lib/main.js
+++ b/lib/node_modules/@stdlib/console/log-each/lib/main.js
@@ -37,6 +37,27 @@ var logger = require( '@stdlib/console/log' );
 * @throws {TypeError} first argument must be a string
 * @throws {RangeError} provided collections must have the same length
 * @returns {void}
+*
+* @example
+* var x = [ 1, 2, 3 ];
+* var y = [ 4, 5, 6 ];
+*
+* logEach( '%d < %d ', x, y );
+* // e.g., => '1 < 4\n2 < 5\n3 < 6\n'
+*
+* @example
+* var x = [ 0.5, 1.0, 1.5 ];
+* var y = [ 0.25, 0.5, 0.75 ];
+*
+* logEach( '%0.2f > %0.2f', x, y );
+* // e.g., => '0.50 > 0.25\n1.00 > 0.50\n1.50 > 0.75\n'
+*
+* @example
+* var x = [ 'foo', 'bar' ];
+* var y = [ 'beep', 'boop' ];
+*
+* logEach( 'x: %s, y: %s', x, y );
+* // e.g., => 'x: foo, y: beep\nx: bar, y: boop\n'
 */
 function logEach( str ) {
 	var strides;


### PR DESCRIPTION
Resolves None

## Description

> What is the purpose of this pull request?

This pull request:

- adds `float` and `string` examples to `@stdlib/console/log-each` JSDoc

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves none

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md