### PR TITLE
chore: fix EditorConfig lint errors (issue #7296)

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/zeros/README.md
+++ b/lib/node_modules/@stdlib/ndarray/base/zeros/README.md
@@ -57,7 +57,7 @@ var dt = arr.dtype;
 
 The function accepts the following arguments:
 
--   **dtype**: underlying [data type][@stdlib/ndarray/dtypes]. Must be a numeric [data type][@stdlib/ndarray/dtypes] or "generic". 
+-   **dtype**: underlying [data type][@stdlib/ndarray/dtypes]. Must be a numeric [data type][@stdlib/ndarray/dtypes] or "generic".
 -   **shape**: array shape.
 -   **order**: specifies whether an [ndarray][@stdlib/ndarray/base/ctor] is `'row-major'` (C-style) or `'column-major'` (Fortran-style).
 


### PR DESCRIPTION
Resolves #7296 

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes Trailing whitespace at `L:60` in `lib/node_modules/@stdlib/ndarray/base/zeros/README.md`

## Related Issues

> Does this pull request have any related issues?

No

This pull request:

-   resolves #7296 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
