### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/log10/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/log10/README.md
@@ -90,17 +90,16 @@ var v = log10( -4.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var log10 = require( '@stdlib/math/base/special/log10' );
 
-var x;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = round( randu() * 100.0 );
-    console.log( 'log10(%d) = %d', x, log10( x ) );
-}
+logEachMap( 'log10(%0.4f) = %0.4f', x, log10 );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/log10/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/log10/examples/index.js
@@ -18,14 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var log10 = require( './../lib' );
 
-var x;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = round( randu() * 100.0 );
-	console.log( 'log10(%d) = %d', x, log10( x ) );
-}
+logEachMap( 'log10(%0.4f) = %0.4f', x, log10 );

--- a/lib/node_modules/@stdlib/math/base/special/log2/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/log2/README.md
@@ -87,17 +87,16 @@ var v = log2( -4.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var log2 = require( '@stdlib/math/base/special/log2' );
 
-var x;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = round( randu() * 100.0 );
-    console.log( 'log2(%d) = %d', x, log2( x ) );
-}
+logEachMap( 'log2(%0.4f) = %0.4f', x, log2 );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/log2/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/log2/examples/index.js
@@ -18,14 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var log2 = require( './../lib' );
 
-var x;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = round( randu() * 100.0 );
-	console.log( 'log2(%d) = %d', x, log2( x ) );
-}
+logEachMap( 'log2(%0.4f) = %0.4f', x, log2 );

--- a/lib/node_modules/@stdlib/math/base/special/logf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/logf/README.md
@@ -66,20 +66,17 @@ v = logf( 2.0, -4.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/array/discrete-uniform' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var logf = require( '@stdlib/math/base/special/logf' );
 
 var opts = {
     'dtype': 'float32'
 };
+var x = discreteUniform( 100, 0, 100, opts );
+var b = discreteUniform( 100, 0, 5, opts );
 
-var x = randu( 100, 0, 100, opts );
-var b = randu( 100, 0, 5, opts );
-
-var i;
-for ( i = 0; i < 100; i++ ) {
-    console.log( 'logf( %d, %d ) = %d', x[ i ], b[ i ], logf( x[ i ], b[ i ] ) );
-}
+logEachMap( 'logf( %0.4f, %0.4f ) = %0.4f', x, b, logf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/logf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/logf/examples/index.js
@@ -18,17 +18,14 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/array/discrete-uniform' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var logf = require( './../lib' );
 
 var opts = {
 	'dtype': 'float32'
 };
+var x = discreteUniform( 100, 0, 100, opts );
+var b = discreteUniform( 100, 0, 5, opts );
 
-var x = randu( 100, 0, 100, opts );
-var b = randu( 100, 0, 5, opts );
-
-var i;
-for ( i = 0; i < 100; i++ ) {
-	console.log( 'logf( %d, %d ) = %d', x[ i ], b[ i ], logf( x[ i ], b[ i ] ) );
-}
+logEachMap( 'logf( %0.4f, %0.4f ) = %0.4f', x, b, logf );

--- a/lib/node_modules/@stdlib/math/base/special/logit/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/logit/README.md
@@ -86,16 +86,16 @@ v = logit( -0.2 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var logit = require( '@stdlib/math/base/special/logit' );
 
-var p;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var p = uniform( 100, 0.0, 1.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    p = randu();
-    console.log( 'logit(%d) = %d', p, logit( p ) );
-}
+logEachMap( 'logit(%0.4f) = %0.4f', p, logit );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/logit/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/logit/examples/index.js
@@ -18,13 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var logit = require( './../lib' );
 
-var p;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var p = uniform( 100, 0.0, 1.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	p = randu();
-	console.log( 'logit(%d) = %d', p, logit( p ) );
-}
+logEachMap( 'logit(%0.4f) = %0.4f', p, logit );

--- a/lib/node_modules/@stdlib/math/base/special/maxabs/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/maxabs/README.md
@@ -83,20 +83,17 @@ v = maxabs( NaN, 3.14 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var maxabs = require( '@stdlib/math/base/special/maxabs' );
 
-var x;
-var y;
-var v;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -500.0, 500.0, opts );
+var y = uniform( 100, -500.0, 500.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = ( randu()*1000.0 ) - 500.0;
-    y = ( randu()*1000.0 ) - 500.0;
-    v = maxabs( x, y );
-    console.log( 'maxabs(%d,%d) = %d', x, y, v );
-}
+logEachMap( 'maxabs(%0.4f,%0.4f) = %0.4f', x, y, maxabs );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/maxabs/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/maxabs/examples/index.js
@@ -18,17 +18,14 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var maxabs = require( './../lib' );
 
-var x;
-var y;
-var v;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -500.0, 500.0, opts );
+var y = uniform( 100, -500.0, 500.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = ( randu()*1000.0 ) - 500.0;
-	y = ( randu()*1000.0 ) - 500.0;
-	v = maxabs( x, y );
-	console.log( 'maxabs(%d,%d) = %d', x, y, v );
-}
+logEachMap( 'maxabs(%0.4f,%0.4f) = %0.4f', x, y, maxabs );

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/README.md
@@ -83,22 +83,17 @@ v = maxabsf( NaN, 3.14 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/array/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var maxabsf = require( '@stdlib/math/base/special/maxabsf' );
 
 var opts = {
     'dtype': 'float32'
 };
+var x = uniform( 100, -500.0, 500.0, opts );
+var y = uniform( 100, -500.0, 500.0, opts );
 
-var x = randu( 100, -500.0, 500.0, opts );
-var y = randu( 100, -500.0, 500.0, opts );
-
-var v;
-var i;
-for ( i = 0; i < 100; i++ ) {
-    v = maxabsf( x[ i ], y[ i ] );
-    console.log( 'maxabsf(%d,%d) = %d', x[ i ], y[ i ], v );
-}
+logEachMap( 'maxabsf(%0.4f,%0.4f) = %0.4f', x, y, maxabsf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/maxabsf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/maxabsf/examples/index.js
@@ -18,19 +18,14 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/array/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var maxabsf = require( './../lib' );
 
 var opts = {
 	'dtype': 'float32'
 };
+var x = uniform( 100, -500.0, 500.0, opts );
+var y = uniform( 100, -500.0, 500.0, opts );
 
-var x = randu( 100, -500.0, 500.0, opts );
-var y = randu( 100, -500.0, 500.0, opts );
-
-var v;
-var i;
-for ( i = 0; i < 100; i++ ) {
-	v = maxabsf( x[ i ], y[ i ] );
-	console.log( 'maxabsf(%d,%d) = %d', x[ i ], y[ i ], v );
-}
+logEachMap( 'maxabsf(%0.4f,%0.4f) = %0.4f', x, y, maxabsf );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `math/base/special/log2`, `math/base/special/log10`, `math/base/special/logf`, `math/base/special/logit`, `math/base/special/maxabs` and `math/base/special/maxabsf` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
