### PR TITLE
chore: refactoring `stats/base/dists/betaprime/logpdf` to use const double

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/src/main.c
@@ -34,7 +34,7 @@
 * double y = stdlib_base_dists_beta_logpdf( 0.5, 1.0, 1.0 );
 * // returns ~-0.811
 */
-double stdlib_base_dists_betaprime_logpdf( const double x, double alpha, const double beta ) {
+double stdlib_base_dists_betaprime_logpdf( const double x, const double alpha, const double beta ) {
 	double out;
 	if (
 		stdlib_base_is_nan( x ) ||


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

-   refactors `stats/base/dists/betaprime/logpdf` to use const double for `var alpha`

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves none

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-  [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
