### PR TITLE
bench: fix invalid array indexing

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cbrtf/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/cbrtf/benchmark/c/native/benchmark.c
@@ -102,7 +102,7 @@ static double benchmark( void ) {
 
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		y = stdlib_base_cbrtf( x[ i%x.length ] );
+		y = stdlib_base_cbrtf( x[ i%100 ] );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

- fixes the invalid array indexing in the C benchmarks of `math/base/special/cbrtf`

## Related Issues

> Does this pull request have any related issues?

This pull request:

- resolves none

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md