### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/cdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/cdf/README.md
@@ -144,23 +144,18 @@ y = mycdf( 1.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var cdf = require( '@stdlib/stats/base/dists/binomial/cdf' );
 
-var i;
-var n;
-var p;
-var x;
-var y;
+var opts = {
+    'dtype': 'float64'
+};
+var x = discreteUniform( 10, 0, 20, opts );
+var n = discreteUniform( 10, 0, 100, opts );
+var p = discreteUniform( 10, 0, 1, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    x = randu() * 20.0;
-    n = round( randu() * 100.0 );
-    p = randu();
-    y = cdf( x, n, p );
-    console.log( 'x: %d, n: %d, p: %d, F(x;n,p): %d', x.toFixed( 4 ), n, p.toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 'x: %0.4f, n: %0.4f, p: %0.4f, F(x;n,p): %0.4f', x, n, p, cdf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/cdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/cdf/README.md
@@ -152,7 +152,7 @@ var cdf = require( '@stdlib/stats/base/dists/binomial/cdf' );
 var opts = {
     'dtype': 'float64'
 };
-var x = discreteUniform( 10, 0, 20, opts );
+var x = uniform( 10, 0.0, 20.0, opts );
 var n = discreteUniform( 10, 0, 100, opts );
 var p = uniform( 10, 0.0, 1.0, opts );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/cdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/cdf/README.md
@@ -145,6 +145,7 @@ y = mycdf( 1.0 );
 
 ```javascript
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var cdf = require( '@stdlib/stats/base/dists/binomial/cdf' );
 
@@ -153,7 +154,7 @@ var opts = {
 };
 var x = discreteUniform( 10, 0, 20, opts );
 var n = discreteUniform( 10, 0, 100, opts );
-var p = discreteUniform( 10, 0, 1, opts );
+var p = uniform( 10, 0.0, 1.0, opts );
 
 logEachMap( 'x: %0.4f, n: %0.4f, p: %0.4f, F(x;n,p): %0.4f', x, n, p, cdf );
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/cdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/cdf/examples/index.js
@@ -19,6 +19,7 @@
 'use strict';
 
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var cdf = require( './../lib' );
 
@@ -27,6 +28,6 @@ var opts = {
 };
 var x = discreteUniform( 10, 0, 20, opts );
 var n = discreteUniform( 10, 0, 100, opts );
-var p = discreteUniform( 10, 0, 1, opts );
+var p = uniform( 10, 0.0, 1.0, opts );
 
 logEachMap( 'x: %0.4f, n: %0.4f, p: %0.4f, F(x;n,p): %0.4f', x, n, p, cdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/cdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/cdf/examples/index.js
@@ -18,20 +18,15 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var cdf = require( './../lib' );
 
-var i;
-var n;
-var p;
-var x;
-var y;
+var opts = {
+	'dtype': 'float64'
+};
+var x = discreteUniform( 10, 0, 20, opts );
+var n = discreteUniform( 10, 0, 100, opts );
+var p = discreteUniform( 10, 0, 1, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	x = randu() * 20.0;
-	n = round( randu() * 100.0 );
-	p = randu();
-	y = cdf( x, n, p );
-	console.log( 'x: %d, n: %d, p: %d, F(x;n,p): %d', x.toFixed( 4 ), n, p.toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 'x: %0.4f, n: %0.4f, p: %0.4f, F(x;n,p): %0.4f', x, n, p, cdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/cdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/cdf/examples/index.js
@@ -26,7 +26,7 @@ var cdf = require( './../lib' );
 var opts = {
 	'dtype': 'float64'
 };
-var x = discreteUniform( 10, 0, 20, opts );
+var x = uniform( 10, 0, 20, opts );
 var n = discreteUniform( 10, 0, 100, opts );
 var p = uniform( 10, 0.0, 1.0, opts );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/cdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/cdf/examples/index.js
@@ -26,7 +26,7 @@ var cdf = require( './../lib' );
 var opts = {
 	'dtype': 'float64'
 };
-var x = uniform( 10, 0, 20, opts );
+var x = uniform( 10, 0.0, 20.0, opts );
 var n = discreteUniform( 10, 0, 100, opts );
 var p = uniform( 10, 0.0, 1.0, opts );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/entropy/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/entropy/README.md
@@ -120,21 +120,17 @@ v = entropy( 20, 1.5 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var entropy = require( '@stdlib/stats/base/dists/binomial/entropy' );
 
-var v;
-var i;
-var n;
-var p;
+var opts = {
+    'dtype': 'float64'
+};
+var n = discreteUniform( 10, 0, 100, opts );
+var p = discreteUniform( 10, 0, 1, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    n = round( randu() * 100.0 );
-    p = randu();
-    v = entropy( n, p );
-    console.log( 'n: %d, p: %d, H(X;n,p): %d', n, p.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'n: %0.4f, p: %0.4f, H(X;n,p): %0.4f', n, p, entropy );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/entropy/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/entropy/README.md
@@ -121,6 +121,7 @@ v = entropy( 20, 1.5 );
 
 ```javascript
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var entropy = require( '@stdlib/stats/base/dists/binomial/entropy' );
 
@@ -128,7 +129,7 @@ var opts = {
     'dtype': 'float64'
 };
 var n = discreteUniform( 10, 0, 100, opts );
-var p = discreteUniform( 10, 0, 1, opts );
+var p = uniform( 10, 0.0, 1.0, opts );
 
 logEachMap( 'n: %0.4f, p: %0.4f, H(X;n,p): %0.4f', n, p, entropy );
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/entropy/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/entropy/examples/index.js
@@ -18,18 +18,14 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var entropy = require( './../lib' );
 
-var v;
-var i;
-var n;
-var p;
+var opts = {
+	'dtype': 'float64'
+};
+var n = discreteUniform( 10, 0, 100, opts );
+var p = discreteUniform( 10, 0, 1, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	n = round( randu() * 100.0 );
-	p = randu();
-	v = entropy( n, p );
-	console.log( 'n: %d, p: %d, H(X;n,p): %d', n, p.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'n: %0.4f, p: %0.4f, H(X;n,p): %0.4f', n, p, entropy );

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/entropy/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/entropy/examples/index.js
@@ -19,6 +19,7 @@
 'use strict';
 
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var entropy = require( './../lib' );
 
@@ -26,6 +27,6 @@ var opts = {
 	'dtype': 'float64'
 };
 var n = discreteUniform( 10, 0, 100, opts );
-var p = discreteUniform( 10, 0, 1, opts );
+var p = uniform( 10, 0.0, 1.0, opts );
 
 logEachMap( 'n: %0.4f, p: %0.4f, H(X;n,p): %0.4f', n, p, entropy );

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/kurtosis/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/kurtosis/README.md
@@ -120,21 +120,17 @@ v = kurtosis( 20, 1.5 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var kurtosis = require( '@stdlib/stats/base/dists/binomial/kurtosis' );
 
-var v;
-var i;
-var n;
-var p;
+var opts = {
+    'dtype': 'float64'
+};
+var n = discreteUniform( 10, 0, 100, opts );
+var p = discreteUniform( 10, 0, 1, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    n = round( randu() * 100.0 );
-    p = randu();
-    v = kurtosis( n, p );
-    console.log( 'n: %d, p: %d, Kurt(X;n,p): %d', n, p.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'n: %0.4f, p: %0.4f, Kurt(X;n,p): %0.4f', n, p, kurtosis );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/kurtosis/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/kurtosis/README.md
@@ -121,6 +121,7 @@ v = kurtosis( 20, 1.5 );
 
 ```javascript
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var kurtosis = require( '@stdlib/stats/base/dists/binomial/kurtosis' );
 
@@ -128,7 +129,7 @@ var opts = {
     'dtype': 'float64'
 };
 var n = discreteUniform( 10, 0, 100, opts );
-var p = discreteUniform( 10, 0, 1, opts );
+var p = uniform( 10, 0.0, 1.0, opts );
 
 logEachMap( 'n: %0.4f, p: %0.4f, Kurt(X;n,p): %0.4f', n, p, kurtosis );
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/kurtosis/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/kurtosis/examples/index.js
@@ -19,6 +19,7 @@
 'use strict';
 
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var kurtosis = require( './../lib' );
 
@@ -26,6 +27,6 @@ var opts = {
 	'dtype': 'float64'
 };
 var n = discreteUniform( 10, 0, 100, opts );
-var p = discreteUniform( 10, 0, 1, opts );
+var p = uniform( 10, 0.0, 1.0, opts );
 
 logEachMap( 'n: %0.4f, p: %0.4f, Kurt(X;n,p): %0.4f', n, p, kurtosis );

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/kurtosis/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/kurtosis/examples/index.js
@@ -18,18 +18,14 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var kurtosis = require( './../lib' );
 
-var v;
-var i;
-var n;
-var p;
+var opts = {
+	'dtype': 'float64'
+};
+var n = discreteUniform( 10, 0, 100, opts );
+var p = discreteUniform( 10, 0, 1, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	n = round( randu() * 100.0 );
-	p = randu();
-	v = kurtosis( n, p );
-	console.log( 'n: %d, p: %d, Kurt(X;n,p): %d', n, p.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'n: %0.4f, p: %0.4f, Kurt(X;n,p): %0.4f', n, p, kurtosis );

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/logpmf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/logpmf/README.md
@@ -130,6 +130,7 @@ y = mylogpmf( 5.0 );
 
 ```javascript
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var logpmf = require( '@stdlib/stats/base/dists/binomial/logpmf' );
 
@@ -138,7 +139,7 @@ var opts = {
 };
 var x = discreteUniform( 10, 0, 20, opts );
 var n = discreteUniform( 10, 0, 100, opts );
-var p = discreteUniform( 10, 0, 1, opts );
+var p = uniform( 10, 0.0, 1.0, opts );
 
 logEachMap( 'x: %0.4f, n: %0.4f, p: %0.4f, ln(P(X = x;n,p)): %0.4f', x, n, p, logpmf );
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/logpmf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/logpmf/README.md
@@ -129,23 +129,18 @@ y = mylogpmf( 5.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var logpmf = require( '@stdlib/stats/base/dists/binomial/logpmf' );
 
-var i;
-var n;
-var p;
-var x;
-var y;
+var opts = {
+    'dtype': 'float64'
+};
+var x = discreteUniform( 10, 0, 20, opts );
+var n = discreteUniform( 10, 0, 100, opts );
+var p = discreteUniform( 10, 0, 1, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    x = round( randu() * 20.0 );
-    n = round( randu() * 100.0 );
-    p = randu();
-    y = logpmf( x, n, p );
-    console.log( 'x: %d, n: %d, p: %d, ln(P(X = x;n,p)): %d', x, n, p.toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 'x: %0.4f, n: %0.4f, p: %0.4f, ln(P(X = x;n,p)): %0.4f', x, n, p, logpmf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/logpmf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/logpmf/examples/index.js
@@ -19,6 +19,7 @@
 'use strict';
 
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var logpmf = require( './../lib' );
 
@@ -27,6 +28,6 @@ var opts = {
 };
 var x = discreteUniform( 10, 0, 20, opts );
 var n = discreteUniform( 10, 0, 100, opts );
-var p = discreteUniform( 10, 0, 1, opts );
+var p = uniform( 10, 0.0, 1.0, opts );
 
 logEachMap( 'x: %0.4f, n: %0.4f, p: %0.4f, ln(P(X = x;n,p)): %0.4f', x, n, p, logpmf );

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/logpmf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/logpmf/examples/index.js
@@ -18,20 +18,15 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var logpmf = require( './../lib' );
 
-var i;
-var n;
-var p;
-var x;
-var y;
+var opts = {
+	'dtype': 'float64'
+};
+var x = discreteUniform( 10, 0, 20, opts );
+var n = discreteUniform( 10, 0, 100, opts );
+var p = discreteUniform( 10, 0, 1, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	x = round( randu() * 20.0 );
-	n = round( randu() * 100.0 );
-	p = randu();
-	y = logpmf( x, n, p );
-	console.log( 'x: %d, n: %d, p: %d, ln(P(X = x;n,p)): %d', x, n, p.toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 'x: %0.4f, n: %0.4f, p: %0.4f, ln(P(X = x;n,p)): %0.4f', x, n, p, logpmf );

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/mean/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/mean/README.md
@@ -120,21 +120,17 @@ v = mean( 20, 1.5 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var mean = require( '@stdlib/stats/base/dists/binomial/mean' );
 
-var v;
-var i;
-var n;
-var p;
+var opts = {
+    'dtype': 'float64'
+};
+var n = discreteUniform( 10, 0, 100, opts );
+var p = discreteUniform( 10, 0, 1, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    n = round( randu() * 100.0 );
-    p = randu();
-    v = mean( n, p );
-    console.log( 'n: %d, p: %d, E(X;n,p): %d', n, p.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'n: %0.4f, p: %0.4f, E(X;n,p): %0.4f', n, p, mean );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/mean/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/mean/README.md
@@ -121,6 +121,7 @@ v = mean( 20, 1.5 );
 
 ```javascript
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var mean = require( '@stdlib/stats/base/dists/binomial/mean' );
 
@@ -128,7 +129,7 @@ var opts = {
     'dtype': 'float64'
 };
 var n = discreteUniform( 10, 0, 100, opts );
-var p = discreteUniform( 10, 0, 1, opts );
+var p = uniform( 10, 0.0, 1.0, opts );
 
 logEachMap( 'n: %0.4f, p: %0.4f, E(X;n,p): %0.4f', n, p, mean );
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/mean/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/mean/examples/index.js
@@ -18,18 +18,14 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var mean = require( './../lib' );
 
-var v;
-var i;
-var n;
-var p;
+var opts = {
+	'dtype': 'float64'
+};
+var n = discreteUniform( 10, 0, 100, opts );
+var p = discreteUniform( 10, 0, 1, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	n = round( randu() * 100.0 );
-	p = randu();
-	v = mean( n, p );
-	console.log( 'n: %d, p: %d, E(X;n,p): %d', n, p.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'n: %0.4f, p: %0.4f, E(X;n,p): %0.4f', n, p, mean );

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/mean/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/mean/examples/index.js
@@ -19,6 +19,7 @@
 'use strict';
 
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var mean = require( './../lib' );
 
@@ -26,6 +27,6 @@ var opts = {
 	'dtype': 'float64'
 };
 var n = discreteUniform( 10, 0, 100, opts );
-var p = discreteUniform( 10, 0, 1, opts );
+var p = uniform( 10, 0.0, 1.0, opts );
 
 logEachMap( 'n: %0.4f, p: %0.4f, E(X;n,p): %0.4f', n, p, mean );

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/median/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/median/README.md
@@ -120,21 +120,17 @@ v = median( 20, 1.5 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var median = require( '@stdlib/stats/base/dists/binomial/median' );
 
-var v;
-var i;
-var n;
-var p;
+var opts = {
+    'dtype': 'float64'
+};
+var n = discreteUniform( 10, 0, 100, opts );
+var p = discreteUniform( 10, 0, 1, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    n = round( randu() * 100.0 );
-    p = randu();
-    v = median( n, p );
-    console.log( 'n: %d, p: %d, Median(X;n,p): %d', n, p.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'n: %0.4f, p: %0.4f, Median(X;n,p): %0.4f', n, p, median );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/median/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/median/README.md
@@ -121,6 +121,7 @@ v = median( 20, 1.5 );
 
 ```javascript
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var median = require( '@stdlib/stats/base/dists/binomial/median' );
 
@@ -128,7 +129,7 @@ var opts = {
     'dtype': 'float64'
 };
 var n = discreteUniform( 10, 0, 100, opts );
-var p = discreteUniform( 10, 0, 1, opts );
+var p = uniform( 10, 0.0, 1.0, opts );
 
 logEachMap( 'n: %0.4f, p: %0.4f, Median(X;n,p): %0.4f', n, p, median );
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/median/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/median/examples/index.js
@@ -19,6 +19,7 @@
 'use strict';
 
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var median = require( './../lib' );
 
@@ -26,6 +27,6 @@ var opts = {
 	'dtype': 'float64'
 };
 var n = discreteUniform( 10, 0, 100, opts );
-var p = discreteUniform( 10, 0, 1, opts );
+var p = uniform( 10, 0.0, 1.0, opts );
 
 logEachMap( 'n: %0.4f, p: %0.4f, Median(X;n,p): %0.4f', n, p, median );

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/median/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/median/examples/index.js
@@ -18,18 +18,14 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var median = require( './../lib' );
 
-var v;
-var i;
-var n;
-var p;
+var opts = {
+	'dtype': 'float64'
+};
+var n = discreteUniform( 10, 0, 100, opts );
+var p = discreteUniform( 10, 0, 1, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	n = round( randu() * 100.0 );
-	p = randu();
-	v = median( n, p );
-	console.log( 'n: %d, p: %d, Median(X;n,p): %d', n, p.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'n: %0.4f, p: %0.4f, Median(X;n,p): %0.4f', n, p, median );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `stats/base/dists/binomial/cdf`, `stats/base/dists/binomial/entropy`, `stats/base/dists/binomial/kurtosis`, `stats/base/dists/binomial/logpmf`, `stats/base/dists/binomial/median` and `stats/base/dists/binomial/mean` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
