### PR TITLE
chore: fix C lint errors (issue #6475)

### DIFF
--- a/lib/node_modules/@stdlib/strided/base/dmap/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/strided/base/dmap/benchmark/c/benchmark.length.c
@@ -104,30 +104,47 @@ static double identity( const double x ) {
 * @param len          array length
 * @return             elapsed time in seconds
 */
-static double benchmark( int iterations, int len ) {
-	double elapsed;
-	double x[ len ];
-	double y[ len ];
-	double t;
-	int i;
-
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( rand_double()*200.0 ) - 100.0;
-		y[ i ] = 0.0;
-	}
-	t = tic();
-	for ( i = 0; i < iterations; i++ ) {
-		stdlib_strided_dmap( len, x, 1, y, 1, identity );
-		if ( y[ i%len ] != y[ i%len ] ) {
-			printf( "should not return NaN\n" );
-			break;
-		}
-	}
-	elapsed = tic() - t;
-	if ( y[ i%len ] != y[ i%len ] ) {
-		printf( "should not return NaN\n" );
-	}
-	return elapsed;
+static double benchmark(int iterations, int len) {
+    // Initialize all variables at declaration
+    double elapsed = 0.0;
+    double *x = malloc(len * sizeof(double));  // Use dynamic allocation instead of VLA
+    double *y = malloc(len * sizeof(double));
+    double t = 0.0;
+    int i = 0;
+    
+    // Check if memory allocation was successful
+    if (x == NULL || y == NULL) {
+        // Handle allocation failure
+        free(x);
+        free(y);
+        return -1.0;
+    }
+    
+    // Initialize arrays
+    for (i = 0; i < len; i++) {
+        x[i] = (rand_double() * 200.0) - 100.0;
+        y[i] = 0.0;
+    }
+    
+    t = tic();
+    for (i = 0; i < iterations; i++) {
+        stdlib_strided_dmap(len, x, 1, y, 1, identity);
+        if (y[i % len] != y[i % len]) {
+            printf("should not return NaN\n");
+            break;
+        }
+    }
+    elapsed = tic() - t;
+    
+    if (y[i % len] != y[i % len]) {
+        printf("should not return NaN\n");
+    }
+    
+    // Free allocated memory
+    free(x);
+    free(y);
+    
+    return elapsed;
 }
 
 /**

--- a/lib/node_modules/@stdlib/strided/base/dmap/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/strided/base/dmap/benchmark/c/benchmark.length.c
@@ -105,21 +105,27 @@ static double identity( const double x ) {
 * @return             elapsed time in seconds
 */
 static double benchmark(int iterations, int len) {
-    // Initialize all variables at declaration
-    double elapsed = 0.0;
-    double *x = malloc(len * sizeof(double));  // Use dynamic allocation instead of VLA
-    double *y = malloc(len * sizeof(double));
-    double t = 0.0;
-    int i = 0;
-    
-    // Check if memory allocation was successful
-    if (x == NULL || y == NULL) {
-        // Handle allocation failure
-        free(x);
-        free(y);
-        return -1.0;
+    double elapsed;
+    double *x;
+    double *y;
+    double t;
+    int i;
+
+    // Allocate input array:
+    x = (double*) malloc(len * sizeof(double));
+    if (x == NULL) {
+        printf("Error allocating memory.\n");
+        exit(1);
     }
     
+    // Allocate output array:
+    y = (double*) malloc(len * sizeof(double));
+    if (y == NULL) {
+        free(x);
+        printf("Error allocating memory.\n");
+        exit(1);
+    }
+
     // Initialize arrays
     for (i = 0; i < len; i++) {
         x[i] = (rand_double() * 200.0) - 100.0;
@@ -140,13 +146,12 @@ static double benchmark(int iterations, int len) {
         printf("should not return NaN\n");
     }
     
-    // Free allocated memory
+    // Free allocated memory:
     free(x);
     free(y);
     
     return elapsed;
 }
-
 /**
 * Main execution sequence.
 */


### PR DESCRIPTION
Resolves #6475 
## Description

> What is the purpose of this pull request?

This PR addresses C linting issues in benchmark.length.c by replacing variable-length arrays (VLAs) with dynamically allocated memory.

- Replaced VLAs (double x[len];) with dynamic memory allocation (malloc) for better compatibility and avoiding potential stack overflows.
- Added memory allocation failure checks to prevent undefined behavior.
- Ensured proper memory deallocation (free) at the end of execution.
- Initialized all variables at declaration to prevent uninitialized variable warnings.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #6475 

## Questions

> Any questions for reviewers of this pull request?

Can we prefer using VLAs (which are valid in C99) ? 

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
