### PR TITLE
bench: update random value generation

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/ldexpf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/ldexpf/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/array/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pkg = require( './../package.json' ).name;
@@ -36,7 +36,7 @@ bench( pkg, function benchmark( b ) {
 	var z;
 	var i;
 
-	x = randu( 100, -10.0, 10.0 );
+	x = uniform( 100, -10.0, 10.0 );
 	y = discreteUniform( 100, -1020.0, 1020.0 );
 
 	b.tic();

--- a/lib/node_modules/@stdlib/math/base/special/ldexpf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/ldexpf/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -45,7 +45,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var z;
 	var i;
 
-	x = randu( 100, -10.0, 10.0 );
+	x = uniform( 100, -10.0, 10.0 );
 	y = discreteUniform( 100, -1020.0, 1020.0 );
 
 	b.tic();

--- a/lib/node_modules/@stdlib/math/base/special/lnf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/lnf/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var lnf = require( './../lib' );
@@ -34,10 +34,11 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, 0.0, 10000.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu() * 10000.0 ) - 0.0;
-		y = lnf( x );
+		y = lnf( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/lnf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/lnf/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -43,10 +43,11 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, 0.0, 10000.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu() * 10000.0 ) - 0.0;
-		y = lnf( x );
+		y = lnf( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/lnf/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/lnf/benchmark/c/native/benchmark.c
@@ -92,14 +92,17 @@ static float rand_float( void ) {
 static double benchmark( void ) {
 	double elapsed;
 	double t;
-	float x;
+	float x[ 100 ];
 	float y;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 10000.0f * rand_float() ) - 0.0f;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 10000.0f * rand_float() ) - 0.0f;
-		y = stdlib_base_lnf( x );
+		y = stdlib_base_lnf( x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/lnf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/lnf/test/test.js
@@ -225,12 +225,12 @@ tape( 'the function evaluates the natural logarithm of `x` (subnormal values)', 
 });
 
 tape( 'the function returns `-infinity` if provided `0`', function test( t ) {
-	t.equal( lnf( 0.0 ), NINF, 'equals -infinity' );
+	t.equal( lnf( 0.0 ), NINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+infinity` if provided `+infinity`', function test( t ) {
-	t.equal( lnf( PINF ), PINF, 'equals +infinity' );
+	t.equal( lnf( PINF ), PINF, 'returns expected value' );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/math/base/special/lnf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/lnf/test/test.native.js
@@ -234,12 +234,12 @@ tape( 'the function evaluates the natural logarithm of `x` (subnormal values)', 
 });
 
 tape( 'the function returns `-infinity` if provided `0`', opts, function test( t ) {
-	t.equal( lnf( 0.0 ), NINF, 'equals -infinity' );
+	t.equal( lnf( 0.0 ), NINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+infinity` if provided `+infinity`', opts, function test( t ) {
-	t.equal( lnf( PINF ), PINF, 'equals +infinity' );
+	t.equal( lnf( PINF ), PINF, 'returns expected value' );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/math/base/special/log1mexp/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/log1mexp/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var log1mexp = require( './../lib' );
@@ -34,10 +34,11 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, 0.0, 1000.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 0.0;
-		y = log1mexp( x );
+		y = log1mexp( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/log1mexp/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/log1mexp/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -43,10 +43,11 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, 0.0, 1000.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 0.0;
-		y = log1mexp( x );
+		y = log1mexp( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/log1mexp/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/log1mexp/benchmark/c/benchmark.c
@@ -109,15 +109,18 @@ double log1mexp( double x ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double x[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0*rand_double() ) - 0.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) - 0.0;
-		y = log1mexp( x );
+		y = log1mexp( x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/log1mexp/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/log1mexp/benchmark/c/native/benchmark.c
@@ -92,15 +92,18 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double x[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0*rand_double() ) - 0.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) - 0.0;
-		y = stdlib_base_log1mexp( x );
+		y = stdlib_base_log1mexp( x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/log1mexp/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/log1mexp/test/test.js
@@ -50,7 +50,7 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'if provided `NaN`, the function returns `NaN`', function test( t ) {
 	var v = log1mexp( NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN when provided a NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 	t.end();
 });
 
@@ -58,10 +58,10 @@ tape( 'if provided `+-0`, the function returns -infinity', function test( t ) {
 	var v;
 
 	v = log1mexp( 0.0 );
-	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.strictEqual( v, NINF, 'returns expected value' );
 
 	v = log1mexp( -0.0 );
-	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.strictEqual( v, NINF, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/log1mexp/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/log1mexp/test/test.native.js
@@ -59,7 +59,7 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'if provided `NaN`, the function returns `NaN`', opts, function test( t ) {
 	var v = log1mexp( NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN when provided a NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 	t.end();
 });
 
@@ -67,10 +67,10 @@ tape( 'if provided `+-0`, the function returns -infinity', opts, function test( 
 	var v;
 
 	v = log1mexp( 0.0 );
-	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.strictEqual( v, NINF, 'returns expected value' );
 
 	v = log1mexp( -0.0 );
-	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.strictEqual( v, NINF, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/log1p/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/log1p/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var log1p = require( './../lib' );
@@ -41,10 +41,11 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, 0.0, 1000.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 0.0;
-		y = log1p( x );
+		y = log1p( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -62,10 +63,11 @@ bench( pkg+'::built-in', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, 0.0, 1000.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 0.0;
-		y = Math.log1p( x ); // eslint-disable-line stdlib/no-builtin-math
+		y = Math.log1p( x[ i%x.length ] ); // eslint-disable-line stdlib/no-builtin-math
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/log1p/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/log1p/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -43,10 +43,11 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, 0.0, 1000.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 0.0;
-		y = log1p( x );
+		y = log1p( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/log1p/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/log1p/benchmark/c/benchmark.c
@@ -90,15 +90,18 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double x[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0*rand_double() ) - 0.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) - 0.0;
-		y = log1p( x );
+		y = log1p( x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/log1p/benchmark/c/cephes/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/log1p/benchmark/c/cephes/benchmark.c
@@ -95,15 +95,18 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double x[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0*rand_double() ) - 0.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) - 0.0;
-		y = log1p( x );
+		y = log1p( x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/log1p/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/log1p/benchmark/c/native/benchmark.c
@@ -91,15 +91,18 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double x[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0*rand_double() ) - 0.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) - 0.0;
-		y = stdlib_base_log1p( x );
+		y = stdlib_base_log1p( x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/log1p/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/log1p/test/test.js
@@ -276,12 +276,12 @@ tape( 'the function accurately computes `ln(x+1)` for positive huge numbers', fu
 });
 
 tape( 'the function returns `-infinity` if provided `-1`', function test( t ) {
-	t.equal( log1p( -1.0 ), NINF, 'equals -infinity' );
+	t.equal( log1p( -1.0 ), NINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+infinity` if provided `+infinity`', function test( t ) {
-	t.equal( log1p( PINF ), PINF, 'equals +infinity' );
+	t.equal( log1p( PINF ), PINF, 'returns expected value' );
 	t.end();
 });
 
@@ -289,26 +289,26 @@ tape( 'the function returns `NaN` if provided a number smaller than -1', functio
 	var val;
 
 	val = log1p( -2.0 );
-	t.equal( isnan( val ), true, 'returns NaN' );
+	t.equal( isnan( val ), true, 'returns expected value' );
 
 	val = log1p( NINF );
-	t.equal( isnan( val ), true, 'returns NaN' );
+	t.equal( isnan( val ), true, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function returns `NaN` if provided `NaN`', function test( t ) {
 	var val = log1p( NaN );
-	t.equal( isnan( val ), true, 'returns NaN' );
+	t.equal( isnan( val ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `0` if provided `+0`', function test( t ) {
-	t.equal( log1p( +0.0 ), 0.0, 'equals 0' );
+	t.equal( log1p( +0.0 ), 0.0, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-0` if provided `-0` (IEEE 754-2008)', function test( t ) {
-	t.equal( isNegativeZero( log1p( -0.0 ) ), true, 'returns -0' );
+	t.equal( isNegativeZero( log1p( -0.0 ) ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/log1p/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/log1p/test/test.native.js
@@ -285,12 +285,12 @@ tape( 'the function accurately computes `ln(x+1)` for positive huge numbers', op
 });
 
 tape( 'the function returns `-infinity` if provided `-1`', opts, function test( t ) {
-	t.equal( log1p( -1.0 ), NINF, 'equals -infinity' );
+	t.equal( log1p( -1.0 ), NINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+infinity` if provided `+infinity`', opts, function test( t ) {
-	t.equal( log1p( PINF ), PINF, 'equals +infinity' );
+	t.equal( log1p( PINF ), PINF, 'returns expected value' );
 	t.end();
 });
 
@@ -298,26 +298,26 @@ tape( 'the function returns `NaN` if provided a number smaller than -1', opts, f
 	var val;
 
 	val = log1p( -2.0 );
-	t.equal( isnan( val ), true, 'returns NaN' );
+	t.equal( isnan( val ), true, 'returns expected value' );
 
 	val = log1p( NINF );
-	t.equal( isnan( val ), true, 'returns NaN' );
+	t.equal( isnan( val ), true, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function returns `NaN` if provided `NaN`', opts, function test( t ) {
 	var val = log1p( NaN );
-	t.equal( isnan( val ), true, 'returns NaN' );
+	t.equal( isnan( val ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `0` if provided `+0`', opts, function test( t ) {
-	t.equal( log1p( +0.0 ), 0.0, 'equals 0' );
+	t.equal( log1p( +0.0 ), 0.0, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-0` if provided `-0` (IEEE 754-2008)', opts, function test( t ) {
-	t.equal( isNegativeZero( log1p( -0.0 ) ), true, 'returns -0' );
+	t.equal( isNegativeZero( log1p( -0.0 ) ), true, 'returns expected value' );
 	t.end();
 });


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors random number generation in JS benchmarks for the `math/base/special/ldexpf`, `math/base/special/lnf`, `math/base/special/log1mexp` and `math/base/special/log1p` packages.
-   Replaces `randu()` with `uniform()` from `@stdlib/random/array/uniform` for cleaner and more consistent code.
-   Moves the random number generation outside the benchmarking loops.
-   Updates the test messages to follow code conventions.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
