### PR TITLE
fix: disable zero-padding for special values in `string/base/format-interpolate`

### DIFF
--- a/lib/node_modules/@stdlib/string/base/format-interpolate/lib/format_double.js
+++ b/lib/node_modules/@stdlib/string/base/format-interpolate/lib/format_double.js
@@ -20,8 +20,6 @@
 
 // MODULES //
 
-var isNumber = require( './is_number.js' );
-
 // NOTE: for the following, we explicitly avoid using stdlib packages in this particular package in order to avoid circular dependencies.
 var abs = Math.abs; // eslint-disable-line stdlib/no-builtin-math
 var lowercase = String.prototype.toLowerCase;
@@ -46,21 +44,15 @@ var RE_ZERO_BEFORE_EXP = /(\..*[^0])0*e/;
 * Formats a token object argument as a floating-point number.
 *
 * @private
+* @param {number} f - parsed number
 * @param {Object} token - token object
 * @throws {Error} must provide a valid floating-point number
 * @returns {string} formatted token argument
 */
-function formatDouble( token ) {
+function formatDouble( f, token ) {
 	var digits;
 	var out;
-	var f = parseFloat( token.arg );
-	if ( !isFinite( f ) ) { // NOTE: We use the global `isFinite` function here instead of `@stdlib/math/base/assert/is-finite` in order to avoid circular dependencies.
-		if ( !isNumber( token.arg ) ) {
-			throw new Error( 'invalid floating-point number. Value: ' + out );
-		}
-		// Case: NaN, Infinity, or -Infinity
-		f = token.arg;
-	}
+
 	switch ( token.specifier ) {
 	case 'e':
 	case 'E':

--- a/lib/node_modules/@stdlib/string/base/format-interpolate/lib/main.js
+++ b/lib/node_modules/@stdlib/string/base/format-interpolate/lib/main.js
@@ -22,6 +22,7 @@
 
 var formatInteger = require( './format_integer.js' );
 var isString = require( './is_string.js' );
+var isNumber = require( './is_number.js' );
 var formatDouble = require( './format_double.js' );
 var spacePad = require( './space_pad.js' );
 var zeroPad = require( './zero_pad.js' );
@@ -96,6 +97,7 @@ function formatInterpolate( tokens ) {
 	var num;
 	var out;
 	var pos;
+	var f;
 	var i;
 	var j;
 
@@ -205,7 +207,16 @@ function formatInterpolate( tokens ) {
 				if ( !hasPeriod ) {
 					token.precision = 6;
 				}
-				token.arg = formatDouble( token );
+				f = parseFloat( token.arg );
+				if ( !isFinite( f ) ) { // NOTE: We use the global `isFinite` function here instead of `@stdlib/math/base/assert/is-finite` in order to avoid circular dependencies.
+					if ( !isNumber( token.arg ) ) {
+						throw new Error( 'invalid floating-point number. Value: ' + out );
+					}
+					// Case: NaN, Infinity, or -Infinity
+					f = token.arg;
+					token.padZeros = false;
+				}
+				token.arg = formatDouble( f, token );
 				break;
 			default:
 				throw new Error( 'invalid specifier: ' + token.specifier );

--- a/lib/node_modules/@stdlib/string/base/format-interpolate/test/test.format_double.js
+++ b/lib/node_modules/@stdlib/string/base/format-interpolate/test/test.format_double.js
@@ -44,7 +44,7 @@ tape( 'the function returns a double-formatted token argument', function test( t
 		'precision': 2
 	};
 	expected = '3.14';
-	actual = formatDouble( token );
+	actual = formatDouble( PI, token );
 	t.strictEqual( actual, expected, 'returns expected value' );
 
 	token = {
@@ -53,7 +53,7 @@ tape( 'the function returns a double-formatted token argument', function test( t
 		'precision': 4
 	};
 	expected = '3.1416';
-	actual = formatDouble( token );
+	actual = formatDouble( PI, token );
 	t.strictEqual( actual, expected, 'returns expected value' );
 
 	token = {
@@ -62,7 +62,7 @@ tape( 'the function returns a double-formatted token argument', function test( t
 		'precision': 2
 	};
 	expected = '3.14e+00';
-	actual = formatDouble( token );
+	actual = formatDouble( PI, token );
 	t.strictEqual( actual, expected, 'returns expected value' );
 
 	token = {
@@ -71,7 +71,7 @@ tape( 'the function returns a double-formatted token argument', function test( t
 		'precision': 2
 	};
 	expected = '3.14E+00';
-	actual = formatDouble( token );
+	actual = formatDouble( PI, token );
 	t.strictEqual( actual, expected, 'returns expected value' );
 
 	t.end();
@@ -89,7 +89,7 @@ tape( 'the function returns a double-formatted token argument (include sign)', f
 		'sign': '+'
 	};
 	expected = '+3.14';
-	actual = formatDouble( token );
+	actual = formatDouble( PI, token );
 	t.strictEqual( actual, expected, 'returns expected value' );
 
 	token = {
@@ -99,7 +99,7 @@ tape( 'the function returns a double-formatted token argument (include sign)', f
 		'sign': '-'
 	};
 	expected = '-3.1416';
-	actual = formatDouble( token );
+	actual = formatDouble( PI, token );
 	t.strictEqual( actual, expected, 'returns expected value' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/string/base/format-interpolate/test/test.js
+++ b/lib/node_modules/@stdlib/string/base/format-interpolate/test/test.js
@@ -625,6 +625,30 @@ tape( 'the function returns a formatted string (`f` specifier, specified precisi
 	expected = 'beep 5.000';
 	t.strictEqual( actual, expected, 'returns expected output' );
 
+	str = '%.10f %.10f baz';
+	tokens = formatTokenize( str );
+	actual = formatInterpolate( tokens, PINF, NINF );
+	expected = 'infinity -infinity baz';
+	t.strictEqual( actual, expected, 'returns expected output' );
+
+	str = '%0.10f %0.10f baz';
+	tokens = formatTokenize( str );
+	actual = formatInterpolate( tokens, PINF, NINF );
+	expected = 'infinity -infinity baz';
+	t.strictEqual( actual, expected, 'returns expected output' );
+
+	str = '%.4f';
+	tokens = formatTokenize( str );
+	actual = formatInterpolate( tokens, NaN );
+	expected = 'nan';
+	t.strictEqual( actual, expected, 'returns expected output' );
+
+	str = '%0.4f';
+	tokens = formatTokenize( str );
+	actual = formatInterpolate( tokens, NaN );
+	expected = 'nan';
+	t.strictEqual( actual, expected, 'returns expected output' );
+
 	t.end();
 });
 
@@ -650,6 +674,18 @@ tape( 'the function returns a formatted string (`f` specifier, variable precisio
 	tokens = formatTokenize( str );
 	actual = formatInterpolate( tokens, 3, PI, 3, PI );
 	expected = '3.142 3.142 baz';
+	t.strictEqual( actual, expected, 'returns expected output' );
+
+	str = '%.*f %.*f baz';
+	tokens = formatTokenize( str );
+	actual = formatInterpolate( tokens, 10, PINF, 10, NINF );
+	expected = 'infinity -infinity baz';
+	t.strictEqual( actual, expected, 'returns expected output' );
+
+	str = '%.*f';
+	tokens = formatTokenize( str );
+	actual = formatInterpolate( tokens, 4, NaN );
+	expected = 'nan';
 	t.strictEqual( actual, expected, 'returns expected output' );
 
 	t.end();
@@ -820,6 +856,18 @@ tape( 'the function returns a formatted string (`f` specifier, minimum width, de
 	expected = '   3.140 5.000 baz';
 	t.strictEqual( actual, expected, 'returns expected output' );
 
+	str = '%10.10f %10.10f baz';
+	tokens = formatTokenize( str );
+	actual = formatInterpolate( tokens, PINF, NINF );
+	expected = '  infinity  -infinity baz';
+	t.strictEqual( actual, expected, 'returns expected output' );
+
+	str = '%8.4f';
+	tokens = formatTokenize( str );
+	actual = formatInterpolate( tokens, NaN );
+	expected = '     nan';
+	t.strictEqual( actual, expected, 'returns expected output' );
+
 	t.end();
 });
 
@@ -845,6 +893,18 @@ tape( 'the function returns a formatted string (`f` specifier, minimum width, le
 	tokens = formatTokenize( str );
 	actual = formatInterpolate( tokens, 3.14, 5.0 );
 	expected = '3.140    5.000 baz';
+	t.strictEqual( actual, expected, 'returns expected output' );
+
+	str = '%-10.10f %10.10f baz';
+	tokens = formatTokenize( str );
+	actual = formatInterpolate( tokens, PINF, NINF );
+	expected = 'infinity    -infinity baz';
+	t.strictEqual( actual, expected, 'returns expected output' );
+
+	str = '%-8.4f';
+	tokens = formatTokenize( str );
+	actual = formatInterpolate( tokens, NaN );
+	expected = 'nan     ';
 	t.strictEqual( actual, expected, 'returns expected output' );
 
 	t.end();

--- a/lib/node_modules/@stdlib/string/base/format-interpolate/test/test.js
+++ b/lib/node_modules/@stdlib/string/base/format-interpolate/test/test.js
@@ -682,7 +682,19 @@ tape( 'the function returns a formatted string (`f` specifier, variable precisio
 	expected = 'infinity -infinity baz';
 	t.strictEqual( actual, expected, 'returns expected output' );
 
+	str = '%0.*f %0.*f baz';
+	tokens = formatTokenize( str );
+	actual = formatInterpolate( tokens, 10, PINF, 10, NINF );
+	expected = 'infinity -infinity baz';
+	t.strictEqual( actual, expected, 'returns expected output' );
+
 	str = '%.*f';
+	tokens = formatTokenize( str );
+	actual = formatInterpolate( tokens, 4, NaN );
+	expected = 'nan';
+	t.strictEqual( actual, expected, 'returns expected output' );
+
+	str = '%0.*f';
 	tokens = formatTokenize( str );
 	actual = formatInterpolate( tokens, 4, NaN );
 	expected = 'nan';


### PR DESCRIPTION
Resolves None

## Description

> What is the purpose of this pull request?

This pull request:

- Updates `format-interpolate` to disable zero-padding for special values

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md