### PR TITLE
chore: fix C lint errors (issue #6629)

### DIFF
--- a/lib/node_modules/@stdlib/math/strided/special/sabs2/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/math/strided/special/sabs2/benchmark/c/benchmark.length.c
@@ -107,6 +107,7 @@ static double benchmark( int iterations, int len ) {
 	}
 	t = tic();
 	for ( i = 0; i < iterations; i++ ) {
+		// cppcheck-suppress uninitvar
 		stdlib_strided_sabs2( len, x, 1, y, 1 );
 		if ( y[ 0 ] != y[ 0 ] ) {
 			printf( "should not return NaN\n" );


### PR DESCRIPTION
Resolves #6629.

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR resolves the C lint error reported in issue #6629 by suppressing a false positive warning for an uninitialized variable using `// cppcheck-suppress uninitvar`, consistent with how similar cases are handled across the codebase.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #6629 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
