### PR TITLE
chore: address commit comments for commit bb378ff (issue #6499)

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/log10/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/log10/README.md
@@ -99,7 +99,7 @@ var opts = {
 };
 var x = discreteUniform( 100, 0, 100, opts );
 
-logEachMap( 'log10(%0.4f) = %0.4f', x, log10 );
+logEachMap( 'log10(%d) = %0.4f', x, log10 );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/log10/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/log10/examples/index.js
@@ -27,4 +27,4 @@ var opts = {
 };
 var x = discreteUniform( 100, 0, 100, opts );
 
-logEachMap( 'log10(%0.4f) = %0.4f', x, log10 );
+logEachMap( 'log10(%d) = %0.4f', x, log10 );

--- a/lib/node_modules/@stdlib/math/base/special/log2/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/log2/README.md
@@ -96,7 +96,7 @@ var opts = {
 };
 var x = discreteUniform( 100, 0, 100, opts );
 
-logEachMap( 'log2(%0.4f) = %0.4f', x, log2 );
+logEachMap( 'log2(%d) = %0.4f', x, log2 );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/log2/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/log2/examples/index.js
@@ -27,4 +27,4 @@ var opts = {
 };
 var x = discreteUniform( 100, 0, 100, opts );
 
-logEachMap( 'log2(%0.4f) = %0.4f', x, log2 );
+logEachMap( 'log2(%d) = %0.4f', x, log2 );

--- a/lib/node_modules/@stdlib/math/base/special/logf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/logf/README.md
@@ -76,7 +76,7 @@ var opts = {
 var x = discreteUniform( 100, 0, 100, opts );
 var b = discreteUniform( 100, 0, 5, opts );
 
-logEachMap( 'logf( %0.4f, %0.4f ) = %0.4f', x, b, logf );
+logEachMap( 'logf( %d, %d ) = %0.4f', x, b, logf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/logf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/logf/examples/index.js
@@ -28,4 +28,4 @@ var opts = {
 var x = discreteUniform( 100, 0, 100, opts );
 var b = discreteUniform( 100, 0, 5, opts );
 
-logEachMap( 'logf( %0.4f, %0.4f ) = %0.4f', x, b, logf );
+logEachMap( 'logf( %d, %d ) = %0.4f', x, b, logf );


### PR DESCRIPTION
Resolves #6499

## Description

> What is the purpose of this pull request?

This pull request:

- Updates example output formatting in the README and example files for `log10`, `log2`, and `logf` to use integer (`%d`) format for input values and floating-point (`%0.4f`) for output values.
- Ensures consistency with stdlib’s preferred output formatting and improves readability of documentation.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #6499

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

All 6 comments from [commit bb378ff](https://github.com/stdlib-js/stdlib/commit/bb378ffa3c07f4acce9504440d26db9d2d97e091) have been addressed, including:

- Updating format strings for `logEachMap` in:
  - `log10` README and examples
  - `log2` README and examples
  - `logf` README and examples
 

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
