### PR TITLE
feat: add functional equivalent of `Array.prototype.copyWithin` and `TypedArray.prototype.copyWithin`

### DIFF
--- a/lib/node_modules/@stdlib/utils/copy-within/README.md
+++ b/lib/node_modules/@stdlib/utils/copy-within/README.md
@@ -1,0 +1,190 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2025 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# copyWithin
+
+> Copy a sequence of elements within a collection to another location in the same collection.
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var copyWithin = require( '@stdlib/utils/copy-within' );
+```
+
+#### copyWithin( collection, target\[, start\[, end]] )
+
+Copies a sequence of elements within a collection to another location in the same collection.
+
+```javascript
+var arr = [ 1, 2, 3, 4, 5 ];
+
+var out = copyWithin( arr, 0, 3 );
+// returns [ 4, 5, 3, 4, 5 ]
+```
+
+The function accepts the following arguments:
+
+-   **collection**: the input collection.
+-   **target**: target index (zero-based).
+-   **start**: source start index (zero-based). Default: 0.
+-   **end**: source end index (zero-based, non-inclusive). Default: collection.length.
+
+If a provided collection has a built-in `copyWithin` method (e.g., [Array.prototype.copyWithin][mdn-copy-within] or [TypedArray.prototype.copyWithin][mdn-typed-array-copy-within]), the function defers to that method. Otherwise, the function provides a polyfill, thus extending `copyWithin` support to environments lacking the built-in API for Array and TypedArray.
+
+The function supports negative indices, which are interpreted as being relative to the end of the collection. For example, if provided `-2` for `target`, the function interprets the index as `collection.length - 2`.
+
+```javascript
+var arr = [ 1, 2, 3, 4, 5 ];
+
+var out = copyWithin( arr, -2, -3, -1 );
+// returns [ 1, 2, 3, 3, 4 ]
+```
+
+If `target` is greater than or equal to the collection length, nothing is copied. If `target` is positioned after `start` after normalization, copying only happens until the end of the collection length (in other words, `copyWithin` never extends the collection).
+
+```javascript
+var arr = [ 1, 2, 3, 4, 5 ];
+
+var out = copyWithin( arr, 10, 0 );
+// returns [ 1, 2, 3, 4, 5 ]
+```
+
+If `start` is greater than or equal to the collection length, nothing is copied.
+
+```javascript
+var arr = [ 1, 2, 3, 4, 5 ];
+
+var out = copyWithin( arr, 0, 10 );
+// returns [ 1, 2, 3, 4, 5 ]
+```
+
+For Uint8Array inputs, the function uses an optimized implementation that copies in 4-byte increments when possible, providing better performance for large arrays.
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+## Notes
+
+-   The function works like the built-in `Array.prototype.copyWithin` and `TypedArray.prototype.copyWithin` methods but extends support to all collection types.
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var copyWithin = require( '@stdlib/utils/copy-within' );
+
+// Regular arrays:
+var arr = [ 1, 2, 3, 4, 5 ];
+console.log( copyWithin( arr, 0, 3 ) );
+// => [ 4, 5, 3, 4, 5 ]
+
+arr = [ 1, 2, 3, 4, 5 ];
+console.log( copyWithin( arr, 0, 3, 4 ) );
+// => [ 4, 2, 3, 4, 5 ]
+
+arr = [ 1, 2, 3, 4, 5 ];
+console.log( copyWithin( arr, -2, -3, -1 ) );
+// => [ 1, 2, 3, 3, 4 ]
+
+// Typed arrays:
+var Uint8Array = require( '@stdlib/array/uint8' );
+var typed = new Uint8Array( [ 1, 2, 3, 4, 5 ] );
+console.log( copyWithin( typed, 0, 3 ) );
+// => <Uint8Array>[ 4, 5, 3, 4, 5 ]
+
+// Array-like objects:
+var obj = {
+    'length': 5,
+    '0': 1,
+    '1': 2,
+    '2': 3,
+    '3': 4,
+    '4': 5
+};
+console.log( copyWithin( obj, 0, 3 ) );
+// => { '0': 4, '1': 5, '2': 3, '3': 4, '4': 5, 'length': 5 }
+```
+
+</section>
+
+<!-- /.examples -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/utils/copy`][@stdlib/utils/copy]</span><span class="delimiter">: </span><span class="description">copy or deep clone a value to an arbitrary depth.</span>
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[mdn-copy-within]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/copyWithin
+[mdn-typed-array-copy-within]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/copyWithin
+
+<!-- <related-links> -->
+
+[@stdlib/utils/copy]: https://github.com/stdlib-js/utils-copy
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/utils/copy-within/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/utils/copy-within/benchmark/benchmark.js
@@ -1,0 +1,290 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var Int8Array = require( '@stdlib/array/int8' );
+var Uint8Array = require( '@stdlib/array/uint8' );
+var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
+var Int16Array = require( '@stdlib/array/int16' );
+var Uint16Array = require( '@stdlib/array/uint16' );
+var Int32Array = require( '@stdlib/array/int32' );
+var Uint32Array = require( '@stdlib/array/uint32' );
+var Float32Array = require( '@stdlib/array/float32' );
+var Float64Array = require( '@stdlib/array/float64' );
+var isArray = require( '@stdlib/assert/is-array' );
+var pkg = require( './../package.json' ).name;
+var copyWithin = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg+'::array', function benchmark( b ) {
+	var arr;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = [ i, i+1, i+2, i+3, i+4, i+5, i+6, i+7, i+8, i+9 ];
+		arr = copyWithin( arr, 0, 5 );
+		if ( !isArray( arr ) ) {
+			b.fail( 'should return an array' );
+		}
+	}
+	b.toc();
+	if ( !isArray( arr ) ) {
+		b.fail( 'should return an array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::array_with_built_in', function benchmark( b ) {
+	var arr;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = [ i, i+1, i+2, i+3, i+4, i+5, i+6, i+7, i+8, i+9 ];
+		arr = arr.copyWithin( 0, 5 );
+		if ( !isArray( arr ) ) {
+			b.fail( 'should return an array' );
+		}
+	}
+	b.toc();
+	if ( !isArray( arr ) ) {
+		b.fail( 'should return an array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::array_like_object', function benchmark( b ) {
+	var arr;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = {
+			'0': i,
+			'1': i+1,
+			'2': i+2,
+			'3': i+3,
+			'4': i+4,
+			'5': i+5,
+			'6': i+6,
+			'7': i+7,
+			'8': i+8,
+			'9': i+9,
+			'length': 10
+		};
+		arr = copyWithin( arr, 0, 5 );
+		if ( typeof arr !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+	if ( typeof arr !== 'object' ) {
+		b.fail( 'should return an object' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::int8array', function benchmark( b ) {
+	var arr;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = new Int8Array( [ i, i+1, i+2, i+3, i+4, i+5, i+6, i+7, i+8, i+9 ] ); // eslint-disable-line max-len
+		arr = copyWithin( arr, 0, 5 );
+		if ( !(arr instanceof Int8Array) ) {
+			b.fail( 'should return an Int8Array' );
+		}
+	}
+	b.toc();
+	if ( !(arr instanceof Int8Array) ) {
+		b.fail( 'should return an Int8Array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::uint8array', function benchmark( b ) {
+	var arr;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = new Uint8Array( [ i, i+1, i+2, i+3, i+4, i+5, i+6, i+7, i+8, i+9 ] ); // eslint-disable-line max-len
+		arr = copyWithin( arr, 0, 5 );
+		if ( !(arr instanceof Uint8Array) ) {
+			b.fail( 'should return a Uint8Array' );
+		}
+	}
+	b.toc();
+	if ( !(arr instanceof Uint8Array) ) {
+		b.fail( 'should return a Uint8Array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::uint8clamped_array', function benchmark( b ) {
+	var arr;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = new Uint8ClampedArray( [ i, i+1, i+2, i+3, i+4, i+5, i+6, i+7, i+8, i+9 ] ); // eslint-disable-line max-len
+		arr = copyWithin( arr, 0, 5 );
+		if ( !(arr instanceof Uint8ClampedArray) ) {
+			b.fail( 'should return a Uint8ClampedArray' );
+		}
+	}
+	b.toc();
+	if ( !(arr instanceof Uint8ClampedArray) ) {
+		b.fail( 'should return a Uint8ClampedArray' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::int16array', function benchmark( b ) {
+	var arr;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = new Int16Array( [ i, i+1, i+2, i+3, i+4, i+5, i+6, i+7, i+8, i+9 ] ); // eslint-disable-line max-len
+		arr = copyWithin( arr, 0, 5 );
+		if ( !(arr instanceof Int16Array) ) {
+			b.fail( 'should return an Int16Array' );
+		}
+	}
+	b.toc();
+	if ( !(arr instanceof Int16Array) ) {
+		b.fail( 'should return an Int16Array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::uint16array', function benchmark( b ) {
+	var arr;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = new Uint16Array( [ i, i+1, i+2, i+3, i+4, i+5, i+6, i+7, i+8, i+9 ] ); // eslint-disable-line max-len
+		arr = copyWithin( arr, 0, 5 );
+		if ( !(arr instanceof Uint16Array) ) {
+			b.fail( 'should return a Uint16Array' );
+		}
+	}
+	b.toc();
+	if ( !(arr instanceof Uint16Array) ) {
+		b.fail( 'should return a Uint16Array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::int32array', function benchmark( b ) {
+	var arr;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = new Int32Array( [ i, i+1, i+2, i+3, i+4, i+5, i+6, i+7, i+8, i+9 ] ); // eslint-disable-line max-len
+		arr = copyWithin( arr, 0, 5 );
+		if ( !(arr instanceof Int32Array) ) {
+			b.fail( 'should return an Int32Array' );
+		}
+	}
+	b.toc();
+	if ( !(arr instanceof Int32Array) ) {
+		b.fail( 'should return an Int32Array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::uint32array', function benchmark( b ) {
+	var arr;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = new Uint32Array( [ i, i+1, i+2, i+3, i+4, i+5, i+6, i+7, i+8, i+9 ] ); // eslint-disable-line max-len
+		arr = copyWithin( arr, 0, 5 );
+		if ( !(arr instanceof Uint32Array) ) {
+			b.fail( 'should return a Uint32Array' );
+		}
+	}
+	b.toc();
+	if ( !(arr instanceof Uint32Array) ) {
+		b.fail( 'should return a Uint32Array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::float32array', function benchmark( b ) {
+	var arr;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = new Float32Array( [ i, i+1, i+2, i+3, i+4, i+5, i+6, i+7, i+8, i+9 ] ); // eslint-disable-line max-len
+		arr = copyWithin( arr, 0, 5 );
+		if ( !(arr instanceof Float32Array) ) {
+			b.fail( 'should return a Float32Array' );
+		}
+	}
+	b.toc();
+	if ( !(arr instanceof Float32Array) ) {
+		b.fail( 'should return a Float32Array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::float64array', function benchmark( b ) {
+	var arr;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		arr = new Float64Array( [ i, i+1, i+2, i+3, i+4, i+5, i+6, i+7, i+8, i+9 ] ); // eslint-disable-line max-len
+		arr = copyWithin( arr, 0, 5 );
+		if ( !(arr instanceof Float64Array) ) {
+			b.fail( 'should return a Float64Array' );
+		}
+	}
+	b.toc();
+	if ( !(arr instanceof Float64Array) ) {
+		b.fail( 'should return a Float64Array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/utils/copy-within/docs/repl.txt
+++ b/lib/node_modules/@stdlib/utils/copy-within/docs/repl.txt
@@ -1,0 +1,55 @@
+{{alias}}( collection, target[, start[, end]] )
+    Copies a sequence of elements within a collection to another location in the
+    same collection.
+
+    Parameters
+    ----------
+    collection: Array|TypedArray|Object
+        Input collection.
+
+    target: integer
+        Target index (i.e., the index at which to start copying elements).
+
+    start: integer (optional)
+        Source start index (i.e., the index from which to start copying
+        elements). Default: 0.
+
+    end: integer (optional)
+        Source end index (i.e., the index up to, but not including, which to
+        stop copying elements). Default: collection.length.
+
+    Returns
+    -------
+    out: Array|TypedArray|Object
+        Modified input collection.
+
+    Examples
+    --------
+    // Regular array:
+    > var arr = [ 1, 2, 3, 4, 5 ];
+    > var out = {{alias}}( arr, 0, 3 )
+    [ 4, 5, 3, 4, 5 ]
+    > arr = [ 1, 2, 3, 4, 5 ];
+    > out = {{alias}}( arr, 0, 3, 4 )
+    [ 4, 2, 3, 4, 5 ]
+    > arr = [ 1, 2, 3, 4, 5 ];
+    > out = {{alias}}( arr, -2, -3, -1 )
+    [ 1, 2, 3, 3, 4 ]
+
+    // Sparse array:
+    > arr = [ 1, , 3, 4, 5 ];
+    > out = {{alias}}( arr, 2, 0, 2 )
+    [ 1, , 1, , 5 ]
+
+    // Typed arrays:
+    > arr = new Int8Array( [ 1, 2, 3, 4, 5 ] );
+    > out = {{alias}}( arr, 0, 3 )
+    <Int8Array>[ 4, 5, 3, 4, 5 ]
+
+    // Array-like object:
+    > arr = { '0': 1, '1': 2, '2': 3, '3': 4, '4': 5, 'length': 5 };
+    > out = {{alias}}( arr, 0, 3 )
+    { '0': 4, '1': 5, '2': 3, '3': 4, '4': 5, 'length': 5 }
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/utils/copy-within/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/utils/copy-within/docs/types/index.d.ts
@@ -1,0 +1,63 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { Collection } from '@stdlib/types/array';
+
+/**
+* Copies a sequence of elements within a collection to another location in the same collection.
+*
+* @param collection - input collection
+* @param target - target index
+* @param start - source start index (default: 0)
+* @param end - source end index (default: collection.length)
+* @returns modified input collection
+*
+* @example
+* var arr = [ 1, 2, 3, 4, 5 ];
+* var out = copyWithin( arr, 0, 3 );
+* // returns [ 4, 5, 3, 4, 5 ]
+*
+* @example
+* var arr = [ 1, 2, 3, 4, 5 ];
+* var out = copyWithin( arr, 0, 3, 4 );
+* // returns [ 4, 2, 3, 4, 5 ]
+*
+* @example
+* var arr = [ 1, 2, 3, 4, 5 ];
+* var out = copyWithin( arr, -2, -3, -1 );
+* // returns [ 1, 2, 3, 3, 4 ]
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+*
+* var arr = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0 ] );
+* // returns <Float64Array>[ 1.0, 2.0, 3.0, 4.0, 5.0 ]
+*
+* var out = copyWithin( arr, 0, 3 );
+* // returns <Float64Array>[ 4.0, 5.0, 3.0, 4.0, 5.0 ]
+*/
+declare function copyWithin<T = unknown>( collection: Collection<T>, target: number, start?: number, end?: number ): Collection<T>;
+
+
+// EXPORTS //
+
+export = copyWithin;

--- a/lib/node_modules/@stdlib/utils/copy-within/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/utils/copy-within/docs/types/test.ts
@@ -1,0 +1,81 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import copyWithin = require( './index' );
+
+
+// TESTS //
+
+// The function returns a collection...
+{
+	const arr = [ 1, 2, 3, 4, 5 ];
+	copyWithin( arr, 0, 3 ); // $ExpectType Collection<number>
+
+	const typedArr = new Int8Array( [ 1, 2, 3, 4, 5 ] );
+	copyWithin( typedArr, 0, 3 ); // $ExpectType Collection<number>
+}
+
+// The compiler throws an error if the function is provided a first argument which is not a collection...
+{
+	copyWithin( 5, 0 ); // $ExpectError
+	copyWithin( true, 0 ); // $ExpectError
+	copyWithin( false, 0 ); // $ExpectError
+	copyWithin( null, 0 ); // $ExpectError
+	copyWithin( undefined, 0 ); // $ExpectError
+	copyWithin( {}, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument which is not a number...
+{
+	const arr = [ 1, 2, 3, 4, 5 ];
+	copyWithin( arr, '5' ); // $ExpectError
+	copyWithin( arr, true ); // $ExpectError
+	copyWithin( arr, false ); // $ExpectError
+	copyWithin( arr, [] ); // $ExpectError
+	copyWithin( arr, {} ); // $ExpectError
+	copyWithin( arr, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a third argument which is not a number...
+{
+	const arr = [ 1, 2, 3, 4, 5 ];
+	copyWithin( arr, 0, '5' ); // $ExpectError
+	copyWithin( arr, 0, true ); // $ExpectError
+	copyWithin( arr, 0, false ); // $ExpectError
+	copyWithin( arr, 0, [] ); // $ExpectError
+	copyWithin( arr, 0, {} ); // $ExpectError
+	copyWithin( arr, 0, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a fourth argument which is not a number...
+{
+	const arr = [ 1, 2, 3, 4, 5 ];
+	copyWithin( arr, 0, 0, '5' ); // $ExpectError
+	copyWithin( arr, 0, 0, true ); // $ExpectError
+	copyWithin( arr, 0, 0, false ); // $ExpectError
+	copyWithin( arr, 0, 0, [] ); // $ExpectError
+	copyWithin( arr, 0, 0, {} ); // $ExpectError
+	copyWithin( arr, 0, 0, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an invalid number of arguments...
+{
+	copyWithin(); // $ExpectError
+	copyWithin( [ 1, 2, 3 ] ); // $ExpectError
+	copyWithin( [ 1, 2, 3 ], 0, 0, 1, 2 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/utils/copy-within/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/copy-within/examples/index.js
@@ -1,0 +1,126 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var Uint8Array = require( '@stdlib/array/uint8' );
+var Int8Array = require( '@stdlib/array/int8' );
+var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
+var Int16Array = require( '@stdlib/array/int16' );
+var Uint16Array = require( '@stdlib/array/uint16' );
+var Int32Array = require( '@stdlib/array/int32' );
+var Uint32Array = require( '@stdlib/array/uint32' );
+var Float64Array = require( '@stdlib/array/float64' );
+var copyWithin = require( './../lib' );
+
+// Regular arrays:
+var arr = [ 1, 2, 3, 4, 5 ];
+console.log( 'Regular array:' );
+console.log( arr );
+console.log( copyWithin( arr, 0, 3 ) );
+// => [ 4, 5, 3, 4, 5 ]
+
+arr = [ 1, 2, 3, 4, 5 ];
+console.log( arr );
+console.log( copyWithin( arr, 0, 3, 4 ) );
+// => [ 4, 2, 3, 4, 5 ]
+
+arr = [ 1, 2, 3, 4, 5 ];
+console.log( arr );
+console.log( copyWithin( arr, -2, -3, -1 ) );
+// => [ 1, 2, 3, 3, 4 ]
+
+// Sparse arrays:
+arr = [ 1, , 3, 4, 5 ]; // eslint-disable-line no-sparse-arrays
+console.log( '\nSparse array:' );
+console.log( arr );
+console.log( copyWithin( arr, 2, 0, 2 ) );
+// => [ 1, , 1, , 5 ]
+
+// Typed arrays - demonstrating optimized implementations for all typed arrays:
+console.log( '\nTyped arrays (with optimized implementations):' );
+
+// Int8Array
+var int8Arr = new Int8Array( [ 1, 2, 3, 4, 5 ] );
+console.log( '\nInt8Array:' );
+console.log( int8Arr );
+console.log( copyWithin( int8Arr, 0, 3 ) );
+// => <Int8Array>[ 4, 5, 3, 4, 5 ]
+
+// Uint8Array
+var uint8Arr = new Uint8Array( [ 1, 2, 3, 4, 5 ] );
+console.log( '\nUint8Array:' );
+console.log( uint8Arr );
+console.log( copyWithin( uint8Arr, 0, 3 ) );
+// => <Uint8Array>[ 4, 5, 3, 4, 5 ]
+
+// Uint8ClampedArray
+var uint8cArr = new Uint8ClampedArray( [ 1, 2, 3, 4, 5 ] );
+console.log( '\nUint8ClampedArray:' );
+console.log( uint8cArr );
+console.log( copyWithin( uint8cArr, 0, 3 ) );
+// => <Uint8ClampedArray>[ 4, 5, 3, 4, 5 ]
+
+// Int16Array
+var int16Arr = new Int16Array( [ 1, 2, 3, 4, 5 ] );
+console.log( '\nInt16Array:' );
+console.log( int16Arr );
+console.log( copyWithin( int16Arr, 0, 3 ) );
+// => <Int16Array>[ 4, 5, 3, 4, 5 ]
+
+// Uint16Array
+var uint16Arr = new Uint16Array( [ 1, 2, 3, 4, 5 ] );
+console.log( '\nUint16Array:' );
+console.log( uint16Arr );
+console.log( copyWithin( uint16Arr, 0, 3 ) );
+// => <Uint16Array>[ 4, 5, 3, 4, 5 ]
+
+// Int32Array
+var int32Arr = new Int32Array( [ 1, 2, 3, 4, 5 ] );
+console.log( '\nInt32Array:' );
+console.log( int32Arr );
+console.log( copyWithin( int32Arr, 0, 3 ) );
+// => <Int32Array>[ 4, 5, 3, 4, 5 ]
+
+// Uint32Array
+var uint32Arr = new Uint32Array( [ 1, 2, 3, 4, 5 ] );
+console.log( '\nUint32Array:' );
+console.log( uint32Arr );
+console.log( copyWithin( uint32Arr, 0, 3 ) );
+// => <Uint32Array>[ 4, 5, 3, 4, 5 ]
+
+// Float64Array
+var float64Arr = new Float64Array( [ 1.1, 2.2, 3.3, 4.4, 5.5 ] );
+console.log( '\nFloat64Array:' );
+console.log( float64Arr );
+console.log( copyWithin( float64Arr, 0, 3 ) );
+// => <Float64Array>[ 4.4, 5.5, 3.3, 4.4, 5.5 ]
+
+// Array-like objects:
+var obj = {
+	'length': 5,
+	'0': 1,
+	'1': 2,
+	'2': 3,
+	'3': 4,
+	'4': 5
+};
+console.log( '\nArray-like object:' );
+console.log( obj );
+console.log( copyWithin( obj, 0, 3 ) );
+// => { '0': 4, '1': 5, '2': 3, '3': 4, '4': 5, 'length': 5 }

--- a/lib/node_modules/@stdlib/utils/copy-within/lib/index.js
+++ b/lib/node_modules/@stdlib/utils/copy-within/lib/index.js
@@ -1,0 +1,49 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Copy a sequence of elements within a collection to another location in the same collection.
+*
+* @module @stdlib/utils/copy-within
+*
+* @example
+* var copyWithin = require( '@stdlib/utils/copy-within' );
+*
+* var arr = [ 1, 2, 3, 4, 5 ];
+* var out = copyWithin( arr, 0, 3 );
+* // returns [ 4, 5, 3, 4, 5 ]
+*
+* arr = [ 1, 2, 3, 4, 5 ];
+* out = copyWithin( arr, 0, 3, 4 );
+* // returns [ 4, 2, 3, 4, 5 ]
+*
+* arr = [ 1, 2, 3, 4, 5 ];
+* out = copyWithin( arr, -2, -3, -1 );
+* // returns [ 1, 2, 3, 3, 4 ]
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/utils/copy-within/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/copy-within/lib/main.js
@@ -1,0 +1,161 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isCollection = require( '@stdlib/assert/is-collection' );
+var isInteger = require( '@stdlib/math/base/assert/is-integer' );
+var format = require( '@stdlib/string/format' );
+var floor = require( '@stdlib/math/base/special/floor' );
+var max = require( '@stdlib/math/base/special/max' );
+var min = require( '@stdlib/math/base/special/min' );
+var copyWithinTypedArrays = require( './typed_arrays.js' );
+
+
+// MAIN //
+
+/**
+* Copies a sequence of elements within a collection to another location in the same collection.
+*
+* @param {Collection} collection - input collection
+* @param {integer} target - target index
+* @param {integer} [start=0] - source start index
+* @param {integer} [end=collection.length] - source end index
+* @throws {TypeError} first argument must be a collection
+* @returns {Collection} modified input collection
+*
+* @example
+* var arr = [ 1, 2, 3, 4, 5 ];
+* var out = copyWithin( arr, 0, 3 );
+* // returns [ 4, 5, 3, 4, 5 ]
+*
+* @example
+* var arr = [ 1, 2, 3, 4, 5 ];
+* var out = copyWithin( arr, 0, 3, 4 );
+* // returns [ 4, 2, 3, 4, 5 ]
+*
+* @example
+* var arr = [ 1, 2, 3, 4, 5 ];
+* var out = copyWithin( arr, -2, -3, -1 );
+* // returns [ 1, 2, 3, 3, 4 ]
+*/
+function copyWithin( collection, target, start, end ) {
+	var result;
+	var len;
+	var t;
+	var s;
+	var e;
+	var i;
+	var n;
+
+	if ( !isCollection( collection ) ) {
+		throw new TypeError( format( 'invalid argument. First argument must be a collection. Value: `%s`.', collection ) );
+	}
+
+	// If the collection has a built-in copyWithin method, use it:
+	if ( typeof collection.copyWithin === 'function' ) {
+		if ( arguments.length === 2 ) {
+			return collection.copyWithin( target );
+		}
+		if ( arguments.length === 3 ) {
+			return collection.copyWithin( target, start );
+		}
+		return collection.copyWithin( target, start, end );
+	}
+
+	// Use optimized implementations for typed arrays:
+	result = copyWithinTypedArrays( collection, target, start, end );
+	if ( result !== null ) {
+		return result;
+	}
+
+	len = collection.length;
+
+	// Convert target to integer and handle negative indices:
+	if ( isInteger( target ) ) {
+		t = target;
+	} else {
+		t = floor( target );
+	}
+	if ( t < 0 ) {
+		t = max( len + t, 0 );
+	} else {
+		t = min( t, len );
+	}
+
+	// Convert start to integer and handle negative indices:
+	if ( start === void 0 ) {
+		s = 0;
+	} else if ( isInteger( start ) ) {
+		s = start;
+	} else {
+		s = floor( start );
+	}
+	if ( s < 0 ) {
+		s = max( len + s, 0 );
+	} else {
+		s = min( s, len );
+	}
+
+	// Convert end to integer and handle negative indices:
+	if ( end === void 0 ) {
+		e = len;
+	} else if ( isInteger( end ) ) {
+		e = end;
+	} else {
+		e = floor( end );
+	}
+	if ( e < 0 ) {
+		e = max( len + e, 0 );
+	} else {
+		e = min( e, len );
+	}
+
+	// Calculate the number of elements to copy:
+	n = min( e - s, len - t );
+
+	// Handle case where copying would overlap:
+	if ( t < s ) {
+		// Copy from left to right:
+		for ( i = 0; i < n; i++ ) {
+			if ( s + i in collection ) {
+				collection[ t + i ] = collection[ s + i ];
+			} else {
+				delete collection[ t + i ];
+			}
+		}
+	} else if ( t > s ) {
+		// Copy from right to left to avoid overwriting elements:
+		for ( i = n - 1; i >= 0; i-- ) {
+			if ( s + i in collection ) {
+				collection[ t + i ] = collection[ s + i ];
+			} else {
+				delete collection[ t + i ];
+			}
+		}
+	}
+
+	return collection;
+}
+
+
+// EXPORTS //
+
+module.exports = copyWithin;

--- a/lib/node_modules/@stdlib/utils/copy-within/lib/typed_arrays.js
+++ b/lib/node_modules/@stdlib/utils/copy-within/lib/typed_arrays.js
@@ -1,0 +1,386 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isInteger = require( '@stdlib/math/base/assert/is-integer' );
+var floor = require( '@stdlib/math/base/special/floor' );
+var max = require( '@stdlib/math/base/special/max' );
+var min = require( '@stdlib/math/base/special/min' );
+var typeOf = require( '@stdlib/utils/type-of' );
+var Uint32Array = require( '@stdlib/array/uint32' );
+var Float64Array = require( '@stdlib/array/float64' );
+
+
+// VARIABLES //
+
+var hash;
+
+
+// FUNCTIONS //
+
+/**
+* Copies a sequence of elements within a typed array to another location in the same array.
+* Optimized implementation that copies in chunks based on the element size when possible.
+*
+* @private
+* @param {TypedArray} arr - input typed array
+* @param {integer} target - target index
+* @param {integer} [start=0] - source start index
+* @param {integer} [end=arr.length] - source end index
+* @param {integer} bytesPerElement - number of bytes per element
+* @returns {TypedArray} modified input array
+*/
+function copyWithinTypedArray( arr, target, start, end, bytesPerElement ) {
+	var ArrayConstructor;
+	var chunkCount;
+	var chunkArray;
+	var byteOffset;
+	var chunkSize;
+	var remainder;
+	var buffer;
+	var len;
+	var t;
+	var s;
+	var e;
+	var n;
+	var i;
+
+	len = arr.length;
+
+	// Convert target to integer and handle negative indices:
+	if ( isInteger( target ) ) {
+		t = target;
+	} else {
+		t = floor( target );
+	}
+	if ( t < 0 ) {
+		t = max( len + t, 0 );
+	} else {
+		t = min( t, len );
+	}
+
+	// Convert start to integer and handle negative indices:
+	if ( start === void 0 ) {
+		s = 0;
+	} else if ( isInteger( start ) ) {
+		s = start;
+	} else {
+		s = floor( start );
+	}
+	if ( s < 0 ) {
+		s = max( len + s, 0 );
+	} else {
+		s = min( s, len );
+	}
+
+	// Convert end to integer and handle negative indices:
+	if ( end === void 0 ) {
+		e = len;
+	} else if ( isInteger( end ) ) {
+		e = end;
+	} else {
+		e = floor( end );
+	}
+	if ( e < 0 ) {
+		e = max( len + e, 0 );
+	} else {
+		e = min( e, len );
+	}
+
+	// Calculate the number of elements to copy:
+	n = min( e - s, len - t );
+
+	if ( n <= 0 ) {
+		return arr;
+	}
+
+	// Determine the optimal chunk size for copying:
+	// For 1-byte elements, use 4-byte chunks
+	// For 2-byte elements, use 4-byte chunks (2 elements at a time)
+	// For 4-byte elements, use 4-byte chunks (1 element at a time)
+	// For 8-byte elements, use 8-byte chunks (1 element at a time)
+	if ( bytesPerElement === 1 ) {
+		chunkSize = 4; // Copy 4 bytes at a time for 1-byte elements
+		ArrayConstructor = Uint32Array;
+	} else if ( bytesPerElement === 2 ) {
+		chunkSize = 4; // Copy 4 bytes (2 elements) at a time for 2-byte elements
+		ArrayConstructor = Uint32Array;
+	} else if ( bytesPerElement === 4 ) {
+		chunkSize = 4; // Copy 4 bytes (1 element) at a time for 4-byte elements
+		ArrayConstructor = Uint32Array;
+	} else { // bytesPerElement === 8
+		chunkSize = 8; // Copy 8 bytes (1 element) at a time for 8-byte elements
+		ArrayConstructor = Float64Array;
+	}
+
+	// Check if we can use the optimized path (chunk-aligned and large enough):
+	if ( n >= (chunkSize / bytesPerElement) &&
+		(s * bytesPerElement) % chunkSize === 0 &&
+		(t * bytesPerElement) % chunkSize === 0 ) {
+		buffer = arr.buffer;
+		byteOffset = arr.byteOffset;
+
+		// Calculate how many chunks we can copy:
+		chunkCount = floor((n * bytesPerElement) / chunkSize);
+		remainder = n - (chunkCount * (chunkSize / bytesPerElement));
+
+		// Create a view of the same buffer with the appropriate chunk size:
+		chunkArray = new ArrayConstructor( buffer, byteOffset, floor((len * bytesPerElement) / chunkSize) ); // eslint-disable-line max-len
+
+		// Copy the chunks:
+		if ( t < s ) {
+			// Copy from left to right:
+			for ( i = 0; i < chunkCount; i++ ) {
+				chunkArray[((t * bytesPerElement) / chunkSize) + i] =
+					chunkArray[((s * bytesPerElement) / chunkSize) + i];
+			}
+
+			// Copy any remaining elements:
+			for ( i = 0; i < remainder; i++ ) {
+				arr[t + (chunkCount * (chunkSize / bytesPerElement)) + i] =
+					arr[s + (chunkCount * (chunkSize / bytesPerElement)) + i];
+			}
+		} else {
+			// Copy from right to left to avoid overwriting elements:
+			for ( i = chunkCount - 1; i >= 0; i-- ) {
+				chunkArray[((t * bytesPerElement) / chunkSize) + i] =
+					chunkArray[((s * bytesPerElement) / chunkSize) + i];
+			}
+
+			// Copy any remaining elements:
+			for ( i = remainder - 1; i >= 0; i-- ) {
+				arr[t + (chunkCount * (chunkSize / bytesPerElement)) + i] =
+					arr[s + (chunkCount * (chunkSize / bytesPerElement)) + i];
+			}
+		}
+	} else {
+		copyElementByElement( arr, t, s, n );
+	}
+
+	return arr;
+}
+
+/**
+* Copies elements one by one within an array.
+*
+* @private
+* @param {Array|TypedArray} arr - input array
+* @param {integer} t - target index
+* @param {integer} s - source index
+* @param {integer} n - number of elements to copy
+* @returns {Array|TypedArray} modified input array
+*/
+function copyElementByElement( arr, t, s, n ) {
+	var i;
+
+	if ( t < s ) {
+		// Copy from left to right:
+		for ( i = 0; i < n; i++ ) {
+			arr[t + i] = arr[s + i];
+		}
+	} else if ( t > s ) {
+		// Copy from right to left to avoid overwriting elements:
+		for ( i = n - 1; i >= 0; i-- ) {
+			arr[t + i] = arr[s + i];
+		}
+	}
+	return arr;
+}
+
+/**
+* Copies a sequence of elements within an Int8Array to another location in the same array.
+*
+* @private
+* @param {Int8Array} arr - input array
+* @param {integer} target - target index
+* @param {integer} [start=0] - source start index
+* @param {integer} [end=arr.length] - source end index
+* @returns {Int8Array} modified input array
+*/
+function int8array( arr, target, start, end ) {
+	return copyWithinTypedArray( arr, target, start, end, 1 );
+}
+
+/**
+* Copies a sequence of elements within a Uint8Array to another location in the same array.
+*
+* @private
+* @param {Uint8Array} arr - input array
+* @param {integer} target - target index
+* @param {integer} [start=0] - source start index
+* @param {integer} [end=arr.length] - source end index
+* @returns {Uint8Array} modified input array
+*/
+function uint8array( arr, target, start, end ) {
+	return copyWithinTypedArray( arr, target, start, end, 1 );
+}
+
+/**
+* Copies a sequence of elements within a Uint8ClampedArray to another location in the same array.
+*
+* @private
+* @param {Uint8ClampedArray} arr - input array
+* @param {integer} target - target index
+* @param {integer} [start=0] - source start index
+* @param {integer} [end=arr.length] - source end index
+* @returns {Uint8ClampedArray} modified input array
+*/
+function uint8clampedarray( arr, target, start, end ) {
+	return copyWithinTypedArray( arr, target, start, end, 1 );
+}
+
+/**
+* Copies a sequence of elements within an Int16Array to another location in the same array.
+*
+* @private
+* @param {Int16Array} arr - input array
+* @param {integer} target - target index
+* @param {integer} [start=0] - source start index
+* @param {integer} [end=arr.length] - source end index
+* @returns {Int16Array} modified input array
+*/
+function int16array( arr, target, start, end ) {
+	return copyWithinTypedArray( arr, target, start, end, 2 );
+}
+
+/**
+* Copies a sequence of elements within a Uint16Array to another location in the same array.
+*
+* @private
+* @param {Uint16Array} arr - input array
+* @param {integer} target - target index
+* @param {integer} [start=0] - source start index
+* @param {integer} [end=arr.length] - source end index
+* @returns {Uint16Array} modified input array
+*/
+function uint16array( arr, target, start, end ) {
+	return copyWithinTypedArray( arr, target, start, end, 2 );
+}
+
+/**
+* Copies a sequence of elements within an Int32Array to another location in the same array.
+*
+* @private
+* @param {Int32Array} arr - input array
+* @param {integer} target - target index
+* @param {integer} [start=0] - source start index
+* @param {integer} [end=arr.length] - source end index
+* @returns {Int32Array} modified input array
+*/
+function int32array( arr, target, start, end ) {
+	return copyWithinTypedArray( arr, target, start, end, 4 );
+}
+
+/**
+* Copies a sequence of elements within a Uint32Array to another location in the same array.
+*
+* @private
+* @param {Uint32Array} arr - input array
+* @param {integer} target - target index
+* @param {integer} [start=0] - source start index
+* @param {integer} [end=arr.length] - source end index
+* @returns {Uint32Array} modified input array
+*/
+function uint32array( arr, target, start, end ) {
+	return copyWithinTypedArray( arr, target, start, end, 4 );
+}
+
+/**
+* Copies a sequence of elements within a Float32Array to another location in the same array.
+*
+* @private
+* @param {Float32Array} arr - input array
+* @param {integer} target - target index
+* @param {integer} [start=0] - source start index
+* @param {integer} [end=arr.length] - source end index
+* @returns {Float32Array} modified input array
+*/
+function float32array( arr, target, start, end ) {
+	return copyWithinTypedArray( arr, target, start, end, 4 );
+}
+
+/**
+* Copies a sequence of elements within a Float64Array to another location in the same array.
+*
+* @private
+* @param {Float64Array} arr - input array
+* @param {integer} target - target index
+* @param {integer} [start=0] - source start index
+* @param {integer} [end=arr.length] - source end index
+* @returns {Float64Array} modified input array
+*/
+function float64array( arr, target, start, end ) {
+	return copyWithinTypedArray( arr, target, start, end, 8 );
+}
+
+/**
+* Returns a hash of functions for copying within typed arrays.
+*
+* @private
+* @returns {Object} function hash
+*/
+function typedarrays() {
+	var out = {
+		'Int8Array': int8array,
+		'Uint8Array': uint8array,
+		'Uint8ClampedArray': uint8clampedarray,
+		'Int16Array': int16array,
+		'Uint16Array': uint16array,
+		'Int32Array': int32array,
+		'Uint32Array': uint32array,
+		'Float32Array': float32array,
+		'Float64Array': float64array
+	};
+	return out;
+}
+
+/**
+* Copies a sequence of elements within a typed array to another location in the same array.
+* Uses optimized implementations based on the array type.
+*
+* @param {TypedArray} arr - input typed array
+* @param {integer} target - target index
+* @param {integer} [start=0] - source start index
+* @param {integer} [end=arr.length] - source end index
+* @returns {TypedArray|null} modified input array or null if not a typed array
+*/
+function copyWithinTypedArrays( arr, target, start, end ) {
+	var typedArrayCopy;
+	var type;
+
+	type = typeOf( arr );
+	typedArrayCopy = hash[ type ];
+
+	if ( typedArrayCopy ) {
+		return typedArrayCopy( arr, target, start, end );
+	}
+	return null;
+}
+
+
+// MAIN //
+
+hash = typedarrays();
+
+
+// EXPORTS //
+
+module.exports = copyWithinTypedArrays;

--- a/lib/node_modules/@stdlib/utils/copy-within/package.json
+++ b/lib/node_modules/@stdlib/utils/copy-within/package.json
@@ -1,0 +1,86 @@
+{
+  "name": "@stdlib/utils-copy-within",
+  "version": "0.0.0",
+  "description": "Copy a sequence of elements within a collection to another location in the same collection.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {
+    "@stdlib/array-float64": "^0.0.x",
+    "@stdlib/array-uint32": "^0.0.x",
+    "@stdlib/assert-has-own-property": "^0.0.x",
+    "@stdlib/assert-is-collection": "^0.0.x",
+    "@stdlib/math-base-assert-is-integer": "^0.0.x",
+    "@stdlib/math-base-special-floor": "^0.0.x",
+    "@stdlib/math-base-special-max": "^0.0.x",
+    "@stdlib/math-base-special-min": "^0.0.x",
+    "@stdlib/string-format": "^0.0.x",
+    "@stdlib/utils-type-of": "^0.0.x"
+  },
+  "devDependencies": {
+    "@stdlib/array-int8": "^0.0.x",
+    "@stdlib/array-uint8": "^0.0.x",
+    "@stdlib/array-uint8c": "^0.0.x",
+    "@stdlib/array-int16": "^0.0.x",
+    "@stdlib/array-uint16": "^0.0.x",
+    "@stdlib/array-int32": "^0.0.x",
+    "@stdlib/array-float32": "^0.0.x"
+  },
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdutils",
+    "stdutil",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "copy",
+    "copywithin",
+    "copy-within",
+    "array",
+    "arr",
+    "collection",
+    "memmove"
+  ]
+}

--- a/lib/node_modules/@stdlib/utils/copy-within/test/test.js
+++ b/lib/node_modules/@stdlib/utils/copy-within/test/test.js
@@ -1,0 +1,323 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var Int8Array = require( '@stdlib/array/int8' );
+var Uint8Array = require( '@stdlib/array/uint8' );
+var Uint8ClampedArray = require( '@stdlib/array/uint8c' );
+var Int16Array = require( '@stdlib/array/int16' );
+var Uint16Array = require( '@stdlib/array/uint16' );
+var Int32Array = require( '@stdlib/array/int32' );
+var Uint32Array = require( '@stdlib/array/uint32' );
+var Float32Array = require( '@stdlib/array/float32' );
+var Float64Array = require( '@stdlib/array/float64' );
+var copyWithin = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof copyWithin, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function throws an error if not provided a collection', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			copyWithin( value, 0, 0 );
+		};
+	}
+});
+
+tape( 'the function copies elements within an array', function test( t ) {
+	var expected;
+	var actual;
+	var arr;
+
+	// Basic usage:
+	arr = [ 1, 2, 3, 4, 5 ];
+	actual = copyWithin( arr, 0, 3 );
+	expected = [ 4, 5, 3, 4, 5 ];
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.strictEqual( actual, arr, 'returns input array' );
+
+	// With end index:
+	arr = [ 1, 2, 3, 4, 5 ];
+	actual = copyWithin( arr, 0, 3, 4 );
+	expected = [ 4, 2, 3, 4, 5 ];
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.strictEqual( actual, arr, 'returns input array' );
+
+	// With negative indices:
+	arr = [ 1, 2, 3, 4, 5 ];
+	actual = copyWithin( arr, -2, -3, -1 );
+	expected = [ 1, 2, 3, 3, 4 ];
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.strictEqual( actual, arr, 'returns input array' );
+
+	t.end();
+});
+
+tape( 'the function copies elements within a sparse array', function test( t ) {
+	var expected;
+	var actual;
+	var arr;
+
+	arr = [ 1, , 3, 4, 5 ]; // eslint-disable-line no-sparse-arrays
+	actual = copyWithin( arr, 2, 0, 2 );
+	expected = [ 1, , 1, , 5 ]; // eslint-disable-line no-sparse-arrays
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.strictEqual( actual, arr, 'returns input array' );
+
+	t.end();
+});
+
+tape( 'the function copies elements within an array-like object', function test( t ) {
+	var expected;
+	var actual;
+	var arr;
+
+	arr = {
+		'0': 1,
+		'1': 2,
+		'2': 3,
+		'3': 4,
+		'4': 5,
+		'length': 5
+	};
+	actual = copyWithin( arr, 0, 3 );
+	expected = {
+		'0': 4,
+		'1': 5,
+		'2': 3,
+		'3': 4,
+		'4': 5,
+		'length': 5
+	};
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.strictEqual( actual, arr, 'returns input array-like object' );
+
+	t.end();
+});
+
+tape( 'the function copies elements within typed arrays (Int8Array)', function test( t ) {
+	var expected;
+	var actual;
+	var arr;
+
+	arr = new Int8Array( [ 1, 2, 3, 4, 5 ] );
+	actual = copyWithin( arr, 0, 3 );
+	expected = new Int8Array( [ 4, 5, 3, 4, 5 ] );
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.strictEqual( actual, arr, 'returns input array' );
+
+	t.end();
+});
+
+tape( 'the function copies elements within typed arrays (Uint8Array)', function test( t ) {
+	var expected;
+	var actual;
+	var arr;
+
+	arr = new Uint8Array( [ 1, 2, 3, 4, 5 ] );
+	actual = copyWithin( arr, 0, 3 );
+	expected = new Uint8Array( [ 4, 5, 3, 4, 5 ] );
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.strictEqual( actual, arr, 'returns input array' );
+
+	t.end();
+});
+
+tape( 'the function copies elements within typed arrays (Uint8ClampedArray)', function test( t ) {
+	var expected;
+	var actual;
+	var arr;
+
+	arr = new Uint8ClampedArray( [ 1, 2, 3, 4, 5 ] );
+	actual = copyWithin( arr, 0, 3 );
+	expected = new Uint8ClampedArray( [ 4, 5, 3, 4, 5 ] );
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.strictEqual( actual, arr, 'returns input array' );
+
+	t.end();
+});
+
+tape( 'the function copies elements within typed arrays (Int16Array)', function test( t ) {
+	var expected;
+	var actual;
+	var arr;
+
+	arr = new Int16Array( [ 1, 2, 3, 4, 5 ] );
+	actual = copyWithin( arr, 0, 3 );
+	expected = new Int16Array( [ 4, 5, 3, 4, 5 ] );
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.strictEqual( actual, arr, 'returns input array' );
+
+	t.end();
+});
+
+tape( 'the function copies elements within typed arrays (Uint16Array)', function test( t ) {
+	var expected;
+	var actual;
+	var arr;
+
+	arr = new Uint16Array( [ 1, 2, 3, 4, 5 ] );
+	actual = copyWithin( arr, 0, 3 );
+	expected = new Uint16Array( [ 4, 5, 3, 4, 5 ] );
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.strictEqual( actual, arr, 'returns input array' );
+
+	t.end();
+});
+
+tape( 'the function copies elements within typed arrays (Int32Array)', function test( t ) {
+	var expected;
+	var actual;
+	var arr;
+
+	arr = new Int32Array( [ 1, 2, 3, 4, 5 ] );
+	actual = copyWithin( arr, 0, 3 );
+	expected = new Int32Array( [ 4, 5, 3, 4, 5 ] );
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.strictEqual( actual, arr, 'returns input array' );
+
+	t.end();
+});
+
+tape( 'the function copies elements within typed arrays (Uint32Array)', function test( t ) {
+	var expected;
+	var actual;
+	var arr;
+
+	arr = new Uint32Array( [ 1, 2, 3, 4, 5 ] );
+	actual = copyWithin( arr, 0, 3 );
+	expected = new Uint32Array( [ 4, 5, 3, 4, 5 ] );
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.strictEqual( actual, arr, 'returns input array' );
+
+	t.end();
+});
+
+tape( 'the function copies elements within typed arrays (Float32Array)', function test( t ) {
+	var expected;
+	var actual;
+	var arr;
+
+	arr = new Float32Array( [ 1.1, 2.2, 3.3, 4.4, 5.5 ] );
+	actual = copyWithin( arr, 0, 3 );
+	expected = new Float32Array( [ 4.4, 5.5, 3.3, 4.4, 5.5 ] );
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.strictEqual( actual, arr, 'returns input array' );
+
+	t.end();
+});
+
+tape( 'the function copies elements within typed arrays (Float64Array)', function test( t ) {
+	var expected;
+	var actual;
+	var arr;
+
+	arr = new Float64Array( [ 1.1, 2.2, 3.3, 4.4, 5.5 ] );
+	actual = copyWithin( arr, 0, 3 );
+	expected = new Float64Array( [ 4.4, 5.5, 3.3, 4.4, 5.5 ] );
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.strictEqual( actual, arr, 'returns input array' );
+
+	t.end();
+});
+
+tape( 'the function handles the case where target and start are the same', function test( t ) {
+	var expected;
+	var actual;
+	var arr;
+
+	arr = [ 1, 2, 3, 4, 5 ];
+	actual = copyWithin( arr, 2, 2 );
+	expected = [ 1, 2, 3, 4, 5 ]; // No change
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.strictEqual( actual, arr, 'returns input array' );
+
+	t.end();
+});
+
+tape( 'the function handles the case where the number of elements to copy is 0', function test( t ) {
+	var expected;
+	var actual;
+	var arr;
+
+	arr = [ 1, 2, 3, 4, 5 ];
+	actual = copyWithin( arr, 0, 3, 3 ); // end - start = 0
+	expected = [ 1, 2, 3, 4, 5 ]; // No change
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.strictEqual( actual, arr, 'returns input array' );
+
+	t.end();
+});
+
+tape( 'the function handles the case where the target is out of bounds', function test( t ) {
+	var expected;
+	var actual;
+	var arr;
+
+	arr = [ 1, 2, 3, 4, 5 ];
+	actual = copyWithin( arr, 10, 0 );
+	expected = [ 1, 2, 3, 4, 5 ]; // No change
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.strictEqual( actual, arr, 'returns input array' );
+
+	t.end();
+});
+
+tape( 'the function handles the case where the start is out of bounds', function test( t ) {
+	var expected;
+	var actual;
+	var arr;
+
+	arr = [ 1, 2, 3, 4, 5 ];
+	actual = copyWithin( arr, 0, 10 );
+	expected = [ 1, 2, 3, 4, 5 ]; // No change
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.strictEqual( actual, arr, 'returns input array' );
+
+	t.end();
+});


### PR DESCRIPTION


Ref #https://github.com/stdlib-js/stdlib/issues/203.

## Description

> What is the purpose of this pull request?

This pull request:

-   This adds a "functional" equivalent of [Array.prototype.copyWithin](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/copyWithin) and [TypedArray.prototype.copyWithin](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/copyWithin).

Package: `@stdlib/utils/copy-within`
Alias: `copyWithin`

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   ref #(https://github.com/stdlib-js/stdlib/issues/203.)

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
