### PR TITLE
fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/utils/async/if-then/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/async/if-then/lib/main.js
@@ -119,7 +119,7 @@ function ifthenAsync( predicate, x, y, done ) {
 			return done( error );
 		}
 		nargs = arguments.length;
-		args = new Array( nargs );
+		args = Array.from({ length: nargs });
 		args[ 0 ] = null;
 		for ( i = 1; i < nargs; i++ ) {
 			args[ i ] = arguments[ i ];


### PR DESCRIPTION
Issue: Using new Array() violates the stdlib/no-new-array rule.

fix: creating an array using an array literal

Resolves #6417 

## Description

> What is the purpose of this pull request?

This pull request:

-   creating an array using an array literal instead of a new Array ()

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #6424 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
