### PR TITLE
chore: fix JavaScript lint errors (issue #6738)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/pkgs/clis/lib/index.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/clis/lib/index.js
@@ -1,3 +1,5 @@
+// cspell:ignore clis
+
 /**
 * @license Apache-2.0
 *


### PR DESCRIPTION
Resolves #{{TODO: add issue number}}.

## Description

> What is the purpose of this pull request?

This pull request:

- Suppressed the spellchecker warning for the word `clis` by adding a `// cspell:ignore clis` comment.
- This word is intentional and refers to Command Line Interfaces (CLIs).

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #6738

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
