### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/lcm/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/lcm/README.md
@@ -101,21 +101,17 @@ v = lcm( 48, NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var lcm = require( '@stdlib/math/base/special/lcm' );
 
-var a;
-var b;
-var v;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var a = discreteUniform( 100, 0, 50, opts );
+var b = discreteUniform( 100, 0, 50, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    a = round( randu()*50 );
-    b = round( randu()*50 );
-    v = lcm( a, b );
-    console.log( 'lcm(%d,%d) = %d', a, b, v );
-}
+logEachMap( 'lcm(%0.4f,%0.4f) = %0.4f', a, b, lcm );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/lcm/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/lcm/examples/index.js
@@ -23,7 +23,7 @@ var logEachMap = require( '@stdlib/console/log-each-map' );
 var lcm = require( './../lib' );
 
 var opts = {
-    'dtype': 'float64'
+	'dtype': 'float64'
 };
 var a = discreteUniform( 100, 0, 50, opts );
 var b = discreteUniform( 100, 0, 50, opts );

--- a/lib/node_modules/@stdlib/math/base/special/lcm/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/lcm/examples/index.js
@@ -18,18 +18,14 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var lcm = require( './../lib' );
 
-var a;
-var b;
-var v;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var a = discreteUniform( 100, 0, 50, opts );
+var b = discreteUniform( 100, 0, 50, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	a = round( randu()*50 );
-	b = round( randu()*50 );
-	v = lcm( a, b );
-	console.log( 'lcm(%d,%d) = %d', a, b, v );
-}
+logEachMap( 'lcm(%0.4f,%0.4f) = %0.4f', a, b, lcm );

--- a/lib/node_modules/@stdlib/math/base/special/lcmf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/lcmf/README.md
@@ -101,16 +101,17 @@ v = lcmf( 48, NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/array/discrete-uniform' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var lcmf = require( '@stdlib/math/base/special/lcmf' );
 
-var a = randu( 100, 0, 50 );
-var b = randu( 100, 0, 50 );
+var opts = {
+    'dtype': 'float32'
+};
+var a = discreteUniform( 100, 0, 50, opts );
+var b = discreteUniform( 100, 0, 50, opts );
 
-var i;
-for ( i = 0; i < 100; i++ ) {
-    console.log( 'lcmf(%d,%d) = %d', a[ i ], b[ i ], lcmf( a[ i ], b[ i ] ) );
-}
+logEachMap( 'lcmf(%0.4f,%0.4f) = %0.4f', a, b, lcmf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/lcmf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/lcmf/examples/index.js
@@ -18,13 +18,14 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/array/discrete-uniform' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var lcmf = require( './../lib' );
 
-var a = randu( 100, 0, 50 );
-var b = randu( 100, 0, 50 );
+var opts = {
+    'dtype': 'float32'
+};
+var a = discreteUniform( 100, 0, 50, opts );
+var b = discreteUniform( 100, 0, 50, opts );
 
-var i;
-for ( i = 0; i < 100; i++ ) {
-	console.log( 'lcmf(%d,%d) = %d', a[ i ], b[ i ], lcmf( a[ i ], b[ i ] ) );
-}
+logEachMap( 'lcmf(%0.4f,%0.4f) = %0.4f', a, b, lcmf );

--- a/lib/node_modules/@stdlib/math/base/special/lcmf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/lcmf/examples/index.js
@@ -23,7 +23,7 @@ var logEachMap = require( '@stdlib/console/log-each-map' );
 var lcmf = require( './../lib' );
 
 var opts = {
-    'dtype': 'float32'
+	'dtype': 'float32'
 };
 var a = discreteUniform( 100, 0, 50, opts );
 var b = discreteUniform( 100, 0, 50, opts );

--- a/lib/node_modules/@stdlib/math/base/special/ln/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/ln/README.md
@@ -66,17 +66,16 @@ var v = ln( -4.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var ln = require( '@stdlib/math/base/special/ln' );
 
-var x;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = round( randu() * 100.0 );
-    console.log( 'ln(%d) = %d', x, ln( x ) );
-}
+logEachMap( 'ln(%0.4f) = %0.4f', x, ln );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/ln/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/ln/examples/index.js
@@ -23,7 +23,7 @@ var logEachMap = require( '@stdlib/console/log-each-map' );
 var ln = require( './../lib' );
 
 var opts = {
-    'dtype': 'float64'
+	'dtype': 'float64'
 };
 var x = discreteUniform( 100, 0, 100, opts );
 

--- a/lib/node_modules/@stdlib/math/base/special/ln/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/ln/examples/index.js
@@ -18,14 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var ln = require( './../lib' );
 
-var x;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = round( randu() * 100.0 );
-	console.log( 'ln(%d) = %d', x, ln( x ) );
-}
+logEachMap( 'ln(%0.4f) = %0.4f', x, ln );

--- a/lib/node_modules/@stdlib/math/base/special/lnf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/lnf/README.md
@@ -66,17 +66,16 @@ var v = lnf( -4.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var lnf = require( '@stdlib/math/base/special/lnf' );
 
-var x;
-var i;
+var opts = {
+    'dtype': 'float32'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = round( randu() * 100.0 );
-    console.log( 'lnf(%d) = %d', x, lnf( x ) );
-}
+logEachMap( 'lnf(%0.4f) = %0.4f', x, lnf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/lnf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/lnf/examples/index.js
@@ -18,14 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var lnf = require( './../lib' );
 
-var x;
-var i;
+var opts = {
+    'dtype': 'float32'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = round( randu() * 100.0 );
-	console.log( 'lnf(%d) = %d', x, lnf( x ) );
-}
+logEachMap( 'lnf(%0.4f) = %0.4f', x, lnf );

--- a/lib/node_modules/@stdlib/math/base/special/lnf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/lnf/examples/index.js
@@ -23,7 +23,7 @@ var logEachMap = require( '@stdlib/console/log-each-map' );
 var lnf = require( './../lib' );
 
 var opts = {
-    'dtype': 'float32'
+	'dtype': 'float32'
 };
 var x = discreteUniform( 100, 0, 100, opts );
 

--- a/lib/node_modules/@stdlib/math/base/special/log/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/log/README.md
@@ -66,19 +66,17 @@ v = log( 2.0, -4.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var log = require( '@stdlib/math/base/special/log' );
 
-var b;
-var x;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = discreteUniform( 100, 0, 100, opts );
+var b = discreteUniform( 100, 0, 5, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = round( randu() * 100.0 );
-    b = round( randu() * 5.0 );
-    console.log( 'log( %d, %d ) = %d', x, b, log( x, b ) );
-}
+logEachMap( 'log( %0.4f, %0.4f ) = %0.4f', x, b, log );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/log/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/log/examples/index.js
@@ -18,16 +18,14 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var log = require( './../lib' );
 
-var b;
-var x;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = discreteUniform( 100, 0, 100, opts );
+var b = discreteUniform( 100, 0, 5, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = round( randu() * 100.0 );
-	b = round( randu() * 5.0 );
-	console.log( 'log( %d, %d ) = %d', x, b, log( x, b ) );
-}
+logEachMap( 'log( %0.4f, %0.4f ) = %0.4f', x, b, log );

--- a/lib/node_modules/@stdlib/math/base/special/log/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/log/examples/index.js
@@ -23,7 +23,7 @@ var logEachMap = require( '@stdlib/console/log-each-map' );
 var log = require( './../lib' );
 
 var opts = {
-    'dtype': 'float64'
+	'dtype': 'float64'
 };
 var x = discreteUniform( 100, 0, 100, opts );
 var b = discreteUniform( 100, 0, 5, opts );

--- a/lib/node_modules/@stdlib/math/base/special/log1p/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/log1p/README.md
@@ -72,17 +72,16 @@ var v = log1p( -2.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var log1p = require( '@stdlib/math/base/special/log1p' );
 
-var x;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = round( randu() * 100.0 );
-    console.log( log1p( x ) );
-}
+logEachMap( x, log1p );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/log1p/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/log1p/README.md
@@ -81,7 +81,7 @@ var opts = {
 };
 var x = discreteUniform( 100, 0, 100, opts );
 
-logEachMap( x, log1p );
+logEachMap( 'log1p( %0.4f ) = %0.4f', x, log1p );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/log1p/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/log1p/examples/index.js
@@ -18,14 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var log1p = require( './../lib' );
 
-var x;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = round( randu() * 100.0 );
-	console.log( log1p( x ) );
-}
+logEachMap( x, log1p );

--- a/lib/node_modules/@stdlib/math/base/special/log1p/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/log1p/examples/index.js
@@ -23,7 +23,7 @@ var logEachMap = require( '@stdlib/console/log-each-map' );
 var log1p = require( './../lib' );
 
 var opts = {
-    'dtype': 'float64'
+	'dtype': 'float64'
 };
 var x = discreteUniform( 100, 0, 100, opts );
 

--- a/lib/node_modules/@stdlib/math/base/special/log1p/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/log1p/examples/index.js
@@ -27,4 +27,4 @@ var opts = {
 };
 var x = discreteUniform( 100, 0, 100, opts );
 
-logEachMap( x, log1p );
+logEachMap( 'log1p( %0.4f ) = %0.4f', x, log1p );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `math/base/special/lcm`, `math/base/special/lcmf`, `math/base/special/ln`, `math/base/special/lnf`, `math/base/special/log` and `math/base/special/log1p` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
