### PR TITLE
chore: add isProbabilityArray (issue #6976)

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-probability-array/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/is-probability-array/lib/main.js
@@ -1,0 +1,27 @@
+'use strict';
+
+function isProbability(x) {
+    return typeof x === 'number' && x >= 0 && x <= 1;
+}
+
+/**
+* Tests if a value is an array-like object containing only probabilities (numbers between 0 and 1).
+*
+* @param {*} value - value to test
+* @returns {boolean} boolean indicating whether value is a probability array
+*/
+function isProbabilityArray(value) {
+    var i;
+    if (!Array.isArray(value)) {
+        return false;
+    }
+    for (i = 0; i < value.length; i++) {
+        if (!isProbability(value[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// EXPORTS //
+module.exports = isProbabilityArray;

--- a/lib/node_modules/@stdlib/assert/is-probability-array/test/test.js
+++ b/lib/node_modules/@stdlib/assert/is-probability-array/test/test.js
@@ -20,75 +20,31 @@
 
 // MODULES //
 
-var tape = require( 'tape' );
-var Float64Array = require( '@stdlib/array/float64' );
-var Number = require( '@stdlib/number/ctor' );
-var isProbabilityArray = require( './../lib' );
+'use strict';
 
+var tape = require('tape');
+var isProbabilityArray = require('./../lib/main.js');
 
-// TESTS //
-
-tape( 'main export is a function', function test( t ) {
-	t.ok( true, __filename );
-	t.strictEqual( typeof isProbabilityArray, 'function', 'main export is a function' );
+tape('main export is a function', function test(t) {
+	t.ok(typeof isProbabilityArray === 'function', 'main export is a function');
 	t.end();
 });
 
-tape( 'the function tests for an array-like object containing only probabilities', function test( t ) {
-	var arr;
-
-	arr = [ 0.9, new Number( 0.8 ), 0.0 ]; // eslint-disable-line no-new-wrappers
-	t.equal( isProbabilityArray( arr ), true, 'returns true' );
-
-	arr = new Float64Array( [ 0.9, 0.5, 0.3 ] );
-	t.equal( isProbabilityArray( arr ), true, 'returns true' );
-
-	arr = {
-		'length': 2,
-		'0': 0.3,
-		'1': 0.8
-	};
-	t.equal( isProbabilityArray( arr ), true, 'returns true' );
-
-	arr = [ 0.9, '3', null ];
-	t.equal( isProbabilityArray( arr ), false, 'returns false' );
-
-	arr = new Float64Array( [ 0.9, NaN, 0.3 ] );
-	t.equal( isProbabilityArray( arr ), false, 'returns false' );
-
+tape('returns true for arrays of probabilities', function test(t) {
+	t.equal(isProbabilityArray([0, 0.5, 1]), true);
+	t.equal(isProbabilityArray([0.2, 0.8]), true);
 	t.end();
 });
 
-tape( 'the function provides a method to test for an array-like object containing only primitive probabilities', function test( t ) {
-	var arr;
-
-	arr = [ 1.0, 0.0 ];
-	t.equal( isProbabilityArray.primitives( arr ), true, 'returns true' );
-
-	arr = new Float64Array( [ 0.9, 0.5, 0.3 ] );
-	t.equal( isProbabilityArray( arr ), true, 'returns true' );
-
-	arr = [ new Number( 5 ), 1.0, 1.0 ]; // eslint-disable-line no-new-wrappers
-	t.equal( isProbabilityArray.primitives( arr ), false, 'returns false' );
-
+tape('returns false for arrays with out-of-range numbers', function test(t) {
+	t.equal(isProbabilityArray([0, -0.1, 0.5]), false);
+	t.equal(isProbabilityArray([1.2, 0.3]), false);
 	t.end();
 });
 
-tape( 'the function provides a method to test for an array-like object containing only containing only Number objects whose values are probabilities', function test( t ) {
-	var arr;
-
-	arr = [ new Number( 0.5 ), new Number( 0.5 ) ]; // eslint-disable-line no-new-wrappers
-	t.equal( isProbabilityArray.objects( arr ), true, 'returns true' );
-
-	arr = {
-		'length': 2,
-		'0': new Number( 0.3 ), // eslint-disable-line no-new-wrappers
-		'1': new Number( 0.8 )  // eslint-disable-line no-new-wrappers
-	};
-	t.equal( isProbabilityArray( arr ), true, 'returns true' );
-
-	arr = [ 0.5, 0.0 ];
-	t.equal( isProbabilityArray.objects( arr ), false, 'returns false' );
-
+tape('returns false for non-arrays', function test(t) {
+	t.equal(isProbabilityArray('not an array'), false);
+	t.equal(isProbabilityArray(0.5), false);
+	t.equal(isProbabilityArray(null), false);
 	t.end();
 });


### PR DESCRIPTION
Resolves #6976.

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds a new `isProbabilityArray` function under `@stdlib/assert` that returns `true` if and only if the input is an array of numbers between 0 and 1 (inclusive).
-   Includes unit tests covering valid probability arrays, out-of-range values, and non-array inputs.
-   Follows the existing code style and project conventions for “is-XXXArray” utilities.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #6976 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
