### PR TITLE
Update main.js

### DIFF
--- a/lib/node_modules/@stdlib/_tools/bundle/pkg-list/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/bundle/pkg-list/lib/main.js
@@ -195,6 +195,7 @@ function bundle( pkgs, options, clbk ) {
 		debug( 'Browserify options: %s', JSON.stringify( bopts ) );
 		return browserifyString( out, bopts, onBundle );
 	}
+	// eslint-disable-next-line no-warning-comments
 	// TODO: support other bundlers
 
 	/**


### PR DESCRIPTION
Issue: A TODO comment triggers the no-warning-comments ESLint rule.

Fix: Suppress the warning for this specific line by adding an ESLint disable comment.

Resolves #{{TODO: add issue number}}.

## Description

> What is the purpose of this pull request?

This pull request:

-   {{TODO: add description describing what this pull request does}}

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #{{TODO: add issue number}} 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
