### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/README.md
@@ -56,18 +56,17 @@ y = gammaDeltaRatio( 100.0, 0.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var gammaDeltaRatio = require( '@stdlib/math/base/special/gamma-delta-ratio' );
 
-var delta;
-var z;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var z = uniform( 100, 0.0, 10.0, opts );
+var delta = uniform( 100, 0.0, 10.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    z = randu()*10.0;
-    delta = randu()*10.0;
-    console.log( 'gamma( %d ) / gamma( %d + %d ) = %d', z, z, delta, gammaDeltaRatio( z, delta ) );
-}
+logEachMap( 'gamma( %0.4f ) / gamma( %0.4f + %0.4f ) = %0.4f', z, z, delta, gammaDeltaRatio );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-delta-ratio/examples/index.js
@@ -18,15 +18,14 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var gammaDeltaRatio = require( './../lib' );
 
-var delta;
-var z;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var z = uniform( 100, 0.0, 10.0, opts );
+var delta = uniform( 100, 0.0, 10.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	z = randu()*10.0;
-	delta = randu()*10.0;
-	console.log( 'gamma( %d ) / gamma( %d + %d ) = %d', z, z, delta, gammaDeltaRatio( z, delta ) );
-}
+logEachMap( 'gamma( %0.4f ) / gamma( %0.4f + %0.4f ) = %0.4f', z, z, delta, gammaDeltaRatio );

--- a/lib/node_modules/@stdlib/math/base/special/gamma-lanczos-sum-expg-scaled/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-lanczos-sum-expg-scaled/README.md
@@ -101,15 +101,16 @@ v = gammaLanczosSumExpGScaled( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var gammaLanczosSumExpGScaled = require( '@stdlib/math/base/special/gamma-lanczos-sum-expg-scaled' );
 
-var x = linspace( -10.0, 10.0, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -10.0, 10.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( 'x: %d, f(x): %d', x[ i ], gammaLanczosSumExpGScaled( x[ i ] ) );
-}
+logEachMap( 'x: %0.4f, f(x): %0.4f', x, gammaLanczosSumExpGScaled );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/gamma-lanczos-sum-expg-scaled/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-lanczos-sum-expg-scaled/README.md
@@ -39,7 +39,7 @@ The [Lanczos approximation][lanczos-approximation] for the [gamma function][gamm
 
 <!-- </equation> -->
 
-where `g` is an [arbitrary constant][@stdlib/constants/float64/gamma-lanczos-g] and `L_g(n)` is the Lanczos sum. The scaled Lanczos sum is given by 
+where `g` is an [arbitrary constant][@stdlib/constants/float64/gamma-lanczos-g] and `L_g(n)` is the Lanczos sum. The scaled Lanczos sum is given by
 
 <!-- <equation class="equation" label="eq:scaled_lanczos_sum" align="center" raw="L_g(n) \cdot \exp(-g)" alt="Scaled Lanczos sum."> -->
 

--- a/lib/node_modules/@stdlib/math/base/special/gamma-lanczos-sum-expg-scaled/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-lanczos-sum-expg-scaled/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var gammaLanczosSumExpGScaled = require( './../lib' );
 
-var x = linspace( -10.0, 10.0, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -10.0, 10.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'x: %d, f(x): %d', x[ i ], gammaLanczosSumExpGScaled( x[ i ] ) );
-}
+logEachMap( 'x: %0.4f, f(x): %0.4f', x, gammaLanczosSumExpGScaled );

--- a/lib/node_modules/@stdlib/math/base/special/gamma-lanczos-sum/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-lanczos-sum/README.md
@@ -88,15 +88,16 @@ v = gammaLanczosSum( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var gammaLanczosSum = require( '@stdlib/math/base/special/gamma-lanczos-sum' );
 
-var x = linspace( -10.0, 10.0, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -10.0, 10.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( 'x: %d, f(x): %d', x[ i ], gammaLanczosSum( x[ i ] ) );
-}
+logEachMap( 'x: %0.4f, f(x): %0.4f', x, gammaLanczosSum );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/gamma-lanczos-sum/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/gamma-lanczos-sum/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var gammaLanczosSum = require( './../lib' );
 
-var x = linspace( -10.0, 10.0, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -10.0, 10.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'x: %d, f(x): %d', x[ i ], gammaLanczosSum( x[ i ] ) );
-}
+logEachMap( 'x: %0.4f, f(x): %0.4f', x, gammaLanczosSum );

--- a/lib/node_modules/@stdlib/math/base/special/gamma/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/gamma/README.md
@@ -106,15 +106,16 @@ v = gamma( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var gamma = require( '@stdlib/math/base/special/gamma' );
 
-var x = linspace( -10.0, 10.0, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -10.0, 10.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( 'x: %d, f(x): %d', x[ i ], gamma( x[ i ] ) );
-}
+logEachMap( 'x: %0.4f, f(x): %0.4f', x, gamma );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/gamma/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/gamma/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var gamma = require( './../lib' );
 
-var x = linspace( -10.0, 10.0, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -10.0, 10.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'x: %d, f(x): %d', x[ i ], gamma( x[ i ] ) );
-}
+logEachMap( 'x: %0.4f, f(x): %0.4f', x, gamma );

--- a/lib/node_modules/@stdlib/math/base/special/gamma1pm1/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/gamma1pm1/README.md
@@ -59,16 +59,16 @@ v = gamma1pm1( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var gamma1pm1 = require( '@stdlib/math/base/special/gamma1pm1' );
 
-var x;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -5.0, 5.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = (randu()*10.0) - 5.0;
-    console.log( 'gamma(%d+1) - 1 = %d', x, gamma1pm1( x ) );
-}
+logEachMap( 'gamma(%0.4f+1) - 1 = %0.4f', x, gamma1pm1 );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/gamma1pm1/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/gamma1pm1/examples/index.js
@@ -18,13 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var gamma1pm1 = require( './../lib' );
 
-var x;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -5.0, 5.0, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = (randu()*10.0) - 5.0;
-	console.log( 'gamma(%d+1) - 1 = %d', x, gamma1pm1( x ) );
-}
+logEachMap( 'gamma(%0.4f+1) - 1 = %0.4f', x, gamma1pm1 );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `math/base/special/gamma`, `math/base/special/gamma-delta-ratio`, `math/base/special/gamma-lanczos-sum`, `math/base/special/gamma-lanczos-sum-expg-scaled` and `math/base/special/gamma1pm1` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
