### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/covercos/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/covercos/README.md
@@ -77,16 +77,17 @@ v = covercos( -3.141592653589793/6.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var covercos = require( '@stdlib/math/base/special/covercos' );
 
-var x = linspace( 0.0, TWO_PI, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, 0.0, TWO_PI, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( covercos( x[ i ] ) );
-}
+logEachMap( 'covercos(%0.4f) = %0.4f', x, covercos );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/covercos/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/covercos/examples/index.js
@@ -18,13 +18,14 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var covercos = require( './../lib' );
 
-var x = linspace( 0.0, TWO_PI, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, 0.0, TWO_PI, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'covercos(%d) = %d', x[ i ], covercos( x[ i ] ) );
-}
+logEachMap( 'covercos(%0.4f) = %0.4f', x, covercos );

--- a/lib/node_modules/@stdlib/math/base/special/coversin/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/coversin/README.md
@@ -77,16 +77,17 @@ v = coversin( -3.141592653589793/6.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var coversin = require( '@stdlib/math/base/special/coversin' );
 
-var x = linspace( 0.0, TWO_PI, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, 0.0, TWO_PI, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( coversin( x[ i ] ) );
-}
+logEachMap( 'coversin(%0.4f) = %0.4f', x, coversin );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/coversin/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/coversin/examples/index.js
@@ -18,13 +18,14 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var coversin = require( './../lib' );
 
-var x = linspace( 0.0, TWO_PI, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, 0.0, TWO_PI, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'coversin(%d) = %d', x[ i ], coversin( x[ i ] ) );
-}
+logEachMap( 'coversin(%0.4f) = %0.4f', x, coversin );

--- a/lib/node_modules/@stdlib/math/base/special/csc/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/csc/README.md
@@ -66,16 +66,17 @@ v = csc( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
-var PI = require( '@stdlib/constants/float64/pi' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
+var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var csc = require( '@stdlib/math/base/special/csc' );
 
-var x = linspace( -PI/2.0, PI/2.0, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -TWO_PI, TWO_PI, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( csc( x[ i ] ) );
-}
+logEachMap( 'csc(%0.4f) = %0.4f', x, csc );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/csc/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/csc/examples/index.js
@@ -18,13 +18,14 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var csc = require( './../lib' );
 
-var x = linspace( -TWO_PI, TWO_PI, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -TWO_PI, TWO_PI, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'csc(%d) = %d', x[i], csc( x[i] ) );
-}
+logEachMap( 'csc(%0.4f) = %0.4f', x, csc );

--- a/lib/node_modules/@stdlib/math/base/special/cscd/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/cscd/README.md
@@ -65,15 +65,16 @@ v = cscd( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var cscd = require( '@stdlib/math/base/special/cscd' );
 
-var x = linspace( 1.1, 5.1, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, 1.1, 5.1, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( cscd( x[ i ] ) );
-}
+logEachMap( 'cscd(%0.4f) = %0.4f', x, cscd );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/cscd/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/cscd/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var cscd = require( './../lib' );
 
-var x = linspace( 1.1, 5.1, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, 1.1, 5.1, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'cscd(%d) = %d', x[ i ], cscd( x[ i ] ) );
-}
+logEachMap( 'cscd(%0.4f) = %0.4f', x, cscd );

--- a/lib/node_modules/@stdlib/math/base/special/csch/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/csch/README.md
@@ -59,15 +59,16 @@ v = csch( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var csch = require( '@stdlib/math/base/special/csch' );
 
-var x = linspace( -5.0, 5.0, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -5.0, 5.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( csch( x[ i ] ) );
-}
+logEachMap( 'csch( %0.4f ) = %0.4f', x, csch );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/csch/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/csch/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var csch = require( './../lib' );
 
-var x = linspace( -5.0, 5.0, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -5.0, 5.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'csch( %d ) = %d', x[ i ], csch( x[ i ] ) );
-}
+logEachMap( 'csch( %0.4f ) = %0.4f', x, csch );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `math/base/special/covercos`, `math/base/special/coversin`, `math/base/special/csc`, `math/base/special/cscd` and `math/base/special/csch` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
