### PR TITLE
chore: fix EditorConfig lint errors (issue #6627)

### DIFF
--- a/lib/node_modules/@stdlib/math/strided/special/drsqrt/manifest.json
+++ b/lib/node_modules/@stdlib/math/strided/special/drsqrt/manifest.json
@@ -1,75 +1,75 @@
 {
-	"options": {
-		"task": "build"
-	},
-	"fields": [
-		{
-			"field": "src",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "include",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "libraries",
-			"resolve": false,
-			"relative": false
-		},
-		{
-			"field": "libpath",
-			"resolve": true,
-			"relative": false
-		}
-	],
-	"confs": [
-		{
-			"task": "build",
-			"src": [
-				"./src/drsqrt.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [],
-			"libpath": [],
-			"dependencies": [
-				"@stdlib/math/base/special/rsqrt",
-				"@stdlib/strided/base/dmap",
-				"@stdlib/strided/napi/dmap"
-			]
-		},
-		{
-			"task": "examples",
-			"src": [
-				"./src/drsqrt.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [],
-			"libpath": [],
-			"dependencies": [
-				"@stdlib/math/base/special/rsqrt",
-				"@stdlib/strided/base/dmap"
-			]
-		},
-		{
-			"task": "benchmark",
-			"src": [
-				"./src/drsqrt.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [],
-			"libpath": [],
-			"dependencies": [
-				"@stdlib/math/base/special/rsqrt",
-				"@stdlib/strided/base/dmap"
-			]
-		}
-	]
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/drsqrt.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/rsqrt",
+        "@stdlib/strided/base/dmap",
+        "@stdlib/strided/napi/dmap"
+      ]
+    },
+    {
+      "task": "examples",
+      "src": [
+        "./src/drsqrt.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/rsqrt",
+        "@stdlib/strided/base/dmap"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/drsqrt.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/rsqrt",
+        "@stdlib/strided/base/dmap"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Resolves #6627

## Description

> What is the purpose of this pull request?

This pull request:

- Fixes an EditorConfig linting error caused by the use of tabs instead of spaces in the `manifest.json` file located at `lib/node_modules/@stdlib/math/strided/special/drsqrt/manifest.json`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

- Resolves #6627

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
