### PR TITLE
chore: address commit comments for commit `f6829da` (issue: #5903)

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/stdev/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/stdev/src/main.c
@@ -19,6 +19,8 @@
 #include "stdlib/stats/base/dists/uniform/stdev.h"
 #include "stdlib/math/base/assert/is_nan.h"
 
+static const double SQRT_ONE_TWELFTH = 0.28867513459481287; // stdlib_base_sqrt( 1.0/12.0 )
+
 /**
 * Returns the standard deviation of a uniform distribution.
 *
@@ -31,7 +33,6 @@
 * // returns ~2.309
 */
 
-static const double SQRT_ONE_TWELFTH = 0.28867513459481287; // stdlib_base_sqrt( 1.0/12.0 )
 
 double stdlib_base_dists_uniform_stdev( const double a, const double b ) {
 	if (
@@ -41,5 +42,5 @@ double stdlib_base_dists_uniform_stdev( const double a, const double b ) {
 	) {
 		return 0.0 / 0.0; // NaN
 	}
-	return  SQRT_ONE_TWELFTH * ( b-a );
+	return SQRT_ONE_TWELFTH * ( b-a );
 }

--- a/lib/node_modules/@stdlib/stats/base/dists/uniform/stdev/src/main.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/uniform/stdev/src/main.c
@@ -32,8 +32,6 @@ static const double SQRT_ONE_TWELFTH = 0.28867513459481287; // stdlib_base_sqrt(
 * double v = stdev( 4.0, 12.0 );
 * // returns ~2.309
 */
-
-
 double stdlib_base_dists_uniform_stdev( const double a, const double b ) {
 	if (
 		stdlib_base_is_nan( a ) ||


### PR DESCRIPTION
Resolves #5903

## Description

This PR addresses the comments of the core contributors to a previously done commit https://github.com/stdlib-js/stdlib/commit/f6829da93ff5ed53f07365ce1b2ce8303a5f517a.

This pull request:

- Moves L33-35 before the function documentation comment. https://github.com/stdlib-js/stdlib/commit/f6829da93ff5ed53f07365ce1b2ce8303a5f517a#r153448125
- Removes the extra space after return in L44. https://github.com/stdlib-js/stdlib/commit/f6829da93ff5ed53f07365ce1b2ce8303a5f517a#r153448162

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [X] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
