### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/falling-factorial/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/falling-factorial/README.md
@@ -92,7 +92,7 @@ var opts = {
 var x = uniform( 100, -20.0, 20.0, opts );
 var n = discreteUniform( 100, 0, 20, opts );
 
-logEachMap( 'fallingFactorial(%0.4f,%0.4f) = %0.4f', x, n, fallingFactorial );
+logEachMap( 'fallingFactorial(%0.4f,%0.4f) = %d', x, n, fallingFactorial );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/falling-factorial/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/falling-factorial/README.md
@@ -81,17 +81,18 @@ v = fallingFactorial( 3.0, -2 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/array/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var fallingFactorial = require( '@stdlib/math/base/special/falling-factorial' );
 
-var x = randu( 100, -20.0, 20.0 );
-var n = discreteUniform( 100, 0, 20 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -20.0, 20.0, opts );
+var n = discreteUniform( 100, 0, 20, opts );
 
-var i;
-for ( i = 0; i < 100; i++ ) {
-    console.log( 'fallingFactorial(%d,%d) = %d', x[ i ], n[ i ], fallingFactorial( x[ i ], n[ i ] ) );
-}
+logEachMap( 'fallingFactorial(%0.4f,%0.4f) = %0.4f', x, n, fallingFactorial );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/falling-factorial/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/falling-factorial/examples/index.js
@@ -18,14 +18,15 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/array/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var fallingFactorial = require( './../lib' );
 
-var x = randu( 100, -20.0, 20.0 );
-var n = discreteUniform( 100, 0, 20 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -20.0, 20.0, opts );
+var n = discreteUniform( 100, 0, 20, opts );
 
-var i;
-for ( i = 0; i < 100; i++ ) {
-	console.log( 'fallingFactorial(%d,%d) = %d', x[ i ], n[ i ], fallingFactorial( x[ i ], n[ i ] ) );
-}
+logEachMap( 'fallingFactorial(%0.4f,%0.4f) = %0.4f', x, n, fallingFactorial );

--- a/lib/node_modules/@stdlib/math/base/special/falling-factorial/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/falling-factorial/examples/index.js
@@ -29,4 +29,4 @@ var opts = {
 var x = uniform( 100, -20.0, 20.0, opts );
 var n = discreteUniform( 100, 0, 20, opts );
 
-logEachMap( 'fallingFactorial(%0.4f,%0.4f) = %0.4f', x, n, fallingFactorial );
+logEachMap( 'fallingFactorial(%0.4f,%d) = %0.4f', x, n, fallingFactorial );

--- a/lib/node_modules/@stdlib/math/base/special/flipsign/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/flipsign/README.md
@@ -75,21 +75,18 @@ z = flipsign( 0.0, -1.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var flipsign = require( '@stdlib/math/base/special/flipsign' );
 
-var x;
-var y;
-var z;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
+var y = uniform( 100, -5.0, 5.0, opts );
 
 // Generate random numbers `x` and `y` and flip the sign of `x` only if `y` is negative...
-for ( i = 0; i < 100; i++ ) {
-    x = (randu()*100.0) - 50.0;
-    y = (randu()*10.0) - 5.0;
-    z = flipsign( x, y );
-    console.log( 'x: %d, y: %d => %d', x, y, z );
-}
+logEachMap( 'x: %0.4f, y: %0.4f => %0.4f', x, y, flipsign );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/flipsign/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/flipsign/examples/index.js
@@ -18,18 +18,15 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var flipsign = require( './../lib' );
 
-var x;
-var y;
-var z;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
+var y = uniform( 100, -5.0, 5.0, opts );
 
 // Generate random numbers `x` and `y` and flip the sign of `x` only if `y` is negative...
-for ( i = 0; i < 100; i++ ) {
-	x = (randu()*100.0) - 50.0;
-	y = (randu()*10.0) - 5.0;
-	z = flipsign( x, y );
-	console.log( 'x: %d, y: %d => %d', x, y, z );
-}
+logEachMap( 'x: %0.4f, y: %0.4f => %0.4f', x, y, flipsign );

--- a/lib/node_modules/@stdlib/math/base/special/flipsignf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/flipsignf/README.md
@@ -75,21 +75,18 @@ z = flipsignf( 0.0, -1.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var flipsignf = require( '@stdlib/math/base/special/flipsignf' );
 
-var x;
-var y;
-var z;
-var i;
+var opts = {
+    'dtype': 'float32'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
+var y = uniform( 100, -5.0, 5.0, opts );
 
 // Generate random numbers `x` and `y` and flip the sign of `x` only if `y` is negative...
-for ( i = 0; i < 100; i++ ) {
-    x = (randu()*100.0) - 50.0;
-    y = (randu()*10.0) - 5.0;
-    z = flipsignf( x, y );
-    console.log( 'x: %d, y: %d => %d', x, y, z );
-}
+logEachMap( 'x: %0.4f, y: %0.4f => %0.4f', x, y, flipsignf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/flipsignf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/flipsignf/examples/index.js
@@ -18,18 +18,15 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var flipsignf = require( './../lib' );
 
-var x;
-var y;
-var z;
-var i;
+var opts = {
+	'dtype': 'float32'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
+var y = uniform( 100, -5.0, 5.0, opts );
 
 // Generate random numbers `x` and `y` and flip the sign of `x` only if `y` is negative...
-for ( i = 0; i < 100; i++ ) {
-	x = (randu()*100.0) - 50.0;
-	y = (randu()*10.0) - 5.0;
-	z = flipsignf( x, y );
-	console.log( 'x: %d, y: %d => %d', x, y, z );
-}
+logEachMap( 'x: %0.4f, y: %0.4f => %0.4f', x, y, flipsignf );

--- a/lib/node_modules/@stdlib/math/base/special/floor/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/floor/README.md
@@ -59,16 +59,16 @@ v = floor( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var floor = require( '@stdlib/math/base/special/floor' );
 
-var x;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = (randu()*100.0) - 50.0;
-    console.log( 'floor(%d) = %d', x, floor( x ) );
-}
+logEachMap( 'floor(%0.4f) = %d', x, floor );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/floor/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/floor/examples/index.js
@@ -18,13 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var floor = require( './../lib' );
 
-var x;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = (randu()*100.0) - 50.0;
-	console.log( 'floor(%d) = %d', x, floor( x ) );
-}
+logEachMap( 'floor(%0.4f) = %d', x, floor );

--- a/lib/node_modules/@stdlib/math/base/special/floor2/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/floor2/README.md
@@ -83,18 +83,16 @@ v = floor2( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var floor2 = require( '@stdlib/math/base/special/floor2' );
 
-var x;
-var v;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = (randu()*100.0) - 50.0;
-    v = floor2( x );
-    console.log( 'Value: %d. Rounded: %d.', x, v );
-}
+logEachMap( 'x: %0.4f. Rounded: %d.', x, floor2 );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/floor2/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/floor2/examples/index.js
@@ -18,15 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var floor2 = require( './../lib' );
 
-var x;
-var v;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = (randu()*100.0) - 50.0;
-	v = floor2( x );
-	console.log( 'x: %d. Rounded: %d.', x, v );
-}
+logEachMap( 'x: %0.4f. Rounded: %d.', x, floor2 );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `math/base/special/falling-factorial`, `math/base/special/flipsign`, `math/base/special/flipsignf`, `math/base/special/floor` and `math/base/special/floor2` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
