### PR TITLE
docs: rename docs-src to src-docs for consistency

### DIFF
--- a/tools/make/README.md
+++ b/tools/make/README.md
@@ -22,7 +22,7 @@ limitations under the License.
 
 > Development utility.
 
-This project uses [`make`][make] as its development utility. For an overview of `make`, see the `make` [manual][make]. 
+This project uses [`make`][make] as its development utility. For an overview of `make`, see the `make` [manual][make].
 
 ## Usage
 
@@ -402,7 +402,7 @@ $ make BENCHMARKS_FILTER=".*/math/base/special/.*" BENCHMARKS_PATTERN=benchmark.
 To generate documentation from [JSDoc][jsdoc] source code comments,
 
 ```bash
-$ make docs-src
+$ make src-docs
 ```
 
 To view the documentation in a local web browser,


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

In `tools/make/README.md` `Documentation` section, there is a typo in the bash command. 
`docs-src` renamed to `src-docs` for consistency.

## Related Issues

> Does this pull request have any related issues?

No

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
