### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/cdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/cdf/README.md
@@ -119,17 +119,16 @@ y = myPDF( 1.0 );
 
 ```javascript
 var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var cdf = require( '@stdlib/stats/base/dists/bradford/cdf' );
 
-var x = uniform( 10, 0.0, 1.0 );
-var c = uniform( 10, 0.1, 10.0 );
+var opts = {
+    'dtype': 'float64'
+};
+var x = uniform( 10, 0.0, 1.0, opts );
+var c = uniform( 10, 0.1, 10.0, opts );
 
-var y;
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    y = cdf( x[ i ], c[ i ] );
-    console.log( 'x: %d, c: %d, F(x;c): %d', x[ i ].toFixed( 4 ), c[ i ].toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 'x: %0.4f, c: %0.4f, F(x;c): %0.4f', x, c, cdf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/cdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/cdf/examples/index.js
@@ -19,14 +19,13 @@
 'use strict';
 
 var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var cdf = require( './../lib' );
 
-var x = uniform( 10, 0.0, 1.0 );
-var c = uniform( 10, 0.1, 10.0 );
+var opts = {
+	'dtype': 'float64'
+};
+var x = uniform( 10, 0.0, 1.0, opts );
+var c = uniform( 10, 0.1, 10.0, opts );
 
-var y;
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	y = cdf( x[ i ], c[ i ] );
-	console.log( 'x: %d, c: %d, F(x;c): %d', x[ i ].toFixed( 4 ), c[ i ].toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 'x: %0.4f, c: %0.4f, F(x;c): %0.4f', x, c, cdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/entropy/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/entropy/README.md
@@ -101,16 +101,15 @@ v = entropy( -1.5 );
 
 ```javascript
 var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var entropy = require( '@stdlib/stats/base/dists/bradford/entropy' );
 
-var c = uniform( 10, 0.1, 10.0 );
+var opts = {
+    'dtype': 'float64'
+};
+var c = uniform( 10, 0.1, 10.0, opts );
 
-var v;
-var i;
-for ( i = 0; i < c.length; i++ ) {
-    v = entropy( c[ i ] );
-    console.log( 'c: %d, h(X;c): %d', c[ i ].toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'c: %0.4f, h(X;c): %0.4f', c, entropy );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/entropy/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/entropy/examples/index.js
@@ -19,13 +19,12 @@
 'use strict';
 
 var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var entropy = require( './../lib' );
 
-var c = uniform( 10, 0.1, 10.0 );
+var opts = {
+	'dtype': 'float64'
+};
+var c = uniform( 10, 0.1, 10.0, opts );
 
-var v;
-var i;
-for ( i = 0; i < c.length; i++ ) {
-	v = entropy( c[ i ] );
-	console.log( 'c: %d, h(X;c): %d', c[ i ].toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'c: %0.4f, h(X;c): %0.4f', c, entropy );

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/mean/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/mean/README.md
@@ -101,16 +101,16 @@ v = mean( -1.5 );
 
 ```javascript
 var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var mean = require( '@stdlib/stats/base/dists/bradford/mean' );
 
-var c = uniform( 10, 0.1, 10.0 );
+var opts = {
+    'dtype': 'float64'
+};
+var c = uniform( 10, 0.1, 10.0, opts );
 
-var v;
-var i;
-for ( i = 0; i < c.length; i++ ) {
-    v = mean( c[ i ] );
-    console.log( 'c: %d, E(X;c): %d', c[ i ].toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'c: %0.4f, E(X;c): %0.4f', c, mean );
+
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/mean/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/mean/examples/index.js
@@ -19,13 +19,12 @@
 'use strict';
 
 var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var mean = require( './../lib' );
 
-var c = uniform( 10, 0.1, 10.0 );
+var opts = {
+	'dtype': 'float64'
+};
+var c = uniform( 10, 0.1, 10.0, opts );
 
-var v;
-var i;
-for ( i = 0; i < c.length; i++ ) {
-	v = mean( c[ i ] );
-	console.log( 'c: %d, E(X;c): %d', c[ i ].toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'c: %0.4f, E(X;c): %0.4f', c, mean );

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/median/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/median/README.md
@@ -101,16 +101,15 @@ v = median( -1.5 );
 
 ```javascript
 var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var median = require( '@stdlib/stats/base/dists/bradford/median' );
 
-var c = uniform( 10, 0.1, 10.0 );
+var opts = {
+    'dtype': 'float64'
+};
+var c = uniform( 10, 0.1, 10.0, opts );
 
-var v;
-var i;
-for ( i = 0; i < c.length; i++ ) {
-    v = median( c[ i ] );
-    console.log( 'c: %d, Median(X;c): %d', c[ i ].toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'c: %0.4f, Median(X;c): %0.4f', c, median );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/median/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/median/examples/index.js
@@ -19,13 +19,12 @@
 'use strict';
 
 var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var median = require( './../lib' );
 
-var c = uniform( 10, 0.1, 10.0 );
+var opts = {
+	'dtype': 'float64'
+};
+var c = uniform( 10, 0.1, 10.0, opts );
 
-var v;
-var i;
-for ( i = 0; i < c.length; i++ ) {
-	v = median( c[ i ] );
-	console.log( 'c: %d, Median(X;c): %d', c[ i ].toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'c: %0.4f, Median(X;c): %0.4f', c, median );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `stats/base/dists/bradford/cdf`, `stats/base/dists/bradford/entropy`, `stats/base/dists/bradford/mean` and `stats/base/dists/bradford/median` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
