### PR TITLE
fix: rename internal variable `fcn` to avoid shadowing and lint errors

### DIFF
--- a/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/cc_c.h
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/cc_c.h
@@ -65,17 +65,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_cc_c_wrapper,                                \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_cc_c_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/cf_c.h
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/cf_c.h
@@ -56,17 +56,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_cf_c_wrapper,                                \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_cf_c_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/ci_c.h
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/ci_c.h
@@ -58,17 +58,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_ci_c_wrapper,                                \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_ci_c_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/dd_d.h
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/dd_d.h
@@ -48,17 +48,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_dd_d_wrapper,                                \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_dd_d_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/di_d.h
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/di_d.h
@@ -51,17 +51,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_di_d_wrapper,                                \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_di_d_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/dz_z.h
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/dz_z.h
@@ -56,17 +56,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_dz_z_wrapper,                                \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_dz_z_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/fc_c.h
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/fc_c.h
@@ -56,17 +56,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_fc_c_wrapper,                                \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_fc_c_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/ff_f.h
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/ff_f.h
@@ -48,17 +48,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_ff_f_wrapper,                                \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_ff_f_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/fi_f.h
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/fi_f.h
@@ -51,17 +51,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_fi_f_wrapper,                                \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_fi_f_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/id_d.h
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/id_d.h
@@ -51,17 +51,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_id_d_wrapper,                                \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_id_d_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/ii_d.h
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/ii_d.h
@@ -51,17 +51,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_ii_d_wrapper,                                \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_ii_d_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/ii_f.h
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/ii_f.h
@@ -51,17 +51,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_ii_f_wrapper,                                \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_ii_f_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/ii_i.h
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/ii_i.h
@@ -51,17 +51,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_ii_i_wrapper,                                \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_ii_i_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/ll_d.h
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/ll_d.h
@@ -51,17 +51,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_ll_d_wrapper,                                \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_ll_d_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/zd_z.h
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/zd_z.h
@@ -56,17 +56,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_zd_z_wrapper,                                \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_zd_z_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/zi_z.h
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/zi_z.h
@@ -58,17 +58,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_zi_z_wrapper,                                \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_zi_z_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/zz_z.h
+++ b/lib/node_modules/@stdlib/math/base/napi/binary/include/stdlib/math/base/napi/binary/zz_z.h
@@ -65,17 +65,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_zz_z_wrapper,                                \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_zz_z_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/quaternary/include/stdlib/math/base/napi/quaternary/dddd_d.h
+++ b/lib/node_modules/@stdlib/math/base/napi/quaternary/include/stdlib/math/base/napi/quaternary/dddd_d.h
@@ -48,17 +48,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_dddd_d_wrapper,                              \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_dddd_d_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/quaternary/include/stdlib/math/base/napi/quaternary/diii_d.h
+++ b/lib/node_modules/@stdlib/math/base/napi/quaternary/include/stdlib/math/base/napi/quaternary/diii_d.h
@@ -51,17 +51,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_diii_d_wrapper,                              \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_diii_d_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/quaternary/include/stdlib/math/base/napi/quaternary/ffff_f.h
+++ b/lib/node_modules/@stdlib/math/base/napi/quaternary/include/stdlib/math/base/napi/quaternary/ffff_f.h
@@ -48,17 +48,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_ffff_f_wrapper,                              \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_ffff_f_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/quinary/include/stdlib/math/base/napi/quinary/ddddd_d.h
+++ b/lib/node_modules/@stdlib/math/base/napi/quinary/include/stdlib/math/base/napi/quinary/ddddd_d.h
@@ -48,17 +48,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_ddddd_d_wrapper,                             \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_ddddd_d_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/quinary/include/stdlib/math/base/napi/quinary/fffff_f.h
+++ b/lib/node_modules/@stdlib/math/base/napi/quinary/include/stdlib/math/base/napi/quinary/fffff_f.h
@@ -48,17 +48,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                        \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_fffff_f_wrapper,                             \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                               \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                            \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_fffff_f_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/quinary/include/stdlib/math/base/napi/quinary/fffff_f.h
+++ b/lib/node_modules/@stdlib/math/base/napi/quinary/include/stdlib/math/base/napi/quinary/fffff_f.h
@@ -48,17 +48,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value f;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_fffff_f_wrapper,                             \
 			NULL,                                                              \
-			&f                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return f;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_fffff_f_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/ternary/include/stdlib/math/base/napi/ternary/ccc_c.h
+++ b/lib/node_modules/@stdlib/math/base/napi/ternary/include/stdlib/math/base/napi/ternary/ccc_c.h
@@ -68,17 +68,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_ccc_c_wrapper,                               \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_ccc_c_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/ternary/include/stdlib/math/base/napi/ternary/ddd_d.h
+++ b/lib/node_modules/@stdlib/math/base/napi/ternary/include/stdlib/math/base/napi/ternary/ddd_d.h
@@ -48,17 +48,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_ddd_d_wrapper,                               \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_ddd_d_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/ternary/include/stdlib/math/base/napi/ternary/did_d.h
+++ b/lib/node_modules/@stdlib/math/base/napi/ternary/include/stdlib/math/base/napi/ternary/did_d.h
@@ -51,17 +51,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_did_d_wrapper,                               \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_did_d_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/ternary/include/stdlib/math/base/napi/ternary/dii_d.h
+++ b/lib/node_modules/@stdlib/math/base/napi/ternary/include/stdlib/math/base/napi/ternary/dii_d.h
@@ -51,17 +51,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_dii_d_wrapper,                               \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_dii_d_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/ternary/include/stdlib/math/base/napi/ternary/fff_f.h
+++ b/lib/node_modules/@stdlib/math/base/napi/ternary/include/stdlib/math/base/napi/ternary/fff_f.h
@@ -48,17 +48,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_fff_f_wrapper,                               \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_fff_f_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/ternary/include/stdlib/math/base/napi/ternary/iid_d.h
+++ b/lib/node_modules/@stdlib/math/base/napi/ternary/include/stdlib/math/base/napi/ternary/iid_d.h
@@ -51,17 +51,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_iid_d_wrapper,                               \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_iid_d_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/ternary/include/stdlib/math/base/napi/ternary/iii_d.h
+++ b/lib/node_modules/@stdlib/math/base/napi/ternary/include/stdlib/math/base/napi/ternary/iii_d.h
@@ -51,17 +51,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_iii_d_wrapper,                               \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_iii_d_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/ternary/include/stdlib/math/base/napi/ternary/zzz_z.h
+++ b/lib/node_modules/@stdlib/math/base/napi/ternary/include/stdlib/math/base/napi/ternary/zzz_z.h
@@ -68,17 +68,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_zzz_z_wrapper,                               \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_zzz_z_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/unary/include/stdlib/math/base/napi/unary/c_c.h
+++ b/lib/node_modules/@stdlib/math/base/napi/unary/include/stdlib/math/base/napi/unary/c_c.h
@@ -60,17 +60,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_c_c_wrapper,                                 \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_c_c_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/unary/include/stdlib/math/base/napi/unary/c_f.h
+++ b/lib/node_modules/@stdlib/math/base/napi/unary/include/stdlib/math/base/napi/unary/c_f.h
@@ -51,17 +51,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_c_f_wrapper,                                 \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_c_f_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/unary/include/stdlib/math/base/napi/unary/d_d.h
+++ b/lib/node_modules/@stdlib/math/base/napi/unary/include/stdlib/math/base/napi/unary/d_d.h
@@ -48,17 +48,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_d_d_wrapper,                                 \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_d_d_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/unary/include/stdlib/math/base/napi/unary/d_f.h
+++ b/lib/node_modules/@stdlib/math/base/napi/unary/include/stdlib/math/base/napi/unary/d_f.h
@@ -48,17 +48,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_d_f_wrapper,                                 \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_d_f_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/unary/include/stdlib/math/base/napi/unary/f_f.h
+++ b/lib/node_modules/@stdlib/math/base/napi/unary/include/stdlib/math/base/napi/unary/f_f.h
@@ -48,17 +48,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_f_f_wrapper,                                 \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_f_f_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/unary/include/stdlib/math/base/napi/unary/f_i.h
+++ b/lib/node_modules/@stdlib/math/base/napi/unary/include/stdlib/math/base/napi/unary/f_i.h
@@ -51,17 +51,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_f_i_wrapper,                                 \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_f_i_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/unary/include/stdlib/math/base/napi/unary/i_d.h
+++ b/lib/node_modules/@stdlib/math/base/napi/unary/include/stdlib/math/base/napi/unary/i_d.h
@@ -51,17 +51,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_i_d_wrapper,                                 \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_i_d_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/unary/include/stdlib/math/base/napi/unary/i_f.h
+++ b/lib/node_modules/@stdlib/math/base/napi/unary/include/stdlib/math/base/napi/unary/i_f.h
@@ -51,17 +51,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_i_f_wrapper,                                 \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_i_f_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/unary/include/stdlib/math/base/napi/unary/i_i.h
+++ b/lib/node_modules/@stdlib/math/base/napi/unary/include/stdlib/math/base/napi/unary/i_i.h
@@ -51,17 +51,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_i_i_wrapper,                                 \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_i_i_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/unary/include/stdlib/math/base/napi/unary/z_d.h
+++ b/lib/node_modules/@stdlib/math/base/napi/unary/include/stdlib/math/base/napi/unary/z_d.h
@@ -51,17 +51,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_z_d_wrapper,                                 \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_z_d_init )
 

--- a/lib/node_modules/@stdlib/math/base/napi/unary/include/stdlib/math/base/napi/unary/z_z.h
+++ b/lib/node_modules/@stdlib/math/base/napi/unary/include/stdlib/math/base/napi/unary/z_z.h
@@ -60,17 +60,17 @@
 		napi_env env,                                                          \
 		napi_value exports                                                     \
 	) {                                                                        \
-		napi_value fcn;                                                        \
+		napi_value f;                                                          \
 		napi_status status = napi_create_function(                             \
 			env,                                                               \
 			"exports",                                                         \
 			NAPI_AUTO_LENGTH,                                                  \
 			stdlib_math_base_napi_z_z_wrapper,                                 \
 			NULL,                                                              \
-			&fcn                                                               \
+			&f                                                                 \
 		);                                                                     \
 		assert( status == napi_ok );                                           \
-		return fcn;                                                            \
+		return f;                                                              \
 	};                                                                         \
 	NAPI_MODULE( NODE_GYP_MODULE_NAME, stdlib_math_base_napi_z_z_init )
 


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

- Renames the internal `fcn` variable to `f`, to avoid shadowing and resolve lint warnings.

## Related Issues

> Does this pull request have any related issues?

This pull request:

- resolves none

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md