### PR TITLE
bench: update random value generation

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/logcdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/logcdf/benchmark/benchmark.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var Float64Array = require( '@stdlib/array/float64' );
-var uniform = require( '@stdlib/random/base/uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -34,24 +33,21 @@ var logcdf = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var alpha;
 	var beta;
-	var len;
+	var opts;
 	var x;
 	var y;
 	var i;
 
-	len = 100;
-	x = new Float64Array( len );
-	alpha = new Float64Array( len );
-	beta = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( EPS, 2.0 );
-		alpha[ i ] = uniform( EPS, 100.0 );
-		beta[ i ] = uniform( EPS, 100.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	alpha = uniform( 100, EPS, 100.0, opts );
+	beta = uniform( 100, EPS, 100.0, opts );
+	x = uniform( 100, EPS, 2.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = logcdf( x[ i % len ], alpha[ i % len ], beta[ i % len ] );
+		y = logcdf( x[ i % x.length ], alpha[ i % alpha.length ], beta[ i % beta.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -68,23 +64,23 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mylogcdf;
 	var alpha;
 	var beta;
-	var len;
+	var opts;
 	var x;
 	var y;
 	var i;
 
+	opts = {
+		'dtype': 'float64'
+	};
+	x = uniform( 100, EPS, 2.0, opts );
+
 	alpha = 100.56789;
 	beta = 55.54321;
 	mylogcdf = logcdf.factory( alpha, beta );
-	len = 100;
-	x = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( EPS, 2.0 );
-	}
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = mylogcdf( x[ i % len ] );
+		y = mylogcdf( x[ i % x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/logcdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/logcdf/test/test.factory.js
@@ -56,23 +56,23 @@ tape( 'if provided `NaN` for any parameter, the created function returns `NaN`',
 
 	logcdf = factory( 1.0, 1.0 );
 	y = logcdf( NaN );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	logcdf = factory( NaN, 1.0 );
 	y = logcdf( 0.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	logcdf = factory( 1.0, NaN );
 	y = logcdf( 0.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	logcdf = factory( NaN, NaN );
 	y = logcdf( 0.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	logcdf = factory( NaN, NaN );
 	y = logcdf( NaN );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -83,19 +83,19 @@ tape( 'if provided a finite `alpha` and `beta`, the function returns a function 
 
 	logcdf = factory( 0.5, 1.0 );
 	y = logcdf( NINF );
-	t.equal( y, NINF, 'returns -infinity' );
+	t.equal( y, NINF, 'returns expected value' );
 
 	y = logcdf( -100.0 );
-	t.equal( y, NINF, 'returns -infinity' );
+	t.equal( y, NINF, 'returns expected value' );
 
 	y = logcdf( -10.0 );
-	t.equal( y, NINF, 'returns -infinity' );
+	t.equal( y, NINF, 'returns expected value' );
 
 	y = logcdf( -1.0 );
-	t.equal( y, NINF, 'returns -infinity' );
+	t.equal( y, NINF, 'returns expected value' );
 
 	y = logcdf( 0.0 );
-	t.equal( y, NINF, 'returns -infinity' );
+	t.equal( y, NINF, 'returns expected value' );
 
 	t.end();
 });
@@ -106,7 +106,7 @@ tape( 'if provided a finite `alpha` and `beta`, the function returns a function 
 
 	logcdf = factory( 0.5, 1.0 );
 	y = logcdf( PINF );
-	t.equal( y, 0.0, 'returns 0' );
+	t.equal( y, 0.0, 'returns expected value' );
 
 	t.end();
 });
@@ -118,31 +118,31 @@ tape( 'if provided a nonpositive `beta`, the created function always returns `Na
 	logcdf = factory( 1.0, 0.0 );
 
 	y = logcdf( 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	logcdf = factory( 1.0, -1.0 );
 
 	y = logcdf( 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logcdf( 0.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	logcdf = factory( 1.0, NINF );
 	y = logcdf( 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	logcdf = factory( PINF, NINF );
 	y = logcdf( 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	logcdf = factory( NINF, NINF );
 	y = logcdf( 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	logcdf = factory( NaN, NINF );
 	y = logcdf( 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -154,31 +154,31 @@ tape( 'if provided a nonpositive `alpha`, the created function always returns `N
 	logcdf = factory( 0.0, 0.5 );
 
 	y = logcdf( 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	logcdf = factory( -1.0, 0.5 );
 
 	y = logcdf( 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logcdf( 0.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	logcdf = factory( NINF, 1.0 );
 	y = logcdf( 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	logcdf = factory( NINF, PINF );
 	y = logcdf( 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	logcdf = factory( NINF, NINF );
 	y = logcdf( 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	logcdf = factory( NINF, NaN );
 	y = logcdf( 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/logcdf/test/test.logcdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/logcdf/test/test.logcdf.js
@@ -46,26 +46,26 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'if provided `NaN` for any parameter, the function returns `NaN`', function test( t ) {
 	var y = logcdf( NaN, 1.0, 1.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 	y = logcdf( 0.0, NaN, 1.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 	y = logcdf( 0.0, 1.0, NaN );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided a number less than or equal to zero for `x` and a finite `alpha` and `beta`, the function returns `-infinity`', function test( t ) {
 	var y = logcdf( NINF, 0.5, 1.0 );
-	t.equal( y, NINF, 'returns -infinity' );
+	t.equal( y, NINF, 'returns expected value' );
 
 	y = logcdf( -100.0, 0.5, 1.0 );
-	t.equal( y, NINF, 'returns -infinity' );
+	t.equal( y, NINF, 'returns expected value' );
 
 	y = logcdf( -1.0, 0.5, 1.0 );
-	t.equal( y, NINF, 'returns -infinity' );
+	t.equal( y, NINF, 'returns expected value' );
 
 	y = logcdf( 0.0, 0.5, 1.0 );
-	t.equal( y, NINF, 'returns -infinity' );
+	t.equal( y, NINF, 'returns expected value' );
 
 	t.end();
 });
@@ -80,25 +80,25 @@ tape( 'if provided a nonpositive `alpha`, the function returns `NaN`', function 
 	var y;
 
 	y = logcdf( 2.0, 0.0, 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logcdf( 2.0, -1.0, 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logcdf( 0.0, -1.0, 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logcdf( 2.0, NINF, 1.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logcdf( 2.0, NINF, PINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logcdf( 2.0, NINF, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logcdf( 2.0, NINF, NaN );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -107,25 +107,25 @@ tape( 'if provided a nonpositive `beta`, the function returns `NaN`', function t
 	var y;
 
 	y = logcdf( 2.0, 2.0, 0.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logcdf( 2.0, 2.0, -1.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logcdf( 0.0, 2.0, -1/0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logcdf( 2.0, 1.0, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logcdf( 2.0, PINF, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logcdf( 2.0, NINF, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logcdf( 2.0, NaN, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/benchmark/benchmark.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var uniform = require( '@stdlib/random/base/uniform' );
-var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -34,24 +33,21 @@ var logpdf = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var alpha;
 	var beta;
-	var len;
+	var opts;
 	var x;
 	var y;
 	var i;
 
-	len = 100;
-	alpha = new Float64Array( len );
-	beta = new Float64Array( len );
-	x = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = uniform( EPS, 100.0 );
-		beta[ i ] = uniform( EPS, 100.0 );
-		x[ i ] = uniform( EPS, 2.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	alpha = uniform( 100, EPS, 100.0, opts );
+	beta = uniform( 100, EPS, 100.0, opts );
+	x = uniform( 100, EPS, 2.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = logpdf( x[ i % len ], alpha[ i % len ], beta[ i % len ] );
+		y = logpdf( x[ i % x.length ], alpha[ i % alpha.length ], beta[ i % beta.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}
@@ -68,24 +64,23 @@ bench( pkg+':factory', function benchmark( b ) {
 	var mylogpdf;
 	var alpha;
 	var beta;
-	var len;
+	var opts;
 	var x;
 	var y;
 	var i;
+
+	opts = {
+		'dtype': 'float64'
+	};
+	x = uniform( 100, EPS, 2.0, opts );
 
 	alpha = 100.56789;
 	beta = 55.54321;
 	mylogpdf = logpdf.factory( alpha, beta );
 
-	len = 100;
-	x = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		x[ i ] = uniform( EPS, 2.0 );
-	}
-
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = mylogpdf( x[ i % len ] );
+		y = mylogpdf( x[ i % x.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/benchmark/benchmark.native.js
@@ -22,8 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var uniform = require( '@stdlib/random/base/uniform' );
-var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -43,24 +42,21 @@ var opts = {
 bench( pkg+'::native', opts, function benchmark( b ) {
 	var alpha;
 	var beta;
-	var len;
+	var opts;
 	var x;
 	var y;
 	var i;
 
-	len = 100;
-	alpha = new Float64Array( len );
-	beta = new Float64Array( len );
-	x = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = uniform( EPS, 100.0 );
-		beta[ i ] = uniform( EPS, 100.0 );
-		x[ i ] = uniform( EPS, 2.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	alpha = uniform( 100, EPS, 100.0, opts );
+	beta = uniform( 100, EPS, 100.0, opts );
+	x = uniform( 100, EPS, 2.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = logpdf( x[ i % len ], alpha[ i % len ], beta[ i % len ] );
+		y = logpdf( x[ i % x.length ], alpha[ i % alpha.length ], beta[ i % beta.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/test/test.factory.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/test/test.factory.js
@@ -56,23 +56,23 @@ tape( 'if provided `NaN` for any parameter, the created function returns `NaN`',
 
 	logpdf = factory( 1.0, 1.0 );
 	y = logpdf( NaN );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	logpdf = factory( NaN, 1.0 );
 	y = logpdf( 0.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	logpdf = factory( 1.0, NaN );
 	y = logpdf( 0.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	logpdf = factory( NaN, NaN );
 	y = logpdf( 0.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	logpdf = factory( NaN, NaN );
 	y = logpdf( NaN );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -83,13 +83,13 @@ tape( 'if provided a valid `alpha` and `beta`, the function returns a function w
 
 	logpdf = factory( 0.5, 1.0 );
 	y = logpdf( NINF );
-	t.equal( y, NINF, 'returns -Infinity' );
+	t.equal( y, NINF, 'returns expected value' );
 
 	y = logpdf( -100.0 );
-	t.equal( y, NINF, 'returns -Infinity' );
+	t.equal( y, NINF, 'returns expected value' );
 
 	y = logpdf( -0.5 );
-	t.equal( y, NINF, 'returns -Infinity' );
+	t.equal( y, NINF, 'returns expected value' );
 
 	t.end();
 });
@@ -101,26 +101,26 @@ tape( 'if provided `beta <= 0`, the created function always returns `NaN`', func
 	logpdf = factory( 0.0, -1.0 );
 
 	y = logpdf( 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logpdf( 0.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	logpdf = factory( 0.0, NINF );
 	y = logpdf( 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	logpdf = factory( PINF, NINF );
 	y = logpdf( 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	logpdf = factory( NINF, NINF );
 	y = logpdf( 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	logpdf = factory( NaN, NINF );
 	y = logpdf( 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -132,26 +132,26 @@ tape( 'if provided `alpha <= 0`, the created function always returns `NaN`', fun
 	logpdf = factory( -1.0, 0.5 );
 
 	y = logpdf( 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logpdf( 0.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	logpdf = factory( NINF, 1.0 );
 	y = logpdf( 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	logpdf = factory( NINF, PINF );
 	y = logpdf( 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	logpdf = factory( NINF, NINF );
 	y = logpdf( 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	logpdf = factory( NINF, NaN );
 	y = logpdf( 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/test/test.logpdf.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/test/test.logpdf.js
@@ -46,11 +46,11 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'if provided `NaN` for any parameter, the function returns `NaN`', function test( t ) {
 	var y = logpdf( NaN, 1.0, 1.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 	y = logpdf( 0.0, NaN, 1.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 	y = logpdf( 0.0, 1.0, NaN );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 	t.end();
 });
 
@@ -58,13 +58,13 @@ tape( 'if provided a number smaller than zero for `x` and a valid `alpha` and `b
 	var y;
 
 	y = logpdf( NINF, 1.0, 1.0 );
-	t.equal( y, NINF, 'returns -Infinity' );
+	t.equal( y, NINF, 'returns expected value' );
 
 	y = logpdf( -100.0, 1.0, 1.0 );
-	t.equal( y, NINF, 'returns -Infinity' );
+	t.equal( y, NINF, 'returns expected value' );
 
 	y = logpdf( -0.5, 1.0, 1.0 );
-	t.equal( y, NINF, 'returns -Infinity' );
+	t.equal( y, NINF, 'returns expected value' );
 
 	t.end();
 });
@@ -73,22 +73,22 @@ tape( 'if provided `alpha <= 0`, the function returns `NaN`', function test( t )
 	var y;
 
 	y = logpdf( 2.0, -1.0, 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logpdf( 0.0, -1.0, 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logpdf( 2.0, NINF, 1.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logpdf( 2.0, NINF, PINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logpdf( 2.0, NINF, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logpdf( 2.0, NINF, NaN );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -97,22 +97,22 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', function test( t ) 
 	var y;
 
 	y = logpdf( 2.0, 2.0, -1.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logpdf( 0.0, 2.0, -1.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logpdf( 2.0, 1.0, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logpdf( 2.0, PINF, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logpdf( 2.0, NINF, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logpdf( 2.0, NaN, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/logpdf/test/test.native.js
@@ -55,11 +55,11 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'if provided `NaN` for any parameter, the function returns `NaN`', opts, function test( t ) {
 	var y = logpdf( NaN, 1.0, 1.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 	y = logpdf( 0.0, NaN, 1.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 	y = logpdf( 0.0, 1.0, NaN );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 	t.end();
 });
 
@@ -67,13 +67,13 @@ tape( 'if provided a number smaller than zero for `x` and a valid `alpha` and `b
 	var y;
 
 	y = logpdf( NINF, 1.0, 1.0 );
-	t.equal( y, NINF, 'returns -Infinity' );
+	t.equal( y, NINF, 'returns expected value' );
 
 	y = logpdf( -100.0, 1.0, 1.0 );
-	t.equal( y, NINF, 'returns -Infinity' );
+	t.equal( y, NINF, 'returns expected value' );
 
 	y = logpdf( -0.5, 1.0, 1.0 );
-	t.equal( y, NINF, 'returns -Infinity' );
+	t.equal( y, NINF, 'returns expected value' );
 
 	t.end();
 });
@@ -82,22 +82,22 @@ tape( 'if provided `alpha <= 0`, the function returns `NaN`', opts, function tes
 	var y;
 
 	y = logpdf( 2.0, -1.0, 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logpdf( 0.0, -1.0, 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logpdf( 2.0, NINF, 1.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logpdf( 2.0, NINF, PINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logpdf( 2.0, NINF, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logpdf( 2.0, NINF, NaN );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -106,22 +106,22 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', opts, function test
 	var y;
 
 	y = logpdf( 2.0, 2.0, -1.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logpdf( 0.0, 2.0, -1.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logpdf( 2.0, 1.0, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logpdf( 2.0, PINF, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logpdf( 2.0, NINF, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = logpdf( 2.0, NaN, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/mean/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/mean/benchmark/benchmark.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var uniform = require( '@stdlib/random/base/uniform' );
-var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -34,21 +33,19 @@ var mean = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var alpha;
 	var beta;
-	var len;
+	var opts;
 	var y;
 	var i;
 
-	len = 100;
-	alpha = new Float64Array( len );
-	beta = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = uniform( EPS, 10.0 );
-		beta[ i ] = uniform( 1.0 + EPS, 11.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	alpha = uniform( 100, EPS, 10.0, opts );
+	beta = uniform( 100, 1.0 + EPS, 11.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = mean( alpha[ i % len ], beta[ i % len ] );
+		y = mean( alpha[ i % alpha.length ], beta[ i % beta.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/mean/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/mean/benchmark/benchmark.native.js
@@ -22,8 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var uniform = require( '@stdlib/random/base/uniform' );
-var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -43,21 +42,19 @@ var opts = {
 bench( pkg+'::native', opts, function benchmark( b ) {
 	var alpha;
 	var beta;
-	var len;
+	var opts;
 	var y;
 	var i;
 
-	len = 100;
-	alpha = new Float64Array( len );
-	beta = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = uniform( EPS, 10.0 );
-		beta[ i ] = uniform( 1.0 + EPS, 11.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	alpha = uniform( 100, EPS, 10.0, opts );
+	beta = uniform( 100, 1.0 + EPS, 11.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = mean( alpha[ i % len ], beta[ i % len ] );
+		y = mean( alpha[ i % alpha.length ], beta[ i % beta.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/mean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/mean/test/test.js
@@ -42,10 +42,10 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'if provided `NaN` for any parameter, the function returns `NaN`', function test( t ) {
 	var v = mean( NaN, 0.5 );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 
 	v = mean( 10.0, NaN );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -54,19 +54,19 @@ tape( 'if provided `alpha <= 0`, the function returns `NaN`', function test( t )
 	var y;
 
 	y = mean( -1.0, 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mean( NINF, 1.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mean( NINF, PINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mean( NINF, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mean( NINF, NaN );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -75,25 +75,25 @@ tape( 'if provided `beta <= 1`, the function returns `NaN`', function test( t ) 
 	var y;
 
 	y = mean( 2.0, 1.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mean( 2.0, 0.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mean( 2.0, -1.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mean( 1.0, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mean( PINF, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mean( NINF, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mean( NaN, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/mean/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/mean/test/test.native.js
@@ -51,10 +51,10 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'if provided `NaN` for any parameter, the function returns `NaN`', opts, function test( t ) {
 	var v = mean( NaN, 0.5 );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 
 	v = mean( 10.0, NaN );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -63,19 +63,19 @@ tape( 'if provided `alpha <= 0`, the function returns `NaN`', opts, function tes
 	var y;
 
 	y = mean( -1.0, 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mean( NINF, 1.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mean( NINF, PINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mean( NINF, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mean( NINF, NaN );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -84,25 +84,25 @@ tape( 'if provided `beta <= 1`, the function returns `NaN`', opts, function test
 	var y;
 
 	y = mean( 2.0, 1.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mean( 2.0, 0.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mean( 2.0, -1.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mean( 1.0, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mean( PINF, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mean( NINF, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mean( NaN, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/mode/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/mode/benchmark/benchmark.js
@@ -42,7 +42,6 @@ bench( pkg, function benchmark( b ) {
 	};
 	alpha = uniform( 100, EPS, 10.0, opts );
 	beta = uniform( 100, EPS, 10.0, opts );
-	p = uniform( 100, 0.0, 1.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/mode/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/mode/benchmark/benchmark.js
@@ -21,8 +21,7 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var uniform = require( '@stdlib/random/base/uniform' );
-var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var pkg = require( './../package.json' ).name;
@@ -34,21 +33,20 @@ var mode = require( './../lib' );
 bench( pkg, function benchmark( b ) {
 	var alpha;
 	var beta;
-	var len;
+	var opts;
 	var y;
 	var i;
 
-	len = 100;
-	alpha = new Float64Array( len );
-	beta = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = uniform( EPS, 10.0 );
-		beta[ i ] = uniform( EPS, 10.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	alpha = uniform( 100, EPS, 10.0, opts );
+	beta = uniform( 100, EPS, 10.0, opts );
+	p = uniform( 100, 0.0, 1.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = mode( alpha[ i % len ], beta[ i % len ] );
+		y = mode( alpha[ i % alpha.length ], beta[ i % beta.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/mode/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/mode/benchmark/benchmark.native.js
@@ -22,8 +22,7 @@
 
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
-var uniform = require( '@stdlib/random/base/uniform' );
-var Float64Array = require( '@stdlib/array/float64' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var EPS = require( '@stdlib/constants/float64/eps' );
@@ -43,21 +42,19 @@ var opts = {
 bench( pkg+'::native', opts, function benchmark( b ) {
 	var alpha;
 	var beta;
-	var len;
+	var opts;
 	var y;
 	var i;
 
-	len = 100;
-	alpha = new Float64Array( len );
-	beta = new Float64Array( len );
-	for ( i = 0; i < len; i++ ) {
-		alpha[ i ] = uniform( EPS, 10.0 );
-		beta[ i ] = uniform( EPS, 10.0 );
-	}
+	opts = {
+		'dtype': 'float64'
+	};
+	alpha = uniform( 100, EPS, 10.0, opts );
+	beta = uniform( 100, EPS, 10.0, opts );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		y = mode( alpha[ i % len ], beta[ i % len ] );
+		y = mode( alpha[ i % alpha.length ], beta[ i % beta.length ] );
 		if ( isnan( y ) ) {
 			b.fail( 'should not return NaN' );
 		}

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/mode/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/mode/test/test.js
@@ -39,10 +39,10 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'if provided `NaN` for any parameter, the function returns `NaN`', function test( t ) {
 	var v = mode( NaN, 0.5 );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 
 	v = mode( 10.0, NaN );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -51,19 +51,19 @@ tape( 'if provided `alpha <= 0`, the function returns `NaN`', function test( t )
 	var y;
 
 	y = mode( -1.0, 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mode( NINF, 1.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mode( NINF, PINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mode( NINF, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mode( NINF, NaN );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -72,22 +72,22 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', function test( t ) 
 	var y;
 
 	y = mode( 2.0, 0.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mode( 2.0, -1.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mode( 1.0, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mode( PINF, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mode( NINF, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mode( NaN, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/betaprime/mode/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/betaprime/mode/test/test.native.js
@@ -48,10 +48,10 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'if provided `NaN` for any parameter, the function returns `NaN`', opts, function test( t ) {
 	var v = mode( NaN, 0.5 );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 
 	v = mode( 10.0, NaN );
-	t.equal( isnan( v ), true, 'returns NaN' );
+	t.equal( isnan( v ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -60,19 +60,19 @@ tape( 'if provided `alpha <= 0`, the function returns `NaN`', opts, function tes
 	var y;
 
 	y = mode( -1.0, 2.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mode( NINF, 1.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mode( NINF, PINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mode( NINF, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mode( NINF, NaN );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	t.end();
 });
@@ -81,22 +81,22 @@ tape( 'if provided `beta <= 0`, the function returns `NaN`', opts, function test
 	var y;
 
 	y = mode( 2.0, 0.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mode( 2.0, -1.0 );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mode( 1.0, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mode( PINF, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mode( NINF, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	y = mode( NaN, NINF );
-	t.equal( isnan( y ), true, 'returns NaN' );
+	t.equal( isnan( y ), true, 'returns expected value' );
 
 	t.end();
 });


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors random number generation in JS benchmarks for the `stats/base/dists/betaprime/logcdf`, `stats/base/dists/betaprime/logpdf`, `stats/base/dists/betaprime/mean` and `stats/base/dists/betaprime/mode` packages.
-   Replaces `uniform()` from `@stdlib/random/array/uniform` for cleaner and more consistent code.
-   Moves the random number generation outside the benchmarking loops.
-   Updates the test messages to follow code conventions.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
