### PR TITLE
chore: address commit comments for commit `4d0f11a` (issue #6715)

### DIFF
--- a/lib/node_modules/@stdlib/math/base/assert/uint32-is-pow2/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/assert/uint32-is-pow2/benchmark/benchmark.js
@@ -22,7 +22,6 @@
 
 var bench = require( '@stdlib/bench' );
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
-var float64ToUint32 = require( '@stdlib/number/float64/base/to-uint32' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var pkg = require( './../package.json' ).name;
 var isPow2 = require( './../lib' );
@@ -43,7 +42,7 @@ bench( pkg, function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = isPow2( float64ToUint32( x[ i%x.length ] ) );
+		y = isPow2( x[ i%x.length ] );
 		if ( typeof y !== 'boolean' ) {
 			b.fail( 'should return a boolean' );
 		}

--- a/lib/node_modules/@stdlib/math/base/assert/uint32-is-pow2/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/assert/uint32-is-pow2/benchmark/benchmark.native.js
@@ -23,7 +23,6 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
-var float64ToUint32 = require( '@stdlib/number/float64/base/to-uint32' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
@@ -52,7 +51,7 @@ bench( pkg+'::native', opts, function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = isPow2( float64ToUint32( x[ i%x.length ] ) );
+		y = isPow2( x[ i%x.length ] );
 		if ( typeof y !== 'boolean' ) {
 			b.fail( 'should return a boolean' );
 		}


### PR DESCRIPTION
Resolves #6715 

## Description

> This PR addresses the commit comments for commit `4d0f11a` from core contributors. The 'float64ToUint32' wrapper was no longer needed so I removed the import statement.

This pull request:

- The PR removes the 'float64ToUint32' wrapper from import statement as it is no longer needed. 
- It resolves the commit https://github.com/stdlib-js/stdlib/commit/4d0f11a021200333b20632885427a8e269454283
- These are the comments which I resolved:
- https://github.com/stdlib-js/stdlib/commit/4d0f11a021200333b20632885427a8e269454283#r155589921
- https://github.com/stdlib-js/stdlib/commit/4d0f11a021200333b20632885427a8e269454283#r155589957

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #6715

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [X] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
