### PR TITLE
bench: update random value generation

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/pdifff/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/pdifff/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pkg = require( './../package.json' ).name;
 var pdifff = require( './../lib' );
@@ -35,11 +35,16 @@ bench( pkg, function benchmark( b ) {
 	var z;
 	var i;
 
+	x = uniform( 100, -500.0, 500.0, {
+		'dtype': 'float32'
+	});
+	y = uniform( 100, -500.0, 500.0, {
+		'dtype': 'float32'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 500.0;
-		y = ( randu()*1000.0 ) - 500.0;
-		z = pdifff( x, y );
+		z = pdifff( x[ i%x.length ], y[ i%y.length ] );
 		if ( isnanf( z ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/pdifff/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/pdifff/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -44,11 +44,16 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var z;
 	var i;
 
+	x = uniform( 100, -500.0, 500.0, {
+		'dtype': 'float32'
+	});
+	y = uniform( 100, -500.0, 500.0, {
+		'dtype': 'float32'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 500.0;
-		y = ( randu()*1000.0 ) - 500.0;
-		z = pdifff( x, y );
+		z = pdifff( x[ i%x.length ], y[ i%y.length ] );
 		if ( isnanf( z ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/pdifff/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/pdifff/benchmark/c/benchmark.c
@@ -108,16 +108,19 @@ float pdifff( float x, float y ) {
 static double benchmark( void ) {
 	double elapsed;
 	double t;
-	float x;
-	float y;
+	float x[ 100 ];
+	float y[ 100 ];
 	float z;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0f*rand_float() ) - 500.0f;
+		y[ i ] = ( 1000.0f*rand_float() ) - 500.0f;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0f*rand_float() ) - 500.0f;
-		y = ( 1000.0f*rand_float() ) - 500.0f;
-		z = pdifff( x, y );
+		z = pdifff( x[ i%100 ], y[ i%100 ] );
 		if ( z != z ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/pdifff/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/pdifff/benchmark/c/native/benchmark.c
@@ -92,16 +92,19 @@ static float rand_float( void ) {
 static double benchmark( void ) {
 	double elapsed;
 	double t;
-	float x;
-	float y;
+	float x[ 100 ];
+	float y[ 100 ];
 	float z;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0f*rand_float() ) - 500.0f;
+		y[ i ] = ( 1000.0f*rand_float() ) - 500.0f;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0f*rand_float() ) - 500.0f;
-		y = ( 1000.0f*rand_float() ) - 500.0f;
-		z = stdlib_base_pdifff( x, y );
+		z = stdlib_base_pdifff( x[ i%100 ], y[ i%100 ] );
 		if ( z != z ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/pdifff/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/pdifff/test/test.js
@@ -41,13 +41,13 @@ tape( 'the function returns `NaN` if provided a `NaN`', function test( t ) {
 	var v;
 
 	v = pdifff( NaN, 3.14 );
-	t.strictEqual( isnanf( v ), true, 'returns NaN' );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
 
 	v = pdifff( 3.14, NaN );
-	t.strictEqual( isnanf( v ), true, 'returns NaN' );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
 
 	v = pdifff( NaN, NaN );
-	t.strictEqual( isnanf( v ), true, 'returns NaN' );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -56,17 +56,17 @@ tape( 'the function returns `+infinity` if the first argument is `+infinity`', f
 	var v;
 
 	v = pdifff( PINF, 3.14 );
-	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.strictEqual( v, PINF, 'returns expected value' );
 
 	v = pdifff( PINF, NINF );
-	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.strictEqual( v, PINF, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function returns `0` if both arguments are `+infinity`', function test( t ) {
 	var v = pdifff( PINF, PINF );
-	t.strictEqual( isPositiveZerof( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns expected value' );
 	t.end();
 });
 
@@ -74,22 +74,22 @@ tape( 'the function returns positive zero if the difference between the first an
 	var v;
 
 	v = pdifff( +0.0, -0.0 );
-	t.strictEqual( isPositiveZerof( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns expected value' );
 
 	v = pdifff( -0.0, +0.0 );
-	t.strictEqual( isPositiveZerof( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns expected value' );
 
 	v = pdifff( -0.0, -0.0 );
-	t.strictEqual( isPositiveZerof( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns expected value' );
 
 	v = pdifff( +0.0, +0.0 );
-	t.strictEqual( isPositiveZerof( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns expected value' );
 
 	v = pdifff( 3.14, 3.14 );
-	t.strictEqual( isPositiveZerof( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns expected value' );
 
 	v = pdifff( 3.14, 4.2 );
-	t.strictEqual( isPositiveZerof( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -98,13 +98,13 @@ tape( 'the function returns the positive difference between `x` and `y`', functi
 	var v;
 
 	v = pdifff( 4.15, 3.15 );
-	t.strictEqual( v, 1.0, 'returns the positive difference' );
+	t.strictEqual( v, 1.0, 'returns expected value' );
 
 	v = pdifff( -4.2, 3.14 );
-	t.strictEqual( v, 0.0, 'returns the positive difference' );
+	t.strictEqual( v, 0.0, 'returns expected value' );
 
 	v = pdifff( -4.2, -5.2 );
-	t.strictEqual( v, 1.0, 'returns the positive difference' );
+	t.strictEqual( v, 1.0, 'returns expected value' );
 
 	t.end();
 });
@@ -115,7 +115,7 @@ tape( 'the function returns `+infinity` if overflow occurs', function test( t ) 
 
 	half = FLOAT32_MAX / 2.0;
 	v = pdifff( half, -(half*1.5) );
-	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.strictEqual( v, PINF, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/pdifff/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/pdifff/test/test.native.js
@@ -50,13 +50,13 @@ tape( 'the function returns `NaN` if provided a `NaN`', opts, function test( t )
 	var v;
 
 	v = pdifff( NaN, 3.14 );
-	t.strictEqual( isnanf( v ), true, 'returns NaN' );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
 
 	v = pdifff( 3.14, NaN );
-	t.strictEqual( isnanf( v ), true, 'returns NaN' );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
 
 	v = pdifff( NaN, NaN );
-	t.strictEqual( isnanf( v ), true, 'returns NaN' );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -65,17 +65,17 @@ tape( 'the function returns `+infinity` if the first argument is `+infinity`', o
 	var v;
 
 	v = pdifff( PINF, 3.14 );
-	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.strictEqual( v, PINF, 'returns expected value' );
 
 	v = pdifff( PINF, NINF );
-	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.strictEqual( v, PINF, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function returns `0` if both arguments are `+infinity`', opts, function test( t ) {
 	var v = pdifff( PINF, PINF );
-	t.strictEqual( isPositiveZerof( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns expected value' );
 	t.end();
 });
 
@@ -83,22 +83,22 @@ tape( 'the function returns positive zero if the difference between the first an
 	var v;
 
 	v = pdifff( +0.0, -0.0 );
-	t.strictEqual( isPositiveZerof( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns expected value' );
 
 	v = pdifff( -0.0, +0.0 );
-	t.strictEqual( isPositiveZerof( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns expected value' );
 
 	v = pdifff( -0.0, -0.0 );
-	t.strictEqual( isPositiveZerof( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns expected value' );
 
 	v = pdifff( +0.0, +0.0 );
-	t.strictEqual( isPositiveZerof( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns expected value' );
 
 	v = pdifff( 3.14, 3.14 );
-	t.strictEqual( isPositiveZerof( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns expected value' );
 
 	v = pdifff( 3.14, 4.2 );
-	t.strictEqual( isPositiveZerof( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -107,13 +107,13 @@ tape( 'the function returns the positive difference between `x` and `y`', opts, 
 	var v;
 
 	v = pdifff( 4.15, 3.15 );
-	t.strictEqual( v, 1.0, 'returns the positive difference' );
+	t.strictEqual( v, 1.0, 'returns expected value' );
 
 	v = pdifff( -4.2, 3.14 );
-	t.strictEqual( v, 0.0, 'returns the positive difference' );
+	t.strictEqual( v, 0.0, 'returns expected value' );
 
 	v = pdifff( -4.2, -5.2 );
-	t.strictEqual( v, 1.0, 'returns the positive difference' );
+	t.strictEqual( v, 1.0, 'returns expected value' );
 
 	t.end();
 });
@@ -124,7 +124,7 @@ tape( 'the function returns `+infinity` if overflow occurs', opts, function test
 
 	half = FLOAT32_MAX / 2.0;
 	v = pdifff( half, -(half*1.5) );
-	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.strictEqual( v, PINF, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/pow/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/pow/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var pow = require( './../lib' );
@@ -35,11 +35,12 @@ bench( pkg, function benchmark( b ) {
 	var z;
 	var i;
 
+	x = uniform( 100, 0.0, 100.0 );
+	y = uniform( 100, -50.0, 50.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*100.0 ) - 0.0;
-		y = ( randu()*100.0 ) - 50.0;
-		z = pow( x, y );
+		z = pow( x[ i%x.length ], y[ i%y.length ] );
 		if ( isnan( z ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -58,11 +59,12 @@ bench( pkg+'::built-in', function benchmark( b ) {
 	var z;
 	var i;
 
+	x = uniform( 100, 0.0, 100.0 );
+	y = uniform( 100, -50.0, 50.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*100.0 ) - 0.0;
-		y = ( randu()*100.0 ) - 50.0;
-		z = Math.pow( x, y ); // eslint-disable-line stdlib/no-builtin-math
+		z = Math.pow( x[ i%x.length ], y[ i%y.length ] ); // eslint-disable-line stdlib/no-builtin-math
 		if ( isnan( z ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/pow/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/pow/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -44,11 +44,12 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	v = uniform( 100, 0.0, 10.0 );
+	x = uniform( 100, -5.0, 5.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		v = ( randu()*10.0 );
-		x = ( randu()*10.0 ) - 5.0;
-		y = pow( v, x );
+		y = pow( v[ i%v.length ], x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/pow/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/pow/benchmark/c/benchmark.c
@@ -90,17 +90,20 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
-	double y;
+	double x[ 100 ];
+	double y[ 100 ];
 	double z;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 100.0*rand_double() ) - 0.0;
+		y[ i ] = ( 100.0*rand_double() ) - 50.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 100.0*rand_double() ) - 0.0;
-		y = ( 100.0*rand_double() ) - 50.0;
-		z = pow( x, y );
+		z = pow( x[ i%100 ], y[ i%100 ] );
 		if ( z != z ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/pow/benchmark/c/cephes/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/pow/benchmark/c/cephes/benchmark.c
@@ -95,17 +95,20 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
-	double y;
+	double x[ 100 ];
+	double y[ 100 ];
 	double z;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 100.0*rand_double() ) - 0.0;
+		y[ i ] = ( 100.0*rand_double() ) - 50.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 100.0*rand_double() ) - 0.0;
-		y = ( 100.0*rand_double() ) - 50.0;
-		z = pow( x, y );
+		z = pow( x[ i%100 ], y[ i%100 ] );
 		if ( z != z ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/pow/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/pow/benchmark/c/native/benchmark.c
@@ -91,17 +91,20 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double b;
-	double x;
+	double b[ 100 ];
+	double x[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		b[ i ] = rand_double() * 10.0;
+		x[ i ] = rand_double() * 5.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		b = rand_double() * 10.0;
-		x = rand_double() * 5.0;
-		y = stdlib_base_pow( b, x );
+		y = stdlib_base_pow( b[ i%100 ], x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/pow/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/pow/test/test.js
@@ -526,10 +526,10 @@ tape( 'the function returns `NaN` if provided `NaN` for the exponent', function 
 	var v;
 
 	v = pow( -3.0, NaN );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 
 	v = pow( 0.0, NaN );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -538,13 +538,13 @@ tape( 'the function returns `NaN` if provided `NaN` for the base', function test
 	var v;
 
 	v = pow( NaN, 5.0 );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 
 	v = pow( NaN, 1.0 );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 
 	v = pow( NaN, 0.0 );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -609,10 +609,10 @@ tape( '`+-0` raised to `-infinity` is `+infinity`', function test( t ) {
 	var v;
 
 	v = pow( +0.0, NINF );
-	t.equal( v, PINF, 'returns +infinity' );
+	t.equal( v, PINF, 'returns expected value' );
 
 	v = pow( -0.0, NINF );
-	t.equal( v, PINF, 'returns +infinity' );
+	t.equal( v, PINF, 'returns expected value' );
 
 	t.end();
 });
@@ -621,10 +621,10 @@ tape( '`+-0` raised to `+infinity` is `0`', function test( t ) {
 	var v;
 
 	v = pow( +0.0, PINF );
-	t.equal( isPositiveZero( v ), true, 'returns +0' );
+	t.equal( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = pow( -0.0, PINF );
-	t.equal( isPositiveZero( v ), true, 'returns +0' );
+	t.equal( isPositiveZero( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -707,10 +707,10 @@ tape( '`-1` raised to `+-infinity` is indeterminate and the function returns `Na
 	var v;
 
 	v = pow( -1.0, PINF );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 
 	v = pow( -1.0, NINF );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -825,7 +825,7 @@ tape( 'the function returns `0` if `+infinity` is raised to any negative finite 
 	for ( i = 0; i < 100; i++ ) {
 		y = -(randu() * 1.0e5) - EPS;
 		v = pow( PINF, y );
-		t.equal( isPositiveZero( v ), true, 'returns 0' );
+		t.equal( isPositiveZero( v ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -837,7 +837,7 @@ tape( 'the function returns `+infinity` if `+infinity` is raised to any positive
 	for ( i = 0; i < 100; i++ ) {
 		y = ( randu()*1.0e5 ) + EPS;
 		v = pow( PINF, y );
-		t.equal( v, PINF, 'returns +infinity' );
+		t.equal( v, PINF, 'returns expected value' );
 	}
 	t.end();
 });
@@ -880,7 +880,7 @@ tape( 'if `y > 2^64` and `x` is greater than `1`, the function overflows', funct
 	x = 1.0 + EPS; // smallest value greater than 1.0
 	y = 3.6893488147419103e19; // 2.0^65
 	v = pow( x, y );
-	t.equal( v, PINF, 'returns +infinity' );
+	t.equal( v, PINF, 'returns expected value' );
 	t.end();
 });
 
@@ -892,7 +892,7 @@ tape( 'if `y < -(2^64)` and `x` is greater than `1`, the function underflows', f
 	x = 1.0 + EPS; // smallest value greater than 1.0
 	y = -3.6893488147419103e19; // -(2.0)^65
 	v = pow( x, y );
-	t.equal( v, 0.0, 'returns 0' );
+	t.equal( v, 0.0, 'returns expected value' );
 	t.end();
 });
 
@@ -904,7 +904,7 @@ tape( 'if `y > 2^64` and `x` is less than `1`, the function underflows', functio
 	x = 1.0 - EPS; // greatest value less than 1.0
 	y = 3.6893488147419103e19; // 2.0^65
 	v = pow( x, y );
-	t.equal( v, 0.0, 'returns 0' );
+	t.equal( v, 0.0, 'returns expected value' );
 	t.end();
 });
 
@@ -916,7 +916,7 @@ tape( 'if `y < -(2^64)` and `x` is less than `1`, the function overflows', funct
 	x = 1.0 - EPS; // greatest value less than 1.0
 	y = -3.6893488147419103e19; // -(2.0^65)
 	v = pow( x, y );
-	t.equal( v, PINF, 'returns +infinity' );
+	t.equal( v, PINF, 'returns expected value' );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/math/base/special/pow/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/pow/test/test.native.js
@@ -596,10 +596,10 @@ tape( 'the function returns `NaN` if provided `NaN` for the exponent', opts, fun
 	var v;
 
 	v = pow( -3.0, NaN );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 
 	v = pow( 0.0, NaN );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -608,13 +608,13 @@ tape( 'the function returns `NaN` if provided `NaN` for the base', opts, functio
 	var v;
 
 	v = pow( NaN, 5.0 );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 
 	v = pow( NaN, 1.0 );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 
 	v = pow( NaN, 0.0 );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -679,10 +679,10 @@ tape( '`+-0` raised to `-infinity` is `+infinity`', opts, function test( t ) {
 	var v;
 
 	v = pow( +0.0, NINF );
-	t.equal( v, PINF, 'returns +infinity' );
+	t.equal( v, PINF, 'returns expected value' );
 
 	v = pow( -0.0, NINF );
-	t.equal( v, PINF, 'returns +infinity' );
+	t.equal( v, PINF, 'returns expected value' );
 
 	t.end();
 });
@@ -691,10 +691,10 @@ tape( '`+-0` raised to `+infinity` is `0`', opts, function test( t ) {
 	var v;
 
 	v = pow( +0.0, PINF );
-	t.equal( isPositiveZero( v ), true, 'returns +0' );
+	t.equal( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = pow( -0.0, PINF );
-	t.equal( isPositiveZero( v ), true, 'returns +0' );
+	t.equal( isPositiveZero( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -777,10 +777,10 @@ tape( '`-1` raised to `+-infinity` is indeterminate and the function returns `Na
 	var v;
 
 	v = pow( -1.0, PINF );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 
 	v = pow( -1.0, NINF );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -895,7 +895,7 @@ tape( 'the function returns `0` if `+infinity` is raised to any negative finite 
 	for ( i = 0; i < 100; i++ ) {
 		y = -(randu() * 1.0e5) - EPS;
 		v = pow( PINF, y );
-		t.equal( isPositiveZero( v ), true, 'returns 0' );
+		t.equal( isPositiveZero( v ), true, 'returns expected value' );
 	}
 	t.end();
 });
@@ -907,7 +907,7 @@ tape( 'the function returns `+infinity` if `+infinity` is raised to any positive
 	for ( i = 0; i < 100; i++ ) {
 		y = ( randu()*1.0e5 ) + EPS;
 		v = pow( PINF, y );
-		t.equal( v, PINF, 'returns +infinity' );
+		t.equal( v, PINF, 'returns expected value' );
 	}
 	t.end();
 });
@@ -962,7 +962,7 @@ tape( 'if `y < -(2^64)` and `x` is greater than `1`, the function underflows', o
 	x = 1.0 + EPS; // smallest value greater than 1.0
 	y = -3.6893488147419103e19; // -(2.0)^65
 	v = pow( x, y );
-	t.equal( v, 0.0, 'returns 0' );
+	t.equal( v, 0.0, 'returns expected value' );
 	t.end();
 });
 
@@ -974,7 +974,7 @@ tape( 'if `y > 2^64` and `x` is less than `1`, the function underflows', opts, f
 	x = 1.0 - EPS; // greatest value less than 1.0
 	y = 3.6893488147419103e19; // 2.0^65
 	v = pow( x, y );
-	t.equal( v, 0.0, 'returns 0' );
+	t.equal( v, 0.0, 'returns expected value' );
 	t.end();
 });
 
@@ -986,7 +986,7 @@ tape( 'if `y < -(2^64)` and `x` is less than `1`, the function overflows', opts,
 	x = 1.0 - EPS; // greatest value less than 1.0
 	y = -3.6893488147419103e19; // -(2.0^65)
 	v = pow( x, y );
-	t.equal( v, PINF, 'returns +infinity' );
+	t.equal( v, PINF, 'returns expected value' );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/math/base/special/pow/test/test.x_is_zero.js
+++ b/lib/node_modules/@stdlib/math/base/special/pow/test/test.x_is_zero.js
@@ -40,10 +40,10 @@ tape( 'the function returns `+infinity` if `y = -infinity`', function test( t ) 
 	var v;
 
 	v = pow( 0.0, NINF );
-	t.equal( v, PINF, 'returns +infinity' );
+	t.equal( v, PINF, 'returns expected value' );
 
 	v = pow( -0.0, NINF );
-	t.equal( v, PINF, 'returns +infinity' );
+	t.equal( v, PINF, 'returns expected value' );
 
 	t.end();
 });
@@ -52,10 +52,10 @@ tape( 'the function returns `+0` if `y = +infinity`', function test( t ) {
 	var v;
 
 	v = pow( 0.0, PINF );
-	t.equal( isPositiveZero( v ), true, 'returns +0' );
+	t.equal( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = pow( -0.0, PINF );
-	t.equal( isPositiveZero( v ), true, 'returns +0' );
+	t.equal( isPositiveZero( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -64,10 +64,10 @@ tape( 'the function returns `x` if `y` is an odd positive integer', function tes
 	var v;
 
 	v = pow( 0.0, 5 );
-	t.equal( isPositiveZero( v ), true, 'returns +0' );
+	t.equal( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = pow( -0.0, 5 );
-	t.equal( isNegativeZero( v ), true, 'returns -0' );
+	t.equal( isNegativeZero( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -76,10 +76,10 @@ tape( 'the function returns `+0` if `y` is positive but not an odd integer', fun
 	var v;
 
 	v = pow( 0.0, 4 );
-	t.equal( isPositiveZero( v ), true, 'returns +0' );
+	t.equal( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = pow( -0.0, 3.14 );
-	t.equal( isPositiveZero( v ), true, 'returns +0' );
+	t.equal( isPositiveZero( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -88,10 +88,10 @@ tape( 'the function returns `+-infinity` if `y` is a negative odd integer', func
 	var v;
 
 	v = pow( 0.0, -5 );
-	t.equal( v, PINF, 'returns +infinity' );
+	t.equal( v, PINF, 'returns expected value' );
 
 	v = pow( -0.0, -5 );
-	t.equal( v, NINF, 'returns -infinity' );
+	t.equal( v, NINF, 'returns expected value' );
 
 	t.end();
 });
@@ -100,10 +100,10 @@ tape( 'the function returns `+infinity` if `y` is negative but not an odd intege
 	var v;
 
 	v = pow( 0.0, -4 );
-	t.equal( v, PINF, 'returns +infinity' );
+	t.equal( v, PINF, 'returns expected value' );
 
 	v = pow( -0.0, -3.14 );
-	t.equal( v, PINF, 'returns +infinity' );
+	t.equal( v, PINF, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/powm1/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/powm1/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var powm1 = require( './../lib' );
@@ -35,11 +35,12 @@ bench( pkg, function benchmark( b ) {
 	var z;
 	var i;
 
+	x = uniform( 100, 0.0, 2.0 );
+	y = uniform( 100, -50.0, 50.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*2.0 ) - 0.0;
-		y = ( randu()*100.0 ) - 50.0;
-		z = powm1( x, y );
+		z = powm1( x[ i%x.length ], y[ i%y.length ] );
 		if ( isnan( z ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/powm1/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/powm1/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -44,11 +44,12 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var z;
 	var i;
 
+	x = uniform( 100, 0.0, 2.0 );
+	y = uniform( 100, -50.0, 50.0 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu() * 2.0 ) - 0.0;
-		y = ( randu() * 100.0 ) - 50.0;
-		z = powm1( x, y );
+		z = powm1( x[ i%x.length ], y[ i%y.length ] );
 		if ( isnan( z ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/powm1/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/powm1/benchmark/c/native/benchmark.c
@@ -91,17 +91,20 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double b;
-	double x;
+	double b[ 100 ];
+	double x[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		b[ i ] = ( rand_double() * 2.0 ) - 0.0;
+		x[ i ] = ( rand_double() * 100.0 ) - 50.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		b = ( rand_double() * 2.0 ) - 0.0;
-		x = ( rand_double() * 100.0 ) - 50.0;
-		y = stdlib_base_powm1( b, x );
+		y = stdlib_base_powm1( b[ i%100 ], x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/powm1/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/powm1/test/test.js
@@ -119,26 +119,26 @@ tape( 'the function returns `NaN` if provided a negative base and a exponent whi
 	var y;
 
 	y = powm1( -125.0, 1.0/3.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = powm1( -16.0, -0.5 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = powm1( -2.0, -1.25 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function returns `NaN` if provided a `NaN` for the exponent', function test( t ) {
 	var y = powm1( -3.0, NaN );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `NaN` if provided a `NaN` for the base', function test( t ) {
 	var y = powm1( NaN, 5.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/math/base/special/rad2deg/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/rad2deg/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var pkg = require( './../package.json' ).name;
@@ -35,10 +35,11 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, 0.0, TWO_PI );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*TWO_PI ) - 0.0;
-		y = rad2deg( x );
+		y = rad2deg( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/rad2deg/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/rad2deg/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -44,10 +44,11 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, 0.0, TWO_PI );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*TWO_PI ) - 0.0;
-		y = rad2deg( x );
+		y = rad2deg( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/rad2deg/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/rad2deg/benchmark/c/benchmark.c
@@ -100,15 +100,18 @@ double rad2deg( double x ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double x[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 2.0*rand_double()*3.14 ) - 0.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 2.0*rand_double()*3.14 ) - 0.0;
-		y = rad2deg( x );
+		y = rad2deg( x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/rad2deg/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/rad2deg/benchmark/c/native/benchmark.c
@@ -92,15 +92,18 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double x[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 2.0*rand_double()*3.14 ) - 0.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 2.0*rand_double()*3.14 ) - 0.0;
-		y = stdlib_base_rad2deg( x );
+		y = stdlib_base_rad2deg( x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/rad2deg/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/rad2deg/test/test.js
@@ -45,19 +45,19 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'if provided `+infinity`, the function returns `+infinity`', function test( t ) {
 	var r = rad2deg( PINF );
-	t.equal( r, PINF, 'returns +infinity' );
+	t.equal( r, PINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided `-infinity`, the function returns `-infinity`', function test( t ) {
 	var r = rad2deg( NINF );
-	t.equal( r, NINF, 'returns -infinity' );
+	t.equal( r, NINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided `NaN`, the function returns `NaN`', function test( t ) {
 	var r = rad2deg( NaN );
-	t.equal( isnan( r ), true, 'returns NaN' );
+	t.equal( isnan( r ), true, 'returns expected value' );
 	t.end();
 });
 
@@ -149,6 +149,6 @@ tape( 'the function converts an angle from radians to degrees (canonical values)
 
 tape( 'if provided a value greater than `~3.14e+306`, the function will underflow', function test( t ) {
 	var r = rad2deg( 3.14e+306 );
-	t.equal( r, PINF, 'returns +infinity' );
+	t.equal( r, PINF, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/rad2deg/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/rad2deg/test/test.native.js
@@ -54,19 +54,19 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'if provided `+infinity`, the function returns `+infinity`', opts, function test( t ) {
 	var r = rad2deg( PINF );
-	t.equal( r, PINF, 'returns +infinity' );
+	t.equal( r, PINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided `-infinity`, the function returns `-infinity`', opts, function test( t ) {
 	var r = rad2deg( NINF );
-	t.equal( r, NINF, 'returns -infinity' );
+	t.equal( r, NINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided `NaN`, the function returns `NaN`', opts, function test( t ) {
 	var r = rad2deg( NaN );
-	t.equal( isnan( r ), true, 'returns NaN' );
+	t.equal( isnan( r ), true, 'returns expected value' );
 	t.end();
 });
 
@@ -158,6 +158,6 @@ tape( 'the function converts an angle from radians to degrees (canonical values)
 
 tape( 'if provided a value greater than `~3.14e+306`, the function will underflow', opts, function test( t ) {
 	var r = rad2deg( 3.14e+306 );
-	t.equal( r, PINF, 'returns +infinity' );
+	t.equal( r, PINF, 'returns expected value' );
 	t.end();
 });


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors random number generation in JS benchmarks for the `math/base/special/pdifff`, `math/base/special/pow`, `math/base/special/powm1` and `math/base/special/rad2deg` packages.
-   Replaces `randu()` with `uniform()` from `@stdlib/random/array/uniform` for cleaner and more consistent code.
-   Moves the random number generation outside the benchmarking loops.
-   Updates the test messages to follow code conventions.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
