### PR TITLE
feat: add `every`, `includes`, `unaryAccumulate`, and `unaryReduceSubarray` to namespace

### DIFF
--- a/lib/node_modules/@stdlib/_tools/github/subscriptions/README.md
+++ b/lib/node_modules/@stdlib/_tools/github/subscriptions/README.md
@@ -205,7 +205,7 @@ function clbk( error, repo, info ) {
 ### Usage
 
 ```bash
-Usage: ghwatching [options] 
+Usage: ghwatching [options]
 
 Options:
 

--- a/lib/node_modules/@stdlib/datasets/nightingales-rose/README.md
+++ b/lib/node_modules/@stdlib/datasets/nightingales-rose/README.md
@@ -161,7 +161,7 @@ date,army_size,disease,wounds,other
 
 ## References
 
--   Nightingale, Florence. 1859. [_A contribution to the sanitary history of the British army during the late war with Russia_][@nightingale:1859a]. London, United Kingdom: John W. Parker and Son. 
+-   Nightingale, Florence. 1859. [_A contribution to the sanitary history of the British army during the late war with Russia_][@nightingale:1859a]. London, United Kingdom: John W. Parker and Son.
 
 </section>
 

--- a/lib/node_modules/@stdlib/ndarray/base/lib/index.js
+++ b/lib/node_modules/@stdlib/ndarray/base/lib/index.js
@@ -302,6 +302,15 @@ setReadOnly( ns, 'empty', require( '@stdlib/ndarray/base/empty' ) );
 setReadOnly( ns, 'emptyLike', require( '@stdlib/ndarray/base/empty-like' ) );
 
 /**
+* @name every
+* @memberof ns
+* @readonly
+* @type {Function}
+* @see {@link module:@stdlib/ndarray/base/every}
+*/
+setReadOnly( ns, 'every', require( '@stdlib/ndarray/base/every' ) );
+
+/**
 * @name expandDimensions
 * @memberof ns
 * @readonly
@@ -390,6 +399,15 @@ setReadOnly( ns, 'scalar2ndarray', require( '@stdlib/ndarray/base/from-scalar' )
 * @see {@link module:@stdlib/ndarray/base/from-scalar-like}
 */
 setReadOnly( ns, 'scalar2ndarrayLike', require( '@stdlib/ndarray/base/from-scalar-like' ) );
+
+/**
+* @name includes
+* @memberof ns
+* @readonly
+* @type {Function}
+* @see {@link module:@stdlib/ndarray/base/includes}
+*/
+setReadOnly( ns, 'includes', require( '@stdlib/ndarray/base/includes' ) );
 
 /**
 * @name ind
@@ -905,6 +923,15 @@ setReadOnly( ns, 'transpose', require( '@stdlib/ndarray/base/transpose' ) );
 setReadOnly( ns, 'unary', require( '@stdlib/ndarray/base/unary' ) );
 
 /**
+* @name unaryAccumulate
+* @memberof ns
+* @readonly
+* @type {Function}
+* @see {@link module:@stdlib/ndarray/base/unary-accumulate}
+*/
+setReadOnly( ns, 'unaryAccumulate', require( '@stdlib/ndarray/base/unary-accumulate' ) );
+
+/**
 * @name unaryBy
 * @memberof ns
 * @readonly
@@ -930,6 +957,15 @@ setReadOnly( ns, 'unaryLoopOrder', require( '@stdlib/ndarray/base/unary-loop-int
 * @see {@link module:@stdlib/ndarray/base/unary-output-dtype}
 */
 setReadOnly( ns, 'unaryOutputDataType', require( '@stdlib/ndarray/base/unary-output-dtype' ) );
+
+/**
+* @name unaryReduceSubarray
+* @memberof ns
+* @readonly
+* @type {Function}
+* @see {@link module:@stdlib/ndarray/base/unary-reduce-subarray}
+*/
+setReadOnly( ns, 'unaryReduceSubarray', require( '@stdlib/ndarray/base/unary-reduce-subarray' ) );
 
 /**
 * @name unaryBlockSize


### PR DESCRIPTION
Resolves #6574 .
Resolves #6589 .

## Description

> What is the purpose of this pull request?

This pull request:

-   Removes whitespaces found in github/subscriptions/README.md and datasets/nightingales-rose/README.md (6574). Additionally, fixes warnings in @stdlib/ndarray/base/lib/index.js (6589)

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #6574 
-   resolves #6589 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
