### PR TITLE
chore: resolve lint errors in `random/base/minstd`

### DIFF
--- a/lib/node_modules/@stdlib/random/base/minstd/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/random/base/minstd/docs/types/test.ts
@@ -86,7 +86,7 @@ import minstd = require( './index' );
 	minstd.factory( { 'state': null } ); // $ExpectError
 	minstd.factory( { 'state': [] } ); // $ExpectError
 	minstd.factory( { 'state': {} } ); // $ExpectError
-	minstd.factory( { 'state': true ); // $ExpectError
+	minstd.factory( { 'state': true } ); // $ExpectError
 	minstd.factory( { 'state': ( x: number ): number => x } ); // $ExpectError
 }
 

--- a/lib/node_modules/@stdlib/random/base/minstd/lib/main.js
+++ b/lib/node_modules/@stdlib/random/base/minstd/lib/main.js
@@ -75,17 +75,14 @@ var randint32 = require( './rand_int32.js' );
 *
 * The values for \\( a \\), \\( c \\), and \\( m \\) are taken from Park and Miller, "Random Number Generators: Good Ones Are Hard To Find". Park's and Miller's article is also the basis for a recipe in the second edition of _Numerical Recipes in C_.
 *
-*
 * ## Notes
 *
 * -   The generator has a period of approximately \\(2.1\mbox{e}9\\) (see [Numerical Recipes in C, 2nd Edition](#references), p. 279).
-*
 *
 * ## References
 *
 * -   Park, S. K., and K. W. Miller. 1988. "Random Number Generators: Good Ones Are Hard to Find." _Communications of the ACM_ 31 (10). New York, NY, USA: ACM: 1192–1201. doi:[10.1145/63039.63042](http://dx.doi.org/10.1145/63039.63042).
 * -   Press, William H., Brian P. Flannery, Saul A. Teukolsky, and William T. Vetterling. 1992. _Numerical Recipes in C: The Art of Scientific Computing, Second Edition_. Cambridge University Press.
-*
 *
 * @function minstd
 * @type {PRNG}

--- a/lib/node_modules/@stdlib/random/base/minstd/manifest.json
+++ b/lib/node_modules/@stdlib/random/base/minstd/manifest.json
@@ -1,40 +1,40 @@
 {
-	"options": {},
-	"fields": [
-		{
-			"field": "src",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "include",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "libraries",
-			"resolve": false,
-			"relative": false
-		},
-		{
-			"field": "libpath",
-			"resolve": true,
-			"relative": false
-		}
-	],
-	"confs": [
-		{
-			"src": [
-				"./src/main.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [],
-			"libpath": [],
-			"dependencies": [
-				"@stdlib/random/base/shared"
-			]
-		}
-	]
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/random/base/shared"
+      ]
+    }
+  ]
 }

--- a/lib/node_modules/@stdlib/random/base/minstd/test/test.factory.js
+++ b/lib/node_modules/@stdlib/random/base/minstd/test/test.factory.js
@@ -32,6 +32,7 @@ var Int32Array = require( '@stdlib/array/int32' );
 var kstest = require( '@stdlib/stats/kstest' );
 var gcopy = require( '@stdlib/blas/base/gcopy' );
 var typedarray2json = require( '@stdlib/array/to-json' );
+var zeros = require( '@stdlib/array/base/zeros' );
 var factory = require( './../lib/factory.js' );
 
 
@@ -1094,7 +1095,7 @@ tape( 'the `normalized` method returns pseudorandom numbers drawn from a uniform
 
 	threshold = 0.10;
 
-	x = new Array( 1e3 ); // eslint-disable-line stdlib/no-new-array
+	x = zeros( 1e3 );
 	N = 500;
 
 	count = -1;

--- a/lib/node_modules/@stdlib/random/base/minstd/test/test.factory.js
+++ b/lib/node_modules/@stdlib/random/base/minstd/test/test.factory.js
@@ -1094,7 +1094,7 @@ tape( 'the `normalized` method returns pseudorandom numbers drawn from a uniform
 
 	threshold = 0.10;
 
-	x = new Array( 1e3 );
+	x = new Array( 1e3 ); // eslint-disable-line stdlib/no-new-array
 	N = 500;
 
 	count = -1;


### PR DESCRIPTION
Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

-   Resolves some lint errors and a syntax error in `random/base/minstd`.

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

Why is `new Array(1e3)` is flagged by the linter? Are there any better way to define an array of a given size?

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
