### PR TITLE
chore: address commit comments for commit `1e0529a` (issue #6912)

### DIFF
--- a/.github/workflows/scripts/generate_pr_commit_message
+++ b/.github/workflows/scripts/generate_pr_commit_message
@@ -259,9 +259,9 @@ main() {
 		#
 		#   - https://github.com/stdlib-js/stdlib/issues/123
 		#   - stdlib-js/stdlib#123
-		#   - #123 (**not** preceded by a word‑char, “/”, or “>”)
+		#   - #123 (**not** preceded by a word‑char, "/", or ">")
 		grep -oE 'https://github\.com/stdlib-js/stdlib/issues/[0-9]+|stdlib-js/stdlib#[0-9]+|(^|[^[:alnum:]_/>])#[0-9]+' |
-		# Strip the prefix so we’re left with the bare issue number:
+		# Strip the prefix so we're left with the bare issue number:
 		sed -E '
 		s@https://github\.com/stdlib-js/stdlib/issues/([0-9]+)@\1@;
 		s@stdlib-js/stdlib#([0-9]+)@\1@;


### PR DESCRIPTION
Resolves #6912 .

This PR addresses a commit comment for commit `1e0529a`.

### Changes Made:
- Replaced a typographic (“smart”) quote with a standard ASCII quote (") in a comment explaining GitHub issue reference formats in `.github/workflows/scripts/generate_pr_commit_message`.
- This change improves clarity and avoids confusion in regex documentation and parsing logic.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
