### PR TITLE
bench: update random value generation

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/logf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/logf/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/array/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pkg = require( './../package.json' ).name;
@@ -36,7 +36,7 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
-	x = randu( 100, 1.0, 1000.0 );
+	x = uniform( 100, 1.0, 1000.0 );
 	base = discreteUniform( 100, 2.0, 10.0 );
 
 	b.tic();

--- a/lib/node_modules/@stdlib/math/base/special/logf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/logf/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/array/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -45,7 +45,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
-	x = randu( 100, 1.0, 1000.0 );
+	x = uniform( 100, 1.0, 1000.0 );
 	base = discreteUniform( 100, 2.0, 10.0 );
 
 	b.tic();

--- a/lib/node_modules/@stdlib/math/base/special/logit/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/logit/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var logit = require( './../lib' );
@@ -34,10 +34,11 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, 0.0, 1.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = logit( x );
+		y = logit( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/logit/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/logit/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -43,10 +43,11 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, 0.0, 1.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = randu();
-		y = logit( x );
+		y = logit( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/logit/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/logit/test/test.js
@@ -46,27 +46,27 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function returns `NaN` when provided `NaN`', function test( t ) {
 	var y = logit( NaN );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `NaN` when provided a number outside `[0,1]`', function test( t ) {
 	var y = logit( 1.2 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 	y = logit( -0.1 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-Infinity` when provided `0`', function test( t ) {
 	var y = logit( 0.0 );
-	t.equal( y, NINF, 'returns -Infinity' );
+	t.equal( y, NINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+Infinity` when provided `1`', function test( t ) {
 	var y = logit( 1.0 );
-	t.equal( y, PINF, 'returns +Infinity' );
+	t.equal( y, PINF, 'returns expected value' );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/math/base/special/logit/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/logit/test/test.native.js
@@ -55,27 +55,27 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function returns `NaN` when provided `NaN`', opts, function test( t ) {
 	var y = logit( NaN );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `NaN` when provided a number outside `[0,1]`', opts, function test( t ) {
 	var y = logit( 1.2 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 	y = logit( -0.1 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-Infinity` when provided `0`', opts, function test( t ) {
 	var y = logit( 0.0 );
-	t.equal( y, NINF, 'returns -Infinity' );
+	t.equal( y, NINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+Infinity` when provided `1`', opts, function test( t ) {
 	var y = logit( 1.0 );
-	t.equal( y, PINF, 'returns +Infinity' );
+	t.equal( y, PINF, 'returns expected value' );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/math/base/special/maxabs/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/maxabs/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var maxabs = require( './../lib' );
@@ -35,11 +35,12 @@ bench( pkg, function benchmark( b ) {
 	var z;
 	var i;
 
+	x = uniform( 100, -500.0, 500.0 );
+	y = uniform( 100, -500.0, 500.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 500.0;
-		y = ( randu()*1000.0 ) - 500.0;
-		z = maxabs( x, y );
+		z = maxabs( x[ i%x.length ], y[ i%y.length ] );
 		if ( isnan( z ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -58,11 +59,12 @@ bench( pkg+'::built-in', function benchmark( b ) {
 	var z;
 	var i;
 
+	x = uniform( 100, -500.0, 500.0 );
+	y = uniform( 100, -500.0, 500.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 500.0;
-		y = ( randu()*1000.0 ) - 500.0;
-		z = Math.max( Math.abs( x ), Math.abs( y ) ); // eslint-disable-line stdlib/no-builtin-math
+		z = Math.max( Math.abs( x[ i%x.length ] ), Math.abs( y[ i%y.length ] ) ); // eslint-disable-line stdlib/no-builtin-math
 		if ( isnan( z ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/maxabs/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/maxabs/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -44,11 +44,12 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var z;
 	var i;
 
+	x = uniform( 100, -500.0, 500.0 );
+	y = uniform( 100, -500.0, 500.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 500.0;
-		y = ( randu()*1000.0 ) - 500.0;
-		z = maxabs( x, y );
+		z = maxabs( x[ i%x.length ], y[ i%y.length ] );
 		if ( isnan( z ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/maxabs/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/maxabs/benchmark/c/benchmark.c
@@ -103,7 +103,7 @@ static double benchmark( void ) {
 
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		z = fmax( fabs(x[ i%100 ]), fabs(y[ i%100 ]) );
+		z = fmax( fabs( x[ i%100 ] ), fabs( y[ i%100 ] ) );
 		if ( z != z ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/maxabs/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/maxabs/benchmark/c/benchmark.c
@@ -90,17 +90,20 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
-	double y;
+	double x[ 100 ];
+	double y[ 100 ];
 	double z;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0*rand_double() ) - 500.0;
+		y[ i ] = ( 1000.0*rand_double() ) - 500.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) - 500.0;
-		y = ( 1000.0*rand_double() ) - 500.0;
-		z = fmax( fabs(x), fabs(y) );
+		z = fmax( fabs(x[ i%100 ]), fabs(y[ i%100 ]) );
 		if ( z != z ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/maxabs/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/maxabs/benchmark/c/native/benchmark.c
@@ -92,16 +92,19 @@ static double rand_double( void ) {
 static double benchmark( void ) {
 	double elapsed;
 	double t;
-	double x;
-	double y;
+	double x[ 100 ];
+	double y[ 100 ];
 	double z;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0*rand_double() ) - 500.0;
+		y[ i ] = ( 1000.0*rand_double() ) - 500.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) - 500.0;
-		y = ( 1000.0*rand_double() ) - 500.0;
-		z = stdlib_base_maxabs( x, y );
+		z = stdlib_base_maxabs( x[ i%100 ], y[ i%100 ] );
 		if ( z != z ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/array/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pkg = require( './../package.json' ).name;
 var maxabsf = require( './../lib' );
@@ -35,8 +35,8 @@ bench( pkg, function benchmark( b ) {
 	var z;
 	var i;
 
-	x = randu( 100, -500.0, 500.0 );
-	y = randu( 100, -500.0, 500.0 );
+	x = uniform( 100, -500.0, 500.0 );
+	y = uniform( 100, -500.0, 500.0 );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/array/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -44,8 +44,8 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var z;
 	var i;
 
-	x = randu( 100, -500.0, 500.0 );
-	y = randu( 100, -500.0, 500.0 );
+	x = uniform( 100, -500.0, 500.0 );
+	y = uniform( 100, -500.0, 500.0 );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/math/base/special/maxabsn/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsn/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var maxabsn = require( './../lib' );
@@ -35,11 +35,12 @@ bench( pkg, function benchmark( b ) {
 	var z;
 	var i;
 
+	x = uniform( 100, -500.0, 500.0 );
+	y = uniform( 100, -500.0, 500.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 500.0;
-		y = ( randu()*1000.0 ) - 500.0;
-		z = maxabsn( x, y );
+		z = maxabsn( x[ i%x.length ], y[ i%y.length ] );
 		if ( isnan( z ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -58,11 +59,12 @@ bench( pkg+'::built-in', function benchmark( b ) {
 	var z;
 	var i;
 
+	x = uniform( 100, -500.0, 500.0 );
+	y = uniform( 100, -500.0, 500.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 500.0;
-		y = ( randu()*1000.0 ) - 500.0;
-		z = Math.max( Math.abs( x ), Math.abs( y ) ); // eslint-disable-line stdlib/no-builtin-math
+		z = Math.max( Math.abs( x[ i%x.length ] ), Math.abs( y[ i%y.length ] ) ); // eslint-disable-line stdlib/no-builtin-math
 		if ( isnan( z ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/maxabsn/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsn/benchmark/c/benchmark.c
@@ -103,7 +103,7 @@ static double benchmark( void ) {
 
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		z = fmax( fabs(x[ i%100 ]), fabs(y[ i%100 ]) );
+		z = fmax( fabs( x[ i%100 ] ), fabs( y[ i%100 ] ) );
 		if ( z != z ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/maxabsn/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsn/benchmark/c/benchmark.c
@@ -90,17 +90,20 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
-	double y;
+	double x[ 100 ];
+	double y[ 100 ];
 	double z;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0*rand_double() ) - 500.0;
+		y[ i ] = ( 1000.0*rand_double() ) - 500.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) - 500.0;
-		y = ( 1000.0*rand_double() ) - 500.0;
-		z = fmax( fabs(x), fabs(y) );
+		z = fmax( fabs(x[ i%100 ]), fabs(y[ i%100 ]) );
 		if ( z != z ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/maxabsn/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsn/test/test.js
@@ -40,16 +40,16 @@ tape( 'the function returns `NaN` if provided a `NaN`', function test( t ) {
 	var v;
 
 	v = maxabsn( NaN, 3.14 );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = maxabsn( 3.14, NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = maxabsn( NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = maxabsn( 3.14, 4.2, NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -58,23 +58,23 @@ tape( 'the function returns `+Infinity` if provided `+Infinity`', function test(
 	var v;
 
 	v = maxabsn( PINF, 3.14 );
-	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.strictEqual( v, PINF, 'returns expected value' );
 
 	v = maxabsn( 3.14, PINF );
-	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.strictEqual( v, PINF, 'returns expected value' );
 
 	v = maxabsn( PINF );
-	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.strictEqual( v, PINF, 'returns expected value' );
 
 	v = maxabsn( 3.14, 4.2, PINF );
-	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.strictEqual( v, PINF, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function returns `+infinity` if not provided any arguments', function test( t ) {
 	var v = maxabsn();
-	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.strictEqual( v, PINF, 'returns expected value' );
 	t.end();
 });
 
@@ -82,25 +82,25 @@ tape( 'the function returns a correctly signed zero', function test( t ) {
 	var v;
 
 	v = maxabsn( +0.0, -0.0 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = maxabsn( -0.0, +0.0 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = maxabsn( -0.0, -0.0 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = maxabsn( +0.0, +0.0 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = maxabsn( -0.0 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = maxabsn( +0.0 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = maxabsn( +0.0, -0.0, +0.0 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/min/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/min/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var min = require( './../lib' );
@@ -35,11 +35,12 @@ bench( pkg, function benchmark( b ) {
 	var z;
 	var i;
 
+	x = uniform( 100, -500.0, 500.0 );
+	y = uniform( 100, -500.0, 500.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 500.0;
-		y = ( randu()*1000.0 ) - 500.0;
-		z = min( x, y );
+		z = min( x[ i%x.length ], y[ i%y.length ] );
 		if ( isnan( z ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -58,11 +59,12 @@ bench( pkg+'::built-in', function benchmark( b ) {
 	var z;
 	var i;
 
+	x = uniform( 100, -500.0, 500.0 );
+	y = uniform( 100, -500.0, 500.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 500.0;
-		y = ( randu()*1000.0 ) - 500.0;
-		z = Math.min( x, y ); // eslint-disable-line stdlib/no-builtin-math
+		z = Math.min( x[ i%x.length ], y[ i%y.length ] ); // eslint-disable-line stdlib/no-builtin-math
 		if ( isnan( z ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/min/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/min/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -44,11 +44,12 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var z;
 	var i;
 
+	x = uniform( 100, -100.0, 100.0 );
+	y = uniform( 100, -100.0, 100.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*200.0 ) - 100.0;
-		y = ( randu()*200.0 ) - 100.0;
-		z = min( x, y );
+		z = min( x[ i%x.length ], y[ i%y.length ] );
 		if ( isnan( z ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/min/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/min/benchmark/c/benchmark.c
@@ -90,17 +90,20 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
-	double y;
+	double x[ 100 ];
+	double y[ 100 ];
 	double z;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0*rand_double() ) - 500.0;
+		y[ i ] = ( 1000.0*rand_double() ) - 500.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0*rand_double() ) - 500.0;
-		y = ( 1000.0*rand_double() ) - 500.0;
-		z = fmin( x, y );
+		z = fmin( x[ i%100 ], y[ i%100 ] );
 		if ( z != z ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/min/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/min/benchmark/c/native/benchmark.c
@@ -92,16 +92,19 @@ static double rand_double( void ) {
 static double benchmark( void ) {
 	double elapsed;
 	double t;
-	double x;
-	double y;
+	double x[ 100 ];
+	double y[ 100 ];
 	double z;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 200.0*rand_double() ) - 100.0;
+		y[ i ] = ( 200.0*rand_double() ) - 100.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 200.0*rand_double() ) - 100.0;
-		y = ( 200.0*rand_double() ) - 100.0;
-		z = stdlib_base_min( x, y );
+		z = stdlib_base_min( x[ i%100 ], y[ i%100 ] );
 		if ( z != z ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/min/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/min/test/test.js
@@ -40,10 +40,10 @@ tape( 'the function returns `NaN` if provided a `NaN`', function test( t ) {
 	var v;
 
 	v = min( NaN, 3.14 );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = min( 3.14, NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -52,10 +52,10 @@ tape( 'the function returns `-Infinity` if provided `-Infinity`', function test(
 	var v;
 
 	v = min( NINF, 3.14 );
-	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.strictEqual( v, NINF, 'returns expected value' );
 
 	v = min( 3.14, NINF );
-	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.strictEqual( v, NINF, 'returns expected value' );
 
 	t.end();
 });
@@ -64,16 +64,16 @@ tape( 'the function returns a correctly signed zero', function test( t ) {
 	var v;
 
 	v = min( +0.0, -0.0 );
-	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( v ), true, 'returns expected value' );
 
 	v = min( -0.0, +0.0 );
-	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( v ), true, 'returns expected value' );
 
 	v = min( -0.0, -0.0 );
-	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( v ), true, 'returns expected value' );
 
 	v = min( +0.0, +0.0 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -82,10 +82,10 @@ tape( 'the function returns the minimum value', function test( t ) {
 	var v;
 
 	v = min( 4.2, 3.14 );
-	t.strictEqual( v, 3.14, 'returns min value' );
+	t.strictEqual( v, 3.14, 'returns expected value' );
 
 	v = min( -4.2, 3.14 );
-	t.strictEqual( v, -4.2, 'returns min value' );
+	t.strictEqual( v, -4.2, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/min/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/min/test/test.native.js
@@ -49,10 +49,10 @@ tape( 'the function returns `NaN` if provided a `NaN`', opts, function test( t )
 	var v;
 
 	v = min( NaN, 3.14 );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = min( 3.14, NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -61,10 +61,10 @@ tape( 'the function returns `-Infinity` if provided `-Infinity`', opts, function
 	var v;
 
 	v = min( NINF, 3.14 );
-	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.strictEqual( v, NINF, 'returns expected value' );
 
 	v = min( 3.14, NINF );
-	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.strictEqual( v, NINF, 'returns expected value' );
 
 	t.end();
 });
@@ -73,16 +73,16 @@ tape( 'the function returns a correctly signed zero', opts, function test( t ) {
 	var v;
 
 	v = min( +0.0, -0.0 );
-	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( v ), true, 'returns expected value' );
 
 	v = min( -0.0, +0.0 );
-	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( v ), true, 'returns expected value' );
 
 	v = min( -0.0, -0.0 );
-	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( v ), true, 'returns expected value' );
 
 	v = min( +0.0, +0.0 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -91,10 +91,10 @@ tape( 'the function returns the minimum value', opts, function test( t ) {
 	var v;
 
 	v = min( 4.2, 3.14 );
-	t.strictEqual( v, 3.14, 'returns min value' );
+	t.strictEqual( v, 3.14, 'returns expected value' );
 
 	v = min( -4.2, 3.14 );
-	t.strictEqual( v, -4.2, 'returns min value' );
+	t.strictEqual( v, -4.2, 'returns expected value' );
 
 	t.end();
 });


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors random number generation in JS benchmarks for the `math/base/special/logf`, `math/base/special/min` , `math/base/special/logit`, `math/base/special/maxabs`, `math/base/special/maxabsf` and `math/base/special/maxabsn` packages.
-   Replaces `randu()` with `uniform()` from `@stdlib/random/array/uniform` for cleaner and more consistent code.
-   Moves the random number generation outside the benchmarking loops.
-   Updates the test messages to follow code conventions.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
