### PR TITLE
feat: add copy button into code blocks

### DIFF
--- a/lib/node_modules/@stdlib/_tools/markdown/to-html/lib/post_process.js
+++ b/lib/node_modules/@stdlib/_tools/markdown/to-html/lib/post_process.js
@@ -28,6 +28,7 @@ var replace = require( '@stdlib/string/replace' );
 var RE_VIEW_BOX = /(?:(view-box)(=".*?"))/g;
 var RE_CLIP_PATH_OPEN = /(?:<(clip-path)(.*?>))/g;
 var RE_CLIP_PATH_CLOSE = /<\/clip-path>/g;
+var RE_CODE_BLOCKS = /<pre>\s*<code class="([^"]*)">\s*([\s\S]*?)\s*<\/code>\s*<\/pre>/g;
 
 
 // MAIN //
@@ -53,7 +54,36 @@ function postProcess( html ) {
 	html = replace( html, RE_VIEW_BOX, 'viewBox$2' );
 	html = replace( html, RE_CLIP_PATH_OPEN, '<clipPath$2' );
 	html = replace( html, RE_CLIP_PATH_CLOSE, '</clipPath>' );
+	html = replace( html, RE_CODE_BLOCKS, injectCopyButton );
+	html += getCopyButtonStyles();
 	return html;
+}
+
+/**
+* Injects a "Copy" button into a code block.
+*
+* This function wraps a `<pre><code>` block in a container div and inserts a
+* "Copy" button above it. The button uses the Clipboard API to copy the visible
+* text content (`innerText`) of the `<code>` element when clicked.
+*
+* @private
+* @param {string} match The entire matched HTML
+* @param {string} lang The language class
+* @param {string} code The raw HTML contents of the code block
+* @returns {string} copy button HTML
+*/
+function injectCopyButton( match, lang, code ) {
+	return '<div class="code-container"><button class="copy-button" onclick="const codeContainer = this.closest(\'.code-container\');if ( codeContainer ) { const codeElement = codeContainer.querySelector( \'code\' ); if ( codeElement ) { try { navigator.clipboard.writeText( codeElement.innerText ); this.innerText = \'Copied\'; setTimeout(() => { this.innerText = \'Copy\' }, 2000); } catch (err) { console.error(err); } } }">Copy</button><pre><code class="' + lang + '">' + code + '</code></pre></div>';
+}
+
+/**
+* Returns copy button styles.
+*
+* @private
+* @returns {string} copy button styles
+*/
+function getCopyButtonStyles() {
+	return '<style>.code-container { position: relative; } .copy-button { position: absolute; top: 8px; right: 8px; background: #eee; border: none; padding: 5px 10px; cursor: pointer; font-size: 0.8em; border-radius: 4px; } .copy-button:hover { background: #ddd; }</style>';
 }
 
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

Adds a "Copy" button to all `<pre><code>` blocks in the generated HTML. Ensures improved UX for users reading code examples.

## Related Issues

> Does this pull request have any related issues?

#6600 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
