### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/trunc/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/trunc/README.md
@@ -68,14 +68,16 @@ v = trunc( -Infinity );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/array/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var trunc = require( '@stdlib/math/base/special/trunc' );
 
-var x = randu( 100, -50.0, 50.0 );
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( 'trunc(%d) = %d', x[ i ], trunc( x[ i ] ) );
-}
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
+
+logEachMap( 'trunc(%0.4f) = %0.4f', x, trunc );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/trunc/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/trunc/examples/index.js
@@ -18,11 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/array/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var trunc = require( './../lib' );
 
-var x = randu( 100, -50.0, 50.0 );
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'trunc(%d) = %d', x[ i ], trunc( x[ i ] ) );
-}
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
+
+logEachMap( 'trunc(%0.4f) = %0.4f', x, trunc );

--- a/lib/node_modules/@stdlib/math/base/special/trunc10/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/trunc10/README.md
@@ -98,18 +98,16 @@ v = trunc10( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var trunc10 = require( '@stdlib/math/base/special/trunc10' );
 
-var x;
-var v;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = (randu()*100.0) - 50.0;
-    v = trunc10( x );
-    console.log( 'Value: %d. Rounded: %d.', x, v );
-}
+logEachMap( 'x: %0.4f. Rounded: %0.4f.', x, trunc10 );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/trunc10/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/trunc10/examples/index.js
@@ -18,15 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var trunc10 = require( './../lib' );
 
-var x;
-var v;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = (randu()*100.0) - 50.0;
-	v = trunc10( x );
-	console.log( 'x: %d. Rounded: %d.', x, v );
-}
+logEachMap( 'x: %0.4f. Rounded: %0.4f.', x, trunc10 );

--- a/lib/node_modules/@stdlib/math/base/special/trunc2/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/trunc2/README.md
@@ -83,18 +83,16 @@ v = trunc2( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var trunc2 = require( '@stdlib/math/base/special/trunc2' );
 
-var x;
-var v;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = (randu()*100.0) - 50.0;
-    v = trunc2( x );
-    console.log( 'Value: %d. Rounded: %d.', x, v );
-}
+logEachMap( 'x: %0.4f. Rounded: %0.4f.', x, trunc2 );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/trunc2/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/trunc2/examples/index.js
@@ -18,15 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var trunc2 = require( './../lib' );
 
-var x;
-var v;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = (randu()*100.0) - 50.0;
-	v = trunc2( x );
-	console.log( 'x: %d. Rounded: %d.', x, v );
-}
+logEachMap( 'x: %0.4f. Rounded: %0.4f.', x, trunc2 );

--- a/lib/node_modules/@stdlib/math/base/special/truncf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/truncf/README.md
@@ -68,16 +68,16 @@ v = truncf( -Infinity );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var truncf = require( '@stdlib/math/base/special/truncf' );
 
-var x;
-var i;
+var opts = {
+    'dtype': 'float32'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = (randu()*100.0) - 50.0;
-    console.log( 'trunc(%d) = %d', x, truncf( x ) );
-}
+logEachMap( 'truncf(%d) = %0.4f', x, truncf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/truncf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/truncf/README.md
@@ -77,7 +77,7 @@ var opts = {
 };
 var x = uniform( 100, -50.0, 50.0, opts );
 
-logEachMap( 'truncf(%d) = %0.4f', x, truncf );
+logEachMap( 'truncf(%0.4f) = %0.4f', x, truncf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/truncf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/truncf/examples/index.js
@@ -27,4 +27,4 @@ var opts = {
 };
 var x = uniform( 100, -50.0, 50.0, opts );
 
-logEachMap( 'truncf(%d) = %0.4f', x, truncf );
+logEachMap( 'truncf(%0.4f) = %0.4f', x, truncf );

--- a/lib/node_modules/@stdlib/math/base/special/truncf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/truncf/examples/index.js
@@ -18,13 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var truncf = require( './../lib' );
 
-var x;
-var i;
+var opts = {
+	'dtype': 'float32'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = (randu()*100.0) - 50.0;
-	console.log( 'trunc(%d) = %d', x, truncf( x ) );
-}
+logEachMap( 'truncf(%d) = %0.4f', x, truncf );

--- a/lib/node_modules/@stdlib/math/base/special/truncsd/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/truncsd/README.md
@@ -65,18 +65,16 @@ v = truncsd( 0.0313, 2, 2 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var truncsd = require( '@stdlib/math/base/special/truncsd' );
 
-var x;
-var y;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -5000.0, 5000.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = (randu()*10000.0) - 5000.0;
-    y = truncsd( x, 5, 10 );
-    console.log( 'x: %d. Rounded: %d.', x, y );
-}
+logEachMap( 'x: %0.4f. a: %d. b: %d. Rounded: %0.4f.', x, 5, 10, truncsd );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/truncsd/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/truncsd/examples/index.js
@@ -18,15 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var truncsd = require( './../lib' );
 
-var x;
-var y;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -5000.0, 5000.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = (randu()*10000.0) - 5000.0;
-	y = truncsd( x, 5, 10 );
-	console.log( 'x: %d. Rounded: %d.', x, y );
-}
+logEachMap( 'x: %0.4f. a: %d. b: %d. Rounded: %0.4f.', x, 5, 10, truncsd );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `math/base/special/trunc`, `math/base/special/trunc2`, `math/base/special/trunc10`, `math/base/special/truncf` and `math/base/special/truncsd` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
