### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/math/base/assert/is-probability/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/is-probability/README.md
@@ -57,14 +57,18 @@ bool = isProbability( NaN );
 
 ```javascript
 var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var isProbability = require( '@stdlib/math/base/assert/is-probability' );
 
-var x = uniform( 100, -1.0, 1.0 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 100, -1.0, 1.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    console.log( '%d is %s', x[ i ], ( isProbability( x[ i ] ) ) ? 'a probability' : 'not a probability' );
+function isProbabilityWrapper( integer ) {
+    return ( isProbability( integer ) ) ? 'a probability' : 'not a probability';
 }
+logEachMap( '%0.4f is %s', x, isProbabilityWrapper );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/assert/is-probability/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-probability/examples/index.js
@@ -19,11 +19,15 @@
 'use strict';
 
 var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var isProbability = require( './../lib' );
 
-var x = uniform( 100, -1.0, 1.0 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 100, -1.0, 1.0, opts );
 
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	console.log( '%d is %s', x[ i ], ( isProbability( x[ i ] ) ) ? 'a probability' : 'not a probability' );
+function isProbabilityWrapper( integer ) {
+	return ( isProbability( integer ) ) ? 'a probability' : 'not a probability';
 }
+logEachMap( '%0.4f is %s', x, isProbabilityWrapper );

--- a/lib/node_modules/@stdlib/math/base/assert/is-probabilityf/README.md
+++ b/lib/node_modules/@stdlib/math/base/assert/is-probabilityf/README.md
@@ -57,16 +57,18 @@ bool = isProbabilityf( NaN );
 
 ```javascript
 var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var isProbabilityf = require( '@stdlib/math/base/assert/is-probabilityf' );
 
-var x = uniform( 100, -1.0, 1.0, {
+var opts = {
     'dtype': 'float32'
-});
+};
+var x = uniform( 100, -1.0, 1.0, opts );
 
-var i;
-for ( i = 0; i < 100; i++ ) {
-    console.log( '%d is %s', x[ i ], ( isProbabilityf( x[ i ] ) ) ? 'a probability' : 'not a probability' );
+function isProbabilityfWrapper( integer ) {
+    return ( isProbabilityf( integer ) ) ? 'a probability' : 'not a probability';
 }
+logEachMap( '%0.4f is %s', x, isProbabilityfWrapper );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/assert/is-probabilityf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/assert/is-probabilityf/examples/index.js
@@ -19,13 +19,15 @@
 'use strict';
 
 var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var isProbabilityf = require( './../lib' );
 
-var x = uniform( 100, -1.0, 1.0, {
+var opts = {
 	'dtype': 'float32'
-});
+};
+var x = uniform( 100, -1.0, 1.0, opts );
 
-var i;
-for ( i = 0; i < 100; i++ ) {
-	console.log( '%d is %s', x[ i ], ( isProbabilityf( x[ i ] ) ) ? 'a probability' : 'not a probability' );
+function isProbabilityfWrapper( integer ) {
+	return ( isProbabilityf( integer ) ) ? 'a probability' : 'not a probability';
 }
+logEachMap( '%0.4f is %s', x, isProbabilityfWrapper );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `math/base/assert/is-probability` and `math/base/assert/is-probabilityf` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
