### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/heaviside/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/heaviside/README.md
@@ -148,15 +148,16 @@ v = heaviside( 0.0, 'right-continuous' );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var heaviside = require( '@stdlib/math/base/special/heaviside' );
 
-var x = linspace( -10.0, 10.0, 101 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 101, -10.0, 10.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( 'H(%d) = %d', x[ i ], heaviside( x[ i ] ) );
-}
+logEachMap( 'H(%0.4f) = %0.4f', x, heaviside );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/heaviside/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/heaviside/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var heaviside = require( './../lib' );
 
-var x = linspace( -10.0, 10.0, 101 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 101, -10.0, 10.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'H(%d) = %d', x[ i ], heaviside( x[ i ] ) );
-}
+logEachMap( 'H(%0.4f) = %0.4f', x, heaviside );

--- a/lib/node_modules/@stdlib/math/base/special/heavisidef/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/heavisidef/README.md
@@ -148,15 +148,16 @@ v = heavisidef( 0.0, 'right-continuous' );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var heavisidef = require( '@stdlib/math/base/special/heavisidef' );
 
-var x = linspace( -10.0, 10.0, 101 );
+var opts = {
+    'dtype': 'float32'
+};
+var x = uniform( 101, -10.0, 10.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( 'H(%d) = %f', x[ i ], heavisidef( x[ i ] ) );
-}
+logEachMap( 'H(%0.4f) = %0.4f', x, heavisidef );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/heavisidef/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/heavisidef/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var heavisidef = require( './../lib' );
 
-var x = linspace( -10.0, 10.0, 101 );
+var opts = {
+	'dtype': 'float32'
+};
+var x = uniform( 101, -10.0, 10.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'H(%d) = %f', x[ i ], heavisidef( x[ i ] ) );
-}
+logEachMap( 'H(%0.4f) = %0.4f', x, heavisidef );

--- a/lib/node_modules/@stdlib/math/base/special/hyp2f1/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/hyp2f1/README.md
@@ -99,18 +99,19 @@ v = hyp2f1( NaN, 3.0, 2.0, 0.5 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var hyp2f1 = require( '@stdlib/math/base/special/hyp2f1' );
 
-var a = linspace( -50.0, 50.0, 100 );
-var b = linspace( -50.0, 50.0, 100 );
-var c = linspace( -50.0, 50.0, 100 );
-var x = linspace( -50.0, 50.0, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var a = uniform( 100, -50.0, 50.0, opts );
+var b = uniform( 100, -50.0, 50.0, opts );
+var c = uniform( 100, -50.0, 50.0, opts );
+var x = uniform( 100, -50.0, 50.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( 'a: %d, b: %d, c: %d, x: %d, 2F1(a,b;c;x): %d', a[ i ], b[ i ], c[ i ], x[ i ], hyp2f1( a[ i ], b[ i ], c[ i ], x[ i ] ) );
-}
+logEachMap( 'a: %0.4f, b: %0.4f, c: %0.4f, x: %0.4f, 2F1(a,b;c;x): %0.4f', a, b, c, x, hyp2f1 );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/hyp2f1/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/hyp2f1/examples/index.js
@@ -18,15 +18,16 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var hyp2f1 = require( './../lib' );
 
-var a = linspace( -50.0, 50.0, 100 );
-var b = linspace( -50.0, 50.0, 100 );
-var c = linspace( -50.0, 50.0, 100 );
-var x = linspace( -50.0, 50.0, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var a = uniform( 100, -50.0, 50.0, opts );
+var b = uniform( 100, -50.0, 50.0, opts );
+var c = uniform( 100, -50.0, 50.0, opts );
+var x = uniform( 100, -50.0, 50.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'a: %d, b: %d, c: %d, x: %d, 2F1(a,b;c;x): %d', a[ i ], b[ i ], c[ i ], x[ i ], hyp2f1( a[ i ], b[ i ], c[ i ], x[ i ] ) );
-}
+logEachMap( 'a: %0.4f, b: %0.4f, c: %0.4f, x: %0.4f, 2F1(a,b;c;x): %0.4f', a, b, c, x, hyp2f1 );

--- a/lib/node_modules/@stdlib/math/base/special/hypot/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/hypot/README.md
@@ -120,16 +120,16 @@ h = hypot( 5.0, NaN );
 
 ```javascript
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var hypot = require( '@stdlib/math/base/special/hypot' );
 
-var len = 100;
-var x = discreteUniform( len, -50, 50 );
-var y = discreteUniform( len, -50, 50 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = discreteUniform( 100, -50, 50, opts );
+var y = discreteUniform( 100, -50, 50, opts );
 
-var i;
-for ( i = 0; i < len; i++ ) {
-    console.log( 'h(%d,%d) = %d', x[ i ], y[ i ], hypot( x[ i ], y[ i ] ) );
-}
+logEachMap( 'h(%d,%d) = %0.4f', x, y, hypot );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/hypot/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/hypot/examples/index.js
@@ -19,13 +19,13 @@
 'use strict';
 
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var hypot = require( './../lib' );
 
-var len = 100;
-var x = discreteUniform( len, -50, 50 );
-var y = discreteUniform( len, -50, 50 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = discreteUniform( 100, -50, 50, opts );
+var y = discreteUniform( 100, -50, 50, opts );
 
-var i;
-for ( i = 0; i < len; i++ ) {
-	console.log( 'h(%d,%d) = %d', x[ i ], y[ i ], hypot( x[ i ], y[ i ] ) );
-}
+logEachMap( 'h(%d,%d) = %0.4f', x, y, hypot );

--- a/lib/node_modules/@stdlib/math/base/special/hypotf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/hypotf/README.md
@@ -84,19 +84,16 @@ h = hypotf( 5.0, NaN );
 
 ```javascript
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var hypotf = require( '@stdlib/math/base/special/hypotf' );
 
-var len = 100;
 var opts = {
     'dtype': 'float32'
 };
-var x = discreteUniform( len, -50, 50, opts );
-var y = discreteUniform( len, -50, 50, opts );
+var x = discreteUniform( 100, -50, 50, opts );
+var y = discreteUniform( 100, -50, 50, opts );
 
-var i;
-for ( i = 0; i < len; i++ ) {
-    console.log( 'h(%d,%d) = %d', x[ i ], y[ i ], hypotf( x[ i ], y[ i ] ) );
-}
+logEachMap( 'h(%d,%d) = %0.4f', x, y, hypotf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/hypotf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/hypotf/examples/index.js
@@ -19,16 +19,13 @@
 'use strict';
 
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var hypotf = require( './../lib' );
 
-var len = 100;
 var opts = {
 	'dtype': 'float32'
 };
-var x = discreteUniform( len, -50, 50, opts );
-var y = discreteUniform( len, -50, 50, opts );
+var x = discreteUniform( 100, -50, 50, opts );
+var y = discreteUniform( 100, -50, 50, opts );
 
-var i;
-for ( i = 0; i < len; i++ ) {
-	console.log( 'h(%d,%d) = %d', x[ i ], y[ i ], hypotf( x[ i ], y[ i ] ) );
-}
+logEachMap( 'h(%d,%d) = %0.4f', x, y, hypotf );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `math/base/special/heaviside`, `math/base/special/heavisidef`, `math/base/special/hyp2f1`, `math/base/special/hypot` and `math/base/special/hypotf` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
