### PR TITLE
bench: update random value generation

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/rcbrtf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/rcbrtf/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pkg = require( './../package.json' ).name;
 var rcbrtf = require( './../lib' );
@@ -34,10 +34,13 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, 0.0, 100000.0, {
+		'dtype': 'float32'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu() * 100000.0 ) - 0.0;
-		y = rcbrtf( x );
+		y = rcbrtf( x[ i%x.length ] );
 		if ( isnanf( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/rcbrtf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/rcbrtf/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -43,10 +43,13 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, 0.0, 100000.0, {
+		'dtype': 'float32'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu() * 100000.0 ) - 0.0;
-		y = rcbrtf( x );
+		y = rcbrtf( x[ i%x.length ] );
 		if ( isnanf( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/rcbrtf/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/rcbrtf/benchmark/c/native/benchmark.c
@@ -92,14 +92,17 @@ static float rand_float( void ) {
 static double benchmark( void ) {
 	double elapsed;
 	double t;
-	float x;
+	float x[ 100 ];
 	float y;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = rand_float() * 100000.0f;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = rand_float() * 100000.0f;
-		y = stdlib_base_rcbrtf( x );
+		y = stdlib_base_rcbrtf( x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/rcbrtf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/rcbrtf/test/test.js
@@ -439,24 +439,24 @@ tape( 'the function returns `NaN` if provided `NaN`', function test( t ) {
 
 tape( 'the function returns `0.0` if provided `+infinity`', function test( t ) {
 	var v = rcbrtf( PINF );
-	t.equal( v, 0.0, 'returns 0.0' );
+	t.equal( v, 0.0, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+infinity` if provided `+0`', function test( t ) {
 	var v = rcbrtf( +0.0 );
-	t.equal( v, PINF, 'returns +infinity' );
+	t.equal( v, PINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-infinity` if provided `-0`', function test( t ) {
 	var v = rcbrtf( -0.0 );
-	t.equal( v, NINF, 'returns -infinity' );
+	t.equal( v, NINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `0.0` if provided `-infinity`', function test( t ) {
 	var v = rcbrtf( NINF );
-	t.equal( v, 0.0, 'returns 0.0' );
+	t.equal( v, 0.0, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/rcbrtf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/rcbrtf/test/test.native.js
@@ -448,24 +448,24 @@ tape( 'the function returns `NaN` if provided `NaN`', opts, function test( t ) {
 
 tape( 'the function returns `0.0` if provided `+infinity`', opts, function test( t ) {
 	var v = rcbrtf( PINF );
-	t.equal( v, 0.0, 'returns 0.0' );
+	t.equal( v, 0.0, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+infinity` if provided `+0`', opts, function test( t ) {
 	var v = rcbrtf( +0.0 );
-	t.equal( v, PINF, 'returns +infinity' );
+	t.equal( v, PINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-infinity` if provided `-0`', opts, function test( t ) {
 	var v = rcbrtf( -0.0 );
-	t.equal( v, NINF, 'returns -infinity' );
+	t.equal( v, NINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `0.0` if provided `-infinity`', opts, function test( t ) {
 	var v = rcbrtf( NINF );
-	t.equal( v, 0.0, 'returns 0.0' );
+	t.equal( v, 0.0, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/rempio2/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/rempio2/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/array/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var rempio2 = require( './../lib' );
@@ -36,7 +36,7 @@ bench( pkg, function benchmark( b ) {
 	var i;
 
 	y = [ 0.0, 0.0 ];
-	x = randu( 100, -100.0, 100.0 );
+	x = uniform( 100, -100.0, 100.0 );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/math/base/special/rempio2/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/rempio2/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/array/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -45,7 +45,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var i;
 
 	y = [ 0.0, 0.0 ];
-	x = randu( 100, -100.0, 100.0 );
+	x = uniform( 100, -100.0, 100.0 );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/math/base/special/riemann-zeta/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/riemann-zeta/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/array/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -35,7 +35,7 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
-	x = randu( 100, 1.0 + EPS, 57.0 + EPS );
+	x = uniform( 100, 1.0 + EPS, 57.0 + EPS );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/math/base/special/riemann-zeta/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/riemann-zeta/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/array/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var tryRequire = require( '@stdlib/utils/try-require' );
@@ -44,7 +44,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
-	x = randu( 100, 1.0 + EPS, 57.0 + EPS );
+	x = uniform( 100, 1.0 + EPS, 57.0 + EPS );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/math/base/special/rising-factorial/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/rising-factorial/benchmark/benchmark.js
@@ -21,8 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var risingFactorial = require( './../lib' );
@@ -36,11 +36,12 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -50.0, 50.0 );
+	n = discreteUniform( 100, -50, 50 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*100.0 ) - 50.0;
-		n = round( ( randu()*100.0 ) - 50.0 );
-		y = risingFactorial( x, n );
+		y = risingFactorial( x[ i%x.length ], n[ i%n.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/rising-factorial/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/rising-factorial/test/test.js
@@ -42,41 +42,41 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function returns `NaN` if provided `NaN` as any argument', function test( t ) {
 	var val = risingFactorial( 0.5, NaN );
-	t.equal( isnan( val ), true, 'returns NaN' );
+	t.equal( isnan( val ), true, 'returns expected value' );
 
 	val = risingFactorial( NaN, -1.0 );
-	t.equal( isnan( val ), true, 'returns NaN' );
+	t.equal( isnan( val ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `1` if provided `n = 0` and a nonnegative `x`', function test( t ) {
 	var val = risingFactorial( 2.0, 0 );
-	t.equal( val, 1.0, 'returns 1' );
+	t.equal( val, 1.0, 'returns expected value' );
 
 	val = risingFactorial( 0.2, 0 );
-	t.equal( val, 1.0, 'returns 1' );
+	t.equal( val, 1.0, 'returns expected value' );
 
 	val = risingFactorial( -2.0, 0 );
-	t.equal( val, 1.0, 'returns 1' );
+	t.equal( val, 1.0, 'returns expected value' );
 
 	val = risingFactorial( -0.2, 0 );
-	t.equal( val, 1.0, 'returns 1' );
+	t.equal( val, 1.0, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function returns `0` if provided `x = 0` and a positive `n`', function test( t ) {
 	var val = risingFactorial( 0.0, 4 );
-	t.equal( val, 0.0, 'returns 0' );
+	t.equal( val, 0.0, 'returns expected value' );
 
 	val = risingFactorial( 0.0, 1 );
-	t.equal( val, 0.0, 'returns 0' );
+	t.equal( val, 0.0, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns evaluates the rising factorial if provided `x = 0` and a negative `n`', function test( t ) {
 	var val = risingFactorial( 0.0, -1 );
-	t.equal( val, -1.0, 'returns -1' );
+	t.equal( val, -1.0, 'returns expected value' );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/math/base/special/round/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/round/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/array/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var round = require( './../lib' );
@@ -34,7 +34,7 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
-	x = randu( 100, -500.0, 500.0 );
+	x = uniform( 100, -500.0, 500.0 );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
@@ -56,7 +56,7 @@ bench( pkg+'::built-in', function benchmark( b ) {
 	var y;
 	var i;
 
-	x = randu( 100, -500.0, 500.0 );
+	x = uniform( 100, -500.0, 500.0 );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/math/base/special/round/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/round/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/array/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -43,7 +43,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
-	x = randu( 100, -500.0, 500.0 );
+	x = uniform( 100, -500.0, 500.0 );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/math/base/special/round2/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/round2/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var round2 = require( './../lib' );
@@ -34,10 +34,11 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -5.0e6, 5.0e6 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1.0e7 ) - 5.0e6;
-		y = round2( x );
+		y = round2( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/round2/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/round2/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -43,10 +43,11 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -5.0e6, 5.0e6 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu() * 1.0e7 ) - 5.0e6;
-		y = round2( x );
+		y = round2( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/round2/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/round2/benchmark/c/native/benchmark.c
@@ -91,15 +91,18 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double x[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1.0e7 * rand_double() ) - 5.0e6;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1.0e7 * rand_double() ) - 5.0e6;
-		y = stdlib_base_round2( x );
+		y = stdlib_base_round2( x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/round2/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/round2/test/test.js
@@ -44,35 +44,35 @@ tape( 'the function returns `+0` if provided `+0`', function test( t ) {
 	var v;
 
 	v = round2( 0.0 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = round2( +0.0 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function returns `-0` if provided `-0`', function test( t ) {
 	var v = round2( -0.0 );
-	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( v ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `NaN` if provided a `NaN`', function test( t ) {
 	var v = round2( NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+infinity` if provided `+infinity`', function test( t ) {
 	var v = round2( PINF );
-	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.strictEqual( v, PINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-infinity` if provided `-infinity`', function test( t ) {
 	var v = round2( NINF );
-	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.strictEqual( v, NINF, 'returns expected value' );
 	t.end();
 });
 
@@ -88,11 +88,11 @@ tape( 'the function overflows if provided a sufficiently large value', function 
 
 	x = exp2( 1023 );
 	v = round2( x + (x/2.0) );
-	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.strictEqual( v, PINF, 'returns expected value' );
 
 	x = -exp2( 1023 );
 	v = round2( x + (x/2.0) );
-	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.strictEqual( v, NINF, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/round2/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/round2/test/test.native.js
@@ -53,17 +53,17 @@ tape( 'the function returns `+0` if provided `+0`', opts, function test( t ) {
 	var v;
 
 	v = round2( 0.0 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = round2( +0.0 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function returns `-0` if provided `-0`', opts, function test( t ) {
 	var v = round2( -0.0 );
-	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( v ), true, 'returns expected value' );
 	t.end();
 });
 
@@ -75,13 +75,13 @@ tape( 'the function returns `NaN` if provided a `NaN`', opts, function test( t )
 
 tape( 'the function returns `+infinity` if provided `+infinity`', opts, function test( t ) {
 	var v = round2( PINF );
-	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.strictEqual( v, PINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-infinity` if provided `-infinity`', opts, function test( t ) {
 	var v = round2( NINF );
-	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.strictEqual( v, NINF, 'returns expected value' );
 	t.end();
 });
 
@@ -97,11 +97,11 @@ tape( 'the function overflows if provided a sufficiently large value', opts, fun
 
 	x = exp2( 1023 );
 	v = round2( x + (x/2.0) );
-	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.strictEqual( v, PINF, 'returns expected value' );
 
 	x = -exp2( 1023 );
 	v = round2( x + (x/2.0) );
-	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.strictEqual( v, NINF, 'returns expected value' );
 
 	t.end();
 });


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors random number generation in JS benchmarks for the `math/base/special/rcbrtf`, `math/base/special/rempio2`, `math/base/special/reimann-zeta`, `math/base/special/rising-factorial`, `math/base/special/round` and `math/base/special/round2` packages.
-   Replaces `randu()` with `uniform()` from `@stdlib/random/array/uniform` for cleaner and more consistent code.
-   Moves the random number generation outside the benchmarking loops.
-   Updates the test messages to follow code conventions.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
