### PR TITLE
fix: use correct dependencies in `manifest.json` of `blas/base/zscal`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/zscal/manifest.json
+++ b/lib/node_modules/@stdlib/blas/base/zscal/manifest.json
@@ -143,7 +143,7 @@
       "dependencies": [
         "@stdlib/blas/base/shared",
         "@stdlib/strided/base/min-view-buffer-index",
-        "@stdlib/complex/float32/ctor"
+        "@stdlib/complex/float64/ctor"
       ]
     },
     {
@@ -165,7 +165,7 @@
       "dependencies": [
         "@stdlib/blas/base/shared",
         "@stdlib/strided/base/min-view-buffer-index",
-        "@stdlib/complex/float32/ctor"
+        "@stdlib/complex/float64/ctor"
       ]
     },
 


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: na
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

none

## Description

> What is the purpose of this pull request?

This pull request:

- Change `@stdlib/complex/float32/ctor` to `@stdlib/complex/float32/ctor` in `manifest.json` of `blas/base/cscal`

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   none 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
