### PR TITLE
feat: add `array/base/broadcasted-quinary5d`

### DIFF
--- a/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/README.md
+++ b/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2023 The Stdlib Authors.
+Copyright (c) 2025 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/README.md
+++ b/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/README.md
@@ -1,0 +1,159 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2023 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# bquinary5d
+
+> Apply a quinary callback to elements in five [broadcasted][@stdlib/array/base/broadcast-array] nested input arrays and assign results to elements in a five-dimensional nested output array.
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var bquinary5d = require( '@stdlib/array/base/broadcasted-quinary5d' );
+```
+
+#### bquinary5d( arrays, shapes, fcn )
+
+Applies a quinary callback to elements in five [broadcasted][@stdlib/array/base/broadcast-array] nested input arrays and assigns results to elements in a five-dimensional nested output array.
+
+```javascript
+var zeros5d = require( '@stdlib/array/base/zeros5d' );
+
+function add( x, y, z, w, v ) {
+    return x + y + z + w + v;
+}
+
+var x = [ [ 1.0, 2.0 ] ];
+var y = [ [ 3.0 ], [ 4.0 ] ];
+var z = [ [ 5.0 ] ];
+var w = [ [ 2.0 ] ];
+var v = [ [ 1.0 ] ];
+var out = zeros5d( [ 1, 1, 2, 2, 2 ] );
+
+var shapes = [
+    [ 1, 2 ],
+    [ 2, 1 ],
+    [ 1, 1 ],
+    [ 1, 1 ],
+    [ 1, 1 ],
+    [ 1, 1, 2, 2, 2 ]
+];
+
+bquinary5d( [ x, y, z, w, v, out ], shapes, add );
+// out => [ [ [ [ [ 12.0, 13.0 ], [ 13.0, 14.0 ] ], [ [ 12.0, 13.0 ], [ 13.0, 14.0 ] ] ] ] ]
+```
+
+The function accepts the following arguments:
+
+-   **arrays**: array-like object containing five input nested arrays and one output nested array.
+-   **shapes**: array shapes.
+-   **fcn**: quinary function to apply.
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   The input and output array shapes must be broadcast [compatible][@stdlib/ndarray/base/broadcast-shapes].
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' ).factory;
+var filled5dBy = require( '@stdlib/array/base/filled5d-by' );
+var zeros5d = require( '@stdlib/array/base/zeros5d' );
+var bquinary5d = require( '@stdlib/array/base/broadcasted-quinary5d' );
+
+function add( x, y, z, w, v ) {
+    return x + y + z + w + v;
+}
+
+var shapes = [
+    [ 1, 1, 1, 1, 3 ],
+    [ 1, 1, 3, 1, 1 ],
+    [ 1, 1, 1, 1, 1 ],
+    [ 1, 1, 1, 3, 1 ],
+    [ 1, 1, 1, 1, 3 ],
+    [ 1, 1, 3, 3, 3 ]
+];
+
+var x = filled5dBy( shapes[ 0 ], discreteUniform( -100, 100 ) );
+console.log( x );
+
+var y = filled5dBy( shapes[ 1 ], discreteUniform( -100, 100 ) );
+console.log( y );
+
+var z = filled5dBy( shapes[ 2 ], discreteUniform( -100, 100 ) );
+console.log( z );
+
+var w = filled5dBy( shapes[ 3 ], discreteUniform( -100, 100 ) );
+console.log( w );
+
+var v = filled5dBy( shapes[ 4 ], discreteUniform( -100, 100 ) );
+console.log( v );
+
+var out = zeros5d( shapes[ 5 ] );
+console.log( out );
+
+bquinary5d( [ x, y, z, w, v, out ], shapes, add );
+console.log( out );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[@stdlib/array/base/broadcast-array]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/base/broadcast-array
+
+[@stdlib/ndarray/base/broadcast-shapes]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/ndarray/base/broadcast-shapes
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/benchmark/benchmark.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/benchmark/benchmark.js
@@ -1,0 +1,156 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var uniform = require( '@stdlib/random/base/uniform' ).factory;
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var floor = require( '@stdlib/math/base/special/floor' );
+var filled5dBy = require( '@stdlib/array/base/filled5d-by' );
+var zeros5d = require( '@stdlib/array/base/zeros5d' );
+var numel = require( '@stdlib/ndarray/base/numel' );
+var pkg = require( './../package.json' ).name;
+var bquinary5d = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Returns the sum.
+*
+* @private
+* @param {number} x - first value
+* @param {number} y - second value
+* @param {number} z - third value
+* @param {number} w - fourth value
+* @param {number} v - fifth value
+* @returns {number} sum
+*/
+function add( x, y, z, w, v ) {
+	return x + y + z + w + v;
+}
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveIntegerArray} shape - output array shape
+* @returns {Function} benchmark function
+*/
+function createBenchmark( shape ) {
+	var arrays;
+	var shapes;
+	var out;
+	var x;
+	var y;
+	var z;
+	var w;
+	var v;
+
+	shapes = [
+		[ 1, 1, 1, 1, shape[ 4 ] ],
+		[ shape[ 0 ], 1, 1, 1, 1 ],
+		[ 1, 1, 1, 1, 1 ],
+		[ 1, shape[ 1 ], 1, 1, 1 ],
+		[ 1, 1, shape[ 2 ], 1, 1 ],
+		shape
+	];
+	x = filled5dBy( shapes[ 0 ], uniform( -100.0, 100.0 ) );
+	y = filled5dBy( shapes[ 1 ], uniform( -100.0, 100.0 ) );
+	z = filled5dBy( shapes[ 2 ], uniform( -100.0, 100.0 ) );
+	w = filled5dBy( shapes[ 3 ], uniform( -100.0, 100.0 ) );
+	v = filled5dBy( shapes[ 4 ], uniform( -100.0, 100.0 ) );
+	out = zeros5d( shapes[ 5 ] );
+
+	arrays = [ x, y, z, w, v, out ];
+
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var i0;
+		var i1;
+		var i2;
+		var i3;
+		var i4;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			bquinary5d( arrays, shapes, add );
+			i4 = i % shapes[ 1 ][ 0 ];
+			i3 = i % shapes[ 3 ][ 1 ];
+			i2 = i % shapes[ 4 ][ 2 ];
+			i1 = i % shapes[ 0 ][ 3 ];
+			i0 = i % shapes[ 0 ][ 4 ];
+			if ( isnan( arrays[ 5 ][ i4 ][ i3 ][ i2 ][ i1 ][ i0 ] ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+
+		i4 = i % shapes[ 1 ][ 0 ];
+		i3 = i % shapes[ 3 ][ 1 ];
+		i2 = i % shapes[ 4 ][ 2 ];
+		i1 = i % shapes[ 0 ][ 3 ];
+		i0 = i % shapes[ 0 ][ 4 ];
+		if ( isnan( arrays[ 5 ][ i4 ][ i3 ][ i2 ][ i1 ][ i0 ] ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var min;
+	var max;
+	var sh;
+	var N;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 5; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		N = floor( pow( pow( 10, i ), 1.0/5.0 ) );
+		sh = [ N, N, N, N, N ];
+		f = createBenchmark( sh );
+		bench( pkg+'::equidimensional:size='+numel( sh ), f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/docs/repl.txt
@@ -1,0 +1,34 @@
+{{alias}}( arrays, shapes, fcn )
+    Applies a quinary callback to elements in five broadcasted input arrays
+    and assigns results to elements in a five-dimensional nested output array.
+
+    Parameters
+    ----------
+    arrays: ArrayLikeObject
+        Array-like object containing five input nested arrays and one output
+        nested array.
+
+    shapes: Array<Array<integer>>
+        Array shapes.
+
+    fcn: Function
+        Quinary callback.
+
+    Examples
+    --------
+    > function fcn( x, y, z, w, v ) { return x + y + z + w + v; };
+    > var x = [ 1.0, 2.0 ];
+    > var y = [ [ 3.0 ], [ 4.0 ] ];
+    > var z = [ [ 1.0 ] ];
+    > var w = [ 2.0 ];
+    > var v = [ 1.0 ];
+    > var out = [ [ [ [ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ] ] ] ];
+    > var shapes = [
+    ...   [ 2 ], [ 2, 1 ], [ 1, 1 ], [ 1 ], [ 1 ], [ 1, 1, 1, 2, 2 ]
+    ... ];
+    > {{alias}}( [ x, y, z, w, v, out ], shapes, fcn );
+    > out
+    [ [ [ [ [ 8.0, 9.0 ], [ 9.0, 10.0 ] ] ] ] ]
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/docs/types/index.d.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/docs/types/index.d.ts
@@ -1,0 +1,127 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { Array1D, Array2D, Array3D, Array4D, Array5D } from '@stdlib/types/array';
+import { Shape1D, Shape2D, Shape3D, Shape4D, Shape5D } from '@stdlib/types/ndarray';
+
+/**
+* Quinary callback.
+*
+* @param v1 - element from first input array
+* @param v2 - element from second input array
+* @param v3 - element from third input array
+* @param v4 - element from fourth input array
+* @param v5 - element from fifth input array
+* @returns result
+*/
+type Quinary<T, U, V, W, X, Y> = ( v1: T, v2: U, v3: V, v4: W, v5: X ) => Y;
+
+/**
+* Input array.
+*/
+type InputArray<T> = Array1D<T> | Array2D<T> | Array3D<T> | Array4D<T> | Array5D<T>;
+
+/**
+* Input array shape.
+*/
+type InputArrayShape = Shape1D | Shape2D | Shape3D | Shape4D | Shape5D;
+
+/**
+* Output array.
+*/
+type OutputArray<T> = Array5D<T>;
+
+/**
+* Output array shape.
+*/
+type OutputArrayShape = Shape5D;
+
+/**
+* Input and output arrays.
+*/
+type InOutArrays<T, U, V, W, X, Y> = [
+	InputArray<T>,
+	InputArray<U>,
+	InputArray<V>,
+	InputArray<W>,
+	InputArray<X>,
+	OutputArray<Y>
+];
+
+/**
+* Input and output array shapes.
+*/
+type InOutShapes = [
+	InputArrayShape,
+	InputArrayShape,
+	InputArrayShape,
+	InputArrayShape,
+	InputArrayShape,
+	OutputArrayShape
+];
+
+/**
+* Applies a quinary callback to elements in five broadcasted input arrays and assigns results to elements in a five-dimensional nested output array.
+*
+* ## Notes
+*
+* -   The input array shapes must be broadcast compatible with the output array shape.
+*
+* @param arrays - array containing five input nested arrays and one output nested array
+* @param shapes - array shapes
+* @param fcn - quinary callback
+*
+* @example
+* var ones5d = require( '@stdlib/array/base/ones5d' );
+* var zeros5d = require( '@stdlib/array/base/zeros5d' );
+*
+* function add( x, y, z, w, v ) {
+*     return x + y + z + w + v;
+* }
+*
+* var shapes = [
+*     [ 1, 1, 1, 1, 2 ],
+*     [ 1, 1, 2, 1, 1 ],
+*     [ 1, 1, 1, 1, 1 ],
+*     [ 1, 1, 1, 2, 1 ],
+*     [ 1, 1, 1, 1, 2 ],
+*     [ 1, 1, 2, 2, 2 ]
+* ];
+*
+* var x = ones5d( shapes[ 0 ] );
+* var y = ones5d( shapes[ 1 ] );
+* var z = ones5d( shapes[ 2 ] );
+* var w = ones5d( shapes[ 3 ] );
+* var v = ones5d( shapes[ 4 ] );
+* var out = zeros5d( shapes[ 5 ] );
+*
+* bquinary5d( [ x, y, z, w, v, out ], shapes, add );
+*
+* console.log( out );
+* // => [ [ [ [ [ 5.0, 5.0 ], [ 5.0, 5.0 ] ], [ [ 5.0, 5.0 ], [ 5.0, 5.0 ] ] ] ] ]
+*/
+declare function bquinary5d<T = unknown, U = unknown, V = unknown, W = unknown, X = unknown, Y = unknown>( arrays: InOutArrays<T, U, V, W, X, Y>, shapes: InOutShapes, fcn: Quinary<T, U, V, W, X, Y> ): void;
+
+
+// EXPORTS //
+
+export = bquinary5d;

--- a/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/docs/types/test.ts
@@ -1,7 +1,7 @@
 /*
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/docs/types/test.ts
@@ -1,0 +1,125 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import bquinary5d = require( './index' );
+
+/**
+* Quinary function.
+*
+* @param x - input value
+* @param y - input value
+* @param z - input value
+* @param w - input value
+* @param v - input value
+* @returns result
+*/
+function fcn( x: number, y: number, z: number, w: number, v: number ): number {
+	return x + y + z + w + v;
+}
+
+/**
+* List of input and output array shapes.
+*/
+type InOutShapes = [ Array<number>, Array<number>, Array<number>, Array<number>, Array<number>, Array<number> ];
+
+
+// TESTS //
+
+// The function returns undefined...
+{
+	const x = [ [ [ [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ] ] ] ];
+	const y = [ [ [ [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ] ] ] ];
+	const z = [ [ [ [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ] ] ] ];
+	const w = [ [ [ [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ] ] ] ];
+	const v = [ [ [ [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ] ] ] ];
+	const out = [ [ [ [ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ] ] ] ];
+
+	const shapes: InOutShapes = [ [ 1, 1, 1, 2, 2 ], [ 1, 1, 1, 2, 2 ], [ 1, 1, 1, 2, 2 ], [ 1, 1, 1, 2, 2 ], [ 1, 1, 1, 2, 2 ], [ 1, 1, 1, 2, 2 ] ];
+
+	bquinary5d( [ x, y, z, w, v, out ], shapes, fcn ); // $ExpectType void
+	bquinary5d( [ x[0][0][0][0], y, z, w, v, out ], [ [ shapes[0][4] ], shapes[1], shapes[2], shapes[3], shapes[4], shapes[5] ], fcn ); // $ExpectType void
+}
+
+// The compiler throws an error if the function is provided a first argument which is not an array of nested arrays...
+{
+	const shapes: InOutShapes = [ [ 1, 1, 1, 2, 2 ], [ 1, 1, 1, 2, 2 ], [ 1, 1, 1, 2, 2 ], [ 1, 1, 1, 2, 2 ], [ 1, 1, 1, 2, 2 ], [ 1, 1, 1, 2, 2 ] ];
+
+	bquinary5d( 'abc', shapes, fcn ); // $ExpectError
+	bquinary5d( 3.14, shapes, fcn ); // $ExpectError
+	bquinary5d( true, shapes, fcn ); // $ExpectError
+	bquinary5d( false, shapes, fcn ); // $ExpectError
+	bquinary5d( null, shapes, fcn ); // $ExpectError
+	bquinary5d( [ '1' ], shapes, fcn ); // $ExpectError
+	bquinary5d( {}, shapes, fcn ); // $ExpectError
+	bquinary5d( ( x: number ): number => x, shapes, fcn ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument which is not an array of arrays...
+{
+	const x = [ [ [ [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ] ] ] ];
+	const y = [ [ [ [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ] ] ] ];
+	const z = [ [ [ [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ] ] ] ];
+	const w = [ [ [ [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ] ] ] ];
+	const v = [ [ [ [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ] ] ] ];
+	const out = [ [ [ [ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ] ] ] ];
+
+	bquinary5d( [ x, y, z, w, v, out ], 'abc', fcn ); // $ExpectError
+	bquinary5d( [ x, y, z, w, v, out ], 3.14, fcn ); // $ExpectError
+	bquinary5d( [ x, y, z, w, v, out ], true, fcn ); // $ExpectError
+	bquinary5d( [ x, y, z, w, v, out ], false, fcn ); // $ExpectError
+	bquinary5d( [ x, y, z, w, v, out ], null, fcn ); // $ExpectError
+	bquinary5d( [ x, y, z, w, v, out ], [ '1' ], fcn ); // $ExpectError
+	bquinary5d( [ x, y, z, w, v, out ], {}, fcn ); // $ExpectError
+	bquinary5d( [ x, y, z, w, v, out ], ( x: number ): number => x, fcn ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a third argument which is not a valid callback...
+{
+	const x = [ [ [ [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ] ] ] ];
+	const y = [ [ [ [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ] ] ] ];
+	const z = [ [ [ [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ] ] ] ];
+	const w = [ [ [ [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ] ] ] ];
+	const v = [ [ [ [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ] ] ] ];
+	const out = [ [ [ [ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ] ] ] ];
+
+	const shapes: InOutShapes = [ [ 1, 1, 1, 2, 2 ], [ 1, 1, 1, 2, 2 ], [ 1, 1, 1, 2, 2 ], [ 1, 1, 1, 2, 2 ], [ 1, 1, 1, 2, 2 ], [ 1, 1, 1, 2, 2 ] ];
+
+	bquinary5d( [ x, y, z, w, v, out ], shapes, 'abc' ); // $ExpectError
+	bquinary5d( [ x, y, z, w, v, out ], shapes, 3.14 ); // $ExpectError
+	bquinary5d( [ x, y, z, w, v, out ], shapes, true ); // $ExpectError
+	bquinary5d( [ x, y, z, w, v, out ], shapes, false ); // $ExpectError
+	bquinary5d( [ x, y, z, w, v, out ], shapes, null ); // $ExpectError
+	bquinary5d( [ x, y, z, w, v, out ], shapes, [ '1' ] ); // $ExpectError
+	bquinary5d( [ x, y, z, w, v, out ], shapes, {} ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	const x = [ [ [ [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ] ] ] ];
+	const y = [ [ [ [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ] ] ] ];
+	const z = [ [ [ [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ] ] ] ];
+	const w = [ [ [ [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ] ] ] ];
+	const v = [ [ [ [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ] ] ] ];
+	const out = [ [ [ [ [ 0.0, 0.0 ], [ 0.0, 0.0 ] ] ] ] ];
+
+	const shapes: InOutShapes = [ [ 1, 1, 1, 2, 2 ], [ 1, 1, 1, 2, 2 ], [ 1, 1, 1, 2, 2 ], [ 1, 1, 1, 2, 2 ], [ 1, 1, 1, 2, 2 ], [ 1, 1, 1, 2, 2 ] ];
+
+	bquinary5d(); // $ExpectError
+	bquinary5d( [ x, y, z, w, v, out ] ); // $ExpectError
+	bquinary5d( [ x, y, z, w, v, out ], shapes, fcn, {} ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/examples/index.js
+++ b/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/examples/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/examples/index.js
+++ b/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/examples/index.js
@@ -1,0 +1,58 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var discreteUniform = require( '@stdlib/random/base/discrete-uniform' ).factory;
+var filled5dBy = require( '@stdlib/array/base/filled5d-by' );
+var zeros5d = require( '@stdlib/array/base/zeros5d' );
+var bquinary5d = require( './../lib' );
+
+function add( x, y, z, w, v ) {
+	return x + y + z + w + v;
+}
+
+var shapes = [
+	[ 1, 1, 1, 1, 3 ],
+	[ 1, 1, 3, 1, 1 ],
+	[ 1, 1, 1, 1, 1 ],
+	[ 1, 1, 1, 3, 1 ],
+	[ 1, 1, 1, 1, 3 ],
+	[ 1, 1, 3, 3, 3 ]
+];
+
+var x = filled5dBy( shapes[ 0 ], discreteUniform( -100, 100 ) );
+console.log( x );
+
+var y = filled5dBy( shapes[ 1 ], discreteUniform( -100, 100 ) );
+console.log( y );
+
+var z = filled5dBy( shapes[ 2 ], discreteUniform( -100, 100 ) );
+console.log( z );
+
+var w = filled5dBy( shapes[ 3 ], discreteUniform( -100, 100 ) );
+console.log( w );
+
+var v = filled5dBy( shapes[ 4 ], discreteUniform( -100, 100 ) );
+console.log( v );
+
+var out = zeros5d( shapes[ 5 ] );
+console.log( out );
+
+bquinary5d( [ x, y, z, w, v, out ], shapes, add );
+console.log( out );

--- a/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/lib/index.js
+++ b/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/lib/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/lib/index.js
+++ b/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/lib/index.js
@@ -1,0 +1,64 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Apply a quinary callback to elements in five broadcasted input arrays and assign results to elements in a five-dimensional nested output array.
+*
+* @module @stdlib/array/base/broadcasted-quinary5d
+*
+* @example
+* var ones5d = require( '@stdlib/array/base/ones5d' );
+* var zeros5d = require( '@stdlib/array/base/zeros5d' );
+* var bquinary5d = require( '@stdlib/array/base/broadcasted-quinary5d' );
+*
+* function add( x, y, z, w, v ) {
+*     return x + y + z + w + v;
+* }
+*
+* var shapes = [
+*     [ 1, 1, 1, 1, 2 ],
+*     [ 1, 1, 2, 1, 1 ],
+*     [ 1, 1, 1, 1, 1 ],
+*     [ 1, 1, 1, 2, 1 ],
+*     [ 1, 1, 1, 1, 2 ],
+*     [ 1, 1, 2, 2, 2 ]
+* ];
+*
+* var x = ones5d( shapes[ 0 ] );
+* var y = ones5d( shapes[ 1 ] );
+* var z = ones5d( shapes[ 2 ] );
+* var w = ones5d( shapes[ 3 ] );
+* var v = ones5d( shapes[ 4 ] );
+* var out = zeros5d( shapes[ 5 ] );
+*
+* bquinary5d( [ x, y, z, w, v, out ], shapes, add );
+*
+* console.log( out );
+* // => [ [ [ [ [ 5.0, 5.0 ], [ 5.0, 5.0 ] ], [ [ 5.0, 5.0 ], [ 5.0, 5.0 ] ] ] ] ]
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/lib/main.js
+++ b/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/lib/main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/lib/main.js
+++ b/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/lib/main.js
@@ -1,0 +1,306 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var broadcastArray = require( '@stdlib/array/base/broadcast-array' );
+
+
+// MAIN //
+
+/**
+* Applies a quinary callback to elements in five broadcasted input arrays and assigns results to elements in a five-dimensional nested output array.
+*
+* @param {ArrayLikeObject<Array>} arrays - array-like object containing five input nested arrays and one output nested array
+* @param {ArrayLikeObject<NonNegativeIntegerArray>} shapes - array shapes
+* @param {Callback} fcn - quinary callback
+* @returns {void}
+*
+* @example
+* var ones5d = require( '@stdlib/array/base/ones5d' );
+* var zeros5d = require( '@stdlib/array/base/zeros5d' );
+*
+* function add( x, y, z, w, v ) {
+*     return x + y + z + w + v;
+* }
+*
+* var shapes = [
+*     [ 1, 1, 1, 1, 2 ],
+*     [ 1, 1, 2, 1, 1 ],
+*     [ 1, 1, 1, 1, 1 ],
+*     [ 1, 1, 1, 2, 1 ],
+*     [ 1, 1, 1, 1, 2 ],
+*     [ 1, 1, 2, 2, 2 ]
+* ];
+*
+* var x = ones5d( shapes[ 0 ] );
+* var y = ones5d( shapes[ 1 ] );
+* var z = ones5d( shapes[ 2 ] );
+* var w = ones5d( shapes[ 3 ] );
+* var v = ones5d( shapes[ 4 ] );
+* var out = zeros5d( shapes[ 5 ] );
+*
+* bquinary5d( [ x, y, z, w, v, out ], shapes, add );
+*
+* console.log( out );
+* // => [ [ [ [ [ 5.0, 5.0 ], [ 5.0, 5.0 ] ], [ [ 5.0, 5.0 ], [ 5.0, 5.0 ] ] ] ] ]
+*/
+function bquinary5d( arrays, shapes, fcn ) { // eslint-disable-line max-statements
+	var dx0;
+	var dx1;
+	var dx2;
+	var dx3;
+	var dx4;
+	var dy0;
+	var dy1;
+	var dy2;
+	var dy3;
+	var dy4;
+	var dz0;
+	var dz1;
+	var dz2;
+	var dz3;
+	var dz4;
+	var dw0;
+	var dw1;
+	var dw2;
+	var dw3;
+	var dw4;
+	var du0;
+	var du1;
+	var du2;
+	var du3;
+	var du4;
+	var S0;
+	var S1;
+	var S2;
+	var S3;
+	var S4;
+	var i0;
+	var i1;
+	var i2;
+	var i3;
+	var i4;
+	var j0;
+	var j1;
+	var j2;
+	var j3;
+	var j4;
+	var k0;
+	var k1;
+	var k2;
+	var k3;
+	var k4;
+	var m0;
+	var m1;
+	var m2;
+	var m3;
+	var m4;
+	var n0;
+	var n1;
+	var n2;
+	var n3;
+	var n4;
+	var p0;
+	var p1;
+	var p2;
+	var p3;
+	var p4;
+	var x0;
+	var x1;
+	var x2;
+	var x3;
+	var y0;
+	var y1;
+	var y2;
+	var y3;
+	var z0;
+	var z1;
+	var z2;
+	var z3;
+	var w0;
+	var w1;
+	var w2;
+	var w3;
+	var u0;
+	var u1;
+	var u2;
+	var u3;
+	var v0;
+	var v1;
+	var v2;
+	var v3;
+	var sh;
+	var st;
+	var o;
+	var x;
+	var y;
+	var z;
+	var w;
+	var u;
+	var v;
+
+	sh = shapes[ 5 ];
+	S0 = sh[ 4 ];
+	S1 = sh[ 3 ];
+	S2 = sh[ 2 ];
+	S3 = sh[ 1 ];
+	S4 = sh[ 0 ];
+	if ( S0 <= 0 || S1 <= 0 || S2 <= 0 || S3 <= 0 || S4 <= 0 ) {
+		return;
+	}
+	o = broadcastArray( arrays[ 0 ], shapes[ 0 ], sh );
+	x = o.data;
+	st = o.strides;
+	dx0 = st[ 4 ];
+	dx1 = st[ 3 ];
+	dx2 = st[ 2 ];
+	dx3 = st[ 1 ];
+	dx4 = st[ 0 ];
+
+	o = broadcastArray( arrays[ 1 ], shapes[ 1 ], sh );
+	y = o.data;
+	st = o.strides;
+	dy0 = st[ 4 ];
+	dy1 = st[ 3 ];
+	dy2 = st[ 2 ];
+	dy3 = st[ 1 ];
+	dy4 = st[ 0 ];
+
+	o = broadcastArray( arrays[ 2 ], shapes[ 2 ], sh );
+	z = o.data;
+	st = o.strides;
+	dz0 = st[ 4 ];
+	dz1 = st[ 3 ];
+	dz2 = st[ 2 ];
+	dz3 = st[ 1 ];
+	dz4 = st[ 0 ];
+
+	o = broadcastArray( arrays[ 3 ], shapes[ 3 ], sh );
+	w = o.data;
+	st = o.strides;
+	dw0 = st[ 4 ];
+	dw1 = st[ 3 ];
+	dw2 = st[ 2 ];
+	dw3 = st[ 1 ];
+	dw4 = st[ 0 ];
+
+	o = broadcastArray( arrays[ 4 ], shapes[ 4 ], sh );
+	u = o.data;
+	st = o.strides;
+	du0 = st[ 4 ];
+	du1 = st[ 3 ];
+	du2 = st[ 2 ];
+	du3 = st[ 1 ];
+	du4 = st[ 0 ];
+
+	v = arrays[ 5 ];
+
+	j4 = 0;
+	k4 = 0;
+	m4 = 0;
+	n4 = 0;
+	p4 = 0;
+	for ( i4 = 0; i4 < S4; i4++ ) {
+		j3 = 0;
+		k3 = 0;
+		m3 = 0;
+		n3 = 0;
+		p3 = 0;
+		x3 = x[ j4 ];
+		y3 = y[ k4 ];
+		z3 = z[ m4 ];
+		w3 = w[ n4 ];
+		u3 = u[ p4 ];
+		v3 = v[ i4 ];
+		for ( i3 = 0; i3 < S3; i3++ ) {
+			j2 = 0;
+			k2 = 0;
+			m2 = 0;
+			n2 = 0;
+			p2 = 0;
+			x2 = x3[ j3 ];
+			y2 = y3[ k3 ];
+			z2 = z3[ m3 ];
+			w2 = w3[ n3 ];
+			u2 = u3[ p3 ];
+			v2 = v3[ i3 ];
+			for ( i2 = 0; i2 < S2; i2++ ) {
+				j1 = 0;
+				k1 = 0;
+				m1 = 0;
+				n1 = 0;
+				p1 = 0;
+				x1 = x2[ j2 ];
+				y1 = y2[ k2 ];
+				z1 = z2[ m2 ];
+				w1 = w2[ n2 ];
+				u1 = u2[ p2 ];
+				v1 = v2[ i2 ];
+				for ( i1 = 0; i1 < S1; i1++ ) {
+					j0 = 0;
+					k0 = 0;
+					m0 = 0;
+					n0 = 0;
+					p0 = 0;
+					x0 = x1[ j1 ];
+					y0 = y1[ k1 ];
+					z0 = z1[ m1 ];
+					w0 = w1[ n1 ];
+					u0 = u1[ p1 ];
+					v0 = v1[ i1 ];
+					for ( i0 = 0; i0 < S0; i0++ ) {
+						v0[ i0 ] = fcn( x0[ j0 ], y0[ k0 ], z0[ m0 ], w0[ n0 ], u0[ p0 ] );
+						j0 += dx0;
+						k0 += dy0;
+						m0 += dz0;
+						n0 += dw0;
+						p0 += du0;
+					}
+					j1 += dx1;
+					k1 += dy1;
+					m1 += dz1;
+					n1 += dw1;
+					p1 += du1;
+				}
+				j2 += dx2;
+				k2 += dy2;
+				m2 += dz2;
+				n2 += dw2;
+				p2 += du2;
+			}
+			j3 += dx3;
+			k3 += dy3;
+			m3 += dz3;
+			n3 += dw3;
+			p3 += du3;
+		}
+		j4 += dx4;
+		k4 += dy4;
+		m4 += dz4;
+		n4 += dw4;
+		p4 += du4;
+	}
+}
+
+
+// EXPORTS //
+
+module.exports = bquinary5d;

--- a/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/package.json
+++ b/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@stdlib/array/base/broadcasted-quinary5d",
+  "version": "0.0.0",
+  "description": "Apply a quinary callback to elements in five broadcasted input arrays and assign results to elements in a five-dimensional nested output array.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "base",
+    "array",
+    "multidimensional",
+    "ndarray",
+    "matrix",
+    "5d",
+    "quinary",
+    "apply",
+    "foreach",
+    "map",
+    "transform",
+    "broadcast"
+  ],
+  "__stdlib__": {}
+}

--- a/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/test/test.js
+++ b/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2023 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/test/test.js
+++ b/lib/node_modules/@stdlib/array/base/broadcasted-quinary5d/test/test.js
@@ -1,0 +1,452 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2023 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var zeros5d = require( '@stdlib/array/base/zeros5d' );
+var bquinary5d = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Returns the sum.
+*
+* @private
+* @param {number} x - first value
+* @param {number} y - second value
+* @param {number} z - third value
+* @param {number} w - fourth value
+* @param {number} v - fifth value
+* @returns {number} sum
+*/
+function add( x, y, z, w, v ) {
+	return x + y + z + w + v;
+}
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof bquinary5d, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function applies a provided callback to broadcasted input arrays and assigns results to a nested output array', function test( t ) { // eslint-disable-line max-lines-per-function
+	var expected;
+	var shapes;
+	var out;
+	var x;
+	var y;
+	var z;
+	var w;
+	var u;
+
+	shapes = [
+		[ 2 ],
+		[ 2, 1 ],
+		[ 1, 1 ],
+		[ 1 ],
+		[ 1, 2 ],
+		[ 2, 2, 2, 2, 2 ]
+	];
+	x = [ 1.0, 2.0 ];
+	y = [
+		[ 3.0 ],
+		[ 4.0 ]
+	];
+	z = [ [ 5.0 ] ];
+	w = [ 1.0 ];
+	u = [ [ 1.0, 2.0 ] ];
+	out = zeros5d( shapes[ 5 ] );
+
+	expected = [
+		[
+			[
+				[
+					[ 11.0, 13.0 ],
+					[ 12.0, 14.0 ]
+				],
+				[
+					[ 11.0, 13.0 ],
+					[ 12.0, 14.0 ]
+				]
+			],
+			[
+				[
+					[ 11.0, 13.0 ],
+					[ 12.0, 14.0 ]
+				],
+				[
+					[ 11.0, 13.0 ],
+					[ 12.0, 14.0 ]
+				]
+			]
+		],
+		[
+			[
+				[
+					[ 11.0, 13.0 ],
+					[ 12.0, 14.0 ]
+				],
+				[
+					[ 11.0, 13.0 ],
+					[ 12.0, 14.0 ]
+				]
+			],
+			[
+				[
+					[ 11.0, 13.0 ],
+					[ 12.0, 14.0 ]
+				],
+				[
+					[ 11.0, 13.0 ],
+					[ 12.0, 14.0 ]
+				]
+			]
+		]
+	];
+	bquinary5d( [ x, y, z, w, u, out ], shapes, add );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	shapes = [
+		[ 1, 2 ],
+		[ 2 ],
+		[ 1 ],
+		[ 2, 2 ],
+		[ 2, 1 ],
+		[ 2, 2, 2, 2, 2 ]
+	];
+	x = [
+		[ 1.0, 2.0 ]
+	];
+	y = [ 3.0, 4.0 ];
+	z = [ 5.0 ];
+	w = [
+		[ 2.0, 3.0 ],
+		[ 4.0, 5.0 ]
+	];
+	u = [
+		[ 1.0 ],
+		[ 2.0 ]
+	];
+	out = zeros5d( shapes[ 5 ] );
+
+	expected = [
+		[
+			[
+				[
+					[ 12.0, 15.0 ],
+					[ 15.0, 18.0 ]
+				],
+				[
+					[ 12.0, 15.0 ],
+					[ 15.0, 18.0 ]
+				]
+			],
+			[
+				[
+					[ 12.0, 15.0 ],
+					[ 15.0, 18.0 ]
+				],
+				[
+					[ 12.0, 15.0 ],
+					[ 15.0, 18.0 ]
+				]
+			]
+		],
+		[
+			[
+				[
+					[ 12.0, 15.0 ],
+					[ 15.0, 18.0 ]
+				],
+				[
+					[ 12.0, 15.0 ],
+					[ 15.0, 18.0 ]
+				]
+			],
+			[
+				[
+					[ 12.0, 15.0 ],
+					[ 15.0, 18.0 ]
+				],
+				[
+					[ 12.0, 15.0 ],
+					[ 15.0, 18.0 ]
+				]
+			]
+		]
+	];
+	bquinary5d( [ x, y, z, w, u, out ], shapes, add );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	// Same shapes:
+	shapes = [
+		[ 1, 1, 1, 1, 2 ],
+		[ 1, 1, 1, 1, 2 ],
+		[ 1, 1, 1, 1, 2 ],
+		[ 1, 1, 1, 1, 2 ],
+		[ 1, 1, 1, 1, 2 ],
+		[ 1, 1, 1, 1, 2 ]
+	];
+	x = [
+		[
+			[
+				[
+					[ 1.0, 2.0 ]
+				]
+			]
+		]
+	];
+	y = [
+		[
+			[
+				[
+					[ 1.0, 2.0 ]
+				]
+			]
+		]
+	];
+	z = [
+		[
+			[
+				[
+					[ 1.0, 2.0 ]
+				]
+			]
+		]
+	];
+	w = [
+		[
+			[
+				[
+					[ 1.0, 2.0 ]
+				]
+			]
+		]
+	];
+	u = [
+		[
+			[
+				[
+					[ 1.0, 2.0 ]
+				]
+			]
+		]
+	];
+	out = zeros5d( shapes[ 5 ] );
+
+	expected = [
+		[
+			[
+				[
+					[ 5.0, 10.0 ]
+				]
+			]
+		]
+	];
+	bquinary5d( [ x, y, z, w, u, out ], shapes, add );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function does not invoke a provided callback if provided an output shape having a first element equal to zero', function test( t ) {
+	var expected;
+	var shapes;
+	var out;
+	var x;
+	var y;
+	var z;
+	var w;
+	var u;
+
+	shapes = [
+		[ 2, 2, 2, 2, 2 ],
+		[ 2, 2, 2, 2, 2 ],
+		[ 2, 2, 2, 2, 2 ],
+		[ 2, 2, 2, 2, 2 ],
+		[ 2, 2, 2, 2, 2 ],
+		[ 0, 2, 2, 2, 2 ]
+	];
+	x = zeros5d( [ 2, 2, 2, 2, 2 ] );
+	y = x;
+	z = x;
+	w = x;
+	u = x;
+	out = zeros5d( [ 2, 2, 2, 2, 2 ] );
+
+	expected = zeros5d( [ 2, 2, 2, 2, 2 ] );
+	bquinary5d( [ x, y, z, w, u, out ], shapes, clbk );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+
+	function clbk() {
+		t.ok( false, 'should not invoke callback' );
+	}
+});
+
+tape( 'the function does not invoke a provided callback if provided an output shape having a second element equal to zero', function test( t ) {
+	var expected;
+	var shapes;
+	var out;
+	var x;
+	var y;
+	var z;
+	var w;
+	var u;
+
+	shapes = [
+		[ 2, 2, 2, 2, 2 ],
+		[ 2, 2, 2, 2, 2 ],
+		[ 2, 2, 2, 2, 2 ],
+		[ 2, 2, 2, 2, 2 ],
+		[ 2, 2, 2, 2, 2 ],
+		[ 2, 0, 2, 2, 2 ]
+	];
+	x = zeros5d( [ 2, 2, 2, 2, 2 ] );
+	y = x;
+	z = x;
+	w = x;
+	u = x;
+	out = zeros5d( [ 2, 2, 2, 2, 2 ] );
+
+	expected = zeros5d( [ 2, 2, 2, 2, 2 ] );
+	bquinary5d( [ x, y, z, w, u, out ], shapes, clbk );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+
+	function clbk() {
+		t.ok( false, 'should not invoke callback' );
+	}
+});
+
+tape( 'the function does not invoke a provided callback if provided an output shape having a third element equal to zero', function test( t ) {
+	var expected;
+	var shapes;
+	var out;
+	var x;
+	var y;
+	var z;
+	var w;
+	var u;
+
+	shapes = [
+		[ 2, 2, 2, 2, 2 ],
+		[ 2, 2, 2, 2, 2 ],
+		[ 2, 2, 2, 2, 2 ],
+		[ 2, 2, 2, 2, 2 ],
+		[ 2, 2, 2, 2, 2 ],
+		[ 2, 2, 0, 2, 2 ]
+	];
+	x = zeros5d( [ 2, 2, 2, 2, 2 ] );
+	y = x;
+	z = x;
+	w = x;
+	u = x;
+	out = zeros5d( [ 2, 2, 2, 2, 2 ] );
+
+	expected = zeros5d( [ 2, 2, 2, 2, 2 ] );
+	bquinary5d( [ x, y, z, w, u, out ], shapes, clbk );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+
+	function clbk() {
+		t.ok( false, 'should not invoke callback' );
+	}
+});
+
+tape( 'the function does not invoke a provided callback if provided an output shape having a fourth element equal to zero', function test( t ) {
+	var expected;
+	var shapes;
+	var out;
+	var x;
+	var y;
+	var z;
+	var w;
+	var u;
+
+	shapes = [
+		[ 2, 2, 2, 2, 2 ],
+		[ 2, 2, 2, 2, 2 ],
+		[ 2, 2, 2, 2, 2 ],
+		[ 2, 2, 2, 2, 2 ],
+		[ 2, 2, 2, 2, 2 ],
+		[ 2, 2, 2, 0, 2 ]
+	];
+	x = zeros5d( [ 2, 2, 2, 2, 2 ] );
+	y = x;
+	z = x;
+	w = x;
+	u = x;
+	out = zeros5d( [ 2, 2, 2, 2, 2 ] );
+
+	expected = zeros5d( [ 2, 2, 2, 2, 2 ] );
+	bquinary5d( [ x, y, z, w, u, out ], shapes, clbk );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+
+	function clbk() {
+		t.ok( false, 'should not invoke callback' );
+	}
+});
+
+tape( 'the function does not invoke a provided callback if provided an output shape having a fifth element equal to zero', function test( t ) {
+	var expected;
+	var shapes;
+	var out;
+	var x;
+	var y;
+	var z;
+	var w;
+	var u;
+
+	shapes = [
+		[ 2, 2, 2, 2, 2 ],
+		[ 2, 2, 2, 2, 2 ],
+		[ 2, 2, 2, 2, 2 ],
+		[ 2, 2, 2, 2, 2 ],
+		[ 2, 2, 2, 2, 2 ],
+		[ 2, 2, 2, 2, 0 ]
+	];
+	x = zeros5d( [ 2, 2, 2, 2, 2 ] );
+	y = x;
+	z = x;
+	w = x;
+	u = x;
+	out = zeros5d( [ 2, 2, 2, 2, 2 ] );
+
+	expected = zeros5d( [ 2, 2, 2, 2, 2 ] );
+	bquinary5d( [ x, y, z, w, u, out ], shapes, clbk );
+	t.deepEqual( out, expected, 'returns expected value' );
+
+	t.end();
+
+	function clbk() {
+		t.ok( false, 'should not invoke callback' );
+	}
+});


### PR DESCRIPTION


Ref #https://github.com/stdlib-js/stdlib/issues/3172.

## Description

> What is the purpose of this pull request?

This pull request:

-   This adds a new package to the array/base/* namespace: @stdlib/array/base/broadcasted-quinary5d.

This package is the quinary equivalent of [@stdlib/array/base/broadcasted-binary5d](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/base/broadcasted-binary5d).

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   ref https://github.com/stdlib-js/stdlib/issues/3172

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
