### PR TITLE
chore: fix C lint errors (issue #6787)

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/smeankbn2/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/stats/base/smeankbn2/benchmark/c/benchmark.length.c
@@ -107,6 +107,7 @@ static double benchmark( int iterations, int len ) {
 	v = 0.0f;
 	t = tic();
 	for ( i = 0; i < iterations; i++ ) {
+		// cppcheck-suppress uninitvar
 		v = stdlib_strided_smeankbn2( len, x, 1 );
 		if ( v != v ) {
 			printf( "should not return NaN\n" );


### PR DESCRIPTION
Resolves #6787.

## Description

> What is the purpose of this pull request?

This pull request:

-   Suppressed a false-positive `uninitvar` warning in benchmark.length.c for smeankbn2. 

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #6787 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
