### PR TITLE
refactor: replace `evalpoly` with compiled polyval functions

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cos/scripts/cephes/evalpoly.js
+++ b/lib/node_modules/@stdlib/math/base/special/cos/scripts/cephes/evalpoly.js
@@ -1,0 +1,86 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/*
+* This script compiles modules for evaluating polynomial functions. If any polynomial coefficients change, this script should be rerun to update the compiled files.
+*/
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var writeFileSync = require( '@stdlib/fs/write-file' ).sync;
+var currentYear = require( '@stdlib/time/current-year' );
+var licenseHeader = require( '@stdlib/_tools/licenses/header' );
+var compile = require( '@stdlib/math/base/tools/evalpoly-compile' );
+
+
+// VARIABLES //
+
+// Polynomial coefficients ordered in ascending degree...
+var SIN_COEF = [
+	-1.66666666666666307295e-1, // 0xbfc5555555555548
+	8.33333333332211858878e-3, // 0x3f8111111110f7d0
+	-1.98412698295895385996e-4, // 0xbf2a01a019bfdf03
+	2.75573136213857245213e-6, // 0x3ec71de3567d48a1
+	-2.50507477628578072866e-8, // 0xbe5ae5e5a9291f5d
+	1.58962301576546568060e-10 // 0x3de5d8fd1fd19ccd
+];
+var COS_COEF = [
+	4.16666666666665929218e-2, // 0x3fa555555555554b
+	-1.38888888888730564116e-3, // 0xbf56c16c16c14f91
+	2.48015872888517045348e-5, // 0x3efa01a019c844f5
+	-2.75573141792967388112e-7, // 0xbe927e4f7eac4bc6
+	2.08757008419747316778e-9, // 0x3e21ee9d7b4e3f05
+	-1.13585365213876817300e-11 // 0xbda8fa49a0861a9b
+];
+
+// Header to add to output files:
+var header = licenseHeader( 'Apache-2.0', 'js', {
+	'year': currentYear(),
+	'copyright': 'The Stdlib Authors'
+});
+header += '\n/* This is a generated file. Do not edit directly. */\n';
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var fpath;
+	var opts;
+	var str;
+
+	opts = {
+		'encoding': 'utf8'
+	};
+
+	fpath = resolve( __dirname, 'polyval_sin.js' );
+	str = header + compile( SIN_COEF );
+	writeFileSync( fpath, str, opts );
+
+	fpath = resolve( __dirname, 'polyval_cos.js' );
+	str = header + compile( COS_COEF );
+	writeFileSync( fpath, str, opts );
+}
+
+main();

--- a/lib/node_modules/@stdlib/math/base/special/cos/scripts/cephes/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/cos/scripts/cephes/index.js
@@ -34,11 +34,12 @@
 
 // MODULES //
 
-var evalpoly = require( '@stdlib/math/base/tools/evalpoly' ).factory; // TODO: replace with compiled polyval functions
 var floor = require( '@stdlib/math/base/special/floor' );
 var ldexp = require( '@stdlib/math/base/special/ldexp' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var isinfinite = require( '@stdlib/math/base/assert/is-infinite' );
+var polyvalSIN = require( './polyval_sin.js' );
+var polyvalCOS = require( './polyval_cos.js' );
 
 
 // VARIABLES //
@@ -47,29 +48,6 @@ var DP1 = 7.85398125648498535156e-1; // 0x3fe921fb40000000, Pi/4 split into thre
 var DP2 = 3.77489470793079817668e-8; // 0x3e64442d00000000,
 var DP3 = 2.69515142907905952645e-15; // 0x3ce8469898cc5170,
 var PIO4 = 7.85398163397448309616E-1; // 4/pi
-var SIN_COEF = [
-	-1.66666666666666307295e-1, // 0xbfc5555555555548
-	8.33333333332211858878e-3, // 0x3f8111111110f7d0
-	-1.98412698295895385996e-4, // 0xbf2a01a019bfdf03
-	2.75573136213857245213e-6, // 0x3ec71de3567d48a1
-	-2.50507477628578072866e-8, // 0xbe5ae5e5a9291f5d
-	1.58962301576546568060e-10 // 0x3de5d8fd1fd19ccd
-];
-var COS_COEF = [
-	4.16666666666665929218e-2, // 0x3fa555555555554b
-	-1.38888888888730564116e-3, // 0xbf56c16c16c14f91
-	2.48015872888517045348e-5, // 0x3efa01a019c844f5
-	-2.75573141792967388112e-7, // 0xbe927e4f7eac4bc6
-	2.08757008419747316778e-9, // 0x3e21ee9d7b4e3f05
-	-1.13585365213876817300e-11 // 0xbda8fa49a0861a9b
-];
-
-
-// FUNCTIONS //
-
-// Compile functions to evaluate polynomial functions based on the above coefficients...
-var polyvalSIN = evalpoly( SIN_COEF );
-var polyvalCOS = evalpoly( COS_COEF );
 
 
 // MAIN //

--- a/lib/node_modules/@stdlib/math/base/special/cos/scripts/cephes/polyval_cos.js
+++ b/lib/node_modules/@stdlib/math/base/special/cos/scripts/cephes/polyval_cos.js
@@ -1,0 +1,47 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* This is a generated file. Do not edit directly. */
+'use strict';
+
+// MAIN //
+
+/**
+* Evaluates a polynomial.
+*
+* ## Notes
+*
+* -   The implementation uses [Horner's rule][horners-method] for efficient computation.
+*
+* [horners-method]: https://en.wikipedia.org/wiki/Horner%27s_method
+*
+* @private
+* @param {number} x - value at which to evaluate the polynomial
+* @returns {number} evaluated polynomial
+*/
+function evalpoly( x ) {
+	if ( x === 0.0 ) {
+		return 0.041666666666666595;
+	}
+	return 0.041666666666666595 + (x * (-0.0013888888888873056 + (x * (0.000024801587288851704 + (x * (-2.755731417929674e-7 + (x * (2.087570084197473e-9 + (x * -1.1358536521387682e-11))))))))); // eslint-disable-line max-len
+}
+
+
+// EXPORTS //
+
+module.exports = evalpoly;

--- a/lib/node_modules/@stdlib/math/base/special/cos/scripts/cephes/polyval_sin.js
+++ b/lib/node_modules/@stdlib/math/base/special/cos/scripts/cephes/polyval_sin.js
@@ -1,0 +1,47 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* This is a generated file. Do not edit directly. */
+'use strict';
+
+// MAIN //
+
+/**
+* Evaluates a polynomial.
+*
+* ## Notes
+*
+* -   The implementation uses [Horner's rule][horners-method] for efficient computation.
+*
+* [horners-method]: https://en.wikipedia.org/wiki/Horner%27s_method
+*
+* @private
+* @param {number} x - value at which to evaluate the polynomial
+* @returns {number} evaluated polynomial
+*/
+function evalpoly( x ) {
+	if ( x === 0.0 ) {
+		return -0.1666666666666663;
+	}
+	return -0.1666666666666663 + (x * (0.008333333333322118 + (x * (-0.0001984126982958954 + (x * (0.0000027557313621385722 + (x * (-2.5050747762857807e-8 + (x * 1.5896230157654656e-10))))))))); // eslint-disable-line max-len
+}
+
+
+// EXPORTS //
+
+module.exports = evalpoly;


### PR DESCRIPTION
Resolves None

## Description

> What is the purpose of this pull request?

This pull request:

- Replaces `evalpoly` with compiled polyval functions.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md