### PR TITLE
chore: fix C lint errors (issue #6502)

### DIFF
--- a/lib/node_modules/@stdlib/math/strided/special/dabs2/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/math/strided/special/dabs2/benchmark/c/benchmark.length.c
@@ -94,29 +94,49 @@ static double rand_double( void ) {
 * @param len          array length
 * @return             elapsed time in seconds
 */
-static double benchmark( int iterations, int len ) {
+static double benchmark(int iterations, int len) {
 	double elapsed;
-	double x[ len ];
-	double y[ len ];
+	double *x;
+	double *y;
 	double t;
 	int i;
 
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( rand_double()*200.0 ) - 100.0;
-		y[ i ] = 0.0;
+	// Allocate input array:
+	x = (double*) malloc(len * sizeof(double));
+	if (x == NULL) {
+		printf("Error allocating memory.\n");
+		exit(1);
+	}
+	
+	// Allocate output array:
+	y = (double*) malloc(len * sizeof(double));
+	if (y == NULL) {
+		free(x);
+		printf("Error allocating memory.\n");
+		exit(1);
+	}
+
+	for (i = 0; i < len; i++) {
+		x[i] = (rand_double()*200.0) - 100.0;
+		y[i] = 0.0;
 	}
 	t = tic();
-	for ( i = 0; i < iterations; i++ ) {
-		stdlib_strided_dabs2( len, x, 1, y, 1 );
-		if ( y[ 0 ] != y[ 0 ] ) {
-			printf( "should not return NaN\n" );
+	for (i = 0; i < iterations; i++) {
+		stdlib_strided_dabs2(len, x, 1, y, 1);
+		if (y[0] != y[0]) {
+			printf("should not return NaN\n");
 			break;
 		}
 	}
 	elapsed = tic() - t;
-	if ( y[ 0 ] != y[ 0 ] ) {
-		printf( "should not return NaN\n" );
+	if (y[0] != y[0]) {
+		printf("should not return NaN\n");
 	}
+	
+	// Free allocated memory:
+	free(x);
+	free(y);
+	
 	return elapsed;
 }
 


### PR DESCRIPTION
Resolves #6502 

## Description

> What is the purpose of this pull request?

This PR fixes the C linting error related to an uninitialized variable in the dabs2 benchmark length test file. The fix replaces variable-length arrays with dynamically allocated memory to ensure proper initialization and memory management.

**Changes made:**
- Replaced VLAs with malloc-allocated arrays
- Added proper memory allocation checks
- Added memory cleanup with free() calls
- Maintained the same functionality as the original code

This pull request:

-   Fixes the C linting error related to an uninitialized variable in the dabs2 benchmark length test file.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #6502  

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Maintained the same functionality as the original code

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
