### PR TITLE
chore: fix C lint errors (issue #6778)

### DIFF
--- a/lib/node_modules/@stdlib/strided/base/unary/examples/c/example.c
+++ b/lib/node_modules/@stdlib/strided/base/unary/examples/c/example.c
@@ -35,10 +35,10 @@ int main( void ) {
 	uint8_t *arrays[] = { x, out };
 
 	// Define the strides:
-	int64_t strides[] = { 1, 8 }; // 1 byte per uint8, 8 bytes per double
+	const int64_t strides[] = { 1, 8 }; // 1 byte per uint8, 8 bytes per double
 
 	// Define the number of elements over which to iterate:
-	int64_t shape[] = { 3 };
+	const int64_t shape[] = { 3 };
 
 	// Apply the callback:
 	stdlib_strided_b_d_as_d_d( arrays, shape, strides, (void *)scale );


### PR DESCRIPTION
This PR addresses C linting issues detected in `example.c` as part of the automated lint workflow (run ID: 14583678082).

### Changes:
- Declared `strides` and `shape` arrays as `const` since they are not modified after initialization, resolving the `constVariable` style warnings.

### Files Modified:
- `lib/node_modules/@stdlib/strided/base/unary/examples/c/example.c`

### Related Issues:
Resolves #6778
Parent: #3235

Linting should now pass for the affected file.


## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
