### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/polygamma/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/polygamma/README.md
@@ -74,7 +74,7 @@ v = polygamma( 2, -1.0 );
 If `x` on the other hand is a negative even `integer`, the function returns `NaN`.
 
 ```javascript
-v = polygamma( 2, -4.0 );
+var v = polygamma( 2, -4.0 );
 // returns NaN
 
 v = polygamma( 2, -2.0 );

--- a/lib/node_modules/@stdlib/math/base/special/polygamma/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/polygamma/README.md
@@ -105,21 +105,18 @@ v = polygamma( NaN, NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var polygamma = require( '@stdlib/math/base/special/polygamma' );
 
-var n;
-var x;
-var v;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
+var n = discreteUniform( 100, 0, 50, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = (randu()*100.0) - 50.0;
-    n = round( randu()*50.0 );
-    v = polygamma( x, n );
-    console.log( 'x: %d, ψ^(%d)(x): %d', x, n, v );
-}
+logEachMap( 'x: %0.4f, ψ^(%d)(x): %0.4f', x, n, polygamma );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/polygamma/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/polygamma/examples/index.js
@@ -18,18 +18,15 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var polygamma = require( './../lib' );
 
-var n;
-var x;
-var v;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
+var n = discreteUniform( 100, 0, 50, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = (randu()*100.0) - 50.0;
-	n = round( randu()*50.0 );
-	v = polygamma( n, x );
-	console.log( 'x: %d, ψ^(%d)(x): %d', x, n, v );
-}
+logEachMap( 'x: %0.4f, ψ^(%d)(x): %0.4f', x, n, polygamma );

--- a/lib/node_modules/@stdlib/math/base/special/pow/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/pow/README.md
@@ -94,19 +94,17 @@ v = pow( NaN, NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var pow = require( '@stdlib/math/base/special/pow' );
 
-var b;
-var x;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var b = discreteUniform( 100, 0, 10, opts );
+var x = discreteUniform( 100, -5, 5, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    b = round( randu()*10.0 );
-    x = round( randu()*10.0 ) - 5.0;
-    console.log( '%d^%d = %d', b, x, pow( b, x ) );
-}
+logEachMap( '%d^%d = %0.4f', b, x, pow );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/pow/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/pow/examples/index.js
@@ -18,16 +18,14 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var pow = require( './../lib' );
 
-var b;
-var x;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var b = discreteUniform( 100, 0, 10, opts );
+var x = discreteUniform( 100, -5, 5, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	b = round( randu()*10.0 );
-	x = round( randu()*10.0 ) - 5.0;
-	console.log( '%d^%d = %d', b, x, pow( b, x ) );
-}
+logEachMap( '%d^%d = %0.4f', b, x, pow );

--- a/lib/node_modules/@stdlib/math/base/special/powm1/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/powm1/README.md
@@ -92,21 +92,17 @@ y = powm1( 5.0, NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var powm1 = require( '@stdlib/math/base/special/powm1' );
 
-var b;
-var x;
-var y;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var b = discreteUniform( 100, 0, 10, opts );
+var x = discreteUniform( 100, -5, 5, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    b = round( randu()*10.0 );
-    x = round( randu()*10.0 ) - 5.0;
-    y = powm1( b, x );
-    console.log( '%d^%d - 1 = %d', b, x, y );
-}
+logEachMap( '%d^%d - 1 = %0.4f', b, x, powm1 );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/powm1/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/powm1/examples/index.js
@@ -18,18 +18,14 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var powm1 = require( './../lib' );
 
-var b;
-var x;
-var y;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var b = discreteUniform( 100, 0, 10, opts );
+var x = discreteUniform( 100, -5, 5, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	b = round( randu()*10.0 );
-	x = round( randu()*10.0 ) - 5.0;
-	y = powm1( b, x );
-	console.log( '%d^%d - 1 = %d', b, x, y );
-}
+logEachMap( '%d^%d - 1 = %0.4f', b, x, powm1 );

--- a/lib/node_modules/@stdlib/math/base/special/rad2deg/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/rad2deg/README.md
@@ -71,19 +71,17 @@ d = rad2deg( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var rad2deg = require( '@stdlib/math/base/special/rad2deg' );
 
-var r;
-var d;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var r = uniform( 100, 0.0, TWO_PI, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    r = randu() * TWO_PI;
-    d = rad2deg( r );
-    console.log( 'radians: %d => degrees: %d', r, d );
-}
+logEachMap( 'radians: %0.4f => degrees: %0.4f', r, rad2deg );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/rad2deg/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/rad2deg/examples/index.js
@@ -18,16 +18,14 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var rad2deg = require( './../lib' );
 
-var r;
-var d;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var r = uniform( 100, 0.0, TWO_PI, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	r = randu() * TWO_PI;
-	d = rad2deg( r );
-	console.log( 'radians: %d => degrees: %d', r, d );
-}
+logEachMap( 'radians: %0.4f => degrees: %0.4f', r, rad2deg );

--- a/lib/node_modules/@stdlib/math/base/special/rad2degf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/rad2degf/README.md
@@ -71,19 +71,17 @@ d = rad2degf( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var TWO_PI = require( '@stdlib/constants/float32/two-pi' );
 var rad2degf = require( '@stdlib/math/base/special/rad2degf' );
 
-var r;
-var d;
-var i;
+var opts = {
+    'dtype': 'float32'
+};
+var r = uniform( 100, 0.0, TWO_PI, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    r = randu() * TWO_PI;
-    d = rad2degf( r );
-    console.log( 'radians: %d => degrees: %d', r, d );
-}
+logEachMap( 'radians: %0.4f => degrees: %0.4f', r, rad2degf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/rad2degf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/rad2degf/examples/index.js
@@ -18,16 +18,14 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var TWO_PI = require( '@stdlib/constants/float32/two-pi' );
 var rad2degf = require( './../lib' );
 
-var r;
-var d;
-var i;
+var opts = {
+	'dtype': 'float32'
+};
+var r = uniform( 100, 0.0, TWO_PI, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	r = randu() * TWO_PI;
-	d = rad2degf( r );
-	console.log( 'radians: %d => degrees: %d', r, d );
-}
+logEachMap( 'radians: %0.4f => degrees: %0.4f', r, rad2degf );

--- a/lib/node_modules/@stdlib/math/base/special/rcbrt/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/rcbrt/README.md
@@ -86,15 +86,16 @@ v = rcbrt( Infinity );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var rcbrt = require( '@stdlib/math/base/special/rcbrt' );
 
-var x;
-var i;
-for ( i = 0; i < 100; i++ ) {
-    x = discreteUniform( 0.0, 100.0 );
-    console.log( 'rcbrt(%d) = %d', x, rcbrt( x ) );
-}
+var opts = {
+    'dtype': 'float64'
+};
+var x = discreteUniform( 100, 0, 100, opts );
+
+logEachMap( 'rcbrt(%d) = %0.4f', x, rcbrt );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/rcbrt/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/rcbrt/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var rcbrt = require( './../lib' );
 
-var x;
-var i;
-for ( i = 0; i < 100; i++ ) {
-	x = discreteUniform( 0.0, 100.0 );
-	console.log( 'rcbrt(%d) = %d', x, rcbrt( x ) );
-}
+var opts = {
+	'dtype': 'float64'
+};
+var x = discreteUniform( 100, 0, 100, opts );
+
+logEachMap( 'rcbrt(%d) = %0.4f', x, rcbrt );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `math/base/special/polygamma`, `math/base/special/pow`, `math/base/special/powm1`, `math/base/special/rad2deg`, `math/base/special/rad2degf` and `math/base/special/rcbrt` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
