### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/math/base/assert/is-even/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/is-even/README.md
@@ -85,19 +85,19 @@ bool = isEven( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var isEven = require( '@stdlib/math/base/assert/is-even' );
 
-var bool;
-var x;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-for ( i = 0; i < 100; i++ ) {
-    x = round( randu()*100.0 );
-    bool = isEven( x );
-    console.log( '%d is %s', x, ( bool ) ? 'even' : 'not even' );
+function isEvenWrapper( integer ) {
+    return ( isEven( integer ) ) ? 'even' : 'not even';
 }
+logEachMap( '%d is %s', x, isEvenWrapper );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/assert/is-even/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-even/examples/index.js
@@ -18,16 +18,16 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var isEven = require( './../lib' );
 
-var bool;
-var x;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-for ( i = 0; i < 100; i++ ) {
-	x = round( randu()*100.0 );
-	bool = isEven( x );
-	console.log( '%d is %s', x, ( bool ) ? 'even' : 'not even' );
+function isEvenWrapper( integer ) {
+    return ( isEven( integer ) ) ? 'even' : 'not even';
 }
+logEachMap( '%d is %s', x, isEvenWrapper );

--- a/lib/node_modules/@stdlib/math/base/assert/is-even/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-even/examples/index.js
@@ -28,6 +28,6 @@ var opts = {
 var x = discreteUniform( 100, 0, 100, opts );
 
 function isEvenWrapper( integer ) {
-    return ( isEven( integer ) ) ? 'even' : 'not even';
+	return ( isEven( integer ) ) ? 'even' : 'not even';
 }
 logEachMap( '%d is %s', x, isEvenWrapper );

--- a/lib/node_modules/@stdlib/math/base/assert/is-evenf/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/is-evenf/README.md
@@ -85,15 +85,19 @@ bool = isEvenf( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/array/discrete-uniform' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var isEvenf = require( '@stdlib/math/base/assert/is-evenf' );
 
-var x = randu( 100, 0, 100 );
+var opts = {
+    'dtype': 'float32'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-var i;
-for ( i = 0; i < 100; i++ ) {
-    console.log( '%d is %s', x[ i ], ( isEvenf( x[ i ] ) ) ? 'even' : 'not even' );
+function isEvenfWrapper( integer ) {
+    return ( isEvenf( integer ) ) ? 'even' : 'not even';
 }
+logEachMap( '%d is %s', x, isEvenfWrapper );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/assert/is-evenf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-evenf/examples/index.js
@@ -28,6 +28,6 @@ var opts = {
 var x = discreteUniform( 100, 0, 100, opts );
 
 function isEvenfWrapper( integer ) {
-    return ( isEvenf( integer ) ) ? 'even' : 'not even';
+	return ( isEvenf( integer ) ) ? 'even' : 'not even';
 }
 logEachMap( '%d is %s', x, isEvenfWrapper );

--- a/lib/node_modules/@stdlib/math/base/assert/is-evenf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-evenf/examples/index.js
@@ -18,12 +18,16 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/array/discrete-uniform' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var isEvenf = require( './../lib' );
 
-var x = randu( 100, 0, 100 );
+var opts = {
+	'dtype': 'float32'
+};
+var x = discreteUniform( 100, 0, 100, opts );
 
-var i;
-for ( i = 0; i < 100; i++ ) {
-	console.log( '%d is %s', x[ i ], ( isEvenf( x[ i ] ) ) ? 'even' : 'not even' );
+function isEvenfWrapper( integer ) {
+    return ( isEvenf( integer ) ) ? 'even' : 'not even';
 }
+logEachMap( '%d is %s', x, isEvenfWrapper );

--- a/lib/node_modules/@stdlib/math/base/assert/is-odd/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/is-odd/README.md
@@ -86,14 +86,18 @@ bool = isOdd( NaN );
 
 ```javascript
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var isOdd = require( '@stdlib/math/base/assert/is-odd' );
 
-var x = discreteUniform( 100, 0, 1000 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = discreteUniform( 100, 0, 1000, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( '%d is %s', x[ i ], ( isOdd( x[ i ] ) ) ? 'odd' : 'not odd' );
+function isOddWrapper( integer ) {
+    return ( isOdd( integer ) ) ? 'odd' : 'not odd';
 }
+logEachMap( '%d is %s', x, isOddWrapper );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/assert/is-odd/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-odd/examples/index.js
@@ -19,11 +19,15 @@
 'use strict';
 
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var isOdd = require( './../lib' );
 
-var x = discreteUniform( 100, 0, 1000 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = discreteUniform( 100, 0, 1000, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( '%d is %s', x[ i ], ( isOdd( x[ i ] ) ) ? 'odd' : 'not odd' );
+function isOddWrapper( integer ) {
+    return ( isOdd( integer ) ) ? 'odd' : 'not odd';
 }
+logEachMap( '%d is %s', x, isOddWrapper );

--- a/lib/node_modules/@stdlib/math/base/assert/is-odd/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-odd/examples/index.js
@@ -28,6 +28,6 @@ var opts = {
 var x = discreteUniform( 100, 0, 1000, opts );
 
 function isOddWrapper( integer ) {
-    return ( isOdd( integer ) ) ? 'odd' : 'not odd';
+	return ( isOdd( integer ) ) ? 'odd' : 'not odd';
 }
 logEachMap( '%d is %s', x, isOddWrapper );

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/README.md
@@ -85,15 +85,19 @@ bool = isOddf( NaN );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/array/discrete-uniform' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var isOddf = require( '@stdlib/math/base/assert/is-oddf' );
 
-var x = randu( 100, 0, 100 );
+var opts = {
+    'dtype': 'float32'
+};
+var x = discreteUniform( 100, 0, 1000, opts );
 
-var i;
-for ( i = 0; i < 100; i++ ) {
-    console.log( '%d is %s', x[ i ], ( isOddf( x[ i ] ) ) ? 'odd' : 'not odd' );
+function isOddfWrapper( integer ) {
+    return ( isOddf( integer ) ) ? 'odd' : 'not odd';
 }
+logEachMap( '%d is %s', x, isOddfWrapper );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/examples/index.js
@@ -18,12 +18,16 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/array/discrete-uniform' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var isOddf = require( './../lib' );
 
-var x = randu( 100, 0, 100 );
+var opts = {
+	'dtype': 'float32'
+};
+var x = discreteUniform( 100, 0, 1000, opts );
 
-var i;
-for ( i = 0; i < 100; i++ ) {
-	console.log( '%d is %s', x[ i ], ( isOddf( x[ i ] ) ) ? 'odd' : 'not odd' );
+function isOddfWrapper( integer ) {
+    return ( isOddf( integer ) ) ? 'odd' : 'not odd';
 }
+logEachMap( '%d is %s', x, isOddfWrapper );

--- a/lib/node_modules/@stdlib/math/base/assert/is-oddf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-oddf/examples/index.js
@@ -28,6 +28,6 @@ var opts = {
 var x = discreteUniform( 100, 0, 1000, opts );
 
 function isOddfWrapper( integer ) {
-    return ( isOddf( integer ) ) ? 'odd' : 'not odd';
+	return ( isOddf( integer ) ) ? 'odd' : 'not odd';
 }
 logEachMap( '%d is %s', x, isOddfWrapper );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `math/base/assert/is-even`, `math/base/assert/is-evenf`, `math/base/assert/is-odd` and `math/base/assert/is-oddf` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
