### PR TITLE
bench: update random value generation

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/log10/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/log10/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var log10 = require( './../lib' );
@@ -41,10 +41,11 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, 0.0, 1000.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 0.0;
-		y = log10( x );
+		y = log10( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -62,10 +63,11 @@ bench( pkg+'::built-in', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, 0.0, 1000.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 0.0;
-		y = Math.log10( x ); // eslint-disable-line stdlib/no-builtin-math
+		y = Math.log10( x[ i%x.length ] ); // eslint-disable-line stdlib/no-builtin-math
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/log10/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/log10/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -43,10 +43,11 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, 0.0, 1000.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 0.0;
-		y = log10( x );
+		y = log10( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/log10/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/log10/benchmark/c/benchmark.c
@@ -90,15 +90,18 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double x[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0*rand_double() ) - 0.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) - 0.0;
-		y = log10( x );
+		y = log10( x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/log10/benchmark/c/cephes/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/log10/benchmark/c/cephes/benchmark.c
@@ -95,15 +95,18 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double x[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0*rand_double() ) - 0.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) - 0.0;
-		y = log10( x );
+		y = log10( x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/log10/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/log10/benchmark/c/native/benchmark.c
@@ -91,15 +91,18 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double x[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0*rand_double() ) - 0.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) - 0.0;
-		y = stdlib_base_log10( x );
+		y = stdlib_base_log10( x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/log10/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/log10/test/test.js
@@ -211,23 +211,23 @@ tape( 'the function evaluates the common logarithm of `x` (subnormal values)', f
 });
 
 tape( 'the function returns `-infinity` if provided `0`', function test( t ) {
-	t.equal( log10( 0.0 ), NINF, 'equals -infinity' );
+	t.equal( log10( 0.0 ), NINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+infinity` if provided `+infinity`', function test( t ) {
-	t.equal( log10( PINF ), PINF, 'equals +infinity' );
+	t.equal( log10( PINF ), PINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `NaN` if provided a negative number', function test( t ) {
 	var v = log10( -1.0 );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns positive zero if provided `1.0`', function test( t ) {
 	var v = log10( 1.0 );
-	t.equal( isPositiveZero( v ), true, 'returns +0' );
+	t.equal( isPositiveZero( v ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/log10/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/log10/test/test.native.js
@@ -220,23 +220,23 @@ tape( 'the function evaluates the common logarithm of `x` (subnormal values)', o
 });
 
 tape( 'the function returns `-infinity` if provided `0`', opts, function test( t ) {
-	t.equal( log10( 0.0 ), NINF, 'equals -infinity' );
+	t.equal( log10( 0.0 ), NINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+infinity` if provided `+infinity`', opts, function test( t ) {
-	t.equal( log10( PINF ), PINF, 'equals +infinity' );
+	t.equal( log10( PINF ), PINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `NaN` if provided a negative number', opts, function test( t ) {
 	var v = log10( -1.0 );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns positive zero if provided `1.0`', opts, function test( t ) {
 	var v = log10( 1.0 );
-	t.equal( isPositiveZero( v ), true, 'returns +0' );
+	t.equal( isPositiveZero( v ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/log1pexp/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/log1pexp/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var log1pexp = require( './../lib' );
@@ -34,10 +34,11 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -500.0, 500.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 500.0;
-		y = log1pexp( x );
+		y = log1pexp( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/log1pexp/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/log1pexp/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -43,10 +43,11 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -500.0, 500.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 500.0;
-		y = log1pexp( x );
+		y = log1pexp( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/log1pexp/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/log1pexp/benchmark/c/benchmark.c
@@ -111,15 +111,18 @@ double log1pexp( double x ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double x[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0*rand_double() ) - 500.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) - 500.0;
-		y = log1pexp( x );
+		y = log1pexp( x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/log1pexp/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/log1pexp/benchmark/c/native/benchmark.c
@@ -91,15 +91,18 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double x[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0*rand_double() ) - 500.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) - 500.0;
-		y = stdlib_base_log1pexp( x );
+		y = stdlib_base_log1pexp( x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/log1pexp/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/log1pexp/test/test.js
@@ -45,7 +45,7 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'if provided `NaN`, the function returns `NaN`', function test( t ) {
 	var v = log1pexp( NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN when provided a NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/math/base/special/log1pexp/test/test.natve.js
+++ b/lib/node_modules/@stdlib/math/base/special/log1pexp/test/test.natve.js
@@ -54,7 +54,7 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'if provided `NaN`, the function returns `NaN`', opts, function test( t ) {
 	var v = log1pexp( NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN when provided a NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/math/base/special/log1pmx/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/log1pmx/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var log1pmx = require( './../lib' );
@@ -34,10 +34,11 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -1.0, 99.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*100.0 ) - 1.0;
-		y = log1pmx( x );
+		y = log1pmx( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/log1pmx/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/log1pmx/benchmark/c/benchmark.c
@@ -110,15 +110,18 @@ double log1pmx( double x ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double x[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0*rand_double() ) - 0.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) - 0.0;
-		y = log1pmx( x );
+		y = log1pmx( x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/log2/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/log2/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var log2 = require( './../lib' );
@@ -41,10 +41,11 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, 0.0, 1000.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 0.0;
-		y = log2( x );
+		y = log2( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -62,10 +63,11 @@ bench( pkg+'::built-in', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, 0.0, 1000.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 0.0;
-		y = Math.log2( x ); // eslint-disable-line stdlib/no-builtin-math
+		y = Math.log2( x[ i%x.length ] ); // eslint-disable-line stdlib/no-builtin-math
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/log2/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/log2/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -43,10 +43,11 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, 0.0, 1000.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 0.0;
-		y = log2( x );
+		y = log2( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/log2/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/log2/benchmark/c/benchmark.c
@@ -90,15 +90,18 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double x[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0*rand_double() ) - 0.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) - 0.0;
-		y = log2( x );
+		y = log2( x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/log2/benchmark/c/cephes/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/log2/benchmark/c/cephes/benchmark.c
@@ -95,15 +95,18 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double x[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0*rand_double() ) - 0.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) - 0.0;
-		y = log2( x );
+		y = log2( x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/log2/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/log2/benchmark/c/native/benchmark.c
@@ -91,15 +91,18 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double x[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0*rand_double() ) - 0.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) - 0.0;
-		y = stdlib_base_log2( x );
+		y = stdlib_base_log2( x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/log2/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/log2/test/test.js
@@ -211,23 +211,23 @@ tape( 'the function evaluates the binary logarithm of `x` (subnormal values)', f
 });
 
 tape( 'the function returns `-infinity` if provided `0`', function test( t ) {
-	t.equal( log2( 0.0 ), NINF, 'equals -infinity' );
+	t.equal( log2( 0.0 ), NINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+infinity` if provided `+infinity`', function test( t ) {
-	t.equal( log2( PINF ), PINF, 'equals +infinity' );
+	t.equal( log2( PINF ), PINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `NaN` if provided a negative number', function test( t ) {
 	var v = log2( -1.0 );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns positive zero if provided `1.0`', function test( t ) {
 	var v = log2( 1.0 );
-	t.equal( isPositiveZero( v ), true, 'returns +0' );
+	t.equal( isPositiveZero( v ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/log2/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/log2/test/test.native.js
@@ -220,23 +220,23 @@ tape( 'the function evaluates the binary logarithm of `x` (subnormal values)', o
 });
 
 tape( 'the function returns `-infinity` if provided `0`', opts, function test( t ) {
-	t.equal( log2( 0.0 ), NINF, 'equals -infinity' );
+	t.equal( log2( 0.0 ), NINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+infinity` if provided `+infinity`', opts, function test( t ) {
-	t.equal( log2( PINF ), PINF, 'equals +infinity' );
+	t.equal( log2( PINF ), PINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `NaN` if provided a negative number', opts, function test( t ) {
 	var v = log2( -1.0 );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns positive zero if provided `1.0`', opts, function test( t ) {
 	var v = log2( 1.0 );
-	t.equal( isPositiveZero( v ), true, 'returns +0' );
+	t.equal( isPositiveZero( v ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/logaddexp/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/logaddexp/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var logaddexp = require( './../lib' );
@@ -35,11 +35,12 @@ bench( pkg, function benchmark( b ) {
 	var v;
 	var i;
 
+	x = uniform( 100, -500.0, 500.0 );
+	y = uniform( 100, -500.0, 500.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 500.0;
-		y = ( randu()*1000.0 ) - 500.0;
-		v = logaddexp( x, y );
+		v = logaddexp( x[ i%x.length ], y[ i%y.length ] );
 		if ( isnan( v ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/logaddexp/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/logaddexp/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -44,11 +44,12 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var v;
 	var i;
 
+	x = uniform( 100, -100.0, 100.0 );
+	y = uniform( 100, -100.0, 100.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*200.0 ) - 100.0;
-		y = ( randu()*200.0 ) - 100.0;
-		v = logaddexp( x, y );
+		v = logaddexp( x[ i%x.length ], y[ i%y.length ] );
 		if ( isnan( v ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/logaddexp/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/logaddexp/benchmark/c/benchmark.c
@@ -112,17 +112,20 @@ double logaddexp( double x, double y ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
-	double y;
+	double x[ 100 ];
+	double y[ 100 ];
 	double v;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0*rand_double() ) - 500.0;
+		y[ i ] = ( 1000.0*rand_double() ) - 500.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) - 500.0;
-		y = ( 1000.0*rand_double() ) - 500.0;
-		v = logaddexp( x, y );
+		v = logaddexp( x[ i%100 ], y[ i%100 ] );
 		if ( v != v ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/logaddexp/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/logaddexp/benchmark/c/native/benchmark.c
@@ -92,17 +92,20 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
-	double y;
+	double x[ 100 ];
+	double y[ 100 ];
 	double v;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 200.0*rand_double() ) - 100.0;;
+		y[ i ] = ( 200.0*rand_double() ) - 100.0;;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 200.0*rand_double() ) - 100.0;
-		y = ( 200.0*rand_double() ) - 100.0;
-		v = stdlib_base_logaddexp( x, y );
+		v = stdlib_base_logaddexp( x[ i%100 ], y[ i%100 ] );
 		if ( v != v ) {
 			printf( "should not return NaN\n" );
 			break;


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors random number generation in JS benchmarks for the `math/base/special/logaddexp`, `math/base/special/log10`, `math/base/special/log1pmx`, `math/base/special/log2` and `math/base/special/log1pexp` packages.
-   Replaces `randu()` with `uniform()` from `@stdlib/random/array/uniform` for cleaner and more consistent code.
-   Moves the random number generation outside the benchmarking loops.
-   Updates the test messages to follow code conventions.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
