### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/ramp/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/ramp/README.md
@@ -92,15 +92,16 @@ v = ramp( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var ramp = require( '@stdlib/math/base/special/ramp' );
 
-var x = linspace( -10.0, 10.0, 101 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 101, -10.0, 10.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( 'R(%d) = %d', x[ i ], ramp( x[ i ] ) );
-}
+logEachMap( 'R(%0.4f) = %0.4f', x, ramp );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/ramp/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/ramp/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var ramp = require( './../lib' );
 
-var x = linspace( -10.0, 10.0, 101 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 101, -10.0, 10.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'R(%d) = %d', x[ i ], ramp( x[ i ] ) );
-}
+logEachMap( 'R(%0.4f) = %0.4f', x, ramp );

--- a/lib/node_modules/@stdlib/math/base/special/rampf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/rampf/README.md
@@ -92,15 +92,16 @@ v = rampf( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var rampf = require( '@stdlib/math/base/special/rampf' );
 
-var x = linspace( -10.0, 10.0, 101 );
+var opts = {
+    'dtype': 'float32'
+};
+var x = uniform( 101, -10.0, 10.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( 'R(%d) = %d', x[ i ], rampf( x[ i ] ) );
-}
+logEachMap( 'R(%0.4f) = %0.4f', x, rampf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/rampf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/rampf/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var rampf = require( './../lib' );
 
-var x = linspace( -10.0, 10.0, 101 );
+var opts = {
+	'dtype': 'float32'
+};
+var x = uniform( 101, -10.0, 10.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'R(%d) = %d', x[ i ], rampf( x[ i ] ) );
-}
+logEachMap( 'R(%0.4f) = %0.4f', x, rampf );

--- a/lib/node_modules/@stdlib/math/base/special/riemann-zeta/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/riemann-zeta/README.md
@@ -88,15 +88,16 @@ v = zeta( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var zeta = require( '@stdlib/math/base/special/riemann-zeta' );
 
-var s = linspace( -50.0, 50.0, 200 );
+var opts = {
+    'dtype': 'float64'
+};
+var s = uniform( 200, -50.0, 50.0, opts );
 
-var i;
-for ( i = 0; i < s.length; i++ ) {
-    console.log( 's: %d, ζ(s): %d', s[ i ], zeta( s[ i ] ) );
-}
+logEachMap( 's: %0.4f, ζ(s): %0.4f', s, zeta );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/riemann-zeta/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/riemann-zeta/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var zeta = require( './../lib' );
 
-var s = linspace( -50.0, 50.0, 200 );
+var opts = {
+	'dtype': 'float64'
+};
+var s = uniform( 200, -50.0, 50.0, opts );
 
-var i;
-for ( i = 0; i < s.length; i++ ) {
-	console.log( 's: %d, ζ(s): %d', s[ i ], zeta( s[ i ] ) );
-}
+logEachMap( 's: %0.4f, ζ(s): %0.4f', s, zeta );

--- a/lib/node_modules/@stdlib/math/base/special/sec/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/sec/README.md
@@ -66,16 +66,17 @@ v = sec( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
-var PI = require( '@stdlib/constants/float64/pi' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
+var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var sec = require( '@stdlib/math/base/special/sec' );
 
-var x = linspace( -PI/2.0, PI/2.0, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -TWO_PI, TWO_PI, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( sec( x[ i ] ) );
-}
+logEachMap( 'sec(%0.4f) = %0.4f', x, sec );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/sec/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/sec/examples/index.js
@@ -18,13 +18,14 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var sec = require( './../lib' );
 
-var x = linspace( -TWO_PI, TWO_PI, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -TWO_PI, TWO_PI, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'sec(%d) = %d', x[ i ], sec( x[ i ] ) );
-}
+logEachMap( 'sec(%0.4f) = %0.4f', x, sec );

--- a/lib/node_modules/@stdlib/math/base/special/secd/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/secd/README.md
@@ -65,15 +65,16 @@ v = secd( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var secd = require( '@stdlib/math/base/special/secd' );
 
-var x = linspace( 1.1, 5.1, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -10.0, 10.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( secd( x[ i ] ) );
-}
+logEachMap( 'secd(%0.4f) = %0.4f', x, secd );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/secd/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/secd/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var secd = require( './../lib' );
 
-var x = linspace( -10, 10, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -10.0, 10.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'secd(%d) = %d', x[ i ], secd( x[ i ] ) );
-}
+logEachMap( 'secd(%0.4f) = %0.4f', x, secd );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `math/base/special/ramp`, `math/base/special/rampf`, `math/base/special/reimann-zeta`, `math/base/special/sec` and `math/base/special/secd` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
