### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/mgf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/mgf/README.md
@@ -141,6 +141,7 @@ var y = myMGF( 0.3 );
 
 ```javascript
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var mgf = require( '@stdlib/stats/base/dists/binomial/mgf' );
 
@@ -149,7 +150,7 @@ var opts = {
 };
 var t = discreteUniform( 10, 0, 5, opts );
 var n = discreteUniform( 10, 0, 10, opts );
-var p = discreteUniform( 10, 0, 1, opts );
+var p = uniform( 10, 0.0, 1.0, opts );
 
 logEachMap( 't: %0.4f, n: %0.4f, p: %0.4f, M_X(t;n,p): %0.4f', t, n, p, mgf );
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/mgf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/mgf/README.md
@@ -140,23 +140,18 @@ var y = myMGF( 0.3 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var mgf = require( '@stdlib/stats/base/dists/binomial/mgf' );
 
-var n;
-var p;
-var t;
-var y;
-var i;
+var opts = {
+    'dtype': 'float64'
+};
+var t = discreteUniform( 10, 0, 5, opts );
+var n = discreteUniform( 10, 0, 10, opts );
+var p = discreteUniform( 10, 0, 1, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    t = round( randu() * 5.0 );
-    n = round( randu() * 10.0 );
-    p = randu();
-    y = mgf( t, n, p );
-    console.log( 't: %d, n: %d, p: %d, M_X(t;n,p): %d', t, n, p.toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 't: %0.4f, n: %0.4f, p: %0.4f, M_X(t;n,p): %0.4f', t, n, p, mgf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/mgf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/mgf/examples/index.js
@@ -19,6 +19,7 @@
 'use strict';
 
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var mgf = require( './../lib' );
 
@@ -27,6 +28,6 @@ var opts = {
 };
 var t = discreteUniform( 10, 0, 5, opts );
 var n = discreteUniform( 10, 0, 10, opts );
-var p = discreteUniform( 10, 0, 1, opts );
+var p = uniform( 10, 0.0, 1.0, opts );
 
 logEachMap( 't: %0.4f, n: %0.4f, p: %0.4f, M_X(t;n,p): %0.4f', t, n, p, mgf );

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/mgf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/mgf/examples/index.js
@@ -18,20 +18,15 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var mgf = require( './../lib' );
 
-var n;
-var p;
-var t;
-var y;
-var i;
+var opts = {
+	'dtype': 'float64'
+};
+var t = discreteUniform( 10, 0, 5, opts );
+var n = discreteUniform( 10, 0, 10, opts );
+var p = discreteUniform( 10, 0, 1, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	t = round( randu() * 5.0 );
-	n = round( randu() * 10.0 );
-	p = randu();
-	y = mgf( t, n, p );
-	console.log( 't: %d, n: %d, p: %d, M_X(t;n,p): %d', t, n, p.toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 't: %0.4f, n: %0.4f, p: %0.4f, M_X(t;n,p): %0.4f', t, n, p, mgf );

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/mode/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/mode/README.md
@@ -121,6 +121,7 @@ v = mode( 20, 1.5 );
 
 ```javascript
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var mode = require( '@stdlib/stats/base/dists/binomial/mode' );
 
@@ -128,7 +129,7 @@ var opts = {
     'dtype': 'float64'
 };
 var n = discreteUniform( 10, 0, 100, opts );
-var p = discreteUniform( 10, 0, 1, opts );
+var p = uniform( 10, 0.0, 1.0, opts );
 
 logEachMap( 'n: %0.4f, p: %0.4f, mode(X;n,p): %0.4f', n, p, mode );
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/mode/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/mode/README.md
@@ -120,21 +120,17 @@ v = mode( 20, 1.5 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var mode = require( '@stdlib/stats/base/dists/binomial/mode' );
 
-var v;
-var i;
-var n;
-var p;
+var opts = {
+    'dtype': 'float64'
+};
+var n = discreteUniform( 10, 0, 100, opts );
+var p = discreteUniform( 10, 0, 1, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    n = round( randu() * 100.0 );
-    p = randu();
-    v = mode( n, p );
-    console.log( 'n: %d, p: %d, mode(X;n,p): %d', n, p.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'n: %0.4f, p: %0.4f, mode(X;n,p): %0.4f', n, p, mode );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/mode/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/mode/examples/index.js
@@ -23,7 +23,7 @@ var logEachMap = require( '@stdlib/console/log-each-map' );
 var mode = require( './../lib' );
 
 var opts = {
-    'dtype': 'float64'
+	'dtype': 'float64'
 };
 var n = discreteUniform( 10, 0, 100, opts );
 var p = discreteUniform( 10, 0, 1, opts );

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/mode/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/mode/examples/index.js
@@ -18,18 +18,14 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var mode = require( './../lib' );
 
-var v;
-var i;
-var n;
-var p;
+var opts = {
+    'dtype': 'float64'
+};
+var n = discreteUniform( 10, 0, 100, opts );
+var p = discreteUniform( 10, 0, 1, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	n = round( randu() * 100.0 );
-	p = randu();
-	v = mode( n, p );
-	console.log( 'n: %d, p: %d, mode(X;n,p): %d', n, p.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'n: %0.4f, p: %0.4f, mode(X;n,p): %0.4f', n, p, mode );

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/mode/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/mode/examples/index.js
@@ -19,6 +19,7 @@
 'use strict';
 
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var mode = require( './../lib' );
 
@@ -26,6 +27,6 @@ var opts = {
 	'dtype': 'float64'
 };
 var n = discreteUniform( 10, 0, 100, opts );
-var p = discreteUniform( 10, 0, 1, opts );
+var p = uniform( 10, 0.0, 1.0, opts );
 
 logEachMap( 'n: %0.4f, p: %0.4f, mode(X;n,p): %0.4f', n, p, mode );

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/pmf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/pmf/README.md
@@ -130,6 +130,7 @@ y = mypmf( 5.0 );
 
 ```javascript
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var pmf = require( '@stdlib/stats/base/dists/binomial/pmf' );
 
@@ -138,7 +139,7 @@ var opts = {
 };
 var x = discreteUniform( 10, 0, 20, opts );
 var n = discreteUniform( 10, 0, 100, opts );
-var p = discreteUniform( 10, 0, 1, opts );
+var p = uniform( 10, 0.0, 1.0, opts );
 
 logEachMap( 'x: %0.4f, n: %0.4f, p: %0.4f, P(X = x;n,p): %0.4f', x, n, p, pmf );
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/pmf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/pmf/README.md
@@ -129,23 +129,18 @@ y = mypmf( 5.0 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var pmf = require( '@stdlib/stats/base/dists/binomial/pmf' );
 
-var i;
-var n;
-var p;
-var x;
-var y;
+var opts = {
+    'dtype': 'float64'
+};
+var x = discreteUniform( 10, 0, 20, opts );
+var n = discreteUniform( 10, 0, 100, opts );
+var p = discreteUniform( 10, 0, 1, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    x = round( randu() * 20.0 );
-    n = round( randu() * 100.0 );
-    p = randu();
-    y = pmf( x, n, p );
-    console.log( 'x: %d, n: %d, p: %d, P(X = x;n,p): %d', x, n, p.toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 'x: %0.4f, n: %0.4f, p: %0.4f, P(X = x;n,p): %0.4f', x, n, p, pmf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/pmf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/pmf/examples/index.js
@@ -18,20 +18,15 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var pmf = require( './../lib' );
 
-var i;
-var n;
-var p;
-var x;
-var y;
+var opts = {
+	'dtype': 'float64'
+};
+var x = discreteUniform( 10, 0, 20, opts );
+var n = discreteUniform( 10, 0, 100, opts );
+var p = discreteUniform( 10, 0, 1, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	x = round( randu() * 20.0 );
-	n = round( randu() * 100.0 );
-	p = randu();
-	y = pmf( x, n, p );
-	console.log( 'x: %d, n: %d, p: %d, P(X = x;n,p): %d', x, n, p.toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 'x: %0.4f, n: %0.4f, p: %0.4f, P(X = x;n,p): %0.4f', x, n, p, pmf );

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/pmf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/pmf/examples/index.js
@@ -19,6 +19,7 @@
 'use strict';
 
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var pmf = require( './../lib' );
 
@@ -27,6 +28,6 @@ var opts = {
 };
 var x = discreteUniform( 10, 0, 20, opts );
 var n = discreteUniform( 10, 0, 100, opts );
-var p = discreteUniform( 10, 0, 1, opts );
+var p = uniform( 10, 0.0, 1.0, opts );
 
 logEachMap( 'x: %0.4f, n: %0.4f, p: %0.4f, P(X = x;n,p): %0.4f', x, n, p, pmf );

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/quantile/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/quantile/README.md
@@ -133,6 +133,7 @@ y = myquantile( 0.9 );
 
 ```javascript
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var quantile = require( '@stdlib/stats/base/dists/binomial/quantile' );
 
@@ -141,7 +142,7 @@ var opts = {
 };
 var r = discreteUniform( 10, 0, 1, opts );
 var n = discreteUniform( 10, 0, 100, opts );
-var p = discreteUniform( 10, 0, 1, opts );
+var p = uniform( 10, 0.0, 1.0, opts );
 
 logEachMap( 'r: %0.4f, n: %0.4f, p: %0.4f, Q(r;n,p): %0.4f', r, n, p, quantile );
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/quantile/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/quantile/README.md
@@ -140,7 +140,7 @@ var quantile = require( '@stdlib/stats/base/dists/binomial/quantile' );
 var opts = {
     'dtype': 'float64'
 };
-var r = discreteUniform( 10, 0, 1, opts );
+var r = uniform( 10, 0.0, 1.0, opts );
 var n = discreteUniform( 10, 0, 100, opts );
 var p = uniform( 10, 0.0, 1.0, opts );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/quantile/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/quantile/README.md
@@ -132,23 +132,18 @@ y = myquantile( 0.9 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var quantile = require( '@stdlib/stats/base/dists/binomial/quantile' );
 
-var r;
-var i;
-var n;
-var p;
-var y;
+var opts = {
+    'dtype': 'float64'
+};
+var r = discreteUniform( 10, 0, 1, opts );
+var n = discreteUniform( 10, 0, 100, opts );
+var p = discreteUniform( 10, 0, 1, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    r = randu();
-    n = round( randu() * 100.0 );
-    p = randu();
-    y = quantile( r, n, p );
-    console.log( 'r: %d, n: %d, p: %d, Q(r;n,p): %d', r.toFixed( 4 ), n, p.toFixed( 4 ) );
-}
+logEachMap( 'r: %0.4f, n: %0.4f, p: %0.4f, Q(r;n,p): %0.4f', r, n, p, quantile );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/quantile/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/quantile/examples/index.js
@@ -18,20 +18,15 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var quantile = require( './../lib' );
 
-var r;
-var i;
-var n;
-var p;
-var y;
+var opts = {
+	'dtype': 'float64'
+};
+var r = discreteUniform( 10, 0, 1, opts );
+var n = discreteUniform( 10, 0, 100, opts );
+var p = discreteUniform( 10, 0, 1, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	r = randu();
-	n = round( randu() * 100.0 );
-	p = randu();
-	y = quantile( r, n, p );
-	console.log( 'r: %d, n: %d, p: %d, Q(r;n,p): %d', r.toFixed( 4 ), n, p.toFixed( 4 ), y );
-}
+logEachMap( 'r: %0.4f, n: %0.4f, p: %0.4f, Q(r;n,p): %0.4f', r, n, p, quantile );

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/quantile/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/quantile/examples/index.js
@@ -19,6 +19,7 @@
 'use strict';
 
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var quantile = require( './../lib' );
 
@@ -27,6 +28,6 @@ var opts = {
 };
 var r = discreteUniform( 10, 0, 1, opts );
 var n = discreteUniform( 10, 0, 100, opts );
-var p = discreteUniform( 10, 0, 1, opts );
+var p = uniform( 10, 0.0, 1.0, opts );
 
 logEachMap( 'r: %0.4f, n: %0.4f, p: %0.4f, Q(r;n,p): %0.4f', r, n, p, quantile );

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/quantile/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/quantile/examples/index.js
@@ -26,7 +26,7 @@ var quantile = require( './../lib' );
 var opts = {
 	'dtype': 'float64'
 };
-var r = discreteUniform( 10, 0, 1, opts );
+var r = uniform( 10, 0.0, 1.0, opts );
 var n = discreteUniform( 10, 0, 100, opts );
 var p = uniform( 10, 0.0, 1.0, opts );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/skewness/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/skewness/README.md
@@ -120,21 +120,17 @@ v = skewness( 20, 1.5 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var skewness = require( '@stdlib/stats/base/dists/binomial/skewness' );
 
-var v;
-var i;
-var n;
-var p;
+var opts = {
+    'dtype': 'float64'
+};
+var n = discreteUniform( 10, 0, 100, opts );
+var p = discreteUniform( 10, 0, 1, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    n = round( randu() * 100.0 );
-    p = randu();
-    v = skewness( n, p );
-    console.log( 'n: %d, p: %d, skew(X;n,p): %d', n, p.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'n: %0.4f, p: %0.4f, skew(X;n,p): %0.4f', n, p, skewness );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/skewness/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/skewness/README.md
@@ -121,6 +121,7 @@ v = skewness( 20, 1.5 );
 
 ```javascript
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var skewness = require( '@stdlib/stats/base/dists/binomial/skewness' );
 
@@ -128,7 +129,7 @@ var opts = {
     'dtype': 'float64'
 };
 var n = discreteUniform( 10, 0, 100, opts );
-var p = discreteUniform( 10, 0, 1, opts );
+var p = uniform( 10, 0.0, 1.0, opts );
 
 logEachMap( 'n: %0.4f, p: %0.4f, skew(X;n,p): %0.4f', n, p, skewness );
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/skewness/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/skewness/examples/index.js
@@ -19,6 +19,7 @@
 'use strict';
 
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var skewness = require( './../lib' );
 
@@ -26,6 +27,6 @@ var opts = {
 	'dtype': 'float64'
 };
 var n = discreteUniform( 10, 0, 100, opts );
-var p = discreteUniform( 10, 0, 1, opts );
+var p = uniform( 10, 0.0, 1.0, opts );
 
 logEachMap( 'n: %0.4f, p: %0.4f, skew(X;n,p): %0.4f', n, p, skewness );

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/skewness/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/skewness/examples/index.js
@@ -18,18 +18,14 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var skewness = require( './../lib' );
 
-var v;
-var i;
-var n;
-var p;
+var opts = {
+	'dtype': 'float64'
+};
+var n = discreteUniform( 10, 0, 100, opts );
+var p = discreteUniform( 10, 0, 1, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	n = round( randu() * 100.0 );
-	p = randu();
-	v = skewness( n, p );
-	console.log( 'n: %d, p: %d, skew(X;n,p): %d', n, p.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'n: %0.4f, p: %0.4f, skew(X;n,p): %0.4f', n, p, skewness );

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/stdev/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/stdev/README.md
@@ -120,21 +120,17 @@ v = stdev( 20, 1.5 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var stdev = require( '@stdlib/stats/base/dists/binomial/stdev' );
 
-var v;
-var i;
-var n;
-var p;
+var opts = {
+    'dtype': 'float64'
+};
+var n = discreteUniform( 10, 0, 100, opts );
+var p = discreteUniform( 10, 0, 1, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    n = round( randu() * 100.0 );
-    p = randu();
-    v = stdev( n, p );
-    console.log( 'n: %d, p: %d, SD(X;n,p): %d', n, p.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'n: %0.4f, p: %0.4f, SD(X;n,p): %0.4f', n, p, stdev );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/stdev/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/stdev/README.md
@@ -121,6 +121,7 @@ v = stdev( 20, 1.5 );
 
 ```javascript
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var stdev = require( '@stdlib/stats/base/dists/binomial/stdev' );
 
@@ -128,7 +129,7 @@ var opts = {
     'dtype': 'float64'
 };
 var n = discreteUniform( 10, 0, 100, opts );
-var p = discreteUniform( 10, 0, 1, opts );
+var p = uniform( 10, 0.0, 1.0, opts );
 
 logEachMap( 'n: %0.4f, p: %0.4f, SD(X;n,p): %0.4f', n, p, stdev );
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/stdev/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/stdev/examples/index.js
@@ -18,18 +18,14 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var stdev = require( './../lib' );
 
-var v;
-var i;
-var n;
-var p;
+var opts = {
+	'dtype': 'float64'
+};
+var n = discreteUniform( 10, 0, 100, opts );
+var p = discreteUniform( 10, 0, 1, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	n = round( randu() * 100.0 );
-	p = randu();
-	v = stdev( n, p );
-	console.log( 'n: %d, p: %d, SD(X;n,p): %d', n, p.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'n: %0.4f, p: %0.4f, SD(X;n,p): %0.4f', n, p, stdev );

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/stdev/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/stdev/examples/index.js
@@ -19,6 +19,7 @@
 'use strict';
 
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var stdev = require( './../lib' );
 
@@ -26,6 +27,6 @@ var opts = {
 	'dtype': 'float64'
 };
 var n = discreteUniform( 10, 0, 100, opts );
-var p = discreteUniform( 10, 0, 1, opts );
+var p = uniform( 10, 0.0, 1.0, opts );
 
 logEachMap( 'n: %0.4f, p: %0.4f, SD(X;n,p): %0.4f', n, p, stdev );

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/variance/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/variance/README.md
@@ -121,6 +121,7 @@ v = variance( 20, 1.5 );
 
 ```javascript
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var variance = require( '@stdlib/stats/base/dists/binomial/variance' );
 
@@ -128,7 +129,7 @@ var opts = {
     'dtype': 'float64'
 };
 var n = discreteUniform( 10, 0, 100, opts );
-var p = discreteUniform( 10, 0, 1, opts );
+var p = uniform( 10, 0.0, 1.0, opts );
 
 logEachMap( 'n: %0.4f, p: %0.4f, Var(X;n,p): %0.4f', n, p, variance );
 ```

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/variance/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/variance/README.md
@@ -120,21 +120,17 @@ v = variance( 20, 1.5 );
 <!-- eslint no-undef: "error" -->
 
 ```javascript
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var variance = require( '@stdlib/stats/base/dists/binomial/variance' );
 
-var v;
-var i;
-var n;
-var p;
+var opts = {
+    'dtype': 'float64'
+};
+var n = discreteUniform( 10, 0, 100, opts );
+var p = discreteUniform( 10, 0, 1, opts );
 
-for ( i = 0; i < 10; i++ ) {
-    n = round( randu() * 100.0 );
-    p = randu();
-    v = variance( n, p );
-    console.log( 'n: %d, p: %d, Var(X;n,p): %d', n, p.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'n: %0.4f, p: %0.4f, Var(X;n,p): %0.4f', n, p, variance );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/variance/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/variance/examples/index.js
@@ -18,18 +18,14 @@
 
 'use strict';
 
-var randu = require( '@stdlib/random/base/randu' );
-var round = require( '@stdlib/math/base/special/round' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var variance = require( './../lib' );
 
-var v;
-var i;
-var n;
-var p;
+var opts = {
+	'dtype': 'float64'
+};
+var n = discreteUniform( 10, 0, 100, opts );
+var p = discreteUniform( 10, 0, 1, opts );
 
-for ( i = 0; i < 10; i++ ) {
-	n = round( randu() * 100.0 );
-	p = randu();
-	v = variance( n, p );
-	console.log( 'n: %d, p: %d, Var(X;n,p): %d', n, p.toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'n: %0.4f, p: %0.4f, Var(X;n,p): %0.4f', n, p, variance );

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/variance/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/variance/examples/index.js
@@ -19,6 +19,7 @@
 'use strict';
 
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var uniform = require( '@stdlib/random/array/uniform' );
 var logEachMap = require( '@stdlib/console/log-each-map' );
 var variance = require( './../lib' );
 
@@ -26,6 +27,6 @@ var opts = {
 	'dtype': 'float64'
 };
 var n = discreteUniform( 10, 0, 100, opts );
-var p = discreteUniform( 10, 0, 1, opts );
+var p = uniform( 10, 0.0, 1.0, opts );
 
 logEachMap( 'n: %0.4f, p: %0.4f, Var(X;n,p): %0.4f', n, p, variance );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `stats/base/dists/binomial/mgf`, `stats/base/dists/binomial/mode`, `stats/base/dists/binomial/pmf`, `stats/base/dists/binomial/quantile`, `stats/base/dists/binomial/skewness`, `stats/base/dists/binomial/stdev` and `stats/base/dists/binomial/variance` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
