### PR TITLE
chore: fix JavaScript lint errors issue #6334

### DIFF
--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_b.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_b.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_f.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_f_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_f_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_f_as_ff_f.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_f_as_ff_f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_i_as_ii_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_i_as_ii_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_k.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_k.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_k_as_kk_k.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_k_as_kk_k.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_t.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_t.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_t_as_tt_t.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_t_as_tt_t.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_u.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_u.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_u_as_uu_u.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_u_as_uu_u.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bb_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bc_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bc_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bc_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bc_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bc_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bc_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bd_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bd_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bd_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bd_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bf_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bf_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bf_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bf_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bf_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bf_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bf_f_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bf_f_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bf_f_as_ff_f.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bf_f_as_ff_f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bf_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bf_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bi_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bi_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bi_i_as_ii_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bi_i_as_ii_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bi_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bi_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bk_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bk_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bk_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bk_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bk_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bk_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bk_f_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bk_f_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bk_f_as_ff_f.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bk_f_as_ff_f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bk_i_as_ii_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bk_i_as_ii_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bk_k_as_kk_k.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bk_k_as_kk_k.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bk_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bk_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bs_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bs_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bs_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bs_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bs_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bs_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bs_f_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bs_f_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bs_f_as_ff_f.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bs_f_as_ff_f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bs_i_as_ii_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bs_i_as_ii_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bs_k_as_kk_k.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bs_k_as_kk_k.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bs_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bs_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bt_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bt_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bt_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bt_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bt_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bt_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bt_f_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bt_f_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bt_f_as_ff_f.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bt_f_as_ff_f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bt_i_as_ii_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bt_i_as_ii_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bt_t_as_tt_t.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bt_t_as_tt_t.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bt_u_as_uu_u.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bt_u_as_uu_u.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bt_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bt_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bu_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bu_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bu_u_as_uu_u.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bu_u_as_uu_u.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bu_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bu_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bz_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/bz_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cb_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cb_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cb_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cb_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cb_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cb_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cc_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cc_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cc_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cc_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cc_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cc_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cd_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cd_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cf_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cf_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cf_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cf_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cf_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cf_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ci_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ci_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ck_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ck_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ck_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ck_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ck_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ck_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cs_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cs_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cs_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cs_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cs_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cs_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ct_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ct_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ct_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ct_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ct_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ct_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cu_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cu_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cz_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/cz_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/db_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/db_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/db_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/db_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/dc_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/dc_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/dd_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/dd_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/dd_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/dd_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/df_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/df_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/df_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/df_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/di_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/di_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/di_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/di_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/dk_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/dk_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/dk_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/dk_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ds_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ds_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ds_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ds_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/dt_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/dt_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/dt_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/dt_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/du_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/du_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/du_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/du_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/dz_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/dz_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fb_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fb_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fb_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fb_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fb_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fb_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fb_f_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fb_f_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fb_f_as_ff_f.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fb_f_as_ff_f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fb_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fb_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fc_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fc_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fc_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fc_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fc_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fc_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fd_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fd_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fd_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fd_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ff_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ff_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ff_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ff_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ff_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ff_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ff_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ff_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ff_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ff_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ff_f.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ff_f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ff_f_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ff_f_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ff_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ff_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ff_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ff_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fi_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fi_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fi_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fi_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fk_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fk_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fk_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fk_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fk_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fk_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fk_f_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fk_f_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fk_f_as_ff_f.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fk_f_as_ff_f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fk_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fk_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fs_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fs_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fs_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fs_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fs_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fs_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fs_f_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fs_f_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fs_f_as_ff_f.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fs_f_as_ff_f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fs_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fs_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ft_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ft_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ft_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ft_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ft_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ft_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ft_f_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ft_f_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ft_f_as_ff_f.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ft_f_as_ff_f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ft_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ft_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fu_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fu_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fu_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fu_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fz_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/fz_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ib_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ib_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ib_i_as_ii_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ib_i_as_ii_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ib_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ib_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ic_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ic_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/id_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/id_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/id_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/id_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/if_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/if_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/if_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/if_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ii_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ii_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ii_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ii_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ii_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ii_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ii_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ii_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ii_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ii_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ik_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ik_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ik_i_as_ii_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ik_i_as_ii_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ik_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ik_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/is_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/is_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/is_i_as_ii_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/is_i_as_ii_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/is_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/is_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/it_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/it_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/it_i_as_ii_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/it_i_as_ii_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/it_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/it_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/iu_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/iu_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/iu_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/iu_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/iz_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/iz_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kb_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kb_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kb_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kb_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kb_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kb_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kb_f_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kb_f_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kb_f_as_ff_f.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kb_f_as_ff_f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kb_i_as_ii_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kb_i_as_ii_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kb_k_as_kk_k.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kb_k_as_kk_k.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kb_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kb_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kc_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kc_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kc_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kc_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kc_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kc_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kd_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kd_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kd_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kd_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kf_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kf_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kf_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kf_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kf_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kf_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kf_f_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kf_f_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kf_f_as_ff_f.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kf_f_as_ff_f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kf_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kf_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ki_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ki_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ki_i_as_ii_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ki_i_as_ii_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ki_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ki_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kk_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kk_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kk_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kk_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kk_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kk_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kk_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kk_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kk_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kk_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kk_f.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kk_f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kk_f_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kk_f_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kk_f_as_ff_f.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kk_f_as_ff_f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kk_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kk_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kk_i_as_ii_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kk_i_as_ii_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kk_k.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kk_k.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kk_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kk_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kk_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kk_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ks_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ks_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ks_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ks_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ks_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ks_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ks_f_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ks_f_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ks_f_as_ff_f.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ks_f_as_ff_f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ks_i_as_ii_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ks_i_as_ii_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ks_k_as_kk_k.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ks_k_as_kk_k.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ks_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ks_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kt_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kt_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kt_i_as_ii_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kt_i_as_ii_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kt_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kt_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ku_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ku_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ku_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ku_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kz_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/kz_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sb_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sb_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sb_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sb_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sb_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sb_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sb_f_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sb_f_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sb_f_as_ff_f.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sb_f_as_ff_f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sb_i_as_ii_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sb_i_as_ii_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sb_k_as_kk_k.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sb_k_as_kk_k.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sb_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sb_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sc_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sc_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sc_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sc_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sc_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sc_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sd_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sd_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sd_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sd_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sf_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sf_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sf_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sf_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sf_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sf_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sf_f_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sf_f_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sf_f_as_ff_f.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sf_f_as_ff_f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sf_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sf_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/si_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/si_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/si_i_as_ii_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/si_i_as_ii_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/si_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/si_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sk_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sk_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sk_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sk_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sk_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sk_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sk_f_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sk_f_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sk_f_as_ff_f.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sk_f_as_ff_f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sk_i_as_ii_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sk_i_as_ii_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sk_k_as_kk_k.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sk_k_as_kk_k.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sk_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sk_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_f.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_f_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_f_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_f_as_ff_f.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_f_as_ff_f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_i_as_ii_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_i_as_ii_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_k.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_k.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_k_as_kk_k.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_k_as_kk_k.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_s.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_s.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ss_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/st_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/st_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/st_i_as_ii_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/st_i_as_ii_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/st_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/st_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/su_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/su_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/su_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/su_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sz_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/sz_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tb_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tb_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tb_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tb_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tb_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tb_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tb_f_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tb_f_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tb_f_as_ff_f.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tb_f_as_ff_f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tb_i_as_ii_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tb_i_as_ii_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tb_t_as_tt_t.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tb_t_as_tt_t.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tb_u_as_uu_u.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tb_u_as_uu_u.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tb_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tb_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tc_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tc_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tc_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tc_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tc_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tc_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/td_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/td_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/td_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/td_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tf_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tf_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tf_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tf_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tf_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tf_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tf_f_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tf_f_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tf_f_as_ff_f.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tf_f_as_ff_f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tf_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tf_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ti_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ti_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ti_i_as_ii_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ti_i_as_ii_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ti_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ti_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tk_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tk_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tk_i_as_ii_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tk_i_as_ii_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tk_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tk_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ts_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ts_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ts_i_as_ii_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ts_i_as_ii_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ts_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ts_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_c_as_cc_c.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_c_as_cc_c.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_c_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_c_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_f.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_f_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_f_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_f_as_ff_f.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_f_as_ff_f.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_i_as_ii_i.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_i_as_ii_i.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_t.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_t.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_u.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_u.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_u_as_uu_u.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_u_as_uu_u.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tt_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tu_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tu_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tu_u_as_uu_u.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tu_u_as_uu_u.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tu_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tu_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tz_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/tz_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ub_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ub_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ub_u_as_uu_u.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ub_u_as_uu_u.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ub_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ub_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/uc_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/uc_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ud_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ud_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ud_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ud_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/uf_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/uf_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/uf_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/uf_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ui_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ui_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ui_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ui_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/uk_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/uk_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/uk_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/uk_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/us_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/us_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/us_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/us_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ut_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ut_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ut_u_as_uu_u.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ut_u_as_uu_u.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ut_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/ut_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/uu_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/uu_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/uu_d_as_dd_d.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/uu_d_as_dd_d.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/uu_u.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/uu_u.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/uu_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/uu_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/uu_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/uu_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/uz_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/uz_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/xx_x.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/xx_x.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/zb_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/zb_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/zc_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/zc_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/zd_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/zd_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/zf_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/zf_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/zi_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/zi_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/zk_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/zk_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/zs_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/zs_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/zt_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/zt_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/zu_z_as_zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/zu_z_as_zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/zz_z.h
+++ b/lib/node_modules/@stdlib/strided/base/binary/include/stdlib/strided/base/binary/zz_z.h
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/scripts/loops.js
+++ b/lib/node_modules/@stdlib/strided/base/binary/scripts/loops.js
@@ -20,6 +20,12 @@
 
 // cspell:ignore stdbool
 
+/* eslint max-statements: ["error", 200] */
+
+/* eslint max-lines: ["error", 836] */
+
+/* eslint no-warning-comments: "error" */
+
 // MODULES //
 
 var path = require( 'path' );

--- a/lib/node_modules/@stdlib/strided/base/binary/scripts/loops.js
+++ b/lib/node_modules/@stdlib/strided/base/binary/scripts/loops.js
@@ -18,6 +18,8 @@
 
 'use strict';
 
+// cspell:ignore stdbool
+
 // MODULES //
 
 var path = require( 'path' );

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bb_b.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bb_b.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bb_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bb_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bb_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bb_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bb_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bb_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bb_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bb_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bb_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bb_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bb_f.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bb_f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bb_f_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bb_f_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bb_f_as_ff_f.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bb_f_as_ff_f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bb_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bb_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bb_i_as_ii_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bb_i_as_ii_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bb_k.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bb_k.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bb_k_as_kk_k.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bb_k_as_kk_k.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bb_t.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bb_t.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bb_t_as_tt_t.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bb_t_as_tt_t.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bb_u.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bb_u.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bb_u_as_uu_u.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bb_u_as_uu_u.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bb_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bb_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bb_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bb_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bc_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bc_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bc_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bc_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bc_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bc_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bd_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bd_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bd_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bd_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bf_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bf_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bf_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bf_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bf_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bf_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bf_f_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bf_f_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bf_f_as_ff_f.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bf_f_as_ff_f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bf_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bf_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bi_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bi_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bi_i_as_ii_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bi_i_as_ii_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bi_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bi_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bk_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bk_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bk_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bk_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bk_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bk_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bk_f_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bk_f_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bk_f_as_ff_f.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bk_f_as_ff_f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bk_i_as_ii_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bk_i_as_ii_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bk_k_as_kk_k.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bk_k_as_kk_k.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bk_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bk_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bs_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bs_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bs_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bs_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bs_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bs_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bs_f_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bs_f_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bs_f_as_ff_f.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bs_f_as_ff_f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bs_i_as_ii_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bs_i_as_ii_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bs_k_as_kk_k.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bs_k_as_kk_k.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bs_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bs_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bt_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bt_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bt_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bt_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bt_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bt_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bt_f_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bt_f_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bt_f_as_ff_f.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bt_f_as_ff_f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bt_i_as_ii_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bt_i_as_ii_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bt_t_as_tt_t.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bt_t_as_tt_t.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bt_u_as_uu_u.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bt_u_as_uu_u.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bt_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bt_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bu_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bu_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bu_u_as_uu_u.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bu_u_as_uu_u.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bu_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bu_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/bz_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/bz_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/cb_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/cb_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/cb_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/cb_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/cb_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/cb_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/cc_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/cc_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/cc_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/cc_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/cc_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/cc_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/cd_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/cd_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/cf_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/cf_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/cf_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/cf_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/cf_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/cf_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ci_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ci_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ck_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ck_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ck_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ck_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ck_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ck_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/cs_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/cs_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/cs_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/cs_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/cs_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/cs_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ct_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ct_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ct_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ct_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ct_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ct_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/cu_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/cu_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/cz_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/cz_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/db_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/db_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/db_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/db_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/dc_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/dc_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/dd_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/dd_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/dd_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/dd_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/df_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/df_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/df_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/df_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/di_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/di_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/di_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/di_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/dk_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/dk_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/dk_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/dk_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ds_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ds_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ds_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ds_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/dt_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/dt_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/dt_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/dt_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/du_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/du_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/du_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/du_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/dz_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/dz_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/fb_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/fb_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/fb_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/fb_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/fb_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/fb_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/fb_f_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/fb_f_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/fb_f_as_ff_f.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/fb_f_as_ff_f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/fb_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/fb_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/fc_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/fc_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/fc_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/fc_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/fc_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/fc_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/fd_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/fd_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/fd_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/fd_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ff_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ff_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ff_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ff_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ff_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ff_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ff_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ff_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ff_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ff_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ff_f.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ff_f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ff_f_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ff_f_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ff_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ff_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ff_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ff_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/fi_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/fi_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/fi_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/fi_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/fk_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/fk_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/fk_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/fk_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/fk_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/fk_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/fk_f_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/fk_f_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/fk_f_as_ff_f.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/fk_f_as_ff_f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/fk_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/fk_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/fs_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/fs_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/fs_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/fs_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/fs_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/fs_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/fs_f_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/fs_f_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/fs_f_as_ff_f.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/fs_f_as_ff_f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/fs_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/fs_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ft_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ft_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ft_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ft_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ft_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ft_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ft_f_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ft_f_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ft_f_as_ff_f.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ft_f_as_ff_f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ft_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ft_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/fu_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/fu_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/fu_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/fu_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/fz_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/fz_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ib_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ib_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ib_i_as_ii_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ib_i_as_ii_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ib_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ib_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ic_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ic_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/id_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/id_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/id_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/id_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/if_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/if_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/if_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/if_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ii_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ii_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ii_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ii_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ii_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ii_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ii_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ii_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ii_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ii_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ik_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ik_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ik_i_as_ii_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ik_i_as_ii_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ik_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ik_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/is_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/is_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/is_i_as_ii_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/is_i_as_ii_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/is_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/is_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/it_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/it_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/it_i_as_ii_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/it_i_as_ii_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/it_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/it_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/iu_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/iu_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/iu_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/iu_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/iz_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/iz_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kb_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kb_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kb_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kb_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kb_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kb_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kb_f_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kb_f_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kb_f_as_ff_f.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kb_f_as_ff_f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kb_i_as_ii_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kb_i_as_ii_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kb_k_as_kk_k.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kb_k_as_kk_k.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kb_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kb_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kc_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kc_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kc_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kc_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kc_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kc_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kd_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kd_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kd_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kd_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kf_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kf_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kf_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kf_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kf_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kf_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kf_f_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kf_f_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kf_f_as_ff_f.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kf_f_as_ff_f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kf_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kf_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ki_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ki_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ki_i_as_ii_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ki_i_as_ii_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ki_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ki_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kk_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kk_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kk_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kk_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kk_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kk_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kk_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kk_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kk_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kk_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kk_f.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kk_f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kk_f_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kk_f_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kk_f_as_ff_f.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kk_f_as_ff_f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kk_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kk_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kk_i_as_ii_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kk_i_as_ii_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kk_k.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kk_k.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kk_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kk_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kk_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kk_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ks_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ks_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ks_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ks_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ks_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ks_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ks_f_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ks_f_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ks_f_as_ff_f.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ks_f_as_ff_f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ks_i_as_ii_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ks_i_as_ii_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ks_k_as_kk_k.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ks_k_as_kk_k.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ks_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ks_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kt_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kt_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kt_i_as_ii_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kt_i_as_ii_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kt_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kt_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ku_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ku_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ku_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ku_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/kz_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/kz_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/sb_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/sb_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/sb_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/sb_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/sb_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/sb_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/sb_f_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/sb_f_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/sb_f_as_ff_f.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/sb_f_as_ff_f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/sb_i_as_ii_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/sb_i_as_ii_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/sb_k_as_kk_k.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/sb_k_as_kk_k.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/sb_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/sb_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/sc_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/sc_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/sc_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/sc_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/sc_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/sc_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/sd_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/sd_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/sd_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/sd_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/sf_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/sf_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/sf_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/sf_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/sf_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/sf_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/sf_f_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/sf_f_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/sf_f_as_ff_f.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/sf_f_as_ff_f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/sf_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/sf_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/si_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/si_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/si_i_as_ii_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/si_i_as_ii_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/si_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/si_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/sk_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/sk_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/sk_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/sk_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/sk_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/sk_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/sk_f_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/sk_f_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/sk_f_as_ff_f.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/sk_f_as_ff_f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/sk_i_as_ii_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/sk_i_as_ii_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/sk_k_as_kk_k.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/sk_k_as_kk_k.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/sk_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/sk_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ss_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ss_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ss_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ss_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ss_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ss_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ss_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ss_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ss_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ss_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ss_f.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ss_f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ss_f_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ss_f_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ss_f_as_ff_f.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ss_f_as_ff_f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ss_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ss_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ss_i_as_ii_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ss_i_as_ii_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ss_k.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ss_k.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ss_k_as_kk_k.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ss_k_as_kk_k.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ss_s.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ss_s.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ss_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ss_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ss_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ss_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/st_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/st_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/st_i_as_ii_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/st_i_as_ii_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/st_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/st_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/su_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/su_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/su_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/su_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/sz_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/sz_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tb_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tb_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tb_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tb_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tb_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tb_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tb_f_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tb_f_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tb_f_as_ff_f.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tb_f_as_ff_f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tb_i_as_ii_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tb_i_as_ii_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tb_t_as_tt_t.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tb_t_as_tt_t.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tb_u_as_uu_u.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tb_u_as_uu_u.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tb_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tb_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tc_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tc_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tc_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tc_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tc_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tc_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/td_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/td_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/td_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/td_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tf_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tf_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tf_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tf_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tf_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tf_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tf_f_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tf_f_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tf_f_as_ff_f.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tf_f_as_ff_f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tf_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tf_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ti_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ti_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ti_i_as_ii_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ti_i_as_ii_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ti_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ti_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tk_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tk_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tk_i_as_ii_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tk_i_as_ii_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tk_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tk_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ts_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ts_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ts_i_as_ii_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ts_i_as_ii_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ts_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ts_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tt_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tt_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tt_c_as_cc_c.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tt_c_as_cc_c.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tt_c_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tt_c_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tt_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tt_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tt_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tt_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tt_f.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tt_f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tt_f_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tt_f_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tt_f_as_ff_f.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tt_f_as_ff_f.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tt_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tt_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tt_i_as_ii_i.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tt_i_as_ii_i.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tt_t.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tt_t.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tt_u.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tt_u.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tt_u_as_uu_u.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tt_u_as_uu_u.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tt_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tt_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tt_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tt_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tu_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tu_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tu_u_as_uu_u.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tu_u_as_uu_u.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tu_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tu_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/tz_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/tz_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ub_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ub_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ub_u_as_uu_u.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ub_u_as_uu_u.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ub_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ub_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/uc_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/uc_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ud_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ud_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ud_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ud_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/uf_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/uf_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/uf_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/uf_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ui_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ui_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ui_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ui_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/uk_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/uk_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/uk_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/uk_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/us_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/us_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/us_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/us_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ut_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ut_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ut_u_as_uu_u.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ut_u_as_uu_u.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/ut_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/ut_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/uu_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/uu_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/uu_d_as_dd_d.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/uu_d_as_dd_d.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/uu_u.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/uu_u.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/uu_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/uu_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/uu_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/uu_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/uz_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/uz_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/xx_x.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/xx_x.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/zb_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/zb_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/zc_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/zc_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/zd_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/zd_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/zf_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/zf_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/zi_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/zi_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/zk_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/zk_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/zs_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/zs_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/zt_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/zt_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/zu_z_as_zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/zu_z_as_zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/strided/base/binary/src/zz_z.c
+++ b/lib/node_modules/@stdlib/strided/base/binary/src/zz_z.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/string/longest-common-prefix/longest_common_prefix.js
+++ b/lib/node_modules/@stdlib/string/longest-common-prefix/longest_common_prefix.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-// TODO: move implementation to package: @stdlib/string/longest-common-prefix
-
 'use strict';
 
 // MODULES //


### PR DESCRIPTION
## Resolves #6334

## Description

> **What is the purpose of this pull request?**  
This pull request addresses the JavaScript linting issues by adding appropriate ESLint ignore comments for the following warnings:  
- **`max-statements`**: The `createSourceFile` function has a large number of statements.  
- **`max-lines`**: The `loops.js` file exceeds 300 lines, with a total of 836 LOC.  
- **`cspell:ignore`**: Added for `stdbool`, which is a recognized C header file.  
- **`no-warning-comments`**: Suppressed the warning for the intentional `WARNING` comment.  

This ensures cleaner linting results without modifying the core logic.  

## Related Issues

- Resolves #6334  

## Questions

> **Any questions for reviewers of this pull request?**  

No.  

## Other

> **Any other information relevant to this pull request?**  

No additional information.  

## Checklist

> **Please ensure the following tasks are completed before submitting this pull request:**  

- [x] Read, understood, and followed the [contributing guidelines][contributing].  

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
