### PR TITLE
refactor(clippath): replace manual args handling with spread operator

### DIFF
--- a/lib/node_modules/@stdlib/plot/components/svg/clip-path/lib/main.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/clip-path/lib/main.js
@@ -129,13 +129,8 @@ function ClipPath( options ) {
 	*/
 	function onRender() {
 		var args;
-		var i;
 		debug( 'Received a render event. Re-emitting...' );
-		args = new Array( arguments.length+1 );
-		args[ 0 ] = 'render';
-		for ( i = 0; i < arguments.length; i++ ) {
-			args[ i+1 ] = arguments[ i ];
-		}
+		args = [ 'render', ...Array.from( arguments ) ];
 		self.emit.apply( self, args );
 	}
 }


### PR DESCRIPTION
Resolves #6956.

## Description

This pull request:

- Refactors the `onRender` function in `ClipPath` to use the spread operator (`...arguments`) instead of manual array creation for emitting events.
- Also solves linting error.
- Improves code readability and aligns with modern JavaScript practices.
- Maintains identical functionality while reducing boilerplate.

## Related Issues

This pull request:
-   resolves #6956 issue.

## Questions

No.

## Other

No.
* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
