### PR TITLE
chore: replace separate `sin` and `cos` calls with `sincos`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/ccis/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/ccis/manifest.json
@@ -40,8 +40,7 @@
         "@stdlib/complex/float64/ctor",
         "@stdlib/complex/float64/reim",
         "@stdlib/math/base/special/exp",
-        "@stdlib/math/base/special/cos",
-        "@stdlib/math/base/special/sin"
+        "@stdlib/math/base/special/sincos"
       ]
     },
     {
@@ -58,8 +57,7 @@
         "@stdlib/complex/float64/ctor",
         "@stdlib/complex/float64/reim",
         "@stdlib/math/base/special/exp",
-        "@stdlib/math/base/special/cos",
-        "@stdlib/math/base/special/sin"
+        "@stdlib/math/base/special/sincos"
       ]
     },
     {
@@ -76,8 +74,7 @@
         "@stdlib/complex/float64/ctor",
         "@stdlib/complex/float64/reim",
         "@stdlib/math/base/special/exp",
-        "@stdlib/math/base/special/cos",
-        "@stdlib/math/base/special/sin"
+        "@stdlib/math/base/special/sincos"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/ccis/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/ccis/src/main.c
@@ -20,8 +20,7 @@
 #include "stdlib/complex/float64/ctor.h"
 #include "stdlib/complex/float64/reim.h"
 #include "stdlib/math/base/special/exp.h"
-#include "stdlib/math/base/special/sin.h"
-#include "stdlib/math/base/special/cos.h"
+#include "stdlib/math/base/special/sincos.h"
 
 /**
 * Evaluates the cis function for a double-precision complex floating-point number.
@@ -68,9 +67,7 @@ stdlib_complex128_t stdlib_base_ccis( const stdlib_complex128_t z ) {
 
 	stdlib_complex128_reim( z, &re, &im );
 
-	// TODO: replace with stdlib/math/base/special/sincos
-	y = stdlib_base_sin( re );
-	x = stdlib_base_cos( re );
+	stdlib_base_sincos( re, &y, &x );
 	if( im != 0.0 ) {
 		e = stdlib_base_exp( -im );
 		y *= e;


### PR DESCRIPTION
Resolves None

## Description

> What is the purpose of this pull request?

This pull request:

- Replaces separate `sin` and `cos` call with `sincos`

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md