### PR TITLE
chore: fix EditorConfig lint errors (issue #6942)

### DIFF
--- a/lib/node_modules/@stdlib/constants/time/minutes-in-week/README.md
+++ b/lib/node_modules/@stdlib/constants/time/minutes-in-week/README.md
@@ -47,7 +47,7 @@ var bool = ( MINUTES_IN_WEEK === 10080 );
 
 ## Notes
 
--   The value is a generalization and does **not** take into account inaccuracies due to daylight savings conventions, crossing timezones, or other complications with time and dates. 
+-   The value is a generalization and does **not** take into account inaccuracies due to daylight savings conventions, crossing timezones, or other complications with time and dates.
 
 </section>
 


### PR DESCRIPTION
### Description
This PR fixes the trailing whitespace error in the `lib/node_modules/@stdlib/constants/time/minutes-in-week/README.md` file (line 50) as detected by the EditorConfig linting workflow.

### Related Issue
Resolves #6942.

No.

## Checklist


-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
