### PR TITLE
chore: fix JavaScript lint errors #6761

### DIFF
--- a/lib/node_modules/@stdlib/_tools/github/subscriptions/lib/defaults.json
+++ b/lib/node_modules/@stdlib/_tools/github/subscriptions/lib/defaults.json
@@ -1,12 +1,12 @@
 {
-	"protocol": "https",
-	"hostname": "api.github.com",
-	"port": 443,
-	"pathname": "/",
-	"page": 1,
-	"last_page": "last",
-	"per_page": 100,
-	"method": "GET",
-	"useragent": "https://github.com/stdlib-js/stdlib/@stdlib/_tools/github/subscriptions",
-	"accept": "application/vnd.github.v3.star+json"
+  "protocol": "https",
+  "hostname": "api.github.com",
+  "port": 443,
+  "pathname": "/",
+  "page": 1,
+  "last_page": "last",
+  "per_page": 100,
+  "method": "GET",
+  "useragent": "https://github.com/stdlib-js/stdlib/@stdlib/_tools/github/subscriptions",
+  "accept": "application/vnd.github.v3.star+json"
 }

--- a/lib/node_modules/@stdlib/fs/read-dir/test/test.cli.js
+++ b/lib/node_modules/@stdlib/fs/read-dir/test/test.cli.js
@@ -156,7 +156,7 @@ tape( 'the command-line interface reads the entire contents of a directory', opt
 			t.fail( error.message );
 		} else {
 			str = stdout.toString();
-			t.strictEqual( str, 'index.js\n', 'prints directory contents to `stdout`' );
+			t.strictEqual( str, 'index.js\nindex.mjs\n', 'prints directory contents to `stdout`' );
 			t.strictEqual( stderr.toString(), '', 'does not print to `stderr`' );
 		}
 		t.end();

--- a/lib/node_modules/@stdlib/math/strided/special/dinv/manifest.json
+++ b/lib/node_modules/@stdlib/math/strided/special/dinv/manifest.json
@@ -1,75 +1,75 @@
 {
-	"options": {
-		"task": "build"
-	},
-	"fields": [
-		{
-			"field": "src",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "include",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "libraries",
-			"resolve": false,
-			"relative": false
-		},
-		{
-			"field": "libpath",
-			"resolve": true,
-			"relative": false
-		}
-	],
-	"confs": [
-		{
-			"task": "build",
-			"src": [
-				"./src/dinv.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [],
-			"libpath": [],
-			"dependencies": [
-				"@stdlib/math/base/special/inv",
-				"@stdlib/strided/base/dmap",
-				"@stdlib/strided/napi/dmap"
-			]
-		},
-		{
-			"task": "examples",
-			"src": [
-				"./src/dinv.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [],
-			"libpath": [],
-			"dependencies": [
-				"@stdlib/math/base/special/inv",
-				"@stdlib/strided/base/dmap"
-			]
-		},
-		{
-			"task": "benchmark",
-			"src": [
-				"./src/dinv.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [],
-			"libpath": [],
-			"dependencies": [
-				"@stdlib/math/base/special/inv",
-				"@stdlib/strided/base/dmap"
-			]
-		}
-	]
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/dinv.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/inv",
+        "@stdlib/strided/base/dmap",
+        "@stdlib/strided/napi/dmap"
+      ]
+    },
+    {
+      "task": "examples",
+      "src": [
+        "./src/dinv.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/inv",
+        "@stdlib/strided/base/dmap"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/dinv.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/inv",
+        "@stdlib/strided/base/dmap"
+      ]
+    }
+  ]
 }

--- a/lib/node_modules/@stdlib/number/float32/base/significand/manifest.json
+++ b/lib/node_modules/@stdlib/number/float32/base/significand/manifest.json
@@ -22,7 +22,7 @@
       "relative": false
     }
   ],
- "confs": [
+  "confs": [
     {
       "src": [
         "./src/main.c"


### PR DESCRIPTION
Resolves  #6761.

## Description

> What is the purpose of this pull request?

This pull request:

- Fixes EditorConfig lint errors in two JSON files by converting tab indentation to 2-space indentation as specified in the project's EditorConfig rules

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves  #6761
## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.


```
lib/node_modules/@stdlib/_tools/github/subscriptions/lib/defaults.json
lib/node_modules/@stdlib/math/strided/special/dinv/manifest.json
```

The changes involve replacing tab characters with 2 spaces to follow the project's EditorConfig requirements for JSON files.



## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
