### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cosm1/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/cosm1/README.md
@@ -61,16 +61,17 @@ v = cosm1( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var PI = require( '@stdlib/constants/float64/pi' );
 var cosm1 = require( '@stdlib/math/base/special/cosm1' );
 
-var x = linspace( 0.0, 2.0*PI, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, 0.0, 2.0*PI, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( cosm1( x[ i ] ) );
-}
+logEachMap( 'cos(%0.4f) - 1 = %0.4f', x, cosm1 );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/cosm1/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/cosm1/examples/index.js
@@ -18,13 +18,14 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var PI = require( '@stdlib/constants/float64/pi' );
 var cosm1 = require( './../lib' );
 
-var x = linspace( 0.0, 2.0*PI, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, 0.0, 2.0*PI, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'cos(%d) - 1 = %d', x[ i ], cosm1( x[ i ] ) );
-}
+logEachMap( 'cos(%0.4f) - 1 = %0.4f', x, cosm1 );

--- a/lib/node_modules/@stdlib/math/base/special/cospi/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/cospi/README.md
@@ -59,15 +59,16 @@ y = cospi( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var cospi = require( '@stdlib/math/base/special/cospi' );
 
-var x = linspace( -100.0, 100.0, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -100.0, 100.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( cospi( x[ i ] ) );
-}
+logEachMap( 'cos( π * %0.4f ) = %0.4f', x, cospi );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/cospi/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/cospi/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var cospi = require( './../lib' );
 
-var x = linspace( -100.0, 100.0, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -100.0, 100.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'cos( π * %d ) = %d', x[ i ], cospi( x[ i ] ) );
-}
+logEachMap( 'cos( π * %0.4f ) = %0.4f', x, cospi );

--- a/lib/node_modules/@stdlib/math/base/special/cot/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/cot/README.md
@@ -66,16 +66,17 @@ v = cot( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var PI = require( '@stdlib/constants/float64/pi' );
 var cot = require( '@stdlib/math/base/special/cot' );
 
-var x = linspace( -PI/2.0, PI/2.0, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -PI/2.0, PI/2.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( cot( x[ i ] ) );
-}
+logEachMap( 'cot(%0.4f) = %0.4f', x, cot );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/cot/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/cot/examples/index.js
@@ -18,13 +18,14 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var PI = require( '@stdlib/constants/float64/pi' );
 var cot = require( './../lib' );
 
-var x = linspace( -PI, PI, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -PI/2.0, PI/2.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'cot(%d) = %d', x[ i ], cot( x[ i ] ) );
-}
+logEachMap( 'cot(%0.4f) = %0.4f', x, cot );

--- a/lib/node_modules/@stdlib/math/base/special/cotd/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/cotd/README.md
@@ -63,15 +63,16 @@ v = cotd( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var cotd = require( '@stdlib/math/base/special/cotd' );
 
-var x = linspace( -180, 180, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -180.0, 180.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( cotd( x[ i ] ) );
-}
+logEachMap( 'cotd(%0.4f) = %0.4f', x, cotd );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/cotd/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/cotd/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var cotd = require( './../lib' );
 
-var x = linspace( -180, 180, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -180.0, 180.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'cotd(%d) = %d', x[ i ], cotd( x[ i ] ) );
-}
+logEachMap( 'cotd(%0.4f) = %0.4f', x, cotd );

--- a/lib/node_modules/@stdlib/math/base/special/coth/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/coth/README.md
@@ -59,15 +59,16 @@ v = coth( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var coth = require( '@stdlib/math/base/special/coth' );
 
-var x = linspace( -10.0, 10.0, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -10.0, 10.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( coth( x[ i ] ) );
-}
+logEachMap( 'coth(%0.4f) = %0.4f', x, coth );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/coth/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/coth/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var coth = require( './../lib' );
 
-var x = linspace( -10.0, 10.0, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -10.0, 10.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'coth(%d) = %d', x[ i ], coth( x[ i ] ) );
-}
+logEachMap( 'coth(%0.4f) = %0.4f', x, coth );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `math/base/special/cosm1`, `math/base/special/cospi`, `math/base/special/cot`, `math/base/special/cotd` and `math/base/special/coth` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
