### PR TITLE
docs: replace manual `for` loop in examples

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/mode/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/mode/README.md
@@ -101,16 +101,15 @@ v = mode( -1.5 );
 
 ```javascript
 var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var mode = require( '@stdlib/stats/base/dists/bradford/mode' );
 
-var c = uniform( 10, 0.1, 10.0 );
+var opts = {
+    'dtype': 'float64'
+};
+var c = uniform( 10, 0.1, 10.0, opts );
 
-var v;
-var i;
-for ( i = 0; i < c.length; i++ ) {
-    v = mode( c[ i ] );
-    console.log( 'c: %d, mode(X;c): %d', c[ i ].toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'c: %0.4f, mode(X;c): %0.4f', c, mode );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/mode/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/mode/examples/index.js
@@ -19,13 +19,12 @@
 'use strict';
 
 var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var mode = require( './../lib' );
 
-var c = uniform( 10, 0.1, 10.0 );
+var opts = {
+	'dtype': 'float64'
+};
+var c = uniform( 10, 0.1, 10.0, opts );
 
-var v;
-var i;
-for ( i = 0; i < c.length; i++ ) {
-	v = mode( c[ i ] );
-	console.log( 'c: %d, mode(X;c): %d', c[ i ].toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'c: %0.4f, mode(X;c): %0.4f', c, mode );

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/pdf/README.md
@@ -123,17 +123,16 @@ y = myPDF( 1.0 );
 
 ```javascript
 var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var pdf = require( '@stdlib/stats/base/dists/bradford/pdf' );
 
-var x = uniform( 10, 0.0, 1.0 );
-var c = uniform( 10, 0.1, 10.0 );
+var opts = {
+    'dtype': 'float64'
+};
+var c = uniform( 10, 0.0, 1.0, opts );
+var x = uniform( 10, 0.1, 10.0, opts );
 
-var y;
-var i;
-for ( i = 0; i < x.length; i++ ) {
-    y = pdf( x[ i ], c[ i ] );
-    console.log( 'x: %d, c: %d, f(x;c): %d', x[ i ].toFixed( 4 ), c[ i ].toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 'x: %0.4f, c: %0.4f, f(x;c): %0.4f', x, c, pdf );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/pdf/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/pdf/examples/index.js
@@ -19,14 +19,13 @@
 'use strict';
 
 var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var pdf = require( './../lib' );
 
-var x = uniform( 10, 0.0, 1.0 );
-var c = uniform( 10, 0.1, 10.0 );
+var opts = {
+	'dtype': 'float64'
+};
+var c = uniform( 10, 0.0, 1.0, opts );
+var x = uniform( 10, 0.1, 10.0, opts );
 
-var y;
-var i;
-for ( i = 0; i < x.length; i++ ) {
-	y = pdf( x[ i ], c[ i ] );
-	console.log( 'x: %d, c: %d, f(x;c): %d', x[ i ].toFixed( 4 ), c[ i ].toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 'x: %0.4f, c: %0.4f, f(x;c): %0.4f', x, c, pdf );

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/quantile/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/quantile/README.md
@@ -126,17 +126,16 @@ y = myquantile( 1.0 );
 
 ```javascript
 var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var quantile = require( '@stdlib/stats/base/dists/bradford/quantile' );
 
-var p = uniform( 10, 0.0, 1.0 );
-var c = uniform( 10, 0.1, 10.0 );
+var opts = {
+    'dtype': 'float64'
+};
+var p = uniform( 10, 0.0, 1.0, opts );
+var c = uniform( 10, 0.1, 10.0, opts );
 
-var y;
-var i;
-for ( i = 0; i < p.length; i++ ) {
-    y = quantile( p[ i ], c[ i ] );
-    console.log( 'p: %d, c: %d, Q(p;c): %d', p[ i ].toFixed( 4 ), c[ i ].toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 'p: %0.4f, c: %0.4f, Q(p;c): %0.4f', p, c, quantile );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/quantile/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/quantile/examples/index.js
@@ -19,14 +19,13 @@
 'use strict';
 
 var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var quantile = require( './../lib' );
 
-var p = uniform( 10, 0.0, 1.0 );
-var c = uniform( 10, 0.1, 10.0 );
+var opts = {
+	'dtype': 'float64'
+};
+var p = uniform( 10, 0.0, 1.0, opts );
+var c = uniform( 10, 0.1, 10.0, opts );
 
-var y;
-var i;
-for ( i = 0; i < p.length; i++ ) {
-	y = quantile( p[ i ], c[ i ] );
-	console.log( 'p: %d, c: %d, Q(p;c): %d', p[ i ].toFixed( 4 ), c[ i ].toFixed( 4 ), y.toFixed( 4 ) );
-}
+logEachMap( 'p: %0.4f, c: %0.4f, Q(p;c): %0.4f', p, c, quantile );

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/stdev/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/stdev/README.md
@@ -101,16 +101,15 @@ v = stdev( -1.5 );
 
 ```javascript
 var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var stdev = require( '@stdlib/stats/base/dists/bradford/stdev' );
 
-var c = uniform( 10, 0.1, 10.0 );
+var opts = {
+    'dtype': 'float64'
+};
+var c = uniform( 10, 0.1, 10.0, opts );
 
-var v;
-var i;
-for ( i = 0; i < c.length; i++ ) {
-    v = stdev( c[ i ] );
-    console.log( 'c: %d, SD(X;c): %d', c[ i ].toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'c: %0.4f, SD(X;c): %0.4f', c, stdev );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/stdev/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/stdev/examples/index.js
@@ -19,13 +19,12 @@
 'use strict';
 
 var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var stdev = require( './../lib' );
 
-var c = uniform( 10, 0.1, 10.0 );
+var opts = {
+	'dtype': 'float64'
+};
+var c = uniform( 10, 0.1, 10.0, opts );
 
-var v;
-var i;
-for ( i = 0; i < c.length; i++ ) {
-	v = stdev( c[ i ] );
-	console.log( 'c: %d, SD(X;c): %d', c[ i ].toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'c: %0.4f, SD(X;c): %0.4f', c, stdev );

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/variance/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/variance/README.md
@@ -101,16 +101,15 @@ v = variance( -1.5 );
 
 ```javascript
 var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var variance = require( '@stdlib/stats/base/dists/bradford/variance' );
 
-var c = uniform( 10, 0.1, 10.0 );
+var opts = {
+    'dtype': 'float64'
+};
+var c = uniform( 10, 0.1, 10.0, opts );
 
-var v;
-var i;
-for ( i = 0; i < c.length; i++ ) {
-    v = variance( c[ i ] );
-    console.log( 'c: %d, Var(X;c): %d', c[ i ].toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'c: %0.4f, Var(X;c): %0.4f', c, variance );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/stats/base/dists/bradford/variance/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bradford/variance/examples/index.js
@@ -19,13 +19,12 @@
 'use strict';
 
 var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
 var variance = require( './../lib' );
 
-var c = uniform( 10, 0.1, 10.0 );
+var opts = {
+	'dtype': 'float64'
+};
+var c = uniform( 10, 0.1, 10.0, opts );
 
-var v;
-var i;
-for ( i = 0; i < c.length; i++ ) {
-	v = variance( c[ i ] );
-	console.log( 'c: %d, Var(X;c): %d', c[ i ].toFixed( 4 ), v.toFixed( 4 ) );
-}
+logEachMap( 'c: %0.4f, Var(X;c): %0.4f', c, variance );


### PR DESCRIPTION
Resolves none .

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces manual for loop in examples for `stats/base/dists/bradford/mode`, `stats/base/dists/bradford/pdf`, `stats/base/dists/bradford/quantile`, `stats/base/dists/bradford/stdev` and `stats/base/dists/bradford/variance` packages.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves no related issues. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
