### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-even/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-even/README.md
@@ -72,8 +72,8 @@ var opts = {
 var x = discreteUniform( 100, 0, 100, opts );
 
 function isEvenWrapper( integer ) {
-	var result = isEven( integer ) ? "even" : "not even";
-	return result;
+    var result = ( isEven( integer ) ) ? 'even' : 'not even';
+    return result;
 }
 logEachMap( '%d is %s', x, isEvenWrapper );
 ```

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-even/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-even/README.md
@@ -62,19 +62,20 @@ bool = isEven( 0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var isEven = require( '@stdlib/math/base/assert/int32-is-even' );
 
-var bool;
-var x;
-var i;
+var opts = {
+    'dtype': 'int32'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = round( randu()*100.0 );
-    bool = isEven( x );
-    console.log( '%d is %s', x, ( bool ) ? 'even' : 'not even' );
+function isEvenWrapper( integer ) {
+	var result = isEven( integer ) ? "even" : "not even";
+	return result;
 }
+logEachMap( '%d is %s', x, isEvenWrapper );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-even/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-even/README.md
@@ -72,8 +72,7 @@ var opts = {
 var x = discreteUniform( 100, 0, 100, opts );
 
 function isEvenWrapper( integer ) {
-    var result = ( isEven( integer ) ) ? 'even' : 'not even';
-    return result;
+    return ( isEven( integer ) ) ? 'even' : 'not even';
 }
 logEachMap( '%d is %s', x, isEvenWrapper );
 ```

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-even/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-even/examples/index.js
@@ -18,16 +18,17 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var isEven = require( './../lib' );
 
-var bool;
-var x;
-var i;
+var opts = {
+	'dtype': 'int32'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = round( randu()*100.0 );
-	bool = isEven( x );
-	console.log( '%d is %s', x, ( bool ) ? 'even' : 'not even' );
+function isEvenWrapper( integer ) {
+	var result = isEven( integer ) ? "even" : "not even";
+	return result;
 }
+logEachMap( '%d is %s', x, isEvenWrapper );

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-even/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-even/examples/index.js
@@ -28,7 +28,7 @@ var opts = {
 var x = discreteUniform( 100, 0, 100, opts );
 
 function isEvenWrapper( integer ) {
-	var result = isEven( integer ) ? "even" : "not even";
+	var result = ( isEven( integer ) ) ? 'even' : 'not even';
 	return result;
 }
 logEachMap( '%d is %s', x, isEvenWrapper );

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-even/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-even/examples/index.js
@@ -28,7 +28,6 @@ var opts = {
 var x = discreteUniform( 100, 0, 100, opts );
 
 function isEvenWrapper( integer ) {
-	var result = ( isEven( integer ) ) ? 'even' : 'not even';
-	return result;
+	return ( isEven( integer ) ) ? 'even' : 'not even';
 }
 logEachMap( '%d is %s', x, isEvenWrapper );

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/README.md
@@ -72,8 +72,8 @@ var opts = {
 var x = discreteUniform( 100, 0, 100, opts );
 
 function isOddWrapper( integer ) {
-	var result = isOdd( integer ) ? "odd" : "not odd";
-	return result;
+    var result = ( isOdd( integer ) ) ? 'odd' : 'not odd';
+    return result;
 }
 logEachMap( '%d is %s', x, isOddWrapper );
 ```

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/README.md
@@ -72,8 +72,7 @@ var opts = {
 var x = discreteUniform( 100, 0, 100, opts );
 
 function isOddWrapper( integer ) {
-    var result = ( isOdd( integer ) ) ? 'odd' : 'not odd';
-    return result;
+    return ( isOdd( integer ) ) ? 'odd' : 'not odd';
 }
 logEachMap( '%d is %s', x, isOddWrapper );
 ```

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/README.md
@@ -62,19 +62,20 @@ bool = isOdd( 0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var isOdd = require( '@stdlib/math/base/assert/int32-is-odd' );
 
-var bool;
-var x;
-var i;
+var opts = {
+    'dtype': 'int32'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = round( randu()*100.0 );
-    bool = isOdd( x );
-    console.log( '%d is %s', x, ( bool ) ? 'odd' : 'not odd' );
+function isOddWrapper( integer ) {
+	var result = isOdd( integer ) ? "odd" : "not odd";
+	return result;
 }
+logEachMap( '%d is %s', x, isOddWrapper );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/examples/index.js
@@ -28,7 +28,6 @@ var opts = {
 var x = discreteUniform( 100, 0, 100, opts );
 
 function isOddWrapper( integer ) {
-	var result = ( isOdd( integer ) ) ? 'odd' : 'not odd';
-	return result;
+	return ( isOdd( integer ) ) ? 'odd' : 'not odd';
 }
 logEachMap( '%d is %s', x, isOddWrapper );

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/examples/index.js
@@ -28,7 +28,7 @@ var opts = {
 var x = discreteUniform( 100, 0, 100, opts );
 
 function isOddWrapper( integer ) {
-	var result = isOdd( integer ) ? "odd" : "not odd";
+	var result = ( isOdd( integer ) ) ? 'odd' : 'not odd';
 	return result;
 }
 logEachMap( '%d is %s', x, isOddWrapper );

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/examples/index.js
@@ -23,7 +23,7 @@ var logEachMap = require( '@stdlib/console/log-each-map' );
 var isOdd = require( './../lib' );
 
 var opts = {
-    'dtype': 'int32'
+	'dtype': 'int32'
 };
 var x = discreteUniform( 100, 0, 100, opts );
 

--- a/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/assert/int32-is-odd/examples/index.js
@@ -18,16 +18,17 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var isOdd = require( './../lib' );
 
-var bool;
-var x;
-var i;
+var opts = {
+    'dtype': 'int32'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = round( randu()*100.0 );
-	bool = isOdd( x );
-	console.log( '%d is %s', x, ( bool ) ? 'odd' : 'not odd' );
+function isOddWrapper( integer ) {
+	var result = isOdd( integer ) ? "odd" : "not odd";
+	return result;
 }
+logEachMap( '%d is %s', x, isOddWrapper );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `math/base/assert/int32-is-even` and `math/base/assert/int32-is-odd` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
