### PR TITLE
test: add tests for IEEE 754-2019 compliance

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/acosd/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/acosd/test/test.js
@@ -25,6 +25,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var abs = require( '@stdlib/math/base/special/abs' );
 var randu = require( '@stdlib/random/base/randu' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
 var acosd = require( './../lib' );
 
 
@@ -115,5 +116,10 @@ tape( 'the function returns `NaN` if provided a value greater than `+1`', functi
 		v = (randu()*1.0e6) + 1.0 + EPS;
 		t.strictEqual( isnan( acosd( v ) ), true, 'returns expected value when provided '+v );
 	}
+	t.end();
+});
+
+tape( 'the function returns `0` if provided `1`', function test( t ) {
+	t.strictEqual( isPositiveZero( acosd( 1.0 ) ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/acosd/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/acosd/test/test.native.js
@@ -26,6 +26,7 @@ var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var abs = require( '@stdlib/math/base/special/abs' );
 var randu = require( '@stdlib/random/base/randu' );
 var EPS = require( '@stdlib/constants/float64/eps' );
+var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -124,5 +125,10 @@ tape( 'the function returns `NaN` if provided a value greater than `+1`', opts, 
 		v = (randu()*1.0e6) + 1.0 + EPS;
 		t.strictEqual( isnan( acosd( v ) ), true, 'returns expected value when provided '+v );
 	}
+	t.end();
+});
+
+tape( 'the function returns `0` if provided `1`', opts, function test( t ) {
+	t.strictEqual( isPositiveZero( acosd( 1.0 ) ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/acosdf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/acosdf/test/test.js
@@ -25,6 +25,7 @@ var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var absf = require( '@stdlib/math/base/special/absf' );
 var randu = require( '@stdlib/random/base/randu' );
 var EPS = require( '@stdlib/constants/float32/eps' );
+var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
 var acosdf = require( './../lib' );
 
 
@@ -115,5 +116,10 @@ tape( 'the function returns `NaN` if provided a value greater than `+1`', functi
 		v = ( randu() * 1.0e6 ) + 1.0 + EPS;
 		t.strictEqual( isnanf( acosdf( v ) ), true, 'returns expected value when provided '+v );
 	}
+	t.end();
+});
+
+tape( 'the function returns `0` if provided `1`', function test( t ) {
+	t.strictEqual( isPositiveZero( acosdf( 1.0 ) ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/acosdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/acosdf/test/test.native.js
@@ -26,6 +26,7 @@ var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var absf = require( '@stdlib/math/base/special/absf' );
 var randu = require( '@stdlib/random/base/randu' );
 var EPS = require( '@stdlib/constants/float32/eps' );
+var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -124,5 +125,10 @@ tape( 'the function returns `NaN` if provided a value greater than `+1`', opts, 
 		v = ( randu() * 1.0e6 ) + 1.0 + EPS;
 		t.strictEqual( isnanf( acosdf( v ) ), true, 'returns expected value when provided '+v );
 	}
+	t.end();
+});
+
+tape( 'the function returns `0` if provided `1`', opts, function test( t ) {
+	t.strictEqual( isPositiveZero( acosdf( 1.0 ) ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/acosf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/acosf/test/test.js
@@ -27,6 +27,7 @@ var uniform = require( '@stdlib/random/base/uniform' );
 var abs = require( '@stdlib/math/base/special/abs' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var PI = require( '@stdlib/constants/float32/pi' );
+var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
 var acosf = require( './../lib' );
 
 
@@ -160,5 +161,10 @@ tape( 'the function returns `0.0` if provided a value equal to `+1`', function t
 tape( 'the function returns `PI` if provided a value equal to `-1`', function test( t ) {
 	var v = acosf( -1.0 );
 	t.strictEqual( v, PI, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `0` if provided `1`', function test( t ) {
+	t.strictEqual( isPositiveZero( acosf( 1.0 ) ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/acosf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/acosf/test/test.native.js
@@ -28,6 +28,7 @@ var uniform = require( '@stdlib/random/base/uniform' );
 var abs = require( '@stdlib/math/base/special/abs' );
 var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
 var PI = require( '@stdlib/constants/float32/pi' );
+var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 
 
@@ -169,5 +170,10 @@ tape( 'the function returns `0.0` if provided a value equal to `+1`', opts, func
 tape( 'the function returns `PI` if provided a value equal to `-1`', opts, function test( t ) {
 	var v = acosf( -1.0 );
 	t.strictEqual( v, PI, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `0` if provided `1`', opts, function test( t ) {
+	t.strictEqual( isPositiveZero( acosf( 1.0 ) ), true, 'returns expected value' );
 	t.end();
 });


### PR DESCRIPTION
Progresses #365

## Description

> What is the purpose of this pull request?

This pull request:

- Add tests for checking that `acosd(1)`, `acosdf(1)`, and `acosf(1)` are `+0`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   progresses #365

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md