### PR TITLE
bench: update random value generation

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/round10/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/round10/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var round10 = require( './../lib' );
@@ -34,10 +34,11 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -5.0e6, 5.0e6 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1.0e7 ) - 5.0e6;
-		y = round10( x );
+		y = round10( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/round10/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/round10/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -43,10 +43,11 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -5.0e6, 5.0e6 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu() * 1.0e7 ) - 5.0e6;
-		y = round10( x );
+		y = round10( x[ i%x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/round10/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/round10/benchmark/c/native/benchmark.c
@@ -91,15 +91,18 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double x[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1.0e7 * rand_double() ) - 5.0e6;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1.0e7 * rand_double() ) - 5.0e6;
-		y = stdlib_base_round10( x );
+		y = stdlib_base_round10( x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/round10/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/round10/test/test.js
@@ -42,35 +42,35 @@ tape( 'the function returns `+0` if provided `+0`', function test( t ) {
 	var v;
 
 	v = round10( 0.0 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = round10( +0.0 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function returns `-0` if provided `-0`', function test( t ) {
 	var v = round10( -0.0 );
-	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( v ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `NaN` if provided a `NaN`', function test( t ) {
 	var v = round10( NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `+infinity` if provided `+infinity`', function test( t ) {
 	var v = round10( PINF );
-	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.strictEqual( v, PINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-infinity` if provided `-infinity`', function test( t ) {
 	var v = round10( NINF );
-	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.strictEqual( v, NINF, 'returns expected value' );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/math/base/special/round10/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/round10/test/test.native.js
@@ -51,17 +51,17 @@ tape( 'the function returns `+0` if provided `+0`', opts, function test( t ) {
 	var v;
 
 	v = round10( 0.0 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = round10( +0.0 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function returns `-0` if provided `-0`', opts, function test( t ) {
 	var v = round10( -0.0 );
-	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( v ), true, 'returns expected value' );
 	t.end();
 });
 
@@ -73,13 +73,13 @@ tape( 'the function returns `NaN` if provided a `NaN`', opts, function test( t )
 
 tape( 'the function returns `+infinity` if provided `+infinity`', opts, function test( t ) {
 	var v = round10( PINF );
-	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.strictEqual( v, PINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-infinity` if provided `-infinity`', opts, function test( t ) {
 	var v = round10( NINF );
-	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.strictEqual( v, NINF, 'returns expected value' );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/math/base/special/roundb/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var roundb = require( './../lib' );
@@ -34,10 +34,11 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -5.0e6, 5.0e6 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1.0e7 ) - 5.0e6;
-		y = roundb( x, 2, 20 );
+		y = roundb( x[ i%x.length ], 2, 20 );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/roundb/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -43,10 +43,11 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -5.0e6, 5.0e6 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu() * 1.0e7 ) - 5.0e6;
-		y = roundb( x, 2, 20 );
+		y = roundb( x[ i%x.length ], 2, 20 );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/roundb/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/benchmark/c/native/benchmark.c
@@ -91,15 +91,18 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	double x;
+	double x[ 100 ];
 	double y;
 	double t;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1.0e7 * rand_double() ) - 5.0e6;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1.0e7 * rand_double() ) - 5.0e6;
-		y = stdlib_base_roundb( x, 2, 20 );
+		y = stdlib_base_roundb( x[ i%100 ], 2, 20 );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/roundb/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/test/test.js
@@ -47,25 +47,25 @@ tape( 'the function returns `NaN` if provided `NaN`', function test( t ) {
 	var v;
 
 	v = roundb( NaN, -2, 1 );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = roundb( 12368.0, NaN, 1 );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = roundb( NaN, NaN, 1 );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = roundb( 12368.0, NaN, 1 );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = roundb( 12368.0, 1, NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = roundb( 12368.0, NaN, NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = roundb( NaN, 1, NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -74,10 +74,10 @@ tape( 'the function returns `NaN` if provided `n = +-infinity`', function test( 
 	var v;
 
 	v = roundb( PI, PINF, 10 );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = roundb( PI, NINF, 10 );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -86,10 +86,10 @@ tape( 'the function returns `NaN` if provided `b = +-infinity`', function test( 
 	var v;
 
 	v = roundb( PI, 1, PINF );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = roundb( PI, 1, NINF );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -98,23 +98,23 @@ tape( 'the function returns `NaN` if provided `b <= 0`', function test( t ) {
 	var v;
 
 	v = roundb( PI, 5, 0 );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = roundb( PI, 5, -1 );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function returns `+infinity` if provided `+infinity`', function test( t ) {
 	var v = roundb( PINF, 5, 10 );
-	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.strictEqual( v, PINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-infinity` if provided `-infinity`', function test( t ) {
 	var v = roundb( NINF, -3, 10 );
-	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.strictEqual( v, NINF, 'returns expected value' );
 	t.end();
 });
 
@@ -122,13 +122,13 @@ tape( 'the function returns `-0` if provided `-0`', function test( t ) {
 	var v;
 
 	v = roundb( -0.0, 0, 10 );
-	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( v ), true, 'returns expected value' );
 
 	v = roundb( -0.0, -2, 10 );
-	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( v ), true, 'returns expected value' );
 
 	v = roundb( -0.0, 2, 10 );
-	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -137,13 +137,13 @@ tape( 'the function returns `+0` if provided `+0`', function test( t ) {
 	var v;
 
 	v = roundb( 0.0, 0, 10 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = roundb( +0.0, -2, 10 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = roundb( +0.0, 2, 10 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -213,9 +213,9 @@ tape( 'if `b^n` is too large, the function returns `+-0` (sign preserving)', fun
 		n = round( randu()*100.0 ) + 309;
 		v = roundb( x, n, 10 );
 		if ( sign === -1.0 ) {
-			t.strictEqual( isNegativeZero( v ), true, ' returns -0 when provided x='+x+', n='+n+'.' );
+			t.strictEqual( isNegativeZero( v ), true, ' returns expected value when provided x='+x+', n='+n+'.' );
 		} else {
-			t.strictEqual( isPositiveZero( v ), true, ' returns +0 when provided x='+x+', n='+n+'.' );
+			t.strictEqual( isPositiveZero( v ), true, ' returns expected value when provided x='+x+', n='+n+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/math/base/special/roundb/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundb/test/test.native.js
@@ -74,13 +74,13 @@ tape( 'the function returns `NaN` if provided `b <= 0`', opts, function test( t 
 
 tape( 'the function returns `+infinity` if provided `+infinity`', opts, function test( t ) {
 	var v = roundb( PINF, 5, 10 );
-	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.strictEqual( v, PINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-infinity` if provided `-infinity`', opts, function test( t ) {
 	var v = roundb( NINF, -3, 10 );
-	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.strictEqual( v, NINF, 'returns expected value' );
 	t.end();
 });
 
@@ -88,13 +88,13 @@ tape( 'the function returns `-0` if provided `-0`', opts, function test( t ) {
 	var v;
 
 	v = roundb( -0.0, 0, 10 );
-	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( v ), true, 'returns expected value' );
 
 	v = roundb( -0.0, -2, 10 );
-	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( v ), true, 'returns expected value' );
 
 	v = roundb( -0.0, 2, 10 );
-	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -103,13 +103,13 @@ tape( 'the function returns `+0` if provided `+0`', opts, function test( t ) {
 	var v;
 
 	v = roundb( 0.0, 0, 10 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = roundb( +0.0, -2, 10 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = roundb( +0.0, 2, 10 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -179,9 +179,9 @@ tape( 'if `b^n` is too large, the function returns `+-0` (sign preserving)', opt
 		n = round( randu()*100.0 ) + 309;
 		v = roundb( x, n, 10 );
 		if ( sign === -1.0 ) {
-			t.strictEqual( isNegativeZero( v ), true, ' returns -0 when provided x='+x+', n='+n+'.' );
+			t.strictEqual( isNegativeZero( v ), true, ' returns expected value when provided x='+x+', n='+n+'.' );
 		} else {
-			t.strictEqual( isPositiveZero( v ), true, ' returns +0 when provided x='+x+', n='+n+'.' );
+			t.strictEqual( isPositiveZero( v ), true, ' returns expected value when provided x='+x+', n='+n+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/math/base/special/roundf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var pkg = require( './../package.json' ).name;
 var roundf = require( './../lib' );
@@ -34,10 +34,13 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -500.0, 500.0, {
+		'dtype': 'float32'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu() * 1000.0 ) - 500.0;
-		y = roundf( x );
+		y = roundf( x[ i%x.length ] );
 		if ( isnanf( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/roundf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnanf = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -43,10 +43,13 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -500.0, 500.0, {
+		'dtype': 'float32'
+	});
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu() * 1000.0 ) - 500.0;
-		y = roundf( x );
+		y = roundf( x[ i%x.length ] );
 		if ( isnanf( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/roundf/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/benchmark/c/native/benchmark.c
@@ -92,14 +92,17 @@ static float rand_float( void ) {
 static double benchmark( void ) {
 	double elapsed;
 	double t;
-	float x;
+	float x[ 100 ];
 	float y;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1000.0f * rand_float() ) - 500.0f;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		x = ( 1000.0f * rand_float() ) - 500.0f;
-		y = roundf( x );
+		y = roundf( x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/roundf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/test/test.js
@@ -52,7 +52,7 @@ tape( 'the function rounds a single-precision floating-point number to the neare
 
 tape( 'the function returns `-0` if provided `-0`', function test( t ) {
 	var v = roundf( -0.0 );
-	t.strictEqual( isNegativeZerof( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZerof( v ), true, 'returns expected value' );
 	t.end();
 });
 
@@ -64,13 +64,13 @@ tape( 'the function returns `NaN` if provided a `NaN`', function test( t ) {
 
 tape( 'the function returns `+infinity` if provided a `+infinity`', function test( t ) {
 	var v = roundf( PINF );
-	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.strictEqual( v, PINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-infinity` if provided a `-infinity`', function test( t ) {
 	var v = roundf( NINF );
-	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.strictEqual( v, NINF, 'returns expected value' );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/math/base/special/roundf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/test/test.native.js
@@ -61,7 +61,7 @@ tape( 'the function rounds a single-precision floating-point number to the neare
 
 tape( 'the function returns `-0` if provided `-0`', opts, function test( t ) {
 	var v = roundf( -0.0 );
-	t.strictEqual( isNegativeZerof( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZerof( v ), true, 'returns expected value' );
 	t.end();
 });
 
@@ -73,13 +73,13 @@ tape( 'the function returns `NaN` if provided a `NaN`', opts, function test( t )
 
 tape( 'the function returns `+infinity` if provided a `+infinity`', opts, function test( t ) {
 	var v = roundf( PINF );
-	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.strictEqual( v, PINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-infinity` if provided a `-infinity`', opts, function test( t ) {
 	var v = roundf( NINF );
-	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.strictEqual( v, NINF, 'returns expected value' );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/math/base/special/roundn/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundn/benchmark/benchmark.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var roundn = require( './../lib' );
@@ -34,10 +34,11 @@ bench( pkg, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -5.0e6, 5.0e6 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1.0e7 ) - 5.0e6;
-		y = roundn( x, -2 );
+		y = roundn( x[ i%x.length ], -2 );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/roundn/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundn/benchmark/benchmark.native.js
@@ -22,7 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -43,10 +43,11 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 	var y;
 	var i;
 
+	x = uniform( 100, -5.0e6, 5.0e6 );
+
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		x = ( randu()*1000.0 ) - 500.0;
-		y = roundn( x, -2 );
+		y = roundn( x[ i%x.length ], -2 );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/math/base/special/roundn/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/roundn/benchmark/c/native/benchmark.c
@@ -92,14 +92,17 @@ static double rand_double( void ) {
 static double benchmark( void ) {
 	double elapsed;
 	double t;
-	double v;
+	double v[ 100 ];
 	double y;
 	int i;
 
+	for ( i = 0; i < 100; i++ ) {
+		v[ i ] = ( 1000.0*rand_double() ) - 500.0;
+	}
+
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		v = ( 1000.0*rand_double() ) - 500.0;
-		y = stdlib_base_roundn( v, -2 );
+		y = stdlib_base_roundn( v[ i%100 ], -2 );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/roundn/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundn/test/test.js
@@ -47,13 +47,13 @@ tape( 'the function returns `NaN` if provided `NaN`', function test( t ) {
 	var v;
 
 	v = roundn( NaN, -2 );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = roundn( 12368.0, NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = roundn( NaN, NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -62,23 +62,23 @@ tape( 'the function returns `NaN` if provided `n = +-infinity`', function test( 
 	var v;
 
 	v = roundn( PI, PINF );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	v = roundn( PI, NINF );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function returns `+infinity` if provided `+infinity`', function test( t ) {
 	var v = roundn( PINF, 5 );
-	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.strictEqual( v, PINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-infinity` if provided `-infinity`', function test( t ) {
 	var v = roundn( NINF, -3 );
-	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.strictEqual( v, NINF, 'returns expected value' );
 	t.end();
 });
 
@@ -86,13 +86,13 @@ tape( 'the function returns `-0` if provided `-0`', function test( t ) {
 	var v;
 
 	v = roundn( -0.0, 0 );
-	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( v ), true, 'returns expected value' );
 
 	v = roundn( -0.0, -2 );
-	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( v ), true, 'returns expected value' );
 
 	v = roundn( -0.0, 2 );
-	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -101,13 +101,13 @@ tape( 'the function returns `+0` if provided `+0`', function test( t ) {
 	var v;
 
 	v = roundn( 0.0, 0 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = roundn( +0.0, -2 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = roundn( +0.0, 2 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -187,9 +187,9 @@ tape( 'if `n > 308`, the function returns `+-0` (sign preserving)', function tes
 		n = round( randu()*100.0 ) + 309;
 		v = roundn( x, n );
 		if ( sign === -1.0 ) {
-			t.strictEqual( isNegativeZero( v ), true, ' returns -0 when provided x='+x+', n='+n+'.' );
+			t.strictEqual( isNegativeZero( v ), true, ' returns expected value when provided x='+x+', n='+n+'.' );
 		} else {
-			t.strictEqual( isPositiveZero( v ), true, ' returns +0 when provided x='+x+', n='+n+'.' );
+			t.strictEqual( isPositiveZero( v ), true, ' returns expected value when provided x='+x+', n='+n+'.' );
 		}
 	}
 	t.end();

--- a/lib/node_modules/@stdlib/math/base/special/roundn/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundn/test/test.native.js
@@ -56,20 +56,20 @@ tape( 'the function returns `NaN` if provided `NaN`', opts, function test( t ) {
 	var v;
 
 	v = roundn( NaN, -2 );
-	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.strictEqual( isnan( v ), true, 'returns expected value' );
 
 	t.end();
 });
 
 tape( 'the function returns `+infinity` if provided `+infinity`', opts, function test( t ) {
 	var v = roundn( PINF, 5 );
-	t.strictEqual( v, PINF, 'returns +infinity' );
+	t.strictEqual( v, PINF, 'returns expected value' );
 	t.end();
 });
 
 tape( 'the function returns `-infinity` if provided `-infinity`', opts, function test( t ) {
 	var v = roundn( NINF, -3 );
-	t.strictEqual( v, NINF, 'returns -infinity' );
+	t.strictEqual( v, NINF, 'returns expected value' );
 	t.end();
 });
 
@@ -77,13 +77,13 @@ tape( 'the function returns `-0` if provided `-0`', opts, function test( t ) {
 	var v;
 
 	v = roundn( -0.0, 0 );
-	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( v ), true, 'returns expected value' );
 
 	v = roundn( -0.0, -2 );
-	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( v ), true, 'returns expected value' );
 
 	v = roundn( -0.0, 2 );
-	t.strictEqual( isNegativeZero( v ), true, 'returns -0' );
+	t.strictEqual( isNegativeZero( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -92,13 +92,13 @@ tape( 'the function returns `+0` if provided `+0`', opts, function test( t ) {
 	var v;
 
 	v = roundn( 0.0, 0 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = roundn( +0.0, -2 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	v = roundn( +0.0, 2 );
-	t.strictEqual( isPositiveZero( v ), true, 'returns +0' );
+	t.strictEqual( isPositiveZero( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -178,9 +178,9 @@ tape( 'if `n > 308`, the function returns `+-0` (sign preserving)', opts, functi
 		n = round( randu()*100.0 ) + 309;
 		v = roundn( x, n );
 		if ( sign === -1.0 ) {
-			t.strictEqual( isNegativeZero( v ), true, ' returns -0 when provided x='+x+', n='+n+'.' );
+			t.strictEqual( isNegativeZero( v ), true, ' returns expected value when provided x='+x+', n='+n+'.' );
 		} else {
-			t.strictEqual( isPositiveZero( v ), true, ' returns +0 when provided x='+x+', n='+n+'.' );
+			t.strictEqual( isPositiveZero( v ), true, ' returns expected value when provided x='+x+', n='+n+'.' );
 		}
 	}
 	t.end();


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors random number generation in JS benchmarks for the `math/base/special/round10`, `math/base/special/roundb`, `math/base/special/roundf` and `math/base/special/roundn` packages.
-   Replaces `randu()` with `uniform()` from `@stdlib/random/array/uniform` for cleaner and more consistent code.
-   Moves the random number generation outside the benchmarking loops.
-   Updates the test messages to follow code conventions.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
