### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/sin/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/sin/README.md
@@ -56,16 +56,17 @@ v = sin( -3.141592653589793/6.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var sin = require( '@stdlib/math/base/special/sin' );
 
-var x = linspace( 0.0, TWO_PI, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, 0.0, TWO_PI, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( sin( x[ i ] ) );
-}
+logEachMap( 'sin(%0.4f) = %0.4f', x, sin );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/sin/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/sin/examples/index.js
@@ -18,13 +18,14 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var sin = require( './../lib' );
 
-var x = linspace( 0.0, TWO_PI, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, 0.0, TWO_PI, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'sin(%d) = %d', x[ i ], sin( x[ i ] ) );
-}
+logEachMap( 'sin(%0.4f) = %0.4f', x, sin );

--- a/lib/node_modules/@stdlib/math/base/special/sin/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/sin/examples/index.js
@@ -24,7 +24,7 @@ var TWO_PI = require( '@stdlib/constants/float64/two-pi' );
 var sin = require( './../lib' );
 
 var opts = {
-    'dtype': 'float64'
+	'dtype': 'float64'
 };
 var x = uniform( 100, 0.0, TWO_PI, opts );
 

--- a/lib/node_modules/@stdlib/math/base/special/sinc/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/sinc/README.md
@@ -82,15 +82,16 @@ v = sinc( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var sinc = require( '@stdlib/math/base/special/sinc' );
 
-var x = linspace( -5.0, 5.0, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -5.0, 5.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( sinc( x[ i ] ) );
-}
+logEachMap( 'sinc( %0.4f ) = %0.4f', x, sinc );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/sinc/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/sinc/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var sinc = require( './../lib' );
 
-var x = linspace( -5.0, 5.0, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -5.0, 5.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'sinc( %d ) = %d', x[ i ], sinc( x[ i ] ) );
-}
+logEachMap( 'sinc( %0.4f ) = %0.4f', x, sinc );

--- a/lib/node_modules/@stdlib/math/base/special/sind/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/sind/README.md
@@ -63,15 +63,16 @@ v = sind( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var sind = require( '@stdlib/math/base/special/sind' );
 
-var x = linspace( -180, 180, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -180.0, 180.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( sind( x[ i ] ) );
-}
+logEachMap( 'sind(%0.4f) = %0.4f', x, sind );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/sind/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/sind/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var sind = require( './../lib' );
 
-var x = linspace( -180, 180, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -180.0, 180.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'sind(%d) = %d', x[ i ], sind( x[ i ] ) );
-}
+logEachMap( 'sind(%0.4f) = %0.4f', x, sind );

--- a/lib/node_modules/@stdlib/math/base/special/sinh/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/sinh/README.md
@@ -62,15 +62,16 @@ v = sinh( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var sinh = require( '@stdlib/math/base/special/sinh' );
 
-var x = linspace( -5.0, 5.0, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -5.0, 5.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( sinh( x[ i ] ) );
-}
+logEachMap( 'sinh( %0.4f ) = %0.4f', x, sinh );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/sinh/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/sinh/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var sinh = require( './../lib' );
 
-var x = linspace( -5.0, 5.0, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -5.0, 5.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'sinh( %d ) = %d', x[ i ], sinh( x[ i ] ) );
-}
+logEachMap( 'sinh( %0.4f ) = %0.4f', x, sinh );

--- a/lib/node_modules/@stdlib/math/base/special/sinpi/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/sinpi/README.md
@@ -59,15 +59,16 @@ y = sinpi( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var sinpi = require( '@stdlib/math/base/special/sinpi' );
 
-var x = linspace( -100.0, 100.0, 100 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -100.0, 100.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( sinpi( x[ i ] ) );
-}
+logEachMap( 'sin( π * %0.4f ) = %0.4f', x, sinpi );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/sinpi/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/sinpi/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var sinpi = require( './../lib' );
 
-var x = linspace( -100.0, 100.0, 100 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -100.0, 100.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'sin( π * %d ) = %d', x[ i ], sinpi( x[ i ] ) );
-}
+logEachMap( 'sin( π * %0.4f ) = %0.4f', x, sinpi );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `math/base/special/sin`, `math/base/special/sinc`, `math/base/special/sind`, `math/base/special/sinh` and `math/base/special/sinpi` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
