### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/ceil10/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/ceil10/README.md
@@ -98,18 +98,16 @@ v = ceil10( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var ceil10 = require( '@stdlib/math/base/special/ceil10' );
 
-var x;
-var v;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = (randu()*100.0) - 50.0;
-    v = ceil10( x );
-    console.log( 'Value: %d. Rounded: %d.', x, v );
-}
+logEachMap( 'x: %0.4f. Rounded: %0.4f.', x, ceil10 );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/ceil10/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/ceil10/examples/index.js
@@ -18,15 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var ceil10 = require( './../lib' );
 
-var x;
-var v;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = (randu()*100.0) - 50.0;
-	v = ceil10( x );
-	console.log( 'x: %d. Rounded: %d.', x, v );
-}
+logEachMap( 'x: %0.4f. Rounded: %0.4f.', x, ceil10 );

--- a/lib/node_modules/@stdlib/math/base/special/ceil2/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/ceil2/README.md
@@ -83,18 +83,16 @@ v = ceil2( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var ceil2 = require( '@stdlib/math/base/special/ceil2' );
 
-var x;
-var v;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = (randu()*100.0) - 50.0;
-    v = ceil2( x );
-    console.log( 'Value: %d. Rounded: %d.', x, v );
-}
+logEachMap( 'x: %0.4f. Rounded: %0.4f.', x, ceil2 );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/ceil2/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/ceil2/examples/index.js
@@ -18,15 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var ceil2 = require( './../lib' );
 
-var x;
-var v;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = (randu()*100.0) - 50.0;
-	v = ceil2( x );
-	console.log( 'x: %d. Rounded: %d.', x, v );
-}
+logEachMap( 'x: %0.4f. Rounded: %0.4f.', x, ceil2 );

--- a/lib/node_modules/@stdlib/math/base/special/ceilsd/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/ceilsd/README.md
@@ -65,18 +65,16 @@ v = ceilsd( 0.0313, 2, 2 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var ceilsd = require( '@stdlib/math/base/special/ceilsd' );
 
-var x;
-var y;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -5000.0, 5000.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = (randu()*10000.0) - 5000.0;
-    y = ceilsd( x, 5, 10 );
-    console.log( 'x: %d. Rounded: %d.', x, y );
-}
+logEachMap( 'x: %0.4f. y: %0.4f. z: %0.4f. Rounded: %0.4f.', x, 5, 10, ceilsd );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/ceilsd/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/ceilsd/README.md
@@ -74,7 +74,7 @@ var opts = {
 };
 var x = uniform( 100, -5000.0, 5000.0, opts );
 
-logEachMap( 'x: %0.4f. y: %0.4f. z: %0.4f. Rounded: %0.4f.', x, 5, 10, ceilsd );
+logEachMap( 'x: %0.4f. y: %d. z: %d. Rounded: %0.4f.', x, 5, 10, ceilsd );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/ceilsd/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/ceilsd/examples/index.js
@@ -18,15 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var ceilsd = require( './../lib' );
 
-var x;
-var y;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -5000.0, 5000.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = (randu()*10000.0) - 5000.0;
-	y = ceilsd( x, 5, 10 );
-	console.log( 'x: %d. Rounded: %d.', x, y );
-}
+logEachMap( 'x: %0.4f. y: %0.4f. z: %0.4f. Rounded: %0.4f.', x, 5, 10, ceilsd );

--- a/lib/node_modules/@stdlib/math/base/special/ceilsd/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/ceilsd/examples/index.js
@@ -27,4 +27,4 @@ var opts = {
 };
 var x = uniform( 100, -5000.0, 5000.0, opts );
 
-logEachMap( 'x: %0.4f. y: %0.4f. z: %0.4f. Rounded: %0.4f.', x, 5, 10, ceilsd );
+logEachMap( 'x: %0.4f. y: %d. z: %d. Rounded: %0.4f.', x, 5, 10, ceilsd );

--- a/lib/node_modules/@stdlib/math/base/special/clamp/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/clamp/README.md
@@ -106,7 +106,7 @@ var min = discreteUniform( 100, 0, 10, opts );
 var max = discreteUniform( 100, 5, 15, opts );
 var v = discreteUniform( 100, -20, 20, opts );
 
-logEachMap( 'clamp(%d,%d,%d) => %0.4f', v, min, max, clamp );
+logEachMap( 'clamp(%d,%d,%d) => %d', v, min, max, clamp );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/clamp/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/clamp/README.md
@@ -95,20 +95,18 @@ v = clamp( 3.14, 0.0, NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var clamp = require( '@stdlib/math/base/special/clamp' );
 
-var min;
-var max;
-var v;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var min = discreteUniform( 100, 0, 10, opts );
+var max = discreteUniform( 100, 5, 15, opts );
+var v = discreteUniform( 100, -20, 20, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    min = discreteUniform( 0.0, 10.0 );
-    max = discreteUniform( 5.0, 15.0 );
-    v = discreteUniform( -20.0, 20.0 );
-    console.log( 'clamp(%d,%d,%d) => %d', v, min, max, clamp( v, min, max ) );
-}
+logEachMap( 'clamp(%d,%d,%d) => %0.4f', v, min, max, clamp );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/clamp/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/clamp/examples/index.js
@@ -18,17 +18,15 @@
 
 'use strict';
 
-var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var clamp = require( './../lib' );
 
-var min;
-var max;
-var v;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var min = discreteUniform( 100, 0, 10, opts );
+var max = discreteUniform( 100, 5, 15, opts );
+var v = discreteUniform( 100, -20, 20, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	min = discreteUniform( 0.0, 10.0 );
-	max = discreteUniform( 5.0, 15.0 );
-	v = discreteUniform( -20.0, 20.0 );
-	console.log( 'clamp(%d,%d,%d) => %d', v, min, max, clamp( v, min, max ) );
-}
+logEachMap( 'clamp(%d,%d,%d) => %0.4f', v, min, max, clamp );

--- a/lib/node_modules/@stdlib/math/base/special/clamp/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/clamp/examples/index.js
@@ -29,4 +29,4 @@ var min = discreteUniform( 100, 0, 10, opts );
 var max = discreteUniform( 100, 5, 15, opts );
 var v = discreteUniform( 100, -20, 20, opts );
 
-logEachMap( 'clamp(%d,%d,%d) => %0.4f', v, min, max, clamp );
+logEachMap( 'clamp(%d,%d,%d) => %d', v, min, max, clamp );

--- a/lib/node_modules/@stdlib/math/base/special/clampf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/clampf/README.md
@@ -95,20 +95,18 @@ v = clampf( 3.14, 0.0, NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var clampf = require( '@stdlib/math/base/special/clampf' );
 
-var min;
-var max;
-var v;
-var i;
+var opts = {
+    'dtype': 'float32'
+};
+var min = discreteUniform( 100, 0, 10, opts );
+var max = discreteUniform( 100, 5, 15, opts );
+var v = discreteUniform( 100, -20, 20, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    min = discreteUniform( 0.0, 10.0 );
-    max = discreteUniform( 5.0, 15.0 );
-    v = discreteUniform( -20.0, 20.0 );
-    console.log( 'clampf(%d,%d,%d) => %d', v, min, max, clampf( v, min, max ) );
-}
+logEachMap( 'clampf(%d,%d,%d) => %0.4f', v, min, max, clampf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/clampf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/clampf/README.md
@@ -106,7 +106,7 @@ var min = discreteUniform( 100, 0, 10, opts );
 var max = discreteUniform( 100, 5, 15, opts );
 var v = discreteUniform( 100, -20, 20, opts );
 
-logEachMap( 'clampf(%d,%d,%d) => %0.4f', v, min, max, clampf );
+logEachMap( 'clampf(%d,%d,%d) => %d', v, min, max, clampf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/clampf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/clampf/examples/index.js
@@ -29,4 +29,4 @@ var min = discreteUniform( 100, 0, 10, opts );
 var max = discreteUniform( 100, 5, 15, opts );
 var v = discreteUniform( 100, -20, 20, opts );
 
-logEachMap( 'clampf(%d,%d,%d) => %0.4f', v, min, max, clampf );
+logEachMap( 'clampf(%d,%d,%d) => %d', v, min, max, clampf );

--- a/lib/node_modules/@stdlib/math/base/special/clampf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/clampf/examples/index.js
@@ -18,17 +18,15 @@
 
 'use strict';
 
-var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var clampf = require( './../lib' );
 
-var min;
-var max;
-var v;
-var i;
+var opts = {
+	'dtype': 'float32'
+};
+var min = discreteUniform( 100, 0, 10, opts );
+var max = discreteUniform( 100, 5, 15, opts );
+var v = discreteUniform( 100, -20, 20, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	min = discreteUniform( 0.0, 10.0 );
-	max = discreteUniform( 5.0, 15.0 );
-	v = discreteUniform( -20.0, 20.0 );
-	console.log( 'clampf(%d,%d,%d) => %d', v, min, max, clampf( v, min, max ) );
-}
+logEachMap( 'clampf(%d,%d,%d) => %0.4f', v, min, max, clampf );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `math/base/special/clamp`, `math/base/special/clampf`, `math/base/special/ceil2`, `math/base/special/ceil10` and `math/base/special/ceilsd` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
