### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/gcdf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/gcdf/README.md
@@ -96,15 +96,16 @@ v = gcdf( 48, NaN );
 
 ```javascript
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var gcdf = require( '@stdlib/math/base/special/gcdf' );
 
-var a = discreteUniform( 100, 0, 50 );
-var b = discreteUniform( a.length, 0, 50 );
+var opts = {
+    'dtype': 'float32'
+};
+var a = discreteUniform( 100, 0, 50, opts );
+var b = discreteUniform( a.length, 0, 50, opts );
 
-var i;
-for ( i = 0; i < a.length; i++ ) {
-    console.log( 'gcdf(%d,%d) = %d', a[ i ], b[ i ], gcdf( a[ i ], b[ i ] ) );
-}
+logEachMap( 'gcdf(%d,%d) = %d', a, b, gcdf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/gcdf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/gcdf/examples/index.js
@@ -19,12 +19,13 @@
 'use strict';
 
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var gcdf = require( './../lib' );
 
-var a = discreteUniform( 100, 0, 50 );
-var b = discreteUniform( a.length, 0, 50 );
+var opts = {
+	'dtype': 'float32'
+};
+var a = discreteUniform( 100, 0, 50, opts );
+var b = discreteUniform( a.length, 0, 50, opts );
 
-var i;
-for ( i = 0; i < a.length; i++ ) {
-	console.log( 'gcdf(%d,%d) = %d', a[ i ], b[ i ], gcdf( a[ i ], b[ i ] ) );
-}
+logEachMap( 'gcdf(%d,%d) = %d', a, b, gcdf );

--- a/lib/node_modules/@stdlib/math/base/special/hacovercos/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/hacovercos/README.md
@@ -77,16 +77,17 @@ v = hacovercos( -3.141592653589793/6.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var hacovercos = require( '@stdlib/math/base/special/hacovercos' );
 
-var x = linspace( 0.0, TWO_PI, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, 0.0, TWO_PI, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( hacovercos( x[ i ] ) );
-}
+logEachMap( 'hacovercos(%0.4f) = %0.4f', x, hacovercos );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/hacovercos/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/hacovercos/examples/index.js
@@ -18,13 +18,14 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var hacovercos = require( './../lib' );
 
-var x = linspace( 0.0, TWO_PI, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, 0.0, TWO_PI, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'hacovercos(%d) = %d', x[ i ], hacovercos( x[ i ] ) );
-}
+logEachMap( 'hacovercos(%0.4f) = %0.4f', x, hacovercos );

--- a/lib/node_modules/@stdlib/math/base/special/hacoversin/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/hacoversin/README.md
@@ -77,16 +77,17 @@ v = hacoversin( -3.141592653589793/6.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var hacoversin = require( '@stdlib/math/base/special/hacoversin' );
 
-var x = linspace( 0.0, TWO_PI, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, 0.0, TWO_PI, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( hacoversin( x[ i ] ) );
-}
+logEachMap( 'hacoversin(%0.4f) = %0.4f', x, hacoversin );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/hacoversin/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/hacoversin/examples/index.js
@@ -18,13 +18,14 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var hacoversin = require( './../lib' );
 
-var x = linspace( 0.0, TWO_PI, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, 0.0, TWO_PI, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'hacoversin(%d) = %d', x[ i ], hacoversin( x[ i ] ) );
-}
+logEachMap( 'hacoversin(%0.4f) = %0.4f', x, hacoversin );

--- a/lib/node_modules/@stdlib/math/base/special/havercos/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/havercos/README.md
@@ -77,16 +77,17 @@ v = havercos( -3.141592653589793/6.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var havercos = require( '@stdlib/math/base/special/havercos' );
 
-var x = linspace( 0.0, TWO_PI, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, 0.0, TWO_PI, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( havercos( x[ i ] ) );
-}
+logEachMap( 'havercos(%0.4f) = %0.4f', x, havercos );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/havercos/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/havercos/examples/index.js
@@ -18,13 +18,14 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var havercos = require( './../lib' );
 
-var x = linspace( 0.0, TWO_PI, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, 0.0, TWO_PI, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'havercos(%d) = %d', x[ i ], havercos( x[ i ] ) );
-}
+logEachMap( 'havercos(%0.4f) = %0.4f', x, havercos );

--- a/lib/node_modules/@stdlib/math/base/special/haversin/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/haversin/README.md
@@ -77,16 +77,17 @@ v = haversin( -3.141592653589793/6.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var haversin = require( '@stdlib/math/base/special/haversin' );
 
-var x = linspace( 0.0, TWO_PI, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, 0.0, TWO_PI, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( haversin( x[ i ] ) );
-}
+logEachMap( 'haversin(%0.4f) = %0.4f', x, haversin );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/haversin/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/haversin/examples/index.js
@@ -18,13 +18,14 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var haversin = require( './../lib' );
 
-var x = linspace( 0.0, TWO_PI, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, 0.0, TWO_PI, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'haversin(%d) = %d', x[ i ], haversin( x[ i ] ) );
-}
+logEachMap( 'haversin(%0.4f) = %0.4f', x, haversin );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `math/base/special/gcdf`, `math/base/special/hacovercos`, `math/base/special/hacoversin`, `math/base/special/havercos` and `math/base/special/haversin` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
