### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cbrt/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/cbrt/README.md
@@ -65,16 +65,16 @@ v = cbrt( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var cbrt = require( '@stdlib/math/base/special/cbrt' );
 
-var x;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -100.0, 100.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = (randu()*200.0) - 100.0;
-    console.log( 'cbrt(%d) = %d', x, cbrt( x ) );
-}
+logEachMap( 'cbrt(%0.4f) = %0.4f', x, cbrt );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/cbrt/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/cbrt/examples/index.js
@@ -18,13 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var cbrt = require( './../lib' );
 
-var x;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -100.0, 100.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = (randu()*200.0) - 100.0;
-	console.log( 'cbrt(%d) = %d', x, cbrt( x ) );
-}
+logEachMap( 'cbrt(%0.4f) = %0.4f', x, cbrt );

--- a/lib/node_modules/@stdlib/math/base/special/cbrtf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/cbrtf/README.md
@@ -65,16 +65,16 @@ v = cbrtf( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var cbrtf = require( '@stdlib/math/base/special/cbrtf' );
 
-var x;
-var i;
+var opts = {
+    'dtype': 'float32'
+};
+var x = uniform( 100, -100.0, 100.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = (randu()*200.0) - 100.0;
-    console.log( 'cbrt(%d) = %d', x, cbrtf( x ) );
-}
+logEachMap( 'cbrt(%0.4f) = %0.4f', x, cbrtf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/cbrtf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/cbrtf/examples/index.js
@@ -18,13 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var cbrtf = require( './../lib' );
 
-var x;
-var i;
+var opts = {
+	'dtype': 'float32'
+};
+var x = uniform( 100, -100.0, 100.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = (randu()*200.0) - 100.0;
-	console.log( 'cbrt(%d) = %d', x, cbrtf( x ) );
-}
+logEachMap( 'cbrt(%0.4f) = %0.4f', x, cbrtf );

--- a/lib/node_modules/@stdlib/math/base/special/ceil/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/ceil/README.md
@@ -59,16 +59,16 @@ v = ceil( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var ceil = require( '@stdlib/math/base/special/ceil' );
 
-var x;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = (randu()*100.0) - 50.0;
-    console.log( 'ceil(%d) = %d', x, ceil( x ) );
-}
+logEachMap( 'ceil(%0.4f) = %0.4f', x, ceil );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/ceil/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/ceil/examples/index.js
@@ -18,13 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var ceil = require( './../lib' );
 
-var x;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = (randu()*100.0) - 50.0;
-	console.log( 'ceil(%d) = %d', x, ceil( x ) );
-}
+logEachMap( 'ceil(%0.4f) = %0.4f', x, ceil );

--- a/lib/node_modules/@stdlib/math/base/special/ceilf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/ceilf/README.md
@@ -59,16 +59,16 @@ v = ceilf( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var ceilf = require( '@stdlib/math/base/special/ceilf' );
 
-var x;
-var i;
+var opts = {
+    'dtype': 'float32'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = (randu()*100.0) - 50.0;
-    console.log( 'ceilf(%d) = %d', x, ceilf( x ) );
-}
+logEachMap( 'ceilf(%0.4f) = %0.4f', x, ceilf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/ceilf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/ceilf/examples/index.js
@@ -18,13 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var ceilf = require( './../lib' );
 
-var x;
-var i;
+var opts = {
+	'dtype': 'float32'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = (randu()*100.0) - 50.0;
-	console.log( 'ceilf(%d) = %d', x, ceilf( x ) );
-}
+logEachMap( 'ceilf(%0.4f) = %0.4f', x, ceilf );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `math/base/special/cbrt`, `math/base/special/cbrtf`, `math/base/special/ceil` and `math/base/special/ceilf` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
