### PR TITLE
refactor: replacing with an `array/base/*` utility for `ndarray/base/unary-strided1d-dispatch`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/unary-strided1d-dispatch/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary-strided1d-dispatch/lib/main.js
@@ -45,6 +45,7 @@ var zeroTo = require( '@stdlib/array/base/zero-to' );
 var join = require( '@stdlib/array/base/join' );
 var copy = require( '@stdlib/array/base/copy' );
 var everyBy = require( '@stdlib/array/base/every-by' );
+var slice = require( '@stdlib/array/base/slice' );
 var objectAssign = require( '@stdlib/object/assign' );
 var format = require( '@stdlib/string/format' );
 var defaults = require( './defaults.json' );
@@ -73,27 +74,23 @@ function types2enums( types ) {
 }
 
 /**
-* Reorders a list of ndarrays such that the output ndarray is the second ndarray argument when passing along to a resolved lower-level strided function.
+* Reorders a list of ndarrays such that the output ndarray is the specified index ndarray argument when passing along to a resolved lower-level strided function.
 *
 * @private
 * @param {Array<ndarray>} arrays - list of input ndarrays
 * @param {ndarray} output - output ndarray
+* @param {NonNegativeInteger} index - specified index
 * @returns {Array<ndarray>} reordered list
 */
-function reorder( arrays, output ) { // TODO: consider replacing with an `array/base/*` utility which expands an input array by inserting a specified value at a specified index and returns a new array
+function reorder( arrays, output, index ) {
 	var out;
-	var i;
-	var j;
+	var a1;
+	var a2;
 
 	out = [];
-	for ( i = 0, j = 0; i <= arrays.length; i++ ) {
-		if ( i === 1 ) {
-			out.push( output );
-		} else {
-			out.push( arrays[ j ] );
-			j += 1;
-		}
-	}
+	a1 = slice( arrays, 0, index );
+	a2 = slice( arrays, index, arrays.length - 1 );
+	out = a1.concat( [ output ], a2 );
 	return out;
 }
 


### PR DESCRIPTION
…ry-strided1d-dispatch

---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: na
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

none

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces current implementation with an `array/base/*` utility for `ndarray/base/unary-strided1d-dispatch`

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   none

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
