### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/kernel-cos/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/kernel-cos/README.md
@@ -82,16 +82,17 @@ v = kernelCos( NaN, 0.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var PI = require( '@stdlib/constants/float64/pi' );
 var kernelCos = require( '@stdlib/math/base/special/kernel-cos' );
 
-var x = linspace( -PI/4.0, PI/4.0, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -PI/4.0, PI/4.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( 'kernelCos(%d) = %d', x[ i ], kernelCos( x[ i ], 0.0 ) );
-}
+logEachMap( 'kernelCos(%0.4f, %0.4f) = %0.4f', x, 0.0, kernelCos );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/kernel-cos/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/kernel-cos/README.md
@@ -58,7 +58,7 @@ v = kernelCos( NaN, 0.0 );
 
 -   For increased accuracy, the number for which the [cosine][cosine] should be evaluated can be supplied as a [double-double number][double-double-arithmetic] (i.e., a non-evaluated sum of two [double-precision floating-point numbers][ieee754] `x` and `y`).
 
--   As components of a [double-double number][double-double-arithmetic], the two [double-precision floating-point numbers][ieee754] `x` and `y` must satisfy 
+-   As components of a [double-double number][double-double-arithmetic], the two [double-precision floating-point numbers][ieee754] `x` and `y` must satisfy
 
     <!-- <equation class="equation" label="eq:double_double_inequality" align="center" raw="|y| \leq \frac{1}{2} \operatorname{ulp}(x)" alt="Inequality for the two components of a double-double number."> -->
 

--- a/lib/node_modules/@stdlib/math/base/special/kernel-cos/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/kernel-cos/examples/index.js
@@ -18,13 +18,14 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var PI = require( '@stdlib/constants/float64/pi' );
 var kernelCos = require( './../lib' );
 
-var x = linspace( -PI/4.0, PI/4.0, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -PI/4.0, PI/4.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'kernelCos(%d) = %d', x[ i ], kernelCos( x[ i ], 0.0 ) );
-}
+logEachMap( 'kernelCos(%0.4f, %0.4f) = %0.4f', x, 0.0, kernelCos );

--- a/lib/node_modules/@stdlib/math/base/special/kernel-log1p/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/kernel-log1p/README.md
@@ -66,16 +66,17 @@ v = kernelLog1p( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
 var kernelLog1p = require( '@stdlib/math/base/special/kernel-log1p' );
 
-var x = linspace( sqrt( 2.0 ) / 2.0, sqrt( 2.0 ), 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, sqrt( 2.0 ) / 2.0, sqrt( 2.0 ), opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( 'kernelLog1p(%d) = %d', x[ i ], kernelLog1p( x[ i ] ) );
-}
+logEachMap( 'kernelLog1p(%0.4f) = %0.4f', x, kernelLog1p );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/kernel-log1p/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/kernel-log1p/examples/index.js
@@ -18,13 +18,14 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
 var kernelLog1p = require( './../lib' );
 
-var x = linspace( sqrt( 2.0 ) / 2.0, sqrt( 2.0 ), 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, sqrt( 2.0 ) / 2.0, sqrt( 2.0 ), opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'kernelLog1p(%d) = %d', x[ i ], kernelLog1p( x[ i ] ) );
-}
+logEachMap( 'kernelLog1p(%0.4f) = %0.4f', x, kernelLog1p );

--- a/lib/node_modules/@stdlib/math/base/special/kernel-sin/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/kernel-sin/README.md
@@ -88,16 +88,17 @@ v = kernelSin( NaN, NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var PI = require( '@stdlib/constants/float64/pi' );
 var kernelSin = require( '@stdlib/math/base/special/kernel-sin' );
 
-var x = linspace( -PI/4.0, PI/4.0, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -PI/4.0, PI/4.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( 'sine(%d) = %d', x[ i ], kernelSin( x[ i ], 0.0 ) );
-}
+logEachMap( 'sine(%0.4f, %0.4f) = %0.4f', x, 0.0, kernelSin );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/kernel-sin/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/kernel-sin/README.md
@@ -64,7 +64,7 @@ v = kernelSin( NaN, NaN );
 
 -   For increased accuracy, the number for which the [sine][sine] should be evaluated can be supplied as a [double-double number][double-double-arithmetic] (i.e., a non-evaluated sum of two [double-precision floating-point numbers][ieee754] `x` and `y`).
 
--   As components of a [double-double number][double-double-arithmetic], the two [double-precision floating-point numbers][ieee754] `x` and `y` must satisfy 
+-   As components of a [double-double number][double-double-arithmetic], the two [double-precision floating-point numbers][ieee754] `x` and `y` must satisfy
 
     <!-- <equation class="equation" label="eq:double_double_inequality" align="center" raw="|y| \leq \frac{1}{2} \operatorname{ulp}(x)" alt="Inequality for the two components of a double-double number."> -->
 
@@ -180,7 +180,7 @@ double stdlib_base_kernel_sin( const double x, const double y );
 
 int main( void ) {
     const double x[] = { -0.7853981633974483, -0.6108652381980153, -0.4363323129985824, -0.26179938779914946, -0.08726646259971649, 0.08726646259971649, 0.26179938779914935, 0.43633231299858233, 0.6108652381980153, 0.7853981633974483 };
-   
+
     double out;
     int i;
     for ( i = 0; i < 10; i++ ) {

--- a/lib/node_modules/@stdlib/math/base/special/kernel-sin/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/kernel-sin/examples/index.js
@@ -18,13 +18,14 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var PI = require( '@stdlib/constants/float64/pi' );
 var kernelSin = require( './../lib' );
 
-var x = linspace( -PI/4.0, PI/4.0, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -PI/4.0, PI/4.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'sine(%d) = %d', x[ i ], kernelSin( x[ i ], 0.0 ) );
-}
+logEachMap( 'sine(%0.4f, %0.4f) = %0.4f', x, 0.0, kernelSin );

--- a/lib/node_modules/@stdlib/math/base/special/kronecker-delta/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/kronecker-delta/README.md
@@ -83,15 +83,16 @@ v = kroneckerDelta( NaN, NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var kroneckerDelta = require( '@stdlib/math/base/special/kronecker-delta' );
 
-var x = linspace( -1.0, 1.0, 101 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 101, -1.0, 1.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( 'kronecker(%d,%d) = %d', x[ i ], 0.0, kroneckerDelta( x[ i ], 0.0 ) );
-}
+logEachMap( 'kronecker(%0.4f,%0.4f) = %0.4f', x, 0.0, kroneckerDelta );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/kronecker-delta/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/kronecker-delta/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var kroneckerDelta = require( './../lib' );
 
-var x = linspace( -1.0, 1.0, 101 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 101, -1.0, 1.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'kronecker(%d,%d) = %d', x[ i ], 0.0, kroneckerDelta( x[ i ], 0.0 ) );
-}
+logEachMap( 'kronecker(%0.4f,%0.4f) = %0.4f', x, 0.0, kroneckerDelta );

--- a/lib/node_modules/@stdlib/math/base/special/kronecker-deltaf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/kronecker-deltaf/README.md
@@ -83,15 +83,16 @@ v = kroneckerDeltaf( NaN, NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var kroneckerDeltaf = require( '@stdlib/math/base/special/kronecker-deltaf' );
 
-var x = linspace( -1.0, 1.0, 101 );
+var opts = {
+    'dtype': 'float32'
+};
+var x = uniform( 101, -1.0, 1.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( 'kronecker(%d,%d) = %d', x[ i ], 0.0, kroneckerDeltaf( x[ i ], 0.0 ) );
-}
+logEachMap( 'kronecker(%0.4f,%0.4f) = %0.4f', x, 0.0, kroneckerDeltaf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/kronecker-deltaf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/kronecker-deltaf/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var kroneckerDeltaf = require( './../lib' );
 
-var x = linspace( -1.0, 1.0, 101 );
+var opts = {
+	'dtype': 'float32'
+};
+var x = uniform( 101, -1.0, 1.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'kronecker(%d,%d) = %d', x[ i ], 0.0, kroneckerDeltaf( x[ i ], 0.0 ) );
-}
+logEachMap( 'kronecker(%0.4f,%0.4f) = %0.4f', x, 0.0, kroneckerDeltaf );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `math/base/special/kernel-cos`, `math/base/special/kernel-log1p`, `math/base/special/kernel-sin`, `math/base/special/kronecker-delta` and `math/base/special/kronecker-deltaf` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
