### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/beta/cdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/cdf/README.md
@@ -141,23 +141,19 @@ y = mycdf( 0.3 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var cdf = require( '@stdlib/stats/base/dists/beta/cdf' );
 
-var alpha;
-var beta;
-var x;
-var y;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 5.0, opts );
+var beta = uniform( 10, EPS, 5.0, opts );
+var x = uniform( 10, 0.0, 1.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    x = randu();
-    alpha = ( randu()*5.0 ) + EPS;
-    beta = ( randu()*5.0 ) + EPS;
-    y = cdf( x, alpha, beta );
-    console.log( 'x: %d, α: %d, β: %d, F(x;α,β): %d', x.toFixed( 4 ), alpha.toFixed( 4 ), beta.toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 'x: %0.4f, α: %0.4f, β: %0.4f, F(x;α,β): %0.4f', x, alpha, beta, cdf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/cdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/cdf/examples/index.js
@@ -18,20 +18,16 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var cdf = require( './../lib' );
 
-var alpha;
-var beta;
-var x;
-var y;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 5.0, opts );
+var beta = uniform( 10, EPS, 5.0, opts );
+var x = uniform( 10, 0.0, 1.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	x = randu();
-	alpha = ( randu()*5.0 ) + EPS;
-	beta = ( randu()*5.0 ) + EPS;
-	y = cdf( x, alpha, beta );
-	console.log( 'x: %d, α: %d, β: %d, F(x;α,β): %d', x.toFixed( 4 ), alpha.toFixed( 4 ), beta.toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 'x: %0.4f, α: %0.4f, β: %0.4f, F(x;α,β): %0.4f', x, alpha, beta, cdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/entropy/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/entropy/README.md
@@ -123,21 +123,18 @@ v = entropy( 1.0, -1.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var entropy = require( '@stdlib/stats/base/dists/beta/entropy' );
 
-var alpha;
-var beta;
-var v;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 10.0, opts );
+var beta = uniform( 10, EPS, 10.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    alpha = ( randu()*10.0 ) + EPS;
-    beta = ( randu()*10.0 ) + EPS;
-    v = entropy( alpha, beta );
-    console.log( 'α: %d, β: %d, h(X;α,β): %d', alpha.toFixed( 4 ), beta.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'α: %0.4f, β: %0.4f, h(X;α,β): %0.4f', alpha, beta, entropy );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/entropy/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/entropy/examples/index.js
@@ -18,18 +18,15 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var entropy = require( './../lib' );
 
-var alpha;
-var beta;
-var v;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 10.0, opts );
+var beta = uniform( 10, EPS, 10.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	alpha = ( randu()*10.0 ) + EPS;
-	beta = ( randu()*10.0 ) + EPS;
-	v = entropy( alpha, beta );
-	console.log( 'α: %d, β: %d, h(X;α,β): %d', alpha.toFixed( 4 ), beta.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'α: %0.4f, β: %0.4f, h(X;α,β): %0.4f', alpha, beta, entropy );

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/kurtosis/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/kurtosis/README.md
@@ -123,21 +123,18 @@ v = kurtosis( 1.0, -1.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var kurtosis = require( '@stdlib/stats/base/dists/beta/kurtosis' );
 
-var alpha;
-var beta;
-var v;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 10.0, opts );
+var beta = uniform( 10, EPS, 10.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    alpha = ( randu()*10.0 ) + EPS;
-    beta = ( randu()*10.0 ) + EPS;
-    v = kurtosis( alpha, beta );
-    console.log( 'α: %d, β: %d, Kurt(X;α,β): %d', alpha.toFixed( 4 ), beta.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'α: %0.4f, β: %0.4f, Kurt(X;α,β): %0.4f', alpha, beta, kurtosis );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/kurtosis/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/kurtosis/examples/index.js
@@ -18,18 +18,15 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var kurtosis = require( './../lib' );
 
-var alpha;
-var beta;
-var v;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 10.0, opts );
+var beta = uniform( 10, EPS, 10.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	alpha = ( randu()*10.0 ) + EPS;
-	beta = ( randu()*10.0 ) + EPS;
-	v = kurtosis( alpha, beta );
-	console.log( 'α: %d, β: %d, Kurt(X;α,β): %d', alpha.toFixed( 4 ), beta.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'α: %0.4f, β: %0.4f, Kurt(X;α,β): %0.4f', alpha, beta, kurtosis );

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/logcdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/logcdf/README.md
@@ -151,23 +151,19 @@ y = mylogcdf( 0.3 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var logcdf = require( '@stdlib/stats/base/dists/beta/logcdf' );
 
-var alpha;
-var beta;
-var x;
-var y;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 10.0, opts );
+var beta = uniform( 10, EPS, 10.0, opts );
+var x = uniform( 10, 0.0, 1.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    x = randu();
-    alpha = ( randu()*5.0 ) + EPS;
-    beta = ( randu()*5.0 ) + EPS;
-    y = logcdf( x, alpha, beta );
-    console.log( 'x: %d, α: %d, β: %d, ln(F(x;α,β)): %d', x.toFixed( 4 ), alpha.toFixed( 4 ), beta.toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 'x: %0.4f, α: %0.4f, β: %0.4f, ln(F(x;α,β)): %0.4f', x, alpha, beta, logcdf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/logcdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/logcdf/examples/index.js
@@ -18,20 +18,16 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var logcdf = require( './../lib' );
 
-var alpha;
-var beta;
-var x;
-var y;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 10.0, opts );
+var beta = uniform( 10, EPS, 10.0, opts );
+var x = uniform( 10, 0.0, 1.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	x = randu();
-	alpha = ( randu()*5.0 ) + EPS;
-	beta = ( randu()*5.0 ) + EPS;
-	y = logcdf( x, alpha, beta );
-	console.log( 'x: %d, α: %d, β: %d, ln(F(x;α,β)): %d', x.toFixed( 4 ), alpha.toFixed( 4 ), beta.toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 'x: %0.4f, α: %0.4f, β: %0.4f, ln(F(x;α,β)): %0.4f', x, alpha, beta, logcdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/logpdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/logpdf/README.md
@@ -146,23 +146,19 @@ y = mylogPDF( 0.3 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var logpdf = require( '@stdlib/stats/base/dists/beta/logpdf' );
 
-var alpha;
-var beta;
-var x;
-var y;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 5.0, opts );
+var beta = uniform( 10, EPS, 5.0, opts );
+var x = uniform( 10, 0.0, 1.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    x = randu();
-    alpha = ( randu()*5.0 ) + EPS;
-    beta = ( randu()*5.0 ) + EPS;
-    y = logpdf( x, alpha, beta );
-    console.log( 'x: %d, α: %d, β: %d, ln(f(x;α,β)): %d', x.toFixed( 4 ), alpha.toFixed( 4 ), beta.toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 'x: %0.4f, α: %0.4f, β: %0.4f, ln(f(x;α,β)): %0.4f', x, alpha, beta, logpdf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/logpdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/logpdf/examples/index.js
@@ -18,20 +18,16 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var logpdf = require( './../lib' );
 
-var alpha;
-var beta;
-var x;
-var y;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 5.0, opts );
+var beta = uniform( 10, EPS, 5.0, opts );
+var x = uniform( 10, 0.0, 1.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	x = randu();
-	alpha = ( randu()*5.0 ) + EPS;
-	beta = ( randu()*5.0 ) + EPS;
-	y = logpdf( x, alpha, beta );
-	console.log( 'x: %d, α: %d, β: %d, ln(f(x;α,β)): %d', x.toFixed( 4 ), alpha.toFixed( 4 ), beta.toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 'x: %0.4f, α: %0.4f, β: %0.4f, ln(f(x;α,β)): %0.4f', x, alpha, beta, logpdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/mean/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/mean/README.md
@@ -123,21 +123,18 @@ v = mean( 1.0, -1.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var mean = require( '@stdlib/stats/base/dists/beta/mean' );
 
-var alpha;
-var beta;
-var v;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 10.0, opts );
+var beta = uniform( 10, EPS, 10.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    alpha = ( randu()*10.0 ) + EPS;
-    beta = ( randu()*10.0 ) + EPS;
-    v = mean( alpha, beta );
-    console.log( 'α: %d, β: %d, E(X;α,β): %d', alpha.toFixed( 4 ), beta.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'α: %0.4f, β: %0.4f, E(X;α,β): %0.4f', alpha, beta, mean );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/mean/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/mean/examples/index.js
@@ -18,18 +18,15 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var mean = require( './../lib' );
 
-var alpha;
-var beta;
-var v;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 10.0, opts );
+var beta = uniform( 10, EPS, 10.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	alpha = ( randu()*10.0 ) + EPS;
-	beta = ( randu()*10.0 ) + EPS;
-	v = mean( alpha, beta );
-	console.log( 'α: %d, β: %d, E(X;α,β): %d', alpha.toFixed( 4 ), beta.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'α: %0.4f, β: %0.4f, E(X;α,β): %0.4f', alpha, beta, mean );

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/median/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/median/README.md
@@ -124,21 +124,18 @@ v = median( 1.0, -1.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var median = require( '@stdlib/stats/base/dists/beta/median' );
 
-var alpha;
-var beta;
-var v;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 10.0, opts );
+var beta = uniform( 10, EPS, 10.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    alpha = ( randu()*10.0 ) + EPS;
-    beta = ( randu()*10.0 ) + EPS;
-    v = median( alpha, beta );
-    console.log( 'α: %d, β: %d, Median(X;α,β): %d', alpha.toFixed( 4 ), beta.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'α: %0.4f, β: %0.4f, Median(X;α,β): %0.4f', alpha, beta, median );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/median/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/median/README.md
@@ -26,7 +26,7 @@ limitations under the License.
 
 <section class="intro">
 
-The [median][median] for a [beta][beta-distribution] random variable is the value for which 
+The [median][median] for a [beta][beta-distribution] random variable is the value for which
 the regularized incomplete beta function `I(α,β)` is equal to `0.5`, i.e.
 
 <!-- <equation class="equation" label="eq:beta_median" align="center" raw="\operatorname{Median}\left[ X \right] = I_{\frac{1}{2}}^{[-1]}(\alpha,\beta)" alt="Median for a beta distribution."> -->

--- a/lib/node_modules/@stdlib/stats/base/dists/beta/median/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/beta/median/examples/index.js
@@ -18,18 +18,15 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var median = require( './../lib' );
 
-var alpha;
-var beta;
-var v;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 10.0, opts );
+var beta = uniform( 10, EPS, 10.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	alpha = ( randu()*10.0 ) + EPS;
-	beta = ( randu()*10.0 ) + EPS;
-	v = median( alpha, beta );
-	console.log( 'α: %d, β: %d, Median(X;α,β): %d', alpha.toFixed( 4 ), beta.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'α: %0.4f, β: %0.4f, Median(X;α,β): %0.4f', alpha, beta, median );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `stats/base/dists/beta/cdf`, `stats/base/dists/beta/entropy`, `stats/base/dists/beta/kurtosis`, `stats/base/dists/beta/logcdf`, `stats/base/dists/beta/logpdf`, `stats/base/dists/beta/mean` and `stats/base/dists/beta/median` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
