### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/vercos/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/vercos/README.md
@@ -77,16 +77,17 @@ v = vercos( -3.141592653589793/6.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var vercos = require( '@stdlib/math/base/special/vercos' );
 
-var x = linspace( 0.0, TWO_PI, 100 );
-
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( vercos( x[ i ] ) );
+var opts = {
+    'dtype': 'float64'
 }
+var x = uniform( 100, 0.0, TWO_PI, opts );
+
+logEachMap( 'vercos(%0.4f) = %0.4f', x, vercos );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/vercos/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/vercos/README.md
@@ -84,7 +84,7 @@ var vercos = require( '@stdlib/math/base/special/vercos' );
 
 var opts = {
     'dtype': 'float64'
-}
+};
 var x = uniform( 100, 0.0, TWO_PI, opts );
 
 logEachMap( 'vercos(%0.4f) = %0.4f', x, vercos );

--- a/lib/node_modules/@stdlib/math/base/special/vercos/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/vercos/examples/index.js
@@ -25,7 +25,7 @@ var vercos = require( './../lib' );
 
 var opts = {
 	'dtype': 'float64'
-}
+};
 var x = uniform( 100, 0.0, TWO_PI, opts );
 
 logEachMap( 'vercos(%0.4f) = %0.4f', x, vercos );

--- a/lib/node_modules/@stdlib/math/base/special/vercos/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/vercos/examples/index.js
@@ -18,13 +18,14 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var vercos = require( './../lib' );
 
-var x = linspace( 0.0, TWO_PI, 100 );
-
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'vercos(%d) = %d', x[ i ], vercos( x[ i ] ) );
+var opts = {
+	'dtype': 'float64'
 }
+var x = uniform( 100, 0.0, TWO_PI, opts );
+
+logEachMap( 'vercos(%0.4f) = %0.4f', x, vercos );

--- a/lib/node_modules/@stdlib/math/base/special/versin/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/versin/README.md
@@ -84,7 +84,7 @@ var versin = require( '@stdlib/math/base/special/versin' );
 
 var opts = {
     'dtype': 'float64'
-}
+};
 var x = uniform( 100, 0.0, TWO_PI, opts );
 
 logEachMap( 'versin(%0.4f) = %0.4f', x, versin );

--- a/lib/node_modules/@stdlib/math/base/special/versin/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/versin/README.md
@@ -77,16 +77,17 @@ v = versin( -3.141592653589793/6.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var versin = require( '@stdlib/math/base/special/versin' );
 
-var x = linspace( 0.0, TWO_PI, 100 );
-
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( versin( x[ i ] ) );
+var opts = {
+    'dtype': 'float64'
 }
+var x = uniform( 100, 0.0, TWO_PI, opts );
+
+logEachMap( 'versin(%0.4f) = %0.4f', x, versin );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/versin/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/versin/examples/index.js
@@ -25,7 +25,7 @@ var versin = require( './../lib' );
 
 var opts = {
 	'dtype': 'float64'
-}
+};
 var x = uniform( 100, 0.0, TWO_PI, opts );
 
 logEachMap( 'versin(%0.4f) = %0.4f', x, versin );

--- a/lib/node_modules/@stdlib/math/base/special/versin/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/versin/examples/index.js
@@ -18,13 +18,14 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var versin = require( './../lib' );
 
-var x = linspace( 0.0, TWO_PI, 100 );
-
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'versin(%d) = %d', x[ i ], versin( x[ i ] ) );
+var opts = {
+	'dtype': 'float64'
 }
+var x = uniform( 100, 0.0, TWO_PI, opts );
+
+logEachMap( 'versin(%0.4f) = %0.4f', x, versin );

--- a/lib/node_modules/@stdlib/math/base/special/wrap/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/wrap/README.md
@@ -113,7 +113,7 @@ var wrap = require( '@stdlib/math/base/special/wrap' );
 
 var opts = {
     'dtype': 'float64'
-}
+};
 var x = uniform( 100, 0.0, TWO_PI, opts );
 
 logEachMap( 'versin(%0.4f) = %0.4f', x, versin );

--- a/lib/node_modules/@stdlib/math/base/special/wrap/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/wrap/README.md
@@ -106,17 +106,18 @@ var v = wrap( 3.14, 3.0, 3.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var uniform = require( '@stdlib/random/array/uniform' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
-var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var wrap = require( '@stdlib/math/base/special/wrap' );
 
 var opts = {
     'dtype': 'float64'
 };
-var x = uniform( 100, 0.0, TWO_PI, opts );
+var min = discreteUniform( 100, 0, 10, opts );
+var max = discreteUniform( 100, 5, 15, opts );
+var v = discreteUniform( 100, -20, 20, opts );
 
-logEachMap( 'versin(%0.4f) = %0.4f', x, versin );
+logEachMap( 'wrap(%d,%d,%d) => %0.4f', v, min, max, wrap );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/wrap/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/wrap/README.md
@@ -106,20 +106,17 @@ var v = wrap( 3.14, 3.0, 3.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
+var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var wrap = require( '@stdlib/math/base/special/wrap' );
 
-var min;
-var max;
-var v;
-var i;
-
-for ( i = 0; i < 100; i++ ) {
-    min = discreteUniform( 0.0, 10.0 );
-    max = discreteUniform( 5.0, 15.0 );
-    v = discreteUniform( -20.0, 20.0 );
-    console.log( 'wrap(%d,%d,%d) => %d', v, min, max, wrap( v, min, max ) );
+var opts = {
+    'dtype': 'float64'
 }
+var x = uniform( 100, 0.0, TWO_PI, opts );
+
+logEachMap( 'versin(%0.4f) = %0.4f', x, versin );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/wrap/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/wrap/examples/index.js
@@ -18,14 +18,15 @@
 
 'use strict';
 
-var uniform = require( '@stdlib/random/array/uniform' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
-var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
-var versin = require( './../lib' );
+var wrap = require( './../lib' );
 
 var opts = {
 	'dtype': 'float64'
 };
-var x = uniform( 100, 0.0, TWO_PI, opts );
+var min = discreteUniform( 100, 0, 10, opts );
+var max = discreteUniform( 100, 5, 15, opts );
+var v = discreteUniform( 100, -20, 20, opts );
 
-logEachMap( 'versin(%0.4f) = %0.4f', x, versin );
+logEachMap( 'wrap(%d,%d,%d) => %0.4f', v, min, max, wrap );

--- a/lib/node_modules/@stdlib/math/base/special/wrap/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/wrap/examples/index.js
@@ -25,7 +25,7 @@ var versin = require( './../lib' );
 
 var opts = {
 	'dtype': 'float64'
-}
+};
 var x = uniform( 100, 0.0, TWO_PI, opts );
 
 logEachMap( 'versin(%0.4f) = %0.4f', x, versin );

--- a/lib/node_modules/@stdlib/math/base/special/wrap/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/wrap/examples/index.js
@@ -18,17 +18,14 @@
 
 'use strict';
 
-var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
-var wrap = require( './../lib' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
+var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
+var versin = require( './../lib' );
 
-var min;
-var max;
-var v;
-var i;
-
-for ( i = 0; i < 100; i++ ) {
-	min = discreteUniform( 0.0, 10.0 );
-	max = discreteUniform( 5.0, 15.0 );
-	v = discreteUniform( -20.0, 20.0 );
-	console.log( 'wrap(%d,%d,%d) => %d', v, min, max, wrap( v, min, max ) );
+var opts = {
+	'dtype': 'float64'
 }
+var x = uniform( 100, 0.0, TWO_PI, opts );
+
+logEachMap( 'versin(%0.4f) = %0.4f', x, versin );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `math/base/special/vercos`, `math/base/special/versin` and `math/base/special/wrap` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
