### PR TITLE
chore: replace `pow` with `stdlib_base_pow`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/ceiln/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/ceiln/manifest.json
@@ -41,6 +41,7 @@
         "@stdlib/math/base/napi/binary",
         "@stdlib/math/base/special/abs",
         "@stdlib/math/base/special/ceil",
+        "@stdlib/math/base/special/pow",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/constants/float64/max-base10-exponent",
@@ -65,6 +66,7 @@
       "dependencies": [
         "@stdlib/math/base/special/abs",
         "@stdlib/math/base/special/ceil",
+        "@stdlib/math/base/special/pow",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/constants/float64/max-base10-exponent",
@@ -89,6 +91,7 @@
       "dependencies": [
         "@stdlib/math/base/special/abs",
         "@stdlib/math/base/special/ceil",
+        "@stdlib/math/base/special/pow",
         "@stdlib/math/base/assert/is-nan",
         "@stdlib/math/base/assert/is-infinite",
         "@stdlib/constants/float64/max-base10-exponent",

--- a/lib/node_modules/@stdlib/math/base/special/ceiln/src/ceiln.c
+++ b/lib/node_modules/@stdlib/math/base/special/ceiln/src/ceiln.c
@@ -19,6 +19,7 @@
 #include "stdlib/math/base/special/ceiln.h"
 #include "stdlib/math/base/special/ceil.h"
 #include "stdlib/math/base/special/abs.h"
+#include "stdlib/math/base/special/pow.h"
 #include "stdlib/math/base/assert/is_nan.h"
 #include "stdlib/math/base/assert/is_infinite.h"
 #include "stdlib/constants/float64/max_base10_exponent.h"
@@ -27,7 +28,6 @@
 #include "stdlib/constants/float64/max_safe_integer.h"
 #include "stdlib/constants/float64/pinf.h"
 #include <stdint.h>
-#include <math.h>
 
 
 // VARIABLES //
@@ -90,14 +90,14 @@ double stdlib_base_ceiln( const double x, const int32_t n ) {
 	}
 	// If we overflow, return `x`, as the number of digits to the right of the decimal is too small (i.e., `x` is too large / lacks sufficient fractional precision) for there to be any effect when rounding...
 	if ( n < STDLIB_CONSTANT_FLOAT64_MIN_BASE10_EXPONENT ) {
-		s = pow( 10.0, -( n + STDLIB_CONSTANT_FLOAT64_MAX_BASE10_EXPONENT ) ); // TODO: replace use of `pow` once have stdlib equivalent
+		s = stdlib_base_pow( 10.0, -( n + STDLIB_CONSTANT_FLOAT64_MAX_BASE10_EXPONENT ) );
 		y = ( x * HUGE_VALUE ) * s; // order of operation matters!
 		if ( stdlib_base_is_infinite( y ) ) {
 			return x;
 		}
 		return ( stdlib_base_ceil( y ) / HUGE_VALUE ) / s;
 	}
-	s = pow( 10.0, -n ); // TODO: replace use of `pow` once have stdlib equivalent
+	s = stdlib_base_pow( 10.0, -n );
 	y = x * s;
 	if ( stdlib_base_is_infinite( y ) ) {
 		return x;


### PR DESCRIPTION
Resolves None

## Description

> What is the purpose of this pull request?

This pull request:

- Replaces `pow` with `stdlib_base_pow`

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md