### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/fast/abs/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/fast/abs/README.md
@@ -97,17 +97,16 @@ v = abs( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var abs = require( '@stdlib/math/base/special/fast/abs' );
 
-var rand;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = discreteUniform( 100, -50, 50, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    rand = round( randu() * 100.0 ) - 50.0;
-    console.log( 'abs(%d) = %d', rand, abs( rand ) );
-}
+logEachMap( 'abs(%d) = %d', x, abs );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/fast/abs/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/fast/abs/examples/index.js
@@ -18,14 +18,13 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var abs = require( './../lib' );
 
-var rand;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = discreteUniform( 100, -50, 50, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	rand = round( randu() * 100.0 ) - 50.0;
-	console.log( 'abs(%d) = %d', rand, abs( rand ) );
-}
+logEachMap( 'abs(%d) = %d', x, abs );

--- a/lib/node_modules/@stdlib/math/base/special/fast/acosh/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/fast/acosh/README.md
@@ -79,15 +79,16 @@ var v = acosh( 0.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var acosh = require( '@stdlib/math/base/special/fast/acosh' );
 
-var x = linspace( 1.0, 5.0, 103 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 103, 1.0, 5.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( acosh( x[ i ] ) );
-}
+logEachMap( 'acosh(%0.4f) = %0.4f', x, acosh );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/fast/acosh/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/fast/acosh/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var acosh = require( './../lib' );
 
-var x = linspace( 1.0, 5.0, 103 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 103, 1.0, 5.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'acosh(%d) = %d', x[ i ], acosh( x[ i ] ) );
-}
+logEachMap( 'acosh(%0.4f) = %0.4f', x, acosh );

--- a/lib/node_modules/@stdlib/math/base/special/fast/alpha-max-plus-beta-min/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/fast/alpha-max-plus-beta-min/README.md
@@ -112,21 +112,17 @@ var h = hypot( 5.0, 12.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var ampbm = require( '@stdlib/math/base/special/fast/alpha-max-plus-beta-min' );
 
-var x;
-var y;
-var h;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = discreteUniform( 100, -50, 50, opts );
+var y = discreteUniform( 100, -50, 50, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = round( randu()*100.0 ) - 50.0;
-    y = round( randu()*100.0 ) - 50.0;
-    h = ampbm( x, y );
-    console.log( 'hypot(%d,%d) = %d', x, y, h );
-}
+logEachMap( 'hypot(%d,%d) = %0.4f', x, y, ampbm );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/fast/alpha-max-plus-beta-min/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/fast/alpha-max-plus-beta-min/examples/index.js
@@ -18,18 +18,14 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var ampbm = require( './../lib' );
 
-var x;
-var y;
-var h;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = discreteUniform( 100, -50, 50, opts );
+var y = discreteUniform( 100, -50, 50, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = round( randu()*100.0 ) - 50.0;
-	y = round( randu()*100.0 ) - 50.0;
-	h = ampbm( x, y );
-	console.log( 'hypot(%d,%d) = %d', x, y, h );
-}
+logEachMap( 'hypot(%d,%d) = %0.4f', x, y, ampbm );

--- a/lib/node_modules/@stdlib/math/base/special/fast/asinh/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/fast/asinh/README.md
@@ -92,15 +92,16 @@ v = asinh( Infinity );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var asinh = require( '@stdlib/math/base/special/fast/asinh' );
 
-var x = linspace( -5.0, 5.0, 103 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 103, -5.0, 5.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( asinh( x[ i ] ) );
-}
+logEachMap( 'asinh(%0.4f) = %0.4f', x, asinh );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/fast/asinh/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/fast/asinh/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var asinh = require( './../lib' );
 
-var x = linspace( -5.0, 5.0, 103 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 103, -5.0, 5.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'asinh(%d) = %d', x[ i ], asinh( x[ i ] ) );
-}
+logEachMap( 'asinh(%0.4f) = %0.4f', x, asinh );

--- a/lib/node_modules/@stdlib/math/base/special/fast/atanh/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/fast/atanh/README.md
@@ -88,15 +88,16 @@ var v = atanh( -3.14 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var atanh = require( '@stdlib/math/base/special/fast/atanh' );
 
-var x = linspace( -1.0, 1.0, 103 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 103, -1.0, 1.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( atanh( x[ i ] ) );
-}
+logEachMap( 'atanh(%0.4f) = %0.4f', x, atanh );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/fast/atanh/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/fast/atanh/examples/index.js
@@ -18,12 +18,13 @@
 
 'use strict';
 
-var linspace = require( '@stdlib/array/base/linspace' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var atanh = require( './../lib' );
 
-var x = linspace( -1.0, 1.0, 103 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 103, -1.0, 1.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( 'atanh(%d) = %d', x[ i ], atanh( x[ i ] ) );
-}
+logEachMap( 'atanh(%0.4f) = %0.4f', x, atanh );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `math/base/special/fast/abs`, `math/base/special/fast/acosh`, `math/base/special/fast/alpha-max-plus-beta-min`, `math/base/special/fast/asinh` and `math/base/special/fast/atanh` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
