### PR TITLE
chore: fix EditorConfig lint errors (issue #7215)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/benchmarks/browser-build/lib/defaults.json
+++ b/lib/node_modules/@stdlib/_tools/benchmarks/browser-build/lib/defaults.json
@@ -1,7 +1,7 @@
 {
-	"pattern": "**/benchmark*.js",
-	"bundle": "benchmark_bundle.js",
-	"mount": "/",
-	"html": "benchmarks.html",
-	"title": "Benchmarks"
+  "pattern": "**/benchmark*.js",
+  "bundle": "benchmark_bundle.js",
+  "mount": "/",
+  "html": "benchmarks.html",
+  "title": "Benchmarks"
 }

--- a/lib/node_modules/@stdlib/ndarray/base/napi/typedarray-type-to-dtype/manifest.json
+++ b/lib/node_modules/@stdlib/ndarray/base/napi/typedarray-type-to-dtype/manifest.json
@@ -1,40 +1,40 @@
 {
-	"options": {},
-	"fields": [
-		{
-			"field": "src",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "include",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "libraries",
-			"resolve": false,
-			"relative": false
-		},
-		{
-			"field": "libpath",
-			"resolve": true,
-			"relative": false
-		}
-	],
-	"confs": [
-		{
-			"src": [
-				"./src/main.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [],
-			"libpath": [],
-			"dependencies": [
-				"@stdlib/ndarray/dtypes"
-			]
-		}
-	]
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/ndarray/dtypes"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: na
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Resolves #7215

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes Wrong indent style ( 2 - 6 ) in `lib/node_modules/@stdlib/_tools/benchmarks/browser-build/lib/defaults.json`
-  Fixes Wrong indent style ( 2-39 ) in `lib/node_modules/@stdlib/ndarray/base/napi/typedarray-type-to-dtype/manifest.json`

## Related Issues

> Does this pull request have any related issues?
No.

-   resolves #7215 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
