### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/copysign/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/copysign/README.md
@@ -72,21 +72,18 @@ z = copysign( -0.0, 1.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var copysign = require( '@stdlib/math/base/special/copysign' );
 
-var x;
-var y;
-var z;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
+var y = uniform( 100, -5.0, 5.0, opts );
 
 // Generate random double-precision floating-point numbers `x` and `y` and copy the sign of `y` to `x`...
-for ( i = 0; i < 100; i++ ) {
-    x = (randu()*100.0) - 50.0;
-    y = (randu()*10.0) - 5.0;
-    z = copysign( x, y );
-    console.log( 'x: %d, y: %d => %d', x, y, z );
-}
+logEachMap( 'x: %0.4f, y: %0.4f => %0.4f', x, y, copysign );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/copysign/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/copysign/examples/index.js
@@ -18,18 +18,15 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var copysign = require( './../lib' );
 
-var x;
-var y;
-var z;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
+var y = uniform( 100, -5.0, 5.0, opts );
 
 // Generate random double-precision floating-point numbers `x` and `y` and copy the sign of `y` to `x`...
-for ( i = 0; i < 100; i++ ) {
-	x = (randu()*100.0) - 50.0;
-	y = (randu()*10.0) - 5.0;
-	z = copysign( x, y );
-	console.log( 'x: %d, y: %d => %d', x, y, z );
-}
+logEachMap( 'x: %0.4f, y: %0.4f => %0.4f', x, y, copysign );

--- a/lib/node_modules/@stdlib/math/base/special/copysignf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/copysignf/README.md
@@ -72,21 +72,18 @@ z = copysignf( -0.0, 1.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var copysignf = require( '@stdlib/math/base/special/copysignf' );
 
-var x;
-var y;
-var z;
-var i;
+var opts = {
+    'dtype': 'float32'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
+var y = uniform( 100, -5.0, 5.0, opts );
 
 // Generate random numbers `x` and `y` and copy the sign of `y` to `x`...
-for ( i = 0; i < 100; i++ ) {
-    x = (randu()*100.0) - 50.0;
-    y = (randu()*10.0) - 5.0;
-    z = copysignf( x, y );
-    console.log( 'x: %d, y: %d => %d', x, y, z );
-}
+logEachMap( 'x: %0.4f, y: %0.4f => %0.4f', x, y, copysignf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/copysignf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/copysignf/examples/index.js
@@ -18,18 +18,15 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var copysignf = require( './../lib' );
 
-var x;
-var y;
-var z;
-var i;
+var opts = {
+	'dtype': 'float32'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
+var y = uniform( 100, -5.0, 5.0, opts );
 
 // Generate random numbers `x` and `y` and copy the sign of `y` to `x`...
-for ( i = 0; i < 100; i++ ) {
-	x = (randu()*100.0) - 50.0;
-	y = (randu()*10.0) - 5.0;
-	z = copysignf( x, y );
-	console.log( 'x: %d, y: %d => %d', x, y, z );
-}
+logEachMap( 'x: %0.4f, y: %0.4f => %0.4f', x, y, copysignf );

--- a/lib/node_modules/@stdlib/math/base/special/cos/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/cos/README.md
@@ -59,16 +59,17 @@ v = cos( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var cos = require( '@stdlib/math/base/special/cos' );
 
-var x = linspace( 0.0, TWO_PI, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, 0.0, TWO_PI, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( cos( x[ i ] ) );
-}
+logEachMap( 'cos(%0.4f) = %0.4f', x, cos );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/cos/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/cos/examples/index.js
@@ -18,13 +18,14 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var cos = require( './../lib' );
 
-var x = linspace( 0.0, TWO_PI, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, 0.0, TWO_PI, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'cos(%d) = %d', x[ i ], cos( x[ i ] ) );
-}
+logEachMap( 'cos(%0.4f) = %0.4f', x, cos );

--- a/lib/node_modules/@stdlib/math/base/special/cosd/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/cosd/README.md
@@ -63,15 +63,16 @@ v = cosd( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var cosd = require( '@stdlib/math/base/special/cosd' );
 
-var x = linspace( -180, 180, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -180, 180, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( cosd( x[ i ] ) );
-}
+logEachMap( 'cosd(%0.4f) = %0.4f', x, cosd );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/cosd/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/cosd/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var cosd = require( './../lib' );
 
-var x = linspace( -180, 180, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -180.0, 180.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'cosd(%d) = %d', x[ i ], cosd( x[ i ] ) );
-}
+logEachMap( 'cosd(%0.4f) = %0.4f', x, cosd );

--- a/lib/node_modules/@stdlib/math/base/special/cosh/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/cosh/README.md
@@ -62,15 +62,16 @@ v = cosh( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var cosh = require( '@stdlib/math/base/special/cosh' );
 
-var x = linspace( -5.0, 5.0, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -5.0, 5.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( cosh( x[ i ] ) );
-}
+logEachMap( 'cosh(%0.4f) = %0.4f', x, cosh );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/cosh/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/cosh/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var cosh = require( './../lib' );
 
-var x = linspace( -5.0, 5.0, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -5.0, 5.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'cosh(%d) = %d', x[ i ], cosh( x[ i ] ) );
-}
+logEachMap( 'cosh(%0.4f) = %0.4f', x, cosh );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `math/base/special/copysign`, `math/base/special/copysignf`, `math/base/special/cos`, `math/base/special/cosd` and `math/base/special/cosh` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
