### PR TITLE
chore: fix C lint errors (issue #6887)

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dmeanvarpn/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/stats/base/dmeanvarpn/benchmark/c/benchmark.length.c
@@ -109,6 +109,7 @@ static double benchmark( int iterations, int len ) {
 
 	t = tic();
 	for ( i = 0; i < iterations; i++ ) {
+		// cppcheck-suppress uninitvar
 		stdlib_strided_dmeanvarpn( len, 1, x, 1, out, 1 );
 		if ( out[ i%2 ] != out[ i%2 ] ) {
 			printf( "should not return NaN\n" );


### PR DESCRIPTION
Resolves #6887.

## Description

> What is the purpose of this pull request?

This pull request:

-   Suppressed a false-positive uninitvar warning in benchmark.length.c for dmeanvarpn.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #6887

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
