### PR TITLE
fix: add missing values in error messages in `blas/base/dgemv`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/dgemv/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/dgemv/lib/ndarray.js
@@ -73,10 +73,10 @@ function dgemv( trans, M, N, alpha, A, strideA1, strideA2, offsetA, x, strideX, 
 		throw new RangeError( format( 'invalid argument. Third argument must be a nonnegative integer. Value: `%d`.', N ) );
 	}
 	if ( strideX === 0 ) {
-		throw new RangeError( format( 'invalid argument. Tenth argument must be non-zero.', strideX ) );
+		throw new RangeError( format( 'invalid argument. Tenth argument must be non-zero. Value: `%d`.', strideX ) );
 	}
 	if ( strideY === 0 ) {
-		throw new RangeError( format( 'invalid argument. Fourteenth argument must be non-zero.', strideY ) );
+		throw new RangeError( format( 'invalid argument. Fourteenth argument must be non-zero. Value: `%d`.', strideY ) );
 	}
 	// Check if we can early return...
 	if ( M === 0 || N === 0 || ( alpha === 0.0 && beta === 1.0 ) ) {

--- a/lib/node_modules/@stdlib/blas/base/dgemv/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/blas/base/dgemv/lib/ndarray.js
@@ -73,10 +73,10 @@ function dgemv( trans, M, N, alpha, A, strideA1, strideA2, offsetA, x, strideX, 
 		throw new RangeError( format( 'invalid argument. Third argument must be a nonnegative integer. Value: `%d`.', N ) );
 	}
 	if ( strideX === 0 ) {
-		throw new RangeError( format( 'invalid argument. Tenth argument must be non-zero.' ) );
+		throw new RangeError( format( 'invalid argument. Tenth argument must be non-zero.', strideX ) );
 	}
 	if ( strideY === 0 ) {
-		throw new RangeError( format( 'invalid argument. Fourteenth argument must be non-zero.' ) );
+		throw new RangeError( format( 'invalid argument. Fourteenth argument must be non-zero.', strideY ) );
 	}
 	// Check if we can early return...
 	if ( M === 0 || N === 0 || ( alpha === 0.0 && beta === 1.0 ) ) {


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: na
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

none

## Description

> What is the purpose of this pull request?

This pull request:

-  Outputs the stride values in error checks in `blas/base/dgemv`

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   none

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
