### PR TITLE
chore: fix EditorConfig lint errors (issue #6663)

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/ind/manifest.json
+++ b/lib/node_modules/@stdlib/ndarray/base/ind/manifest.json
@@ -1,43 +1,43 @@
 {
-	"options": {},
-	"fields": [
-		{
-			"field": "src",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "include",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "libraries",
-			"resolve": false,
-			"relative": false
-		},
-		{
-			"field": "libpath",
-			"resolve": true,
-			"relative": false
-		}
-	],
-	"confs": [
-		{
-			"src": [
-				"./src/main.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [],
-			"libpath": [],
-			"dependencies": [
-				"@stdlib/ndarray/base/clamp-index",
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/ndarray/base/clamp-index",
         "@stdlib/ndarray/base/normalize-index",
-				"@stdlib/ndarray/base/wrap-index",
-				"@stdlib/ndarray/index-modes"
-			]
-		}
-	]
+        "@stdlib/ndarray/base/wrap-index",
+        "@stdlib/ndarray/index-modes"
+      ]
+    }
+  ]
 }

--- a/lib/node_modules/@stdlib/random/streams/pareto-type1/lib/defaults.json
+++ b/lib/node_modules/@stdlib/random/streams/pareto-type1/lib/defaults.json
@@ -1,7 +1,7 @@
 {
-	"objectMode": false,
-	"encoding": null,
-	"sep": "\n",
-	"copy": true,
-	"siter": 1e308
+  "objectMode": false,
+  "encoding": null,
+  "sep": "\n",
+  "copy": true,
+  "siter": 1e308
 }


### PR DESCRIPTION
Resolves #6663.

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR fixes EditorConfig linting issues related to tab indentation in:
- lib/node_modules/@stdlib/ndarray/base/ind/manifest.json
- lib/node_modules/@stdlib/random/streams/pareto-type1/lib/defaults.json

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #6663 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
