### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/roundsd/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/roundsd/README.md
@@ -69,18 +69,16 @@ var v = roundsd( 0.0313, 2, 2 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var roundsd = require( '@stdlib/math/base/special/roundsd' );
 
-var x;
-var y;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -5000.0, 5000.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = (randu()*10000.0) - 5000.0;
-    y = roundsd( x, 5 );
-    console.log( 'x: %d. Rounded: %d.', x, y );
-}
+logEachMap( 'x: %0.4f. y: %d. Rounded: %0.4f.', x, 5, roundsd );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/roundsd/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/roundsd/examples/index.js
@@ -18,15 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var roundsd = require( './../lib' );
 
-var x;
-var y;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -5000.0, 5000.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = (randu()*10000.0) - 5000.0;
-	y = roundsd( x, 5 );
-	console.log( 'x: %d. Rounded: %d.', x, y );
-}
+logEachMap( 'x: %0.4f. y: %d. Rounded: %0.4f.', x, 5, roundsd );

--- a/lib/node_modules/@stdlib/math/base/special/rsqrt/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/rsqrt/README.md
@@ -93,17 +93,16 @@ var v = rsqrt( -4.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var rsqrt = require( '@stdlib/math/base/special/rsqrt' );
 
-var x;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = round( randu() * 100.0 );
-    console.log( 'rsqrt(%d) = %d', x, rsqrt( x ) );
-}
+logEachMap( 'rsqrt(%d) = %0.4f', x, rsqrt );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/rsqrt/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/rsqrt/examples/index.js
@@ -18,14 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var rsqrt = require( './../lib' );
 
-var x;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = round( randu() * 100.0 );
-	console.log( 'rsqrt(%d) = %d', x, rsqrt( x ) );
-}
+logEachMap( 'rsqrt(%d) = %0.4f', x, rsqrt );

--- a/lib/node_modules/@stdlib/math/base/special/rsqrtf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/rsqrtf/README.md
@@ -90,17 +90,16 @@ var v = rsqrtf( -4.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var rsqrtf = require( '@stdlib/math/base/special/rsqrtf' );
 
-var x;
-var i;
+var opts = {
+    'dtype': 'float32'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = round( randu() * 100.0 );
-    console.log( 'rsqrt(%d) = %d', x, rsqrtf( x ) );
-}
+logEachMap( 'rsqrt(%d) = %0.4f', x, rsqrtf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/rsqrtf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/rsqrtf/examples/index.js
@@ -18,14 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var rsqrtf = require( './../lib' );
 
-var x;
-var i;
+var opts = {
+	'dtype': 'float32'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = round( randu() * 100.0 );
-	console.log( 'rsqrt(%d) = %d', x, rsqrtf( x ) );
-}
+logEachMap( 'rsqrt(%d) = %0.4f', x, rsqrtf );

--- a/lib/node_modules/@stdlib/math/base/special/signum/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/signum/README.md
@@ -103,19 +103,16 @@ Table of results:
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var signum = require( '@stdlib/math/base/special/signum' );
 
-var sign;
-var x;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = discreteUniform( 100, -50, 50, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = round( randu()*100.0 ) - 50.0;
-    sign = signum( x );
-    console.log( 'signum(%d) = %d', x, sign );
-}
+logEachMap( 'signum(%d) = %0.4f', x, signum );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/signum/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/signum/examples/index.js
@@ -18,16 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var signum = require( './../lib' );
 
-var sign;
-var x;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = discreteUniform( 100, -50, 50, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = round( randu()*100.0 ) - 50.0;
-	sign = signum( x );
-	console.log( 'signum(%d) = %d', x, sign );
-}
+logEachMap( 'signum(%d) = %0.4f', x, signum );

--- a/lib/node_modules/@stdlib/math/base/special/signumf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/signumf/README.md
@@ -103,19 +103,16 @@ Table of results:
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var signumf = require( '@stdlib/math/base/special/signumf' );
 
-var sign;
-var x;
-var i;
+var opts = {
+    'dtype': 'float32'
+};
+var x = discreteUniform( 100, -50, 50, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = round( randu()*100.0 ) - 50.0;
-    sign = signumf( x );
-    console.log( 'signum(%d) = %d', x, sign );
-}
+logEachMap( 'signum(%d) = %0.4f', x, signumf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/signumf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/signumf/examples/index.js
@@ -18,16 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var signumf = require( './../lib' );
 
-var sign;
-var x;
-var i;
+var opts = {
+	'dtype': 'float32'
+};
+var x = discreteUniform( 100, -50, 50, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = round( randu()*100.0 ) - 50.0;
-	sign = signumf( x );
-	console.log( 'signum(%d) = %d', x, sign );
-}
+logEachMap( 'signum(%d) = %0.4f', x, signumf );

--- a/lib/node_modules/@stdlib/math/base/special/spence/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/spence/README.md
@@ -99,16 +99,16 @@ var v = spence( -4.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var spence = require( '@stdlib/math/base/special/spence' );
 
-var x;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, 0.0, 100.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = randu() * 100.0;
-    console.log( 'spence( %d ) = %d', x, spence( x ) );
-}
+logEachMap( 'spence( %0.4f ) = %0.4f', x, spence );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/spence/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/spence/examples/index.js
@@ -18,13 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var spence = require( './../lib' );
 
-var x;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, 0.0, 100.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = randu() * 100.0;
-	console.log( 'spence( %d ) = %d', x, spence( x ) );
-}
+logEachMap( 'spence( %0.4f ) = %0.4f', x, spence );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `math/base/special/roundsd`, `math/base/special/rsqrt`, `math/base/special/rsqrtf`, `math/base/special/signum`, `math/base/special/signumf` and `math/base/special/spence` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
