### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/README.md
@@ -135,23 +135,19 @@ y = mycdf( 0.3 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var cdf = require( '@stdlib/stats/base/dists/betaprime/cdf' );
 
-var alpha;
-var beta;
-var x;
-var y;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 5.0, opts );
+var beta = uniform( 10, EPS, 5.0, opts );
+var x = uniform( 10, 0.0, 1.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    x = randu();
-    alpha = ( randu()*5.0 ) + EPS;
-    beta = ( randu()*5.0 ) + EPS;
-    y = cdf( x, alpha, beta );
-    console.log( 'x: %d, α: %d, β: %d, F(x;α,β): %d', x.toFixed( 4 ), alpha.toFixed( 4 ), beta.toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 'x: %0.4f, α: %0.4f, β: %0.4f, F(x;α,β): %0.4f', x, alpha, beta, cdf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/cdf/examples/index.js
@@ -18,20 +18,16 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var cdf = require( './../lib' );
 
-var alpha;
-var beta;
-var x;
-var y;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 5.0, opts );
+var beta = uniform( 10, EPS, 5.0, opts );
+var x = uniform( 10, 0.0, 1.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	x = randu();
-	alpha = ( randu()*5.0 ) + EPS;
-	beta = ( randu()*5.0 ) + EPS;
-	y = cdf( x, alpha, beta );
-	console.log( 'x: %d, α: %d, β: %d, F(x;α,β): %d', x.toFixed( 4 ), alpha.toFixed( 4 ), beta.toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 'x: %0.4f, α: %0.4f, β: %0.4f, F(x;α,β): %0.4f', x, alpha, beta, cdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/kurtosis/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/kurtosis/README.md
@@ -126,21 +126,18 @@ v = kurtosis( 1.0, -1.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var kurtosis = require( '@stdlib/stats/base/dists/betaprime/kurtosis' );
 
-var alpha;
-var beta;
-var v;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 10.0, opts );
+var beta = uniform( 10, 4.0 + EPS, 10.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    alpha = ( randu()*10.0 ) + EPS;
-    beta = ( randu()*10.0 ) + 4.0 + EPS;
-    v = kurtosis( alpha, beta );
-    console.log( 'α: %d, β: %d, Kurt(X;α,β): %d', alpha.toFixed( 4 ), beta.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'α: %0.4f, β: %0.4f, Kurt(X;α,β): %0.4f', alpha, beta, kurtosis );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/kurtosis/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/kurtosis/examples/index.js
@@ -18,18 +18,15 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var kurtosis = require( './../lib' );
 
-var alpha;
-var beta;
-var v;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 10.0, opts );
+var beta = uniform( 10, 4.0 + EPS, 10.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	alpha = ( randu()*10.0 ) + EPS;
-	beta = ( randu()*10.0 ) + 4.0 + EPS;
-	v = kurtosis( alpha, beta );
-	console.log( 'α: %d, β: %d, Kurt(X;α,β): %d', alpha.toFixed( 4 ), beta.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'α: %0.4f, β: %0.4f, Kurt(X;α,β): %0.4f', alpha, beta, kurtosis );

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/logcdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/logcdf/README.md
@@ -145,23 +145,19 @@ y = mylogcdf( 0.3 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var logcdf = require( '@stdlib/stats/base/dists/betaprime/logcdf' );
 
-var alpha;
-var beta;
-var x;
-var y;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 5.0, opts );
+var beta = uniform( 10, EPS, 5.0, opts );
+var x = uniform( 10, 0.0, 1.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    x = randu();
-    alpha = ( randu()*5.0 ) + EPS;
-    beta = ( randu()*5.0 ) + EPS;
-    y = logcdf( x, alpha, beta );
-    console.log( 'x: %d, α: %d, β: %d, ln(F(x;α,β)): %d', x.toFixed( 4 ), alpha.toFixed( 4 ), beta.toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 'x: %0.4f, α: %0.4f, β: %0.4f, ln(F(x;α,β)): %0.4f', x, alpha, beta, logcdf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/logcdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/logcdf/examples/index.js
@@ -18,20 +18,16 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var logcdf = require( './../lib' );
 
-var alpha;
-var beta;
-var x;
-var y;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 5.0, opts );
+var beta = uniform( 10, EPS, 5.0, opts );
+var x = uniform( 10, 0.0, 1.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	x = randu();
-	alpha = ( randu()*5.0 ) + EPS;
-	beta = ( randu()*5.0 ) + EPS;
-	y = logcdf( x, alpha, beta );
-	console.log( 'x: %d, α: %d, β: %d, ln(F(x;α,β)): %d', x.toFixed( 4 ), alpha.toFixed( 4 ), beta.toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 'x: %0.4f, α: %0.4f, β: %0.4f, ln(F(x;α,β)): %0.4f', x, alpha, beta, logcdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/README.md
@@ -143,23 +143,19 @@ y = mylogPDF( 0.3 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var logpdf = require( '@stdlib/stats/base/dists/betaprime/logpdf' );
 
-var alpha;
-var beta;
-var x;
-var y;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 5.0, opts );
+var beta = uniform( 10, EPS, 5.0, opts );
+var x = uniform( 10, 0.0, 1.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    x = randu();
-    alpha = ( randu()*5.0 ) + EPS;
-    beta = ( randu()*5.0 ) + EPS;
-    y = logpdf( x, alpha, beta );
-    console.log( 'x: %d, α: %d, β: %d, ln(f(x;α,β)): %d', x.toFixed( 4 ), alpha.toFixed( 4 ), beta.toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 'x: %0.4f, α: %0.4f, β: %0.4f, ln(f(x;α,β)): %0.4f', x, alpha, beta, logpdf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/examples/index.js
@@ -18,20 +18,16 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var logpdf = require( './../lib' );
 
-var alpha;
-var beta;
-var x;
-var y;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 5.0, opts );
+var beta = uniform( 10, EPS, 5.0, opts );
+var x = uniform( 10, 0.0, 1.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	x = randu();
-	alpha = ( randu()*5.0 ) + EPS;
-	beta = ( randu()*5.0 ) + EPS;
-	y = logpdf( x, alpha, beta );
-	console.log( 'x: %d, α: %d, β: %d, ln(f(x;α,β)): %d', x.toFixed( 4 ), alpha.toFixed( 4 ), beta.toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 'x: %0.4f, α: %0.4f, β: %0.4f, ln(f(x;α,β)): %0.4f', x, alpha, beta, logpdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/mean/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/mean/README.md
@@ -123,21 +123,18 @@ v = mean( 1.0, -1.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var mean = require( '@stdlib/stats/base/dists/betaprime/mean' );
 
-var alpha;
-var beta;
-var v;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 10.0, opts );
+var beta = uniform( 10, 1.0 + EPS, 10.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    alpha = ( randu()*10.0 ) + EPS;
-    beta = ( randu()*10.0 ) + 1.0 + EPS;
-    v = mean( alpha, beta );
-    console.log( 'α: %d, β: %d, E(X;α,β): %d', alpha.toFixed( 4 ), beta.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'α: %0.4f, β: %0.4f, E(X;α,β): %0.4f', alpha, beta, mean );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/mean/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/mean/examples/index.js
@@ -18,18 +18,15 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var mean = require( './../lib' );
 
-var alpha;
-var beta;
-var v;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 10.0, opts );
+var beta = uniform( 10, 1.0 + EPS, 10.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	alpha = ( randu()*10.0 ) + EPS;
-	beta = ( randu()*10.0 ) + 1.0 + EPS;
-	v = mean( alpha, beta );
-	console.log( 'α: %d, β: %d, E(X;α,β): %d', alpha.toFixed( 4 ), beta.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'α: %0.4f, β: %0.4f, E(X;α,β): %0.4f', alpha, beta, mean );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `stats/base/dists/betaprime/cdf`, `stats/base/dists/betaprime/kurtosis`, `stats/base/dists/betaprime/logcdf`, `stats/base/dists/betaprime/logpdf` and `stats/base/dists/betaprime/mean` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
