### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/sqrt/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/sqrt/README.md
@@ -87,17 +87,16 @@ var v = sqrt( -4.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
 
-var x;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = round( randu() * 100.0 );
-    console.log( 'sqrt(%d) = %d', x, sqrt( x ) );
-}
+logEachMap( 'sqrt(%d) = %0.4f', x, sqrt );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/sqrt/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/sqrt/examples/index.js
@@ -18,14 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var sqrt = require( './../lib' );
 
-var x;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = round( randu() * 100.0 );
-	console.log( 'sqrt(%d) = %d', x, sqrt( x ) );
-}
+logEachMap( 'sqrt(%d) = %0.4f', x, sqrt );

--- a/lib/node_modules/@stdlib/math/base/special/sqrt1pm1/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/sqrt1pm1/README.md
@@ -32,7 +32,7 @@ var sqrt1pm1 = require( '@stdlib/math/base/special/sqrt1pm1' );
 
 #### sqrt1pm1( x )
 
-Computes `sqrt( 1 + x ) - 1` more accurately for small `x`. 
+Computes `sqrt( 1 + x ) - 1` more accurately for small `x`.
 
 ```javascript
 var v = sqrt1pm1( 3.0 );
@@ -109,7 +109,7 @@ logEachMap( 'sqrt(1+%d) - 1 = %0.4f', x, sqrt1pm1 );
 
 #### stdlib_base_sqrt1pm1( x )
 
-Computes `sqrt( 1 + x ) - 1` more accurately for small `x`. 
+Computes `sqrt( 1 + x ) - 1` more accurately for small `x`.
 
 ```c
 double out = stdlib_base_sqrt1pm1( 3.0 );

--- a/lib/node_modules/@stdlib/math/base/special/sqrt1pm1/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/sqrt1pm1/README.md
@@ -65,17 +65,16 @@ v = sqrt1pm1( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var sqrt1pm1 = require( '@stdlib/math/base/special/sqrt1pm1' );
 
-var x;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = round( randu() * 100.0 );
-    console.log( 'sqrt(1+%d) - 1 = %d', x, sqrt1pm1( x ) );
-}
+logEachMap( 'sqrt(1+%d) - 1 = %0.4f', x, sqrt1pm1 );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/sqrt1pm1/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/sqrt1pm1/examples/index.js
@@ -18,14 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var sqrt1pm1 = require( './../lib' );
 
-var x;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = round( randu() * 100.0 );
-	console.log( 'sqrt(1+%d) - 1 = %d', x, sqrt1pm1( x ) );
-}
+logEachMap( 'sqrt(1+%d) - 1 = %0.4f', x, sqrt1pm1 );

--- a/lib/node_modules/@stdlib/math/base/special/sqrtf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/sqrtf/README.md
@@ -87,17 +87,16 @@ var v = sqrtf( -4.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var sqrtf = require( '@stdlib/math/base/special/sqrtf' );
 
-var x;
-var i;
+var opts = {
+    'dtype': 'float32'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = round( randu() * 100.0 );
-    console.log( 'sqrt(%d) = %d', x, sqrtf( x ) );
-}
+logEachMap( 'sqrt(%d) = %0.4f', x, sqrtf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/sqrtf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/sqrtf/examples/index.js
@@ -18,14 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var sqrtf = require( './../lib' );
 
-var x;
-var i;
+var opts = {
+	'dtype': 'float32'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = round( randu() * 100.0 );
-	console.log( 'sqrt(%d) = %d', x, sqrtf( x ) );
-}
+logEachMap( 'sqrt(%d) = %0.4f', x, sqrtf );

--- a/lib/node_modules/@stdlib/math/base/special/sqrtpi/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/sqrtpi/README.md
@@ -66,16 +66,16 @@ var v = sqrtpi( -4.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var sqrtpi = require( '@stdlib/math/base/special/sqrtpi' );
 
-var x;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = discreteUniform( 0, 100 );
-    console.log( 'sqrtpi(%d) = %d', x, sqrtpi( x ) );
-}
+logEachMap( 'sqrtpi(%d) = %0.4f', x, sqrtpi );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/sqrtpi/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/sqrtpi/examples/index.js
@@ -18,13 +18,13 @@
 
 'use strict';
 
-var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var sqrtpi = require( './../lib' );
 
-var x;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = discreteUniform( 0, 100 );
-	console.log( 'sqrtpi(%d) = %d', x, sqrtpi( x ) );
-}
+logEachMap( 'sqrtpi(%d) = %0.4f', x, sqrtpi );

--- a/lib/node_modules/@stdlib/math/base/special/sqrtpif/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/sqrtpif/README.md
@@ -66,15 +66,16 @@ var v = sqrtpif( -4.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/array/discrete-uniform' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var sqrtpif = require( '@stdlib/math/base/special/sqrtpif' );
 
-var x = randu( 100, 0.0, 100.0 );
+var opts = {
+    'dtype': 'float32'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-var i;
-for ( i = 0; i < 100; i++ ) {
-    console.log( 'sqrtpif(%d) = %d', x[ i ], sqrtpif( x[ i ] ) );
-}
+logEachMap( 'sqrtpif(%d) = %0.4f', x, sqrtpif );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/sqrtpif/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/sqrtpif/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/array/discrete-uniform' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var sqrtpif = require( './../lib' );
 
-var x = randu( 100, 0.0, 100.0 );
+var opts = {
+	'dtype': 'float32'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-var i;
-for ( i = 0; i < 100; i++ ) {
-	console.log( 'sqrtpif(%d) = %d', x[ i ], sqrtpif( x[ i ] ) );
-}
+logEachMap( 'sqrtpif(%d) = %0.4f', x, sqrtpif );

--- a/lib/node_modules/@stdlib/math/base/special/trigamma/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/trigamma/README.md
@@ -97,18 +97,16 @@ var v = trigamma( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var trigamma = require( '@stdlib/math/base/special/trigamma' );
 
-var x;
-var v;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    x = (randu()*100.0) - 50.0;
-    v = trigamma( x );
-    console.log( 'x: %d, ψ^(1)(x): %d', x, v );
-}
+logEachMap( 'x: %0.4f, ψ^(1)(x): %0.4f', x, trigamma );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/trigamma/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/trigamma/examples/index.js
@@ -18,15 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var trigamma = require( './../lib' );
 
-var x;
-var v;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = (randu()*100.0) - 50.0;
-	v = trigamma( x );
-	console.log( 'x: %d, ψ^(1)(x): %d', x, v );
-}
+logEachMap( 'x: %0.4f, ψ^(1)(x): %0.4f', x, trigamma );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `math/base/special/sqrt`, `math/base/special/sqrtf`, `math/base/special/sqrt1pm1`, `math/base/special/sqrtpi`, `math/base/special/sqrtpif` and `math/base/special/trigamma` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
