### PR TITLE
chore: fix EditorConfig lint errors (issue #6885)

### DIFF
--- a/lib/node_modules/@stdlib/complex/dtypes/lib/dtypes.json
+++ b/lib/node_modules/@stdlib/complex/dtypes/lib/dtypes.json
@@ -1,4 +1,4 @@
 [
-	"complex64",
-  "complex128"
+    "complex64",
+    "complex128"
 ]

--- a/lib/node_modules/@stdlib/complex/dtypes/lib/dtypes.json
+++ b/lib/node_modules/@stdlib/complex/dtypes/lib/dtypes.json
@@ -1,4 +1,4 @@
 [
-    "complex64",
-    "complex128"
+  "complex64",
+  "complex128"
 ]


### PR DESCRIPTION
Resolves #6885

## Description
- Replaced tab characters with spaces in `lib/node_modules/@stdlib/complex/dtypes/lib/dtypes.json` to comply with the project's indentation rules.


## Checklist


-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
