### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/ellipe/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/ellipe/README.md
@@ -98,16 +98,16 @@ v = ellipe( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var ellipe = require( '@stdlib/math/base/special/ellipe' );
 
-var m;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var m = uniform( 100, -1.0, 1.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    m = -1.0 + ( randu() * 2.0 );
-    console.log( 'ellipe(%d) = %d', m, ellipe( m ) );
-}
+logEachMap( 'ellipe(%0.4f) = %0.4f', m, ellipe );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/ellipe/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/ellipe/examples/index.js
@@ -18,13 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var ellipe = require( './../lib' );
 
-var m;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var m = uniform( 100, -1.0, 1.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	m = -1.0 + ( randu() * 2.0 );
-	console.log( 'ellipe(%d) = %d', m, ellipe( m ) );
-}
+logEachMap( 'ellipe(%0.4f) = %0.4f', m, ellipe );

--- a/lib/node_modules/@stdlib/math/base/special/ellipk/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/ellipk/README.md
@@ -98,16 +98,16 @@ v = ellipk( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var ellipk = require( '@stdlib/math/base/special/ellipk' );
 
-var m;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var m = uniform( 100, -1.0, 1.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    m = -1.0 + ( randu() * 2.0 );
-    console.log( 'ellipk(%d) = %d', m, ellipk( m ) );
-}
+logEachMap( 'ellipk(%0.4f) = %0.4f', m, ellipk );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/ellipk/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/ellipk/examples/index.js
@@ -18,13 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var ellipk = require( './../lib' );
 
-var m;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var m = uniform( 100, -1.0, 1.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	m = -1.0 + ( randu() * 2.0 );
-	console.log( 'ellipk(%d) = %d', m, ellipk( m ) );
-}
+logEachMap( 'ellipk(%0.4f) = %0.4f', m, ellipk );

--- a/lib/node_modules/@stdlib/math/base/special/erf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/erf/README.md
@@ -88,15 +88,16 @@ var y = erf( -0.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var erf = require( '@stdlib/math/base/special/erf' );
 
-var x = linspace( -10.0, 10.0, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -10.0, 10.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( 'x: %d, erf(x): %d', x[ i ], erf( x[ i ] ) );
-}
+logEachMap( 'x: %0.4f, erf(x): %0.4f', x, erf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/erf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/erf/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var erf = require( './../lib' );
 
-var x = linspace( -10.0, 10.0, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -10.0, 10.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'x: %d, erf(x): %d', x[ i ], erf( x[ i ] ) );
-}
+logEachMap( 'x: %0.4f, erf(x): %0.4f', x, erf );

--- a/lib/node_modules/@stdlib/math/base/special/erfc/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/erfc/README.md
@@ -102,15 +102,16 @@ var y = erfc( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var erfc = require( '@stdlib/math/base/special/erfc' );
 
-var x = linspace( -10.0, 10.0, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -10.0, 10.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( 'x: %d, erfc(x): %d', x[ i ], erfc( x[ i ] ) );
-}
+logEachMap( 'x: %0.4f, erfc(x): %0.4f', x, erfc );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/erfc/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/erfc/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var erfc = require( './../lib' );
 
-var x = linspace( -10.0, 10.0, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -10.0, 10.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'x: %d, erfc(x): %d', x[ i ], erfc( x[ i ] ) );
-}
+logEachMap( 'x: %0.4f, erfc(x): %0.4f', x, erfc );

--- a/lib/node_modules/@stdlib/math/base/special/erfcinv/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/erfcinv/README.md
@@ -96,15 +96,16 @@ var y = erfcinv( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var erfcinv = require( '@stdlib/math/base/special/erfcinv' );
 
-var x = linspace( 0.0, 2.0, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, 0.0, 2.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( 'x: %d, erfcinv(x): %d', x[ i ], erfcinv( x[ i ] ) );
-}
+logEachMap( 'x: %0.4f, erfcinv(x): %0.4f', x, erfcinv );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/erfcinv/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/erfcinv/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var erfcinv = require( './../lib' );
 
-var x = linspace( 0.0, 2.0, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, 0.0, 2.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'x: %d, erfcinv(x): %d', x[ i ], erfcinv( x[ i ] ) );
-}
+logEachMap( 'x: %0.4f, erfcinv(x): %0.4f', x, erfcinv );

--- a/lib/node_modules/@stdlib/math/base/special/erfcx/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/erfcx/README.md
@@ -105,15 +105,16 @@ var y = erfcx( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var erfcx = require( '@stdlib/math/base/special/erfcx' );
 
-var x = linspace( -30.0, 30.0, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -30.0, 30.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( 'x: %d, erfcx(x): %d', x[ i ], erfcx( x[ i ] ) );
-}
+logEachMap( 'x: %0.4f, erfcx(x): %0.4f', x, erfcx );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/erfcx/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/erfcx/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var erfcx = require( './../lib' );
 
-var x = linspace( -30.0, 30.0, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -30.0, 30.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'x: %d, erfcx(x): %d', x[ i ], erfcx( x[ i ] ) );
-}
+logEachMap( 'x: %0.4f, erfcx(x): %0.4f', x, erfcx );

--- a/lib/node_modules/@stdlib/math/base/special/erfinv/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/erfinv/README.md
@@ -116,15 +116,16 @@ var y = erfinv( -0.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var erfinv = require( '@stdlib/math/base/special/erfinv' );
 
-var x = linspace( -1.0, 1.0, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -1.0, 1.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( 'x: %d, erfinv(x): %d', x[ i ], erfinv( x[ i ] ) );
-}
+logEachMap( 'x: %0.4f, erfinv(x): %0.4f', x, erfinv );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/erfinv/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/erfinv/README.md
@@ -39,7 +39,7 @@ The [inverse error function][inverse-error-function] is defined in terms of the 
 
 <!-- </equation> -->
 
-where `c_0 = 1` and 
+where `c_0 = 1` and
 
 <!-- <equation class="equation" label="eq:inverse_error_function_series_coefficients" align="center" raw="c_k=\sum_{m=0}^{k-1}\frac{c_m c_{k-1-m}}{(m+1)(2m+1)} = \left\{1,1,\frac{7}{6},\frac{127}{90},\frac{4369}{2520},\frac{34807}{16200},\ldots\right\}" alt="Series coefficients."> -->
 

--- a/lib/node_modules/@stdlib/math/base/special/erfinv/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/erfinv/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var erfinv = require( './../lib' );
 
-var x = linspace( -1.0, 1.0, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -1.0, 1.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'x: %d, erfinv(x): %d', x[ i ], erfinv( x[ i ] ) );
-}
+logEachMap( 'x: %0.4f, erfinv(x): %0.4f', x, erfinv );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `math/base/special/ellipe`, `math/base/special/ellipk`, `math/base/special/erf`, `math/base/special/erfc`, `math/base/special/erfcinv`, `math/base/special/erfcx` and `math/base/special/erfinv` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
