### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/mode/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/mode/README.md
@@ -123,21 +123,18 @@ v = mode( 1.0, -1.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var mode = require( '@stdlib/stats/base/dists/betaprime/mode' );
 
-var alpha;
-var beta;
-var v;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 10.0, opts );
+var beta = uniform( 10, 1.0 + EPS, 10.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    alpha = ( randu()*10.0 ) + EPS;
-    beta = ( randu()*10.0 ) + EPS;
-    v = mode( alpha, beta );
-    console.log( 'α: %d, β: %d, mode(X;α,β): %d', alpha.toFixed( 4 ), beta.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'α: %0.4f, β: %0.4f, mode(X;α,β): %0.4f', alpha, beta, mode );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/mode/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/mode/examples/index.js
@@ -18,18 +18,15 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var mode = require( './../lib' );
 
-var alpha;
-var beta;
-var v;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 10.0, opts );
+var beta = uniform( 10, 1.0 + EPS, 10.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	alpha = ( randu()*10.0 ) + EPS;
-	beta = ( randu()*10.0 ) + 1.0 + EPS;
-	v = mode( alpha, beta );
-	console.log( 'α: %d, β: %d, mode(X;α,β): %d', alpha.toFixed( 4 ), beta.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'α: %0.4f, β: %0.4f, mode(X;α,β): %0.4f', alpha, beta, mode );

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/pdf/README.md
@@ -136,23 +136,19 @@ y = mypdf( 0.3 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pdf = require( '@stdlib/stats/base/dists/betaprime/pdf' );
 
-var alpha;
-var beta;
-var x;
-var y;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 5.0, opts );
+var beta = uniform( 10, EPS, 5.0, opts );
+var x = uniform( 10, 0.0, 1.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    x = randu();
-    alpha = ( randu()*5.0 ) + EPS;
-    beta = ( randu()*5.0 ) + EPS;
-    y = pdf( x, alpha, beta );
-    console.log( 'x: %d, α: %d, β: %d, f(x;α,β): %d', x.toFixed( 4 ), alpha.toFixed( 4 ), beta.toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 'x: %0.4f, α: %0.4f, β: %0.4f, f(x;α,β): %0.4f', x, alpha, beta, pdf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/pdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/pdf/examples/index.js
@@ -18,20 +18,16 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pdf = require( './../lib' );
 
-var alpha;
-var beta;
-var x;
-var y;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 5.0, opts );
+var beta = uniform( 10, EPS, 5.0, opts );
+var x = uniform( 10, 0.0, 1.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	x = randu();
-	alpha = ( randu()*5.0 ) + EPS;
-	beta = ( randu()*5.0 ) + EPS;
-	y = pdf( x, alpha, beta );
-	console.log( 'x: %d, α: %d, β: %d, f(x;α,β): %d', x.toFixed( 4 ), alpha.toFixed( 4 ), beta.toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 'x: %0.4f, α: %0.4f, β: %0.4f, f(x;α,β): %0.4f', x, alpha, beta, pdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/quantile/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/quantile/README.md
@@ -133,23 +133,19 @@ y = myQuantile( 0.4 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var quantile = require( '@stdlib/stats/base/dists/betaprime/quantile' );
 
-var alpha;
-var beta;
-var p;
-var y;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 5.0, opts );
+var beta = uniform( 10, EPS, 5.0, opts );
+var p = uniform( 10, 0.0, 1.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    p = randu();
-    alpha = ( randu()*5.0 ) + EPS;
-    beta = ( randu()*5.0 ) + EPS;
-    y = quantile( p, alpha, beta );
-    console.log( 'p: %d, α: %d, β: %d, Q(p;α,β): %d', p.toFixed( 4 ), alpha.toFixed( 4 ), beta.toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 'p: %0.4f, α: %0.4f, β: %0.4f, Q(p;α,β): %0.4f', p, alpha, beta, quantile );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/quantile/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/quantile/examples/index.js
@@ -18,20 +18,16 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var quantile = require( './../lib' );
 
-var alpha;
-var beta;
-var p;
-var y;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 5.0, opts );
+var beta = uniform( 10, EPS, 5.0, opts );
+var p = uniform( 10, 0.0, 1.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	p = randu();
-	alpha = ( randu()*5.0 ) + EPS;
-	beta = ( randu()*5.0 ) + EPS;
-	y = quantile( p, alpha, beta );
-	console.log( 'p: %d, α: %d, β: %d, Q(p;α,β): %d', p.toFixed( 4 ), alpha.toFixed( 4 ), beta.toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 'p: %0.4f, α: %0.4f, β: %0.4f, Q(p;α,β): %0.4f', p, alpha, beta, quantile );

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/skewness/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/skewness/README.md
@@ -126,21 +126,18 @@ v = skewness( 1.0, -1.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var skewness = require( '@stdlib/stats/base/dists/betaprime/skewness' );
 
-var alpha;
-var beta;
-var v;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 10.0, opts );
+var beta = uniform( 10, 3.0 + EPS, 10.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    alpha = ( randu()*10.0 ) + EPS;
-    beta = ( randu()*10.0 ) + 3.0 + EPS;
-    v = skewness( alpha, beta );
-    console.log( 'α: %d, β: %d, skew(X;α,β): %d', alpha.toFixed( 4 ), beta.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'α: %0.4f, β: %0.4f, skew(X;α,β): %0.4f', alpha, beta, skewness );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/skewness/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/skewness/examples/index.js
@@ -18,18 +18,15 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var skewness = require( './../lib' );
 
-var alpha;
-var beta;
-var v;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 10.0, opts );
+var beta = uniform( 10, 3.0 + EPS, 10.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	alpha = ( randu()*10.0 ) + EPS;
-	beta = ( randu()*10.0 ) + 3.0 + EPS;
-	v = skewness( alpha, beta );
-	console.log( 'α: %d, β: %d, skew(X;α,β): %d', alpha.toFixed( 4 ), beta.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'α: %0.4f, β: %0.4f, skew(X;α,β): %0.4f', alpha, beta, skewness );

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/stdev/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/stdev/README.md
@@ -126,21 +126,18 @@ v = stdev( 1.0, -1.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var stdev = require( '@stdlib/stats/base/dists/betaprime/stdev' );
 
-var alpha;
-var beta;
-var v;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 10.0, opts );
+var beta = uniform( 10, 2.0 + EPS, 10.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    alpha = ( randu()*10.0 ) + EPS;
-    beta = ( randu()*10.0 ) + 2.0 + EPS;
-    v = stdev( alpha, beta );
-    console.log( 'α: %d, β: %d, SD(X;α,β): %d', alpha.toFixed( 4 ), beta.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'α: %0.4f, β: %0.4f, SD(X;α,β): %0.4f', alpha, beta, stdev );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/stdev/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/stdev/examples/index.js
@@ -18,18 +18,15 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var stdev = require( './../lib' );
 
-var alpha;
-var beta;
-var v;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 10.0, opts );
+var beta = uniform( 10, 2.0 + EPS, 10.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	alpha = ( randu()*10.0 ) + EPS;
-	beta = ( randu()*10.0 ) + 2.0 + EPS;
-	v = stdev( alpha, beta );
-	console.log( 'α: %d, β: %d, SD(X;α,β): %d', alpha.toFixed( 4 ), beta.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'α: %0.4f, β: %0.4f, SD(X;α,β): %0.4f', alpha, beta, stdev );

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/variance/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/variance/README.md
@@ -126,21 +126,18 @@ v = variance( 1.0, -1.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var variance = require( '@stdlib/stats/base/dists/betaprime/variance' );
 
-var alpha;
-var beta;
-var v;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 10.0, opts );
+var beta = uniform( 10, 2.0, 10.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    alpha = ( randu()*10.0 ) + EPS;
-    beta = ( randu()*10.0 ) + 2.0 + EPS;
-    v = variance( alpha, beta );
-    console.log( 'α: %d, β: %d, Var(X;α,β): %d', alpha.toFixed( 4 ), beta.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'α: %0.4f, β: %0.4f, Var(X;α,β): %0.4f', alpha, beta, variance );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/variance/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/variance/examples/index.js
@@ -18,18 +18,15 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var variance = require( './../lib' );
 
-var alpha;
-var beta;
-var v;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var alpha = uniform( 10, EPS, 10.0, opts );
+var beta = uniform( 10, 2.0, 10.0, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	alpha = ( randu()*10.0 ) + EPS;
-	beta = ( randu()*10.0 ) + 2.0;
-	v = variance( alpha, beta );
-	console.log( 'α: %d, β: %d, Var(X;α,β): %d', alpha.toFixed( 4 ), beta.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'α: %0.4f, β: %0.4f, Var(X;α,β): %0.4f', alpha, beta, variance );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `stats/base/dists/betaprime/mode`, `stats/base/dists/betaprime/pdf`, `stats/base/dists/betaprime/quantile`, `stats/base/dists/betaprime/skewness`, `stats/base/dists/betaprime/stdev` and `stats/base/dists/betaprime/variance` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
