### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/rcbrtf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/rcbrtf/README.md
@@ -86,15 +86,16 @@ v = rcbrtf( Infinity );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var rcbrtf = require( '@stdlib/math/base/special/rcbrtf' );
 
-var x;
-var i;
-for ( i = 0; i < 100; i++ ) {
-    x = discreteUniform( 0.0, 100.0 );
-    console.log( 'rcbrtf(%d) = %d', x, rcbrtf( x ) );
-}
+var opts = {
+    'dtype': 'float32'
+};
+var x = discreteUniform( 100, 0, 100, opts );
+
+logEachMap( 'rcbrtf(%d) = %0.4f', x, rcbrtf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/rcbrtf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/rcbrtf/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var rcbrtf = require( './../lib' );
 
-var x;
-var i;
-for ( i = 0; i < 100; i++ ) {
-	x = discreteUniform( 0.0, 100.0 );
-	console.log( 'rcbrtf(%d) = %d', x, rcbrtf( x ) );
-}
+var opts = {
+	'dtype': 'float32'
+};
+var x = discreteUniform( 100, 0, 100, opts );
+
+logEachMap( 'rcbrtf(%d) = %0.4f', x, rcbrtf );

--- a/lib/node_modules/@stdlib/math/base/special/round/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/round/README.md
@@ -90,16 +90,16 @@ v = round( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var round = require( '@stdlib/math/base/special/round' );
 
-var x;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = (randu()*100.0) - 50.0;
-    console.log( 'Value: %d. Rounded: %d.', x, round( x ) );
-}
+logEachMap( 'Value: %0.4f. Rounded: %0.4f.', x, round );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/round/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/round/examples/index.js
@@ -18,13 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var round = require( './../lib' );
 
-var x;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = (randu()*100.0) - 50.0;
-	console.log( 'Value: %d. Rounded: %d.', x, round( x ) );
-}
+logEachMap( 'Value: %0.4f. Rounded: %0.4f.', x, round );

--- a/lib/node_modules/@stdlib/math/base/special/round10/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/round10/README.md
@@ -83,18 +83,16 @@ v = round10( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var round10 = require( '@stdlib/math/base/special/round10' );
 
-var x;
-var v;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = (randu()*100.0) - 50.0;
-    v = round10( x );
-    console.log( 'Value: %d. Rounded: %d.', x, v );
-}
+logEachMap( 'x: %0.4f. Rounded: %0.4f.', x, round10 );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/round10/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/round10/examples/index.js
@@ -23,7 +23,7 @@ var logEachMap = require( '@stdlib/console/log-each-map' );
 var round10 = require( './../lib' );
 
 var opts = {
-    'dtype': 'float64'
+	'dtype': 'float64'
 };
 var x = uniform( 100, -50.0, 50.0, opts );
 

--- a/lib/node_modules/@stdlib/math/base/special/round10/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/round10/examples/index.js
@@ -18,15 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var round10 = require( './../lib' );
 
-var x;
-var v;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = (randu()*100.0) - 50.0;
-	v = round10( x );
-	console.log( 'x: %d. Rounded: %d.', x, v );
-}
+logEachMap( 'x: %0.4f. Rounded: %0.4f.', x, round10 );

--- a/lib/node_modules/@stdlib/math/base/special/round2/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/round2/README.md
@@ -83,18 +83,16 @@ v = round2( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var round2 = require( '@stdlib/math/base/special/round2' );
 
-var x;
-var v;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = (randu()*100.0) - 50.0;
-    v = round2( x );
-    console.log( 'Value: %d. Rounded: %d.', x, v );
-}
+logEachMap( 'x: %0.4f. Rounded: %0.4f.', x, round2 );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/round2/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/round2/examples/index.js
@@ -18,15 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var round2 = require( './../lib' );
 
-var x;
-var v;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = (randu()*100.0) - 50.0;
-	v = round2( x );
-	console.log( 'x: %d. Rounded: %d.', x, v );
-}
+logEachMap( 'x: %0.4f. Rounded: %0.4f.', x, round2 );

--- a/lib/node_modules/@stdlib/math/base/special/round2/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/round2/examples/index.js
@@ -23,7 +23,7 @@ var logEachMap = require( '@stdlib/console/log-each-map' );
 var round2 = require( './../lib' );
 
 var opts = {
-    'dtype': 'float64'
+	'dtype': 'float64'
 };
 var x = uniform( 100, -50.0, 50.0, opts );
 

--- a/lib/node_modules/@stdlib/math/base/special/roundf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/README.md
@@ -90,16 +90,16 @@ v = roundf( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var roundf = require( '@stdlib/math/base/special/roundf' );
 
-var x;
-var i;
+var opts = {
+    'dtype': 'float32'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = ( randu() * 100.0 ) - 50.0;
-    console.log( 'Value: %d. Rounded: %d.', x, roundf( x ) );
-}
+logEachMap( 'Value: %0.4f. Rounded: %0.4f.', x, roundf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/roundf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundf/examples/index.js
@@ -18,13 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var roundf = require( './../lib' );
 
-var x;
-var i;
+var opts = {
+	'dtype': 'float32'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = ( randu() * 100.0) - 50.0;
-	console.log( 'Value: %d. Rounded: %d.', x, roundf( x ) );
-}
+logEachMap( 'Value: %0.4f. Rounded: %0.4f.', x, roundf );

--- a/lib/node_modules/@stdlib/math/base/special/roundn/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/roundn/README.md
@@ -78,20 +78,18 @@ v = roundn( 12368.0, 3 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var roundn = require( '@stdlib/math/base/special/roundn' );
 
-var x;
-var n;
-var v;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
+var n = discreteUniform( 100, -5, 0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = (randu()*100.0) - 50.0;
-    n = roundn( randu()*5.0, 0 );
-    v = roundn( x, -n );
-    console.log( 'x: %d. Number of decimals: %d. Rounded: %d.', x, n, v );
-}
+logEachMap( 'x: %0.4f. Number of decimals: %d. Rounded: %0.4f.', x, n, roundn );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/roundn/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundn/examples/index.js
@@ -18,17 +18,15 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var roundn = require( './../lib' );
 
-var x;
-var n;
-var v;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
+var n = discreteUniform( 100, -5, 0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = (randu()*100.0) - 50.0;
-	n = roundn( randu()*5.0, 0 );
-	v = roundn( x, -n );
-	console.log( 'x: %d. Number of decimals: %d. Rounded: %d.', x, n, v );
-}
+logEachMap( 'x: %0.4f. Number of decimals: %d. Rounded: %0.4f.', x, n, roundn );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `math/base/special/rcbrtf`, `math/base/special/round`, `math/base/special/round2`, `math/base/special/round10`, `math/base/special/roundf` and `math/base/special/roundn` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
