### PR TITLE
feat: add implementation of `math/base/special/round2f` function

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/round2f/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/round2f/README.md
@@ -1,0 +1,218 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2025 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# round2f
+
+> Round a single-precision floating-point number to the nearest power of two on a linear scale.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var round2f = require( '@stdlib/math/base/special/round2f' );
+```
+
+#### round2f( x )
+
+Rounds a single-precision floating-point number to the nearest power of two on a linear scale.
+
+```javascript
+var v = round2f( -4.2 );
+// returns -4.0
+
+v = round2f( -4.5 );
+// returns -4.0
+
+v = round2f( -4.6 );
+// returns -4.0
+
+v = round2f( 9.99999 );
+// returns 8.0
+
+v = round2f( 9.5 );
+// returns 8.0
+
+v = round2f( 13.0 );
+// returns 16.0
+
+v = round2f( -13.0 );
+// returns -16.0
+
+v = round2f( 0.0 );
+// returns 0.0
+
+v = round2f( -0.0 );
+// returns -0.0
+
+v = round2f( Infinity );
+// returns Infinity
+
+v = round2f( -Infinity );
+// returns -Infinity
+
+v = round2f( NaN );
+// returns NaN
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
+var round2f = require( '@stdlib/math/base/special/round2f' );
+
+var opts = {
+    'dtype': 'float32'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
+
+logEachMap( 'x: %0.4f. Rounded: %0.4f.', x, round2f );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/math/base/special/round2f.h"
+```
+
+#### stdlib_base_round2f( x )
+
+Rounds a single-precision floating-point number to the nearest power of two on a linear scale.
+
+```c
+float out = stdlib_base_round2f( -4.2 );
+// returns -4.0
+```
+
+The function accepts the following arguments:
+
+-   **x**: `[in] float` input value.
+
+```c
+float stdlib_base_round2f( const float x );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/math/base/special/round2f.h"
+#include <stdio.h>
+
+int main( void ) {
+    const float x[] = { -5.0, -3.89, -2.78, -1.67, -0.56, 0.56, 1.67, 2.78, 3.89, 5.0 };
+
+    float v;
+    int i;
+    for ( i = 0; i < 10; i++ ) {
+        v = stdlib_base_round2f( x[ i ] );
+        printf( "round2f(%lf) = %lf\n", x[ i ], v );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/math/base/special/ceil2`][@stdlib/math/base/special/ceil2]</span><span class="delimiter">: </span><span class="description">round a numeric value to the nearest power of two toward positive infinity.</span>
+-   <span class="package-name">[`@stdlib/math/base/special/floor2`][@stdlib/math/base/special/floor2]</span><span class="delimiter">: </span><span class="description">round a numeric value to the nearest power of two toward negative infinity.</span>
+-   <span class="package-name">[`@stdlib/math/base/special/round`][@stdlib/math/base/special/round]</span><span class="delimiter">: </span><span class="description">round a numeric value to the nearest integer.</span>
+-   <span class="package-name">[`@stdlib/math/base/special/round10`][@stdlib/math/base/special/round10]</span><span class="delimiter">: </span><span class="description">round a numeric value to the nearest power of 10 on a linear scale.</span>
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+<!-- <related-links> -->
+
+[@stdlib/math/base/special/round2]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/round2
+
+[@stdlib/math/base/special/roundf]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/roundf
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/math/base/special/round2f/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/round2f/benchmark/benchmark.js
@@ -1,0 +1,54 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var pkg = require( './../package.json' ).name;
+var round2f = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	x = uniform( 100, -5.0e6, 5.0e6, {
+		'dtype': 'float32'
+	});
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		y = round2f( x[ i%x.length ] );
+		if ( isnanf( y ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnanf( y ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/round2f/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/round2f/benchmark/benchmark.native.js
@@ -1,0 +1,63 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var round2f = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( round2f instanceof Error )
+};
+
+
+// MAIN //
+
+bench( pkg+'::native', opts, function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	x = uniform( 100, -5.0e6, 5.0e6, {
+		'dtype': 'float32'
+	});
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		y = round2f( x[ i%x.length ] );
+		if ( isnanf( y ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnanf( y ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/round2f/benchmark/c/native/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/round2f/benchmark/c/native/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2025 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/round2f/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/round2f/benchmark/c/native/benchmark.c
@@ -1,0 +1,136 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/round2f.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "round2f"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+static void print_version( void ) {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+static void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+static void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+static double tic( void ) {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1).
+*
+* @return random number
+*/
+static float rand_float( void ) {
+	int r = rand();
+	return (float)r / ( (float)RAND_MAX + 1.0f );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+static double benchmark( void ) {
+	double elapsed;
+	float x[ 100 ];
+	float y;
+	double t;
+	int i;
+
+	for ( i = 0; i < 100; i++ ) {
+		x[ i ] = ( 1.0e7 * rand_float() ) - 5.0e6;
+	}
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		y = stdlib_base_round2f( x[ i%100 ] );
+		if ( y != y ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( y != y ) {
+		printf( "should not return NaN\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::native::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/math/base/special/round2f/binding.gyp
+++ b/lib/node_modules/@stdlib/math/base/special/round2f/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2025 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/math/base/special/round2f/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/round2f/docs/repl.txt
@@ -1,0 +1,34 @@
+
+{{alias}}( x )
+    Rounds a single-precision floating-point number to the nearest power of two on a linear scale.
+
+    Parameters
+    ----------
+    x: number
+        Input value.
+
+    Returns
+    -------
+    y: number
+        Rounded value.
+
+    Examples
+    --------
+    > var y = {{alias}}( 3.14 )
+    4.0
+    > y = {{alias}}( -4.2 )
+    -4.0
+    > y = {{alias}}( -4.6 )
+    -4.0
+    > y = {{alias}}( 9.5 )
+    8.0
+    > y = {{alias}}( 13.0 )
+    16.0
+    > y = {{alias}}( -13.0 )
+    -16.0
+    > y = {{alias}}( -0.0 )
+    -0.0
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/math/base/special/round2f/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/round2f/docs/types/index.d.ts
@@ -1,0 +1,44 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Rounds a single-precision floating-point number to the nearest power of two on a linear scale.
+*
+* @param x - input value
+* @returns rounded value
+*
+* @example
+* var v = round2f( 3.141592653589793 );
+* // returns 4.0
+*
+* @example
+* var v = round2f( 13.0 );
+* // returns 16.0
+*
+* @example
+* var v = round2f( -0.314 );
+* // returns -0.25
+*/
+declare function round2f( x: number ): number;
+
+
+// EXPORTS //
+
+export = round2f;

--- a/lib/node_modules/@stdlib/math/base/special/round2f/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/math/base/special/round2f/docs/types/test.ts
@@ -1,0 +1,43 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import round2f from './index';
+
+// TESTS //
+
+// The function returns a number...
+{
+	round2f( 8.78 ); // $ExpectType number
+}
+
+// The compiler throws an error if the function is provided a value other than a number...
+{
+	round2f( true ); // $ExpectError
+	round2f( false ); // $ExpectError
+	round2f( null ); // $ExpectError
+	round2f( undefined ); // $ExpectError
+	round2f( '5' ); // $ExpectError
+	round2f( [] ); // $ExpectError
+	round2f( {} ); // $ExpectError
+	round2f( ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided insufficient arguments...
+{
+	round2f(); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/math/base/special/round2f/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/round2f/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2025 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/round2f/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/round2f/examples/c/example.c
@@ -1,0 +1,31 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/round2f.h"
+#include <stdio.h>
+
+int main( void ) {
+	const float x[] = { -5.0, -3.89, -2.78, -1.67, -0.56, 0.56, 1.67, 2.78, 3.89, 5.0 };
+
+	float v;
+	int i;
+	for ( i = 0; i < 10; i++ ) {
+		v = stdlib_base_round2f( x[ i ] );
+		printf( "round2f(%lf) = %lf\n", x[ i ], v );
+	}
+}

--- a/lib/node_modules/@stdlib/math/base/special/round2f/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/round2f/examples/index.js
@@ -1,0 +1,30 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
+var round2f = require( './../lib' );
+
+var opts = {
+	'dtype': 'float32'
+};
+var x = uniform( 100, -50.0, 50.0, opts );
+
+logEachMap( 'x: %0.4f. Rounded: %0.4f.', x, round2f );

--- a/lib/node_modules/@stdlib/math/base/special/round2f/include.gypi
+++ b/lib/node_modules/@stdlib/math/base/special/round2f/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2025 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/math/base/special/round2f/include/stdlib/math/base/special/round2f.h
+++ b/lib/node_modules/@stdlib/math/base/special/round2f/include/stdlib/math/base/special/round2f.h
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_MATH_BASE_SPECIAL_ROUND2F_H
+#define STDLIB_MATH_BASE_SPECIAL_ROUND2F_H
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Rounds a numeric value to the nearest power of two on a linear scale.
+*/
+float stdlib_base_round2f( const float x );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_MATH_BASE_SPECIAL_ROUND2F_H

--- a/lib/node_modules/@stdlib/math/base/special/round2f/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/round2f/lib/index.js
@@ -1,0 +1,46 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Round a single-precision floating-point number to the nearest power of two on a linear scale.
+*
+* @module @stdlib/math/base/special/round2f
+*
+* @example
+* var round2f = require( '@stdlib/math/base/special/round2f' );
+*
+* var v = round2f( 3.141592653589793 );
+* // returns 4.0
+*
+* v = round2f( 13.0 );
+* // returns 16.0
+*
+* v = round2f( -0.314 );
+* // returns -0.25
+*/
+
+// MODULES //
+
+var round2f = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = round2f;

--- a/lib/node_modules/@stdlib/math/base/special/round2f/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/round2f/lib/main.js
@@ -1,0 +1,122 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var isInfinitef = require( '@stdlib/math/base/assert/is-infinitef' );
+var powf = require( '@stdlib/math/base/special/powf' );
+var floorf = require( '@stdlib/math/base/special/floorf' );
+var ceilf = require( '@stdlib/math/base/special/ceilf' );
+var log2f = require( '@stdlib/math/base/special/log2f' );
+var MAX_BASE2_EXPONENT_F = require( '@stdlib/constants/float32/max-base2-exponent' );
+var MIN_BASE2_EXP_SUBNORMAL_F = require( '@stdlib/constants/float32/min-base2-exponent-subnormal' );
+var PINF = require( '@stdlib/constants/float32/pinf' );
+
+
+// VARIABLES //
+
+// 2^1023:
+var HUGE = powf( float64ToFloat32( 2.0 ), MAX_BASE2_EXPONENT_F );
+var HALF_HUGE = HUGE / float64ToFloat32( 2.0 );
+
+
+// MAIN //
+
+/**
+* Rounds a single-precision floating-point number to the nearest power of two on a linear scale.
+*
+* @param {number} x - input value
+* @returns {number} rounded value
+*
+* @example
+* var v = round2f( 3.141592653589793 );
+* // returns 4.0
+*
+* @example
+* var v = round2f( 13.0 );
+* // returns 16.0
+*
+* @example
+* var v = round2f( -0.314 );
+* // returns -0.25
+*/
+function round2f( x ) {
+	var sign;
+	var half;
+	var p1;
+	var p2;
+	var y1;
+	var y2;
+	var p;
+
+	x = float64ToFloat32( x );
+
+	if (
+		isnanf( x ) ||
+		isInfinitef( x ) ||
+		x === 0.0
+	) {
+		return x;
+	}
+	if ( x < 0 ) {
+		x = -x;
+		sign = -1.0;
+	} else {
+		sign = 1.0;
+	}
+
+	// Solve the equation `2^p = x` for `p`:
+	p = log2f( x );
+
+	// If provided the smallest subnormal, no rounding possible:
+	if ( p === MIN_BASE2_EXP_SUBNORMAL_F ) {
+		return x;
+	}
+
+	// Find the previous and next integer powers:
+	p1 = floorf( p );
+	p2 = ceilf( p );
+
+	// Handle overflow:
+	if ( p1 === MAX_BASE2_EXPONENT_F ) {
+		if ( x - HUGE >= HALF_HUGE ) {
+			return sign * PINF; // sign-preserving
+		}
+		return sign * HUGE;
+	}
+
+	// Compute previous and next powers of two:
+	y1 = powf( 2.0, p1 );
+	y2 = powf( 2.0, p2 );
+
+	// Find the closest power of two:
+	half = ( y2 - y1 ) / 2.0;
+	if ( y1 + half > x ) {
+		return sign * y1;
+	}
+	return sign * y2;
+}
+
+
+// EXPORTS //
+
+module.exports = round2f;

--- a/lib/node_modules/@stdlib/math/base/special/round2f/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/round2f/lib/native.js
@@ -1,0 +1,54 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Rounds a single-precision floating-point number to the nearest power of two on a linear scale.
+*
+* @private
+* @param {number} x - input value
+* @returns {number} rounded value
+*
+* @example
+* var v = round2f( 3.141592653589793 );
+* // returns 4.0
+*
+* @example
+* var v = round2f( 13.0 );
+* // returns 16.0
+*
+* @example
+* var v = round2f( -0.314 );
+* // returns -0.25
+*/
+function round2f( x ) {
+	return addon( x );
+}
+
+
+// EXPORTS //
+
+module.exports = round2f;

--- a/lib/node_modules/@stdlib/math/base/special/round2f/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/round2f/manifest.json
@@ -1,0 +1,76 @@
+{
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/napi/unary",
+        "@stdlib/math/base/assert/is-nanf",
+        "@stdlib/math/base/assert/is-infinitef",
+        "@stdlib/math/base/special/floorf",
+        "@stdlib/math/base/special/powf",
+        "@stdlib/math/base/special/ceilf",
+        "@stdlib/math/base/special/log2f",
+        "@stdlib/constants/float32/max-base2-exponent",
+        "@stdlib/constants/float32/min-base2-exponent-subnormal",
+        "@stdlib/constants/float32/pinf"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": []
+    },
+    {
+      "task": "examples",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": []
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/special/round2f/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/round2f/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@stdlib/math/base/special/round2f",
+  "version": "0.0.0",
+  "description": "Return the minimum absolute single-precision floating-point number.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "gypfile": true,
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "src": "./src",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
+    "math.min",
+    "math.abs",
+    "minimum",
+    "min",
+    "smallest",
+    "absolute",
+    "value",
+    "abs",
+    "minabs"
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/special/round2f/src/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/round2f/src/Makefile
@@ -1,0 +1,70 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2025 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+
+# RULES #
+
+#/
+# Removes generated files for building an add-on.
+#
+# @example
+# make clean-addon
+#/
+clean-addon:
+	$(QUIET) -rm -f *.o *.node
+
+.PHONY: clean-addon
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean: clean-addon
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/round2f/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/round2f/src/addon.c
@@ -1,0 +1,22 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/round2f.h"
+#include "stdlib/math/base/napi/unary.h"
+
+STDLIB_MATH_BASE_NAPI_MODULE_F_F( stdlib_base_round2f )

--- a/lib/node_modules/@stdlib/math/base/special/round2f/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/round2f/src/main.c
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2024 The Stdlib Authors.
+* Copyright (c) 2025 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/math/base/special/round2f/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/round2f/src/main.c
@@ -1,0 +1,97 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/round2f.h"
+#include "stdlib/math/base/assert/is_nanf.h"
+#include "stdlib/math/base/assert/is_infinitef.h"
+#include "stdlib/math/base/special/floorf.h"
+#include "stdlib/math/base/special/powf.h"
+#include "stdlib/math/base/special/ceilf.h"
+#include "stdlib/math/base/special/log2f.h"
+#include "stdlib/constants/float32/max_base2_exponent.h"
+#include "stdlib/constants/float32/min_base2_exponent_subnormal.h"
+#include "stdlib/constants/float32/pinf.h"
+
+/**
+* Rounds a single-precision floating-popint number to the nearest power of two on a linear scale.
+*
+* @param x    input value
+* @return     rounded value
+*
+* @example
+* float out = stdlib_base_round2f( 3.141592653589793 );
+* // returns 4.0
+*/
+float stdlib_base_round2f( const float x ) {
+	float HALF_HUGE_VALUE;
+	float HUGE_VALUE;
+	float sign;
+	float half;
+	float p1;
+	float p2;
+	float y1;
+	float y2;
+	float xc;
+	float p;
+
+	if ( stdlib_base_is_nanf( x ) || stdlib_base_is_infinitef( x ) || x == 0.0 ) {
+		return x;
+	}
+	xc = x;
+	if ( xc < 0 ) {
+		xc = -xc;
+		sign = -1.0;
+	} else {
+		sign = 1.0;
+	}
+
+	// Solve the equation `2^p = x` for `p`:
+	p = stdlib_base_log2f( xc );
+
+	// If provided the smallest subnormal, no rounding possible:
+	if ( p == STDLIB_CONSTANT_FLOAT32_MIN_BASE2_EXPONENT_SUBNORMAL ) {
+		return xc;
+	}
+
+	// Find the previous and next integer powers:
+	p1 = stdlib_base_floorf( p );
+	p2 = stdlib_base_ceilf( p );
+
+	// 2^1023:
+	HUGE_VALUE = stdlib_base_powf( 2.0, STDLIB_CONSTANT_FLOAT32_MAX_BASE2_EXPONENT );
+	HALF_HUGE_VALUE = HUGE_VALUE / 2.0;
+
+	// Handle overflow:
+	if ( p1 == STDLIB_CONSTANT_FLOAT32_MAX_BASE2_EXPONENT ) {
+		if ( xc - HUGE_VALUE >= HALF_HUGE_VALUE ) {
+			return sign * STDLIB_CONSTANT_FLOAT32_PINF; // sign-preserving
+		}
+		return sign * HUGE_VALUE;
+	}
+
+	// Compute previous and next powers of two:
+	y1 = stdlib_base_powf( 2.0, p1 );
+	y2 = stdlib_base_powf( 2.0, p2 );
+
+	// Find the closest power of two:
+	half = ( y2 - y1 ) / 2.0;
+	if ( y1 + half > xc ) {
+		return sign * y1;
+	}
+	return sign * y2;
+}

--- a/lib/node_modules/@stdlib/math/base/special/round2f/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/round2f/test/test.js
@@ -1,0 +1,172 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var NINF = require( '@stdlib/constants/float32/ninf' );
+var PINF = require( '@stdlib/constants/float32/pinf' );
+var SMALLEST_SUBNORMAL = require( '@stdlib/constants/float32/smallest-subnormal' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
+var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
+var exp2f = require( '@stdlib/math/base/special/exp2f' );
+var powf = require( '@stdlib/math/base/special/powf' );
+var round2f = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof round2, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `+0` if provided `+0`', function test( t ) {
+	var v;
+
+	v = round2f( 0.0 );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns expected value' );
+
+	v = round2f( +0.0 );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `-0` if provided `-0`', function test( t ) {
+	var v = round2f( -0.0 );
+	t.strictEqual( isNegativeZerof( v ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `NaN` if provided a `NaN`', function test( t ) {
+	var v = round2f( NaN );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `+infinity` if provided `+infinity`', function test( t ) {
+	var v = round2f( PINF );
+	t.strictEqual( v, PINF, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `-infinity` if provided `-infinity`', function test( t ) {
+	var v = round2f( NINF );
+	t.strictEqual( v, NINF, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns the minimum double-precision floating-point value if provided the minimum double-precision floating-point value', function test( t ) {
+	var v = round2f( SMALLEST_SUBNORMAL );
+	t.strictEqual( v, SMALLEST_SUBNORMAL, 'returns smallest subnormal' );
+	t.end();
+});
+
+tape( 'the function overflows if provided a sufficiently large value', function test( t ) {
+	var x;
+	var v;
+
+	x = exp2f( float64ToFloat32( 1023 ) );
+	v = round2f( x + (x/2.0) );
+	t.strictEqual( v, PINF, 'returns expected value' );
+
+	x = -exp2f( float64ToFloat32( 1023 ) );
+	v = round2f( x + (x/2.0) );
+	t.strictEqual( v, NINF, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports rounding large values', function test( t ) {
+	var x;
+	var v;
+
+	x = exp2f( float64ToFloat32( 1023 ) );
+	v = round2f( x + (x/3.0) );
+	t.strictEqual( v, x, 'returns expected value' );
+
+	x = -exp2f( float64ToFloat32( 1023 ) );
+	v = round2f( x + (x/3.0) );
+	t.strictEqual( v, x, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports rounding subnormal values', function test( t ) {
+	var expected;
+	var x;
+	var v;
+
+	expected = powf( float64ToFloat32( 2.0 ), -1044 );
+
+	x = powf( float64ToFloat32( 2.0 ), -1045 );
+	v = round2f( x + (x/2.0) );
+	t.strictEqual( v, expected, 'returns expected value' );
+
+	expected = powf( float64ToFloat32( 2.0 ), -1045 );
+
+	x = powf( float64ToFloat32( 2.0 ), -1045 );
+	v = round2f( x + (x/3.0) );
+	t.strictEqual( v, expected, 'returns expected value' );
+
+	expected = -powf( float64ToFloat32( 2.0 ), -1044 );
+
+	x = -powf( float64ToFloat32( 2.0 ), -1045 );
+	v = round2f( x + (x/2.0) );
+	t.strictEqual( v, expected, 'returns expected value' );
+
+	expected = -powf( float64ToFloat32( 2.0 ), -1045 );
+
+	x = -powf( float64ToFloat32( 2.0 ), -1045 );
+	v = round2f( x + (x/3.0) );
+	t.strictEqual( v, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function rounds a numeric value to the nearest power of two on a linear scale', function test( t ) {
+	t.strictEqual( round2f( -4.2 ), float64ToFloat32( -4.0 ), 'returns expected value' );
+	t.strictEqual( round2f( -4.5 ), float64ToFloat32( -4.0 ), 'returns expected value' );
+	t.strictEqual( round2f( -4.8 ), float64ToFloat32( -4.0 ), 'returns expected value' );
+	t.strictEqual( round2f( 4.2 ), float64ToFloat32( 4.0 ), 'returns expected value' );
+	t.strictEqual( round2f( 9.99999 ), float64ToFloat32( 8.0 ), 'returns expected value' );
+	t.strictEqual( round2f( 9.5 ), float64ToFloat32( 8.0 ), 'returns expected value' );
+	t.strictEqual( round2f( 9.4 ), float64ToFloat32( 8.0 ), 'returns expected value' );
+	t.strictEqual( round2f( 12.0 ), float64ToFloat32( 16.0 ), 'returns expected value' );
+	t.strictEqual( round2f( -12.0 ), float64ToFloat32( -16.0 ), 'returns expected value' );
+	t.strictEqual( round2f( 13.0 ), float64ToFloat32( 16.0 ), 'returns expected value' );
+	t.strictEqual( round2f( -13.0 ), float64ToFloat32( -16.0 ), 'returns expected value' );
+	t.strictEqual( round2f( 23.0 ), float64ToFloat32( 16.0 ), 'returns expected value' );
+	t.strictEqual( round2f( -23.0 ), float64ToFloat32( -16.0 ), 'returns expected value' );
+	t.strictEqual( round2f( 0.0 ), float64ToFloat32( 0.0 ), 'returns expected value' );
+	t.strictEqual( round2f( 27.0 ), float64ToFloat32( 32.0 ), 'returns expected value' );
+	t.strictEqual( round2f( -27.0 ), float64ToFloat32( -32.0 ), 'returns expected value' );
+	t.strictEqual( round2f( 48.1 ), float64ToFloat32( 64.0 ), 'returns expected value' );
+	t.strictEqual( round2f( -48.1 ), float64ToFloat32( -64.0 ), 'returns expected value' );
+	t.strictEqual( round2f( 0.3 ), float64ToFloat32( 0.25 ), 'returns expected value' );
+	t.strictEqual( round2f( -0.3 ), float64ToFloat32( -0.25 ), 'returns expected value' );
+	t.strictEqual( round2f( 0.45 ), float64ToFloat32( 0.5 ), 'returns expected value' );
+	t.strictEqual( round2f( -0.45 ), float64ToFloat32( -0.5 ), 'returns expected value' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/round2f/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/round2f/test/test.native.js
@@ -1,0 +1,181 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var NINF = require( '@stdlib/constants/float32/ninf' );
+var PINF = require( '@stdlib/constants/float32/pinf' );
+var SMALLEST_SUBNORMAL = require( '@stdlib/constants/float32/smallest-subnormal' );
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
+var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
+var exp2f = require( '@stdlib/math/base/special/exp2f' );
+var powf = require( '@stdlib/math/base/special/powf' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var round2f = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( round2f instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof round2f, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `+0` if provided `+0`', opts, function test( t ) {
+	var v;
+
+	v = round2f( 0.0 );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns expected value' );
+
+	v = round2f( +0.0 );
+	t.strictEqual( isPositiveZerof( v ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `-0` if provided `-0`', opts, function test( t ) {
+	var v = round2f( -0.0 );
+	t.strictEqual( isNegativeZerof( v ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `NaN` if provided a `NaN`', opts, function test( t ) {
+	var v = round2f( NaN );
+	t.strictEqual( isnanf( v ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `+infinity` if provided `+infinity`', opts, function test( t ) {
+	var v = round2f( PINF );
+	t.strictEqual( v, PINF, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `-infinity` if provided `-infinity`', opts, function test( t ) {
+	var v = round2f( NINF );
+	t.strictEqual( v, NINF, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns the minimum single-precision floating-point value if provided the minimum single-precision floating-point value', opts, function test( t ) {
+	var v = round2f( SMALLEST_SUBNORMAL );
+	t.strictEqual( v, SMALLEST_SUBNORMAL, 'returns smallest subnormal' );
+	t.end();
+});
+
+tape( 'the function overflows if provided a sufficiently large value', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = exp2f( 1023 );
+	v = round2f( x + ( x/2.0 ) );
+	t.strictEqual( v, PINF, 'returns expected value' );
+
+	x = -exp2f( float64ToFloat32( 1023 ) );
+	v = round2f( x + ( x/2.0 ) );
+	t.strictEqual( v, NINF, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports rounding large values', opts, function test( t ) {
+	var x;
+	var v;
+
+	x = exp2f( float64ToFloat32( 1023 ) );
+	v = round2f( x + ( x/3.0 ) );
+	t.strictEqual( v, x, 'returns expected value' );
+
+	x = -exp2f( float64ToFloat32( 1023 ) );
+	v = round2f( x + (x/3.0 ) );
+	t.strictEqual( v, x, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function supports rounding subnormal values', opts, function test( t ) {
+	var expected;
+	var x;
+	var v;
+
+	expected = powf( float64ToFloat32( 2.0 ), float64ToFloat32( -1044 ) );
+
+	x = powf( float64ToFloat32( 2.0 ), float64ToFloat32( -1045 ) );
+	v = round2f( x + ( x/2.0 ) );
+	t.strictEqual( v, expected, 'returns expected value' );
+
+	expected = powf( float64ToFloat32( 2.0 ), float64ToFloat32( -1045 ) );
+
+	x = powf( float64ToFloat32( 2.0 ), float64ToFloat32( -1045 ) );
+	v = round2f( x + ( x/3.0 ) );
+	t.strictEqual( v, expected, 'returns expected value' );
+
+	expected = -powf( float64ToFloat32( 2.0 ), float64ToFloat32( -1044 ) );
+
+	x = -powf( float64ToFloat32( 2.0 ), float64ToFloat32( -1045 ) );
+	v = round2f( x + ( x/2.0 ) );
+	t.strictEqual( v, expected, 'returns expected value' );
+
+	expected = -powf( float64ToFloat32( 2.0 ), float64ToFloat32( -1045 ) );
+
+	x = -powf( float64ToFloat32( 2.0 ), float64ToFloat32( -1045 ) );
+	v = round2f( x + ( x/3.0 ) );
+	t.strictEqual( v, expected, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function rounds a numeric value to the nearest power of two on a linear scale', opts, function test( t ) {
+	t.strictEqual( round2f( -4.2 ), float64ToFloat32( -4.0 ), 'returns expected value' );
+	t.strictEqual( round2f( -4.5 ), float64ToFloat32( -4.0 ), 'returns expected value' );
+	t.strictEqual( round2f( -4.8 ), float64ToFloat32( -4.0 ), 'returns expected value' );
+	t.strictEqual( round2f( 4.2 ), float64ToFloat32( 4.0 ), 'returns expected value' );
+	t.strictEqual( round2f( 9.99999 ), float64ToFloat32( 8.0 ), 'returns expected value' );
+	t.strictEqual( round2f( 9.5 ), float64ToFloat32( 8.0 ), 'returns expected value' );
+	t.strictEqual( round2f( 9.4 ), float64ToFloat32( 8.0 ), 'returns expected value' );
+	t.strictEqual( round2f( 12.0 ), float64ToFloat32( 16.0 ), 'returns expected value' );
+	t.strictEqual( round2f( -12.0 ), float64ToFloat32( -16.0 ), 'returns expected value' );
+	t.strictEqual( round2f( 13.0 ), float64ToFloat32( 16.0 ), 'returns expected value' );
+	t.strictEqual( round2f( -13.0 ), float64ToFloat32( -16.0 ), 'returns expected value' );
+	t.strictEqual( round2f( 23.0 ), float64ToFloat32( 16.0 ), 'returns expected value' );
+	t.strictEqual( round2f( -23.0 ), float64ToFloat32( -16.0 ), 'returns expected value' );
+	t.strictEqual( round2f( 0.0 ), float64ToFloat32( 0.0 ), 'returns expected value' );
+	t.strictEqual( round2f( 27.0 ), float64ToFloat32( 32.0 ), 'returns expected value' );
+	t.strictEqual( round2f( -27.0 ), float64ToFloat32( -32.0 ), 'returns expected value' );
+	t.strictEqual( round2f( 48.1 ), float64ToFloat32( 64.0 ), 'returns expected value' );
+	t.strictEqual( round2f( -48.1 ), float64ToFloat32( -64.0 ), 'returns expected value' );
+	t.strictEqual( round2f( 0.3 ), float64ToFloat32( 0.25 ), 'returns expected value' );
+	t.strictEqual( round2f( -0.3 ), float64ToFloat32( -0.25 ), 'returns expected value' );
+	t.strictEqual( round2f( 0.45 ), float64ToFloat32( 0.5 ), 'returns expected value' );
+	t.strictEqual( round2f( -0.45 ), float64ToFloat32( -0.5 ), 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
Resolves #6734 .

## Description

> What is the purpose of this pull request?

This pull request:

-   This pull request adds round2f implementation to stdlib. This includes benchmarks, lib files, tests, examples, src files, README, etc

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   progresses #649 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Currently, this pull request is dependant on the implementation of powf and log2f implementation. I will update this pull request after those 2 PRs [5739](https://github.com/stdlib-js/stdlib/pull/5739) and [4179](https://github.com/stdlib-js/stdlib/pull/4179) have been merged.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
