### PR TITLE
feat: add assign and strided methods to csignumf

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/csignumf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2018 The Stdlib Authors.
+Copyright (c) 2025 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -75,7 +75,7 @@ im = imag( v );
 
 #### csignumf.assign( re, im, out, strideOut, offsetOut )
 
-Evaluates the signum function and assigns the result to a provided output array.
+Evaluates the signum function of single-precision complex floating-point number and assigns the result to a provided output array.
 
 ```javascript
 var Float32Array = require( '@stdlib/array/float32' );
@@ -88,9 +88,17 @@ var bool = ( out === v );
 // returns true
 ```
 
+The function supports the following parameters:
+
+-   **re**: real component of the complex number.
+-   **im**: imaginary component of the complex number.
+-   **out**: output array.
+-   **strideOut**: stride length for `out`.
+-   **offsetOut**: starting index for `out`.
+
 #### csignumf.strided( z, sz, oz, out, so, oo )
 
-Evaluates the signum function for single-precision complex numbers stored in a real-valued strided array and assigns results to a strided output array.
+Evaluates the signum function for single-precision complex floating-point number stored in a real-valued strided array and assigns results to a strided output array.
 
 ```javascript
 var Float32Array = require( '@stdlib/array/float32' );
@@ -105,11 +113,24 @@ var bool = ( out === v );
 // returns true
 ```
 
+The function supports the following parameters:
+
+-   **z**: complex number strided array view.
+-   **sz**: stride length for `z`.
+-   **oz**: starting index for `z`.
+-   **out**: output array.
+-   **so**: stride length for `out`.
+-   **oo**: starting index for `out`.
+
 </section>
+
+<!-- /.usage -->
 
 <section class="examples">
 
 ## Examples
+
+<!-- eslint no-undef: "error" -->
 
 ```javascript
 var uniform = require( '@stdlib/random/base/uniform' ).factory;

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/README.md
@@ -2,7 +2,7 @@
 
 @license Apache-2.0
 
-Copyright (c) 2025 The Stdlib Authors.
+Copyright (c) 2018 The Stdlib Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,15 +22,11 @@ limitations under the License.
 
 > Evaluate the [signum][signum] function of a single-precision complex floating-point number.
 
-<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
-
 <section class="intro">
 
 </section>
 
 <!-- /.intro -->
-
-<!-- Package usage documentation. -->
 
 <section class="usage">
 
@@ -77,25 +73,43 @@ im = imag( v );
 // returns NaN
 ```
 
+#### csignumf.assign( re, im, out, strideOut, offsetOut )
+
+Evaluates the signum function and assigns the result to a provided output array.
+
+```javascript
+var Float32Array = require( '@stdlib/array/float32' );
+
+var out = new Float32Array( 2 );
+var v = csignumf.assign( -4.2, 5.5, out, 1, 0 );
+// returns <Float32Array>[ ~-0.607, ~0.795 ]
+
+var bool = ( out === v );
+// returns true
+```
+
+#### csignumf.strided( z, sz, oz, out, so, oo )
+
+Evaluates the signum function for single-precision complex numbers stored in a real-valued strided array and assigns results to a strided output array.
+
+```javascript
+var Float32Array = require( '@stdlib/array/float32' );
+
+var z = new Float32Array( [ -4.2, 5.5 ] );
+var out = new Float32Array( 2 );
+
+var v = csignumf.strided( z, 1, 0, out, 1, 0 );
+// returns <Float32Array>[ ~-0.607, ~0.795 ]
+
+var bool = ( out === v );
+// returns true
+```
+
 </section>
-
-<!-- /.usage -->
-
-<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
-
-<section class="notes">
-
-</section>
-
-<!-- /.notes -->
-
-<!-- Package usage examples. -->
 
 <section class="examples">
 
 ## Examples
-
-<!-- eslint no-undef: "error" -->
 
 ```javascript
 var uniform = require( '@stdlib/random/base/uniform' ).factory;

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/benchmark/benchmark.assign.js
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/benchmark/benchmark.assign.js
@@ -1,0 +1,69 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var Float32Array = require( '@stdlib/array/float32' );
+var pkg = require( './../package.json' ).name;
+var csignumf = require( './../lib' );
+
+
+// VARIABLES //
+
+var options = {
+	'dtype': 'float32'
+};
+
+
+// MAIN //
+
+bench( pkg+':assign', function benchmark( b ) {
+	var out;
+	var re;
+	var im;
+	var N;
+	var i;
+	var j;
+
+	N = 100;
+	re = uniform( N, -500.0, 500.0, options );
+	im = uniform( N, -500.0, 500.0, options );
+
+	out = new Float32Array( 2 );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		j = i % N;
+		out = csignumf.assign( re[ j ], im[ j ], out, 1, 0 );
+		if ( typeof out !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+
+	if ( isnanf( out[ 0 ] ) || isnanf( out[ 1 ] ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/benchmark/benchmark.strided.js
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/benchmark/benchmark.strided.js
@@ -1,0 +1,65 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var Float32Array = require( '@stdlib/array/float32' );
+var pkg = require( './../package.json' ).name;
+var csignumf = require( './../lib' );
+
+
+// VARIABLES //
+
+var options = {
+	'dtype': 'float32'
+};
+
+
+// MAIN //
+
+bench( pkg+':strided', function benchmark( b ) {
+	var out;
+	var z;
+	var N;
+	var i;
+	var j;
+
+	N = 50;
+	z = uniform( N*2, -500.0, 500.0, options );
+	out = new Float32Array( 2 );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		j = ( i % N ) * 2;
+		out = csignumf.strided( z, 1, j, out, 1, 0 );
+		if ( typeof out !== 'object' ) {
+			b.fail( 'should return an object' );
+		}
+	}
+	b.toc();
+	if ( isnan( out[ 0 ] ) || isnan( out[ 1 ] ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/docs/repl.txt
@@ -1,7 +1,6 @@
-
 {{alias}}( z )
-    Evaluates the signum function of a single-precision complex floating-point
-    number.
+    Evaluates the signum function of a single-precision
+    complex floating-point number.
 
     Parameters
     ----------
@@ -15,12 +14,90 @@
 
     Examples
     --------
-    > var v = {{alias}}( new {{alias:@stdlib/complex/float32/ctor}}( -4.2, 5.5 ) )
+    > var Complex64 = {{alias:@stdlib/complex/float32/ctor}}
+    <Function>
+    > var realf = {{alias:@stdlib/complex/float32/real}}
+    <Function>
+    > var imagf = {{alias:@stdlib/complex/float32/imag}}
+    <Function>
+    > var v = {{alias}}( new Complex64( -4.2, 5.5 ) )
     <Complex64>
-    > var re = {{alias:@stdlib/complex/float32/real}}( v )
+    > var re = realf( v )
     ~-0.607
-    > var im = {{alias:@stdlib/complex/float32/imag}}( v )
+    > var im = imagf( v )
     ~0.795
+
+
+{{alias}}.assign( re, im, out, stride, offset )
+    Evaluates the signum function and assigns the result to a
+    provided output array.
+
+    Parameters
+    ----------
+    re: number
+        Real component.
+
+    im: number
+        Imaginary component.
+
+    out: Float32Array
+        Output array.
+
+    stride: integer
+        Output stride length.
+
+    offset: integer
+        Starting index for output.
+
+    Returns
+    -------
+    out: Float32Array
+        Output array.
+
+    Examples
+    --------
+    > var out = new Float32Array( 2 );
+    > {{alias}}.assign( -4.2, 5.5, out, 1, 0 )
+    <Float32Array>[ ~-0.607, ~0.795 ]
+
+
+{{alias}}.strided( z, sz, oz, out, so, oo )
+    Evaluates the signum function for single-precision complex numbers
+    stored in a real-valued strided input array and assigns
+    the results to a strided output array.
+
+    Parameters
+    ----------
+    z: Float32Array
+        Input array containing interleaved real and imaginary components.
+
+    sz: integer
+        Input stride length.
+
+    oz: integer
+        Starting index for input.
+
+    out: Float32Array
+        Output array.
+
+    so: integer
+        Output stride length.
+
+    oo: integer
+        Starting index for output.
+
+    Returns
+    -------
+    out: Float32Array
+        Output array.
+
+    Examples
+    --------
+    > var z = new Float32Array( [ -4.2, 5.5 ] );
+    > var out = new Float32Array( 2 );
+    > {{alias}}.strided( z, 1, 0, out, 1, 0 )
+    <Float32Array>[ ~-0.607, ~0.795 ]
+
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/docs/repl.txt
@@ -1,6 +1,7 @@
+
 {{alias}}( z )
-    Evaluates the signum function of a single-precision
-    complex floating-point number.
+    Evaluates the signum function of a single-precision complex floating-point
+    number.
 
     Parameters
     ----------
@@ -14,91 +15,83 @@
 
     Examples
     --------
-    > var Complex64 = {{alias:@stdlib/complex/float32/ctor}}
-    <Function>
-    > var realf = {{alias:@stdlib/complex/float32/real}}
-    <Function>
-    > var imagf = {{alias:@stdlib/complex/float32/imag}}
-    <Function>
-    > var v = {{alias}}( new Complex64( -4.2, 5.5 ) )
+    > var v = {{alias}}( new {{alias:@stdlib/complex/float32/ctor}}( -4.2, 5.5 ) )
     <Complex64>
-    > var re = realf( v )
+    > var re = {{alias:@stdlib/complex/float32/real}}( v )
     ~-0.607
-    > var im = imagf( v )
+    > var im = {{alias:@stdlib/complex/float32/imag}}( v )
     ~0.795
 
 
-{{alias}}.assign( re, im, out, stride, offset )
-    Evaluates the signum function and assigns the result to a
-    provided output array.
+{{alias}}.assign( re, im, out, strideOut, offsetOut )
+    Evaluates the signum function of a single-precision floating-point complex
+    number and assigns results to a provided output array.
 
     Parameters
     ----------
     re: number
-        Real component.
+        Real component of the complex number.
 
     im: number
-        Imaginary component.
+        Imaginary component of the complex number.
 
-    out: Float32Array
+    out: ArrayLikeObject
         Output array.
 
-    stride: integer
-        Output stride length.
+    strideOut: integer
+        Stride length.
 
-    offset: integer
-        Starting index for output.
+    offsetOut: integer
+        Starting index.
 
     Returns
     -------
-    out: Float32Array
+    out: ArrayLikeObject
         Output array.
 
     Examples
     --------
-    > var out = new Float32Array( 2 );
+    > var out = new {{alias:@stdlib/array/float32}}( 2 );
     > {{alias}}.assign( -4.2, 5.5, out, 1, 0 )
     <Float32Array>[ ~-0.607, ~0.795 ]
 
 
 {{alias}}.strided( z, sz, oz, out, so, oo )
-    Evaluates the signum function for single-precision complex numbers
-    stored in a real-valued strided input array and assigns
-    the results to a strided output array.
+    Evaluates the signum function of a single-precision floating-point complex
+    number stored in a real-valued strided array view and assigns results to a
+    provided strided output array.
 
     Parameters
     ----------
-    z: Float32Array
-        Input array containing interleaved real and imaginary components.
+    z: ArrayLikeObject
+        Complex number view.
 
     sz: integer
-        Input stride length.
+        Stride length for `z`.
 
     oz: integer
-        Starting index for input.
+        Starting index for `z`.
 
-    out: Float32Array
+    out: ArrayLikeObject
         Output array.
 
     so: integer
-        Output stride length.
+        Stride length for `out`.
 
     oo: integer
-        Starting index for output.
+        Starting index for `out`.
 
     Returns
     -------
-    out: Float32Array
+    out: ArrayLikeObject
         Output array.
 
     Examples
     --------
-    > var z = new Float32Array( [ -4.2, 5.5 ] );
-    > var out = new Float32Array( 2 );
+    > var z = new {{alias:@stdlib/array/float32}}( [ -4.2, 5.5 ] );
+    > var out = new {{alias:@stdlib/array/float32}}( 2 );
     > {{alias}}.strided( z, 1, 0, out, 1, 0 )
     <Float32Array>[ ~-0.607, ~0.795 ]
 
-
     See Also
     --------
-

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/docs/types/index.d.ts
@@ -30,62 +30,69 @@ interface Csignumf {
 	/**
 	* Evaluates the signum function of a single-precision complex floating-point number.
 	*
-	* @param z - input value
+	* @param z - complex number
 	* @returns result
 	*
 	* @example
 	* var Complex64 = require( '@stdlib/complex/float32/ctor' );
-	* var v = csignumf( new Complex64( -4.0, 3.0 ) );
+	* var real = require( '@stdlib/complex/float64/real' );
+	* var imag = require( '@stdlib/complex/float64/imag' );
+	*
+	* var z = new Complex64( -4.2, 5.5 );
 	* // returns <Complex64>
+	*
+	* var out = csignumf( z );
+	* // returns <Complex64>
+	*
+	* var re = real( out );
+	* // returns ~-0.607
+	*
+	* var im = imag( out );
+	* // returns ~0.795
 	*/
 	( z: Complex64 ): Complex64;
 
 	/**
 	* Evaluates the signum function and assigns the result to a provided output array.
 	*
-	* @param re - real component of the input number
-	* @param im - imaginary component of the input number
+	* @param re - real component of the complex number
+	* @param im - imaginary component of the complex number
 	* @param out - output array
-	* @param strideOut - output stride length
-	* @param offsetOut - starting index for the output
+	* @param strideOut - stride length
+	* @param offsetOut - starting index
 	* @returns output array
 	*
 	* @example
 	* var Float32Array = require( '@stdlib/array/float32' );
 	*
 	* var out = new Float32Array( 2 );
-	* var v = csignumf.assign( 3.0, 4.0, out, 1, 0 );
-	* // returns <Float32Array>[ ~0.6, ~0.8 ]
+	* var v = csignumf.assign( -4.2, 5.5, out, 1, 0 );
+	* // returns <Float32Array>[ ~-0.607, ~0.795 ]
+	*
+	* var bool = (out === v);
+	* // returns true
 	*/
 	assign<T extends NumericArray | Collection<number>>( re: number, im: number, out: T, strideOut: number, offsetOut: number ): T;
 
 	/**
-	* Evaluates the signum function for single-precision complex numbers in a strided input array and assigns the results to a strided output array.
+	* Evaluates the signum function for single-precision complex floating-point numbers stored in real-valued strided array views and assigns results to a provided strided output array.
 	*
-	* @param z - input array (interleaved real and imaginary values)
-	* @param strideZ - stride length for the input array
-	* @param offsetZ - starting index for the input array
-	* @param out - output array (interleaved real and imaginary values)
-	* @param strideOut - stride length for the output array
-	* @param offsetOut - starting index for the output array
+	* @param z - complex number view
+	* @param strideZ - stride length for `z`
+	* @param offsetZ - starting index for `z`
+	* @param out - output array
+	* @param strideOut - stride length for `out`
+	* @param offsetOut - starting index for `out`
 	* @returns output array
 	*
 	* @example
 	* var Float32Array = require( '@stdlib/array/float32' );
 	*
-	* var z = new Float32Array( [ 3.0, 4.0 ] );
-	* var out = new Float32Array( 2 );
-	* csignumf.strided( z, 1, 0, out, 1, 0 );
-	* // out => <Float32Array>[ ~0.6, ~0.8 ]
+	* var z = new Float32Array( [ -4.2, 5.5 ] );
+	* var out = csignumf.strided( z, 1, 0, out, 1, 0 );
+	* // returns <Float32Array>[ ~-0.607, ~0.795 ]
 	*/
-	strided<T extends NumericArray | Collection<number>, U extends NumericArray | Collection<number>>(
-		z: T,
-		strideZ: number,
-		offsetZ: number,
-		out: U,
-		strideOut: number,
-		offsetOut: number
-	): U;
+	strided<T extends NumericArray | Collection<number>, U extends NumericArray | Collection<number>>( z: T, strideZ: number, offsetZ: number, out: U, strideOut: number, offsetOut: number ): U;
 }
 
 /**
@@ -96,23 +103,38 @@ interface Csignumf {
 *
 * @example
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var v = csignumf( new Complex64( -4.2, 5.5 ) );
+* var real = require( '@stdlib/complex/float64/real' );
+* var imag = require( '@stdlib/complex/float64/imag' );
+*
+* var z = new Complex64( -4.2, 5.5 );
 * // returns <Complex64>
 *
+* var out = csignumf( z );
+* // returns <Complex64>
+*
+* var re = real( out );
+* // returns ~-0.607
+*
+* var im = imag( out );
+* // returns ~0.795
+*
 * @example
 * var Float32Array = require( '@stdlib/array/float32' );
 *
 * var out = new Float32Array( 2 );
-* var v = csignumf.assign( 3.0, 4.0, out, 1, 0 );
-* // returns <Float32Array>[ ~0.6, ~0.8 ]
+* var v = csignumf.assign( -4.2, 5.5, out, 1, 0 );
+* // returns <Float32Array>[ ~-0.607, ~0.795 ]
+*
+* var bool = (out === v);
+* // returns true
 *
 * @example
 * var Float32Array = require( '@stdlib/array/float32' );
 *
-* var z = new Float32Array( [ 3.0, 4.0 ] );
-* var out = new Float32Array( 2 );
-* csignumf.strided( z, 1, 0, out, 1, 0 );
-* // out => <Float32Array>[ ~0.6, ~0.8 ]
+* var z = new Float32Array( [ -4.2, 5.5 ] );
+*
+* var out = csignumf.strided( z, 1, 0, out, 1, 0 );
+* // returns <Float32Array>[ ~-0.607, ~0.795 ]
 */
 declare const csignumf: Csignumf;
 

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/docs/types/index.d.ts
@@ -21,6 +21,72 @@
 /// <reference types="@stdlib/types"/>
 
 import { Complex64 } from '@stdlib/types/complex';
+import { NumericArray, Collection } from '@stdlib/types/array';
+
+/**
+* Interface for evaluating the signum function of a single-precision complex number.
+*/
+interface Csignumf {
+	/**
+	* Evaluates the signum function of a single-precision complex floating-point number.
+	*
+	* @param z - input value
+	* @returns result
+	*
+	* @example
+	* var Complex64 = require( '@stdlib/complex/float32/ctor' );
+	* var v = csignumf( new Complex64( -4.0, 3.0 ) );
+	* // returns <Complex64>
+	*/
+	( z: Complex64 ): Complex64;
+
+	/**
+	* Evaluates the signum function and assigns the result to a provided output array.
+	*
+	* @param re - real component of the input number
+	* @param im - imaginary component of the input number
+	* @param out - output array
+	* @param strideOut - output stride length
+	* @param offsetOut - starting index for the output
+	* @returns output array
+	*
+	* @example
+	* var Float32Array = require( '@stdlib/array/float32' );
+	*
+	* var out = new Float32Array( 2 );
+	* var v = csignumf.assign( 3.0, 4.0, out, 1, 0 );
+	* // returns <Float32Array>[ ~0.6, ~0.8 ]
+	*/
+	assign<T extends NumericArray | Collection<number>>( re: number, im: number, out: T, strideOut: number, offsetOut: number ): T;
+
+	/**
+	* Evaluates the signum function for single-precision complex numbers in a strided input array and assigns the results to a strided output array.
+	*
+	* @param z - input array (interleaved real and imaginary values)
+	* @param strideZ - stride length for the input array
+	* @param offsetZ - starting index for the input array
+	* @param out - output array (interleaved real and imaginary values)
+	* @param strideOut - stride length for the output array
+	* @param offsetOut - starting index for the output array
+	* @returns output array
+	*
+	* @example
+	* var Float32Array = require( '@stdlib/array/float32' );
+	*
+	* var z = new Float32Array( [ 3.0, 4.0 ] );
+	* var out = new Float32Array( 2 );
+	* csignumf.strided( z, 1, 0, out, 1, 0 );
+	* // out => <Float32Array>[ ~0.6, ~0.8 ]
+	*/
+	strided<T extends NumericArray | Collection<number>, U extends NumericArray | Collection<number>>(
+		z: T,
+		strideZ: number,
+		offsetZ: number,
+		out: U,
+		strideOut: number,
+		offsetOut: number
+	): U;
+}
 
 /**
 * Evaluates the signum function of a single-precision complex floating-point number.
@@ -30,19 +96,25 @@ import { Complex64 } from '@stdlib/types/complex';
 *
 * @example
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var real = require( '@stdlib/complex/float32/real' );
-* var imag = require( '@stdlib/complex/float32/imag' );
-*
 * var v = csignumf( new Complex64( -4.2, 5.5 ) );
 * // returns <Complex64>
 *
-* var re = real( v );
-* // returns ~-0.607
+* @example
+* var Float32Array = require( '@stdlib/array/float32' );
 *
-* var im = imag( v );
-* // returns ~0.795
+* var out = new Float32Array( 2 );
+* var v = csignumf.assign( 3.0, 4.0, out, 1, 0 );
+* // returns <Float32Array>[ ~0.6, ~0.8 ]
+*
+* @example
+* var Float32Array = require( '@stdlib/array/float32' );
+*
+* var z = new Float32Array( [ 3.0, 4.0 ] );
+* var out = new Float32Array( 2 );
+* csignumf.strided( z, 1, 0, out, 1, 0 );
+* // out => <Float32Array>[ ~0.6, ~0.8 ]
 */
-declare function csignumf( z: Complex64 ): Complex64;
+declare const csignumf: Csignumf;
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/docs/types/test.ts
@@ -1,4 +1,4 @@
-/**
+/*
 * @license Apache-2.0
 *
 * Copyright (c) 2025 The Stdlib Authors.
@@ -22,12 +22,12 @@ import csignumf = require( './index' );
 
 // TESTS //
 
-// The function returns a Complex64...
+// The function returns an array of numbers...
 {
 	csignumf( new Complex64( 1.0, 2.0 ) ); // $ExpectType Complex64
 }
 
-// The compiler throws an error if the function is provided a value other than a Complex64...
+// The compiler throws an error if the function is provided a value other than a complex number...
 {
 	csignumf( true ); // $ExpectError
 	csignumf( false ); // $ExpectError
@@ -44,52 +44,202 @@ import csignumf = require( './index' );
 	csignumf(); // $ExpectError
 }
 
-// assign(): returns the same array type
+// Attached to the main export is an `assign` method which returns a collection...
 {
-	const out = new Float32Array( 2 );
-	csignumf.assign( 1.0, 2.0, out, 1, 0 ); // $ExpectType Float32Array
+	csignumf.assign( 1.0, 1.0, new Float64Array( 2 ), 1, 0 ); // $ExpectType Float64Array
+	csignumf.assign( 1.0, 1.0, new Float32Array( 2 ), 1, 0 ); // $ExpectType Float32Array
+	csignumf.assign( 1.0, 1.0, [ 0.0, 0.0 ], 1, 0 ); // $ExpectType number[]
 }
 
-// assign(): accepts generic collections
-{
-	const out = [ 0.0, 0.0 ];
-	csignumf.assign( 1.0, 2.0, out, 1, 0 ); // $ExpectType number[]
-}
-
-// assign(): compiler errors for invalid args
+// The compiler throws an error if the `assign` method is provided a first argument which is not a number...
 {
 	const out = new Float32Array( 2 );
-	csignumf.assign( '1', 2.0, out, 1, 0 ); // $ExpectError
+
+	csignumf.assign( true, 2.0, out, 1, 0 ); // $ExpectError
+	csignumf.assign( false, 2.0, out, 1, 0 ); // $ExpectError
+	csignumf.assign( null, 2.0, out, 1, 0 ); // $ExpectError
+	csignumf.assign( undefined, 2.0, out, 1, 0 ); // $ExpectError
+	csignumf.assign( '5', 2.0, out, 1, 0 ); // $ExpectError
+	csignumf.assign( [], 2.0, out, 1, 0 ); // $ExpectError
+	csignumf.assign( {}, 2.0, out, 1, 0 ); // $ExpectError
+	csignumf.assign( ( x: number ): number => x, 2.0, out, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `assign` method is provided a second argument which is not a number...
+{
+	const out = new Float32Array( 2 );
+
 	csignumf.assign( 1.0, true, out, 1, 0 ); // $ExpectError
+	csignumf.assign( 1.0, false, out, 1, 0 ); // $ExpectError
+	csignumf.assign( 1.0, null, out, 1, 0 ); // $ExpectError
+	csignumf.assign( 1.0, undefined, out, 1, 0 ); // $ExpectError
+	csignumf.assign( 1.0, '5', out, 1, 0 ); // $ExpectError
+	csignumf.assign( 1.0, [], out, 1, 0 ); // $ExpectError
+	csignumf.assign( 1.0, {}, out, 1, 0 ); // $ExpectError
+	csignumf.assign( 1.0, ( x: number ): number => x, out, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `assign` method is provided a third argument which is not a collection...
+{
+	csignumf.assign( 1.0, 2.0, 1, 1, 0 ); // $ExpectError
+	csignumf.assign( 1.0, 2.0, true, 1, 0 ); // $ExpectError
+	csignumf.assign( 1.0, 2.0, false, 1, 0 ); // $ExpectError
+	csignumf.assign( 1.0, 2.0, null, 1, 0 ); // $ExpectError
+	csignumf.assign( 1.0, 2.0, undefined, 1, 0 ); // $ExpectError
+	csignumf.assign( 1.0, 2.0, '5', 1, 0 ); // $ExpectError
+	csignumf.assign( 1.0, 2.0, [ '5' ], 1, 0 ); // $ExpectError
 	csignumf.assign( 1.0, 2.0, {}, 1, 0 ); // $ExpectError
-	csignumf.assign( 1.0, 2.0, out, '1', 0 ); // $ExpectError
-	csignumf.assign( 1.0, 2.0, out, 1, '0' ); // $ExpectError
-	csignumf.assign(); // $ExpectError
+	csignumf.assign( 1.0, 2.0, ( x: number ): number => x, 1, 0 ); // $ExpectError
 }
 
-// strided(): returns the same array type as output
+// The compiler throws an error if the `assign` method is provided a fourth argument which is not a number...
 {
-	const z = new Float32Array( [ 3.0, 4.0 ] );
 	const out = new Float32Array( 2 );
-	csignumf.strided( z, 2, 0, out, 2, 0 ); // $ExpectType Float32Array
+
+	csignumf.assign( 1.0, 2.0, out, true, 0 ); // $ExpectError
+	csignumf.assign( 1.0, 2.0, out, false, 0 ); // $ExpectError
+	csignumf.assign( 1.0, 2.0, out, null, 0 ); // $ExpectError
+	csignumf.assign( 1.0, 2.0, out, undefined, 0 ); // $ExpectError
+	csignumf.assign( 1.0, 2.0, out, '5', 0 ); // $ExpectError
+	csignumf.assign( 1.0, 2.0, out, [], 0 ); // $ExpectError
+	csignumf.assign( 1.0, 2.0, out, {}, 0 ); // $ExpectError
+	csignumf.assign( 1.0, 2.0, out, ( x: number ): number => x, 0 ); // $ExpectError
 }
 
-// strided(): accepts generic collections
+// The compiler throws an error if the `assign` method is provided a fifth argument which is not a number...
 {
-	const z = [ 3.0, 4.0 ];
-	const out = [ 0.0, 0.0 ];
-	csignumf.strided( z, 2, 0, out, 2, 0 ); // $ExpectType number[]
+	const out = new Float32Array( 2 );
+
+	csignumf.assign( 1.0, 2.0, out, 1, true ); // $ExpectError
+	csignumf.assign( 1.0, 2.0, out, 1, false ); // $ExpectError
+	csignumf.assign( 1.0, 2.0, out, 1, null ); // $ExpectError
+	csignumf.assign( 1.0, 2.0, out, 1, undefined ); // $ExpectError
+	csignumf.assign( 1.0, 2.0, out, 1, '5' ); // $ExpectError
+	csignumf.assign( 1.0, 2.0, out, 1, [] ); // $ExpectError
+	csignumf.assign( 1.0, 2.0, out, 1, {} ); // $ExpectError
+	csignumf.assign( 1.0, 2.0, out, 1, ( x: number ): number => x ); // $ExpectError
 }
 
-// strided(): compiler errors for invalid args
+// The compiler throws an error if the `assign` method is provided an unsupported number of arguments...
+{
+	const out = new Float32Array( 2 );
+
+	csignumf.assign(); // $ExpectError
+	csignumf.assign( 1.0 ); // $ExpectError
+	csignumf.assign( 1.0, 2.0 ); // $ExpectError
+	csignumf.assign( 1.0, 2.0, out ); // $ExpectError
+	csignumf.assign( 1.0, 2.0, out, 1 ); // $ExpectError
+	csignumf.assign( 1.0, 2.0, out, 1, 0, {} ); // $ExpectError
+}
+
+// Attached to the main export is a `strided` method which returns a collection...
 {
 	const z = new Float32Array( 2 );
-	const out = new Float32Array( 2 );
-	csignumf.strided( 'z', 2, 0, out, 2, 0 ); // $ExpectError
-	csignumf.strided( z, true, 0, out, 2, 0 ); // $ExpectError
-	csignumf.strided( z, 2, {}, out, 2, 0 ); // $ExpectError
-	csignumf.strided( z, 2, 0, 42, 2, 0 ); // $ExpectError
-	csignumf.strided( z, 2, 0, out, '2', 0 ); // $ExpectError
-	csignumf.strided( z, 2, 0, out, 2, [] ); // $ExpectError
+
+	csignumf.strided( z, 1, 0, new Float64Array( 2 ), 1, 0 ); // $ExpectType Float64Array
+	csignumf.strided( z, 1, 0, new Float32Array( 2 ), 1, 0 ); // $ExpectType Float32Array
+	csignumf.strided( z, 1, 0, [ 0.0, 0.0 ], 1, 0 ); // $ExpectType number[]
+}
+
+// The compiler throws an error if the `strided` method is provided a first argument which is not a collection...
+{
+	const z = new Float32Array( 2 );
+	const out = new Float32Array( z.length );
+
+	csignumf.strided( true, 1, 0, out, 1, 0 ); // $ExpectError
+	csignumf.strided( false, 1, 0, out, 1, 0 ); // $ExpectError
+	csignumf.strided( null, 1, 0, out, 1, 0 ); // $ExpectError
+	csignumf.strided( undefined, 1, 0, out, 1, 0 ); // $ExpectError
+	csignumf.strided( '5', 1, 0, out, 1, 0 ); // $ExpectError
+	csignumf.strided( [ '5' ], 1, 0, out, 1, 0 ); // $ExpectError
+	csignumf.strided( {}, 1, 0, out, 1, 0 ); // $ExpectError
+	csignumf.strided( ( x: number ): number => x, 1, 0, out, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `strided` method is provided a second argument which is not a number...
+{
+	const z = new Float32Array( 2 );
+	const out = new Float32Array( z.length );
+
+	csignumf.strided( z, true, 0, out, 1, 0 ); // $ExpectError
+	csignumf.strided( z, false, 0, out, 1, 0 ); // $ExpectError
+	csignumf.strided( z, null, 0, out, 1, 0 ); // $ExpectError
+	csignumf.strided( z, undefined, 0, out, 1, 0 ); // $ExpectError
+	csignumf.strided( z, '5', 0, out, 1, 0 ); // $ExpectError
+	csignumf.strided( z, [ '5' ], 0, out, 1, 0 ); // $ExpectError
+	csignumf.strided( z, {}, 0, out, 1, 0 ); // $ExpectError
+	csignumf.strided( z, ( x: number ): number => x, 0, out, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `strided` method is provided a third argument which is not a number...
+{
+	const z = new Float32Array( 2 );
+	const out = new Float32Array( z.length );
+
+	csignumf.strided( z, 1, true, out, 1, 0 ); // $ExpectError
+	csignumf.strided( z, 1, false, out, 1, 0 ); // $ExpectError
+	csignumf.strided( z, 1, null, out, 1, 0 ); // $ExpectError
+	csignumf.strided( z, 1, undefined, out, 1, 0 ); // $ExpectError
+	csignumf.strided( z, 1, '5', out, 1, 0 ); // $ExpectError
+	csignumf.strided( z, 1, [ '5' ], out, 1, 0 ); // $ExpectError
+	csignumf.strided( z, 1, {}, out, 1, 0 ); // $ExpectError
+	csignumf.strided( z, 1, ( x: number ): number => x, out, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `strided` method is provided a fourth argument which is not a collection...
+{
+	const z = new Float32Array( 2 );
+
+	csignumf.strided( z, 1, 0, true, 1, 0 ); // $ExpectError
+	csignumf.strided( z, 1, 0, false, 1, 0 ); // $ExpectError
+	csignumf.strided( z, 1, 0, null, 1, 0 ); // $ExpectError
+	csignumf.strided( z, 1, 0, undefined, 1, 0 ); // $ExpectError
+	csignumf.strided( z, 1, 0, '5', 1, 0 ); // $ExpectError
+	csignumf.strided( z, 1, 0, [ '5' ], 1, 0 ); // $ExpectError
+	csignumf.strided( z, 1, 0, {}, 1, 0 ); // $ExpectError
+	csignumf.strided( z, 1, 0, ( x: number ): number => x, 1, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `strided` method is provided a fifth argument which is not a number...
+{
+	const z = new Float32Array( 2 );
+	const out = new Float32Array( z.length );
+
+	csignumf.strided( z, 1, 0, out, true, 0 ); // $ExpectError
+	csignumf.strided( z, 1, 0, out, false, 0 ); // $ExpectError
+	csignumf.strided( z, 1, 0, out, null, 0 ); // $ExpectError
+	csignumf.strided( z, 1, 0, out, undefined, 0 ); // $ExpectError
+	csignumf.strided( z, 1, 0, out, '5', 0 ); // $ExpectError
+	csignumf.strided( z, 1, 0, out, [ '5' ], 0 ); // $ExpectError
+	csignumf.strided( z, 1, 0, out, {}, 0 ); // $ExpectError
+	csignumf.strided( z, 1, 0, out, ( x: number ): number => x, 0 ); // $ExpectError
+}
+
+// The compiler throws an error if the `strided` method is provided a sixth argument which is not a number...
+{
+	const z = new Float32Array( 2 );
+	const out = new Float32Array( z.length );
+
+	csignumf.strided( z, 1, 0, out, 1, true ); // $ExpectError
+	csignumf.strided( z, 1, 0, out, 1, false ); // $ExpectError
+	csignumf.strided( z, 1, 0, out, 1, null ); // $ExpectError
+	csignumf.strided( z, 1, 0, out, 1, undefined ); // $ExpectError
+	csignumf.strided( z, 1, 0, out, 1, '5' ); // $ExpectError
+	csignumf.strided( z, 1, 0, out, 1, [ '5' ] ); // $ExpectError
+	csignumf.strided( z, 1, 0, out, 1, {} ); // $ExpectError
+	csignumf.strided( z, 1, 0, out, 1, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the `strided` method is provided an unsupported number of arguments...
+{
+	const z = new Float32Array( 2 );
+	const out = new Float32Array( z.length );
+
 	csignumf.strided(); // $ExpectError
+	csignumf.strided( z ); // $ExpectError
+	csignumf.strided( z, 1 ); // $ExpectError
+	csignumf.strided( z, 1, 0 ); // $ExpectError
+	csignumf.strided( z, 1, 0, out ); // $ExpectError
+	csignumf.strided( z, 1, 0, out, 1 ); // $ExpectError
+	csignumf.strided( z, 1, 0, out, 1, 0, {} ); // $ExpectError
 }

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/docs/types/test.ts
@@ -1,4 +1,4 @@
-/*
+/**
 * @license Apache-2.0
 *
 * Copyright (c) 2025 The Stdlib Authors.
@@ -22,12 +22,12 @@ import csignumf = require( './index' );
 
 // TESTS //
 
-// The function returns an array of numbers...
+// The function returns a Complex64...
 {
 	csignumf( new Complex64( 1.0, 2.0 ) ); // $ExpectType Complex64
 }
 
-// The compiler throws an error if the function is provided a value other than a complex number...
+// The compiler throws an error if the function is provided a value other than a Complex64...
 {
 	csignumf( true ); // $ExpectError
 	csignumf( false ); // $ExpectError
@@ -42,4 +42,54 @@ import csignumf = require( './index' );
 // The compiler throws an error if the function is provided insufficient arguments...
 {
 	csignumf(); // $ExpectError
+}
+
+// assign(): returns the same array type
+{
+	const out = new Float32Array( 2 );
+	csignumf.assign( 1.0, 2.0, out, 1, 0 ); // $ExpectType Float32Array
+}
+
+// assign(): accepts generic collections
+{
+	const out = [ 0.0, 0.0 ];
+	csignumf.assign( 1.0, 2.0, out, 1, 0 ); // $ExpectType number[]
+}
+
+// assign(): compiler errors for invalid args
+{
+	const out = new Float32Array( 2 );
+	csignumf.assign( '1', 2.0, out, 1, 0 ); // $ExpectError
+	csignumf.assign( 1.0, true, out, 1, 0 ); // $ExpectError
+	csignumf.assign( 1.0, 2.0, {}, 1, 0 ); // $ExpectError
+	csignumf.assign( 1.0, 2.0, out, '1', 0 ); // $ExpectError
+	csignumf.assign( 1.0, 2.0, out, 1, '0' ); // $ExpectError
+	csignumf.assign(); // $ExpectError
+}
+
+// strided(): returns the same array type as output
+{
+	const z = new Float32Array( [ 3.0, 4.0 ] );
+	const out = new Float32Array( 2 );
+	csignumf.strided( z, 2, 0, out, 2, 0 ); // $ExpectType Float32Array
+}
+
+// strided(): accepts generic collections
+{
+	const z = [ 3.0, 4.0 ];
+	const out = [ 0.0, 0.0 ];
+	csignumf.strided( z, 2, 0, out, 2, 0 ); // $ExpectType number[]
+}
+
+// strided(): compiler errors for invalid args
+{
+	const z = new Float32Array( 2 );
+	const out = new Float32Array( 2 );
+	csignumf.strided( 'z', 2, 0, out, 2, 0 ); // $ExpectError
+	csignumf.strided( z, true, 0, out, 2, 0 ); // $ExpectError
+	csignumf.strided( z, 2, {}, out, 2, 0 ); // $ExpectError
+	csignumf.strided( z, 2, 0, 42, 2, 0 ); // $ExpectError
+	csignumf.strided( z, 2, 0, out, '2', 0 ); // $ExpectError
+	csignumf.strided( z, 2, 0, out, 2, [] ); // $ExpectError
+	csignumf.strided(); // $ExpectError
 }

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/lib/assign.js
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/lib/assign.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
 * @license Apache-2.0
 *
@@ -18,10 +16,12 @@
 * limitations under the License.
 */
 
+'use strict';
+
 // MODULES //
 
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
-var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var f32 = require( '@stdlib/number/float64/base/to-float32' );
 var real = require( '@stdlib/complex/float32/real' );
 var imag = require( '@stdlib/complex/float32/imag' );
 var csignumf = require( './main.js' );
@@ -30,27 +30,27 @@ var csignumf = require( './main.js' );
 // MAIN //
 
 /**
-* Evaluates the signum function for a single-precision complex number and assigns results to a strided output array.
+* Evaluates the signum function of a single-precision floating-point complex number and assigns results to a provided output array.
 *
 * @param {number} re - real component
 * @param {number} im - imaginary component
 * @param {Collection} out - output array
-* @param {integer} strideOut - stride length for output array
-* @param {NonNegativeInteger} offsetOut - starting index for output array
+* @param {integer} strideOut - stride length
+* @param {NonNegativeInteger} offsetOut - starting index
 * @returns {Collection} output array
 *
 * @example
 * var Float32Array = require( '@stdlib/array/float32' );
 *
-* var out = assign( 3.0, -4.0, new Float32Array( 2 ), 1, 0 );
-* // returns <Float32Array>[ 0.6000000238418579, -0.800000011920929 ]
+* var out = assign( -4.2, 5.5, new Float32Array( 2 ), 1, 0 );
+* // returns <Float32Array>[ ~-0.607, ~0.795 ]
 */
 function assign( re, im, out, strideOut, offsetOut ) {
-	var z = new Complex64( re, im );
-	var v = csignumf( z );
+	var z;
+	var v;
 
-	re = float64ToFloat32( re );
-	im = float64ToFloat32( im );
+	z = new Complex64( f32( re ), f32( im ) );
+	v = csignumf( z );
 
 	out[ offsetOut ] = real( v );
 	out[ offsetOut + strideOut ] = imag( v );

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/lib/assign.js
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/lib/assign.js
@@ -1,0 +1,64 @@
+'use strict';
+
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// MODULES //
+
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var real = require( '@stdlib/complex/float32/real' );
+var imag = require( '@stdlib/complex/float32/imag' );
+var csignumf = require( './main.js' );
+
+
+// MAIN //
+
+/**
+* Evaluates the signum function for a single-precision complex number and assigns results to a strided output array.
+*
+* @param {number} re - real component
+* @param {number} im - imaginary component
+* @param {Collection} out - output array
+* @param {integer} strideOut - stride length for output array
+* @param {NonNegativeInteger} offsetOut - starting index for output array
+* @returns {Collection} output array
+*
+* @example
+* var Float32Array = require( '@stdlib/array/float32' );
+*
+* var out = assign( 3.0, -4.0, new Float32Array( 2 ), 1, 0 );
+* // returns <Float32Array>[ 0.6000000238418579, -0.800000011920929 ]
+*/
+function assign( re, im, out, strideOut, offsetOut ) {
+	var z = new Complex64( re, im );
+	var v = csignumf( z );
+
+	re = float64ToFloat32( re );
+	im = float64ToFloat32( im );
+
+	out[ offsetOut ] = real( v );
+	out[ offsetOut + strideOut ] = imag( v );
+
+	return out;
+}
+
+
+// EXPORTS //
+
+module.exports = assign;

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/lib/index.js
@@ -59,9 +59,20 @@
 
 // MODULES //
 
+var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
 var main = require( './main.js' );
+var assign = require( './assign.js' );
+var strided = require( './strided.js' );
+
+
+// MAIN //
+
+setReadOnly( main, 'assign', assign );
+setReadOnly( main, 'strided', strided );
 
 
 // EXPORTS //
 
 module.exports = main;
+
+// exports: { "assign": "main.assign", "strided": "main.strided" }

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/lib/strided.js
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/lib/strided.js
@@ -32,11 +32,11 @@ var csignumf = require( './main.js' );
 * Computes the signum of a single-precision complex number stored in a real-valued strided array view and assigns the result to a provided strided output array.
 *
 * @param {Float32Array} z - complex number view (interleaved real and imaginary)
-* @param {integer} strideZ - stride length for `z`
-* @param {NonNegativeInteger} offsetZ - starting index for `z`
+* @param {integer} sz - stride length for `z`
+* @param {NonNegativeInteger} oz - starting index for `z`
 * @param {Float32Array} out - output array
-* @param {integer} strideOut - stride length for `out`
-* @param {NonNegativeInteger} offsetOut - starting index for `out`
+* @param {integer} so - stride length for `out`
+* @param {NonNegativeInteger} oo - starting index for `out`
 * @returns {Float32Array} output array
 *
 * @example
@@ -50,17 +50,17 @@ var csignumf = require( './main.js' );
 * console.log( out );
 * // => <Float32Array>[ ~0.6, ~0.8 ]
 */
-function strided( z, strideZ, offsetZ, out, strideOut, offsetOut ) {
+function strided( z, sz, oz, out, so, oo ) {
 	var result;
 	var re;
 	var im;
 
-	re = z[ offsetZ ];
-	im = z[ offsetZ + strideZ ];
+	re = z[ oz ];
+	im = z[ oz + sz ];
 	result = csignumf( new Complex64( re, im ) );
 
-	out[ offsetOut ] = real( result );
-	out[ offsetOut + strideOut ] = imag( result );
+	out[ oo ] = real( result );
+	out[ oo + so ] = imag( result );
 
 	return out;
 }

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/lib/strided.js
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/lib/strided.js
@@ -1,0 +1,71 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var real = require( '@stdlib/complex/float32/real' );
+var imag = require( '@stdlib/complex/float32/imag' );
+var csignumf = require( './main.js' );
+
+
+// MAIN //
+
+/**
+* Computes the signum of a single-precision complex number stored in a real-valued strided array view and assigns the result to a provided strided output array.
+*
+* @param {Float32Array} z - complex number view (interleaved real and imaginary)
+* @param {integer} strideZ - stride length for `z`
+* @param {NonNegativeInteger} offsetZ - starting index for `z`
+* @param {Float32Array} out - output array
+* @param {integer} strideOut - stride length for `out`
+* @param {NonNegativeInteger} offsetOut - starting index for `out`
+* @returns {Float32Array} output array
+*
+* @example
+* var Float32Array = require( '@stdlib/array/float32' );
+* var strided = require( '@stdlib/math/base/special/csignumf' ).strided;
+*
+* var z = new Float32Array( [ 3.0, 4.0 ] );
+* var out = new Float32Array( 2 );
+*
+* strided( z, 1, 0, out, 1, 0 );
+* console.log( out );
+* // => <Float32Array>[ ~0.6, ~0.8 ]
+*/
+function strided( z, strideZ, offsetZ, out, strideOut, offsetOut ) {
+	var result;
+	var re;
+	var im;
+
+	re = z[ offsetZ ];
+	im = z[ offsetZ + strideZ ];
+	result = csignumf( new Complex64( re, im ) );
+
+	out[ offsetOut ] = real( result );
+	out[ offsetOut + strideOut ] = imag( result );
+
+	return out;
+}
+
+
+// EXPORTS //
+
+module.exports = strided;

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/lib/strided.js
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/lib/strided.js
@@ -29,38 +29,31 @@ var csignumf = require( './main.js' );
 // MAIN //
 
 /**
-* Computes the signum of a single-precision complex number stored in a real-valued strided array view and assigns the result to a provided strided output array.
+* Evaluates the signum function of a single-precision floating-point complex number stored in a real-valued strided array view and assigns results to a provided strided output array.
 *
-* @param {Float32Array} z - complex number view (interleaved real and imaginary)
-* @param {integer} sz - stride length for `z`
-* @param {NonNegativeInteger} oz - starting index for `z`
-* @param {Float32Array} out - output array
-* @param {integer} so - stride length for `out`
-* @param {NonNegativeInteger} oo - starting index for `out`
-* @returns {Float32Array} output array
+* @param {Float32Array} z - complex number view
+* @param {integer} strideZ - stride length for `z`
+* @param {NonNegativeInteger} offsetZ - starting index for `z`
+* @param {Collection} out - output array
+* @param {integer} strideOut - stride length for `out`
+* @param {NonNegativeInteger} offsetOut - starting index for `out`
+* @returns {Collection} output array
 *
 * @example
 * var Float32Array = require( '@stdlib/array/float32' );
-* var strided = require( '@stdlib/math/base/special/csignumf' ).strided;
 *
-* var z = new Float32Array( [ 3.0, 4.0 ] );
-* var out = new Float32Array( 2 );
+* var z = new Float32Array( [ -4.2, 5.5 ] );
 *
-* strided( z, 1, 0, out, 1, 0 );
-* console.log( out );
-* // => <Float32Array>[ ~0.6, ~0.8 ]
+* var out = strided( z, 1, 0, new Float32Array( 2 ), 1, 0 );
+* // returns <Float32Array>[ ~-0.607, ~0.795 ]
 */
-function strided( z, sz, oz, out, so, oo ) {
-	var result;
-	var re;
-	var im;
+function strided( z, strideZ, offsetZ, out, strideOut, offsetOut ) {
+	var v;
 
-	re = z[ oz ];
-	im = z[ oz + sz ];
-	result = csignumf( new Complex64( re, im ) );
+	v = csignumf( new Complex64( z[ offsetZ ], z[ offsetZ + strideZ ] ) );
 
-	out[ oo ] = real( result );
-	out[ oo + so ] = imag( result );
+	out[ offsetOut ] = real( v );
+	out[ offsetOut + strideOut ] = imag( v );
 
 	return out;
 }

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/test/test.assign.js
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/test/test.assign.js
@@ -23,12 +23,11 @@
 var tape = require( 'tape' );
 var Float32Array = require( '@stdlib/array/float32' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
-var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
 var absf = require( '@stdlib/math/base/special/absf' );
 var EPS = require( '@stdlib/constants/float32/eps' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
+var isSameFloat32Array = require( '@stdlib/assert/is-same-float32array' );
 var csignumf = require( './../lib' );
 
 
@@ -45,91 +44,152 @@ tape( 'main export is a function', function test( t ) {
 	t.end();
 });
 
-tape( 'the function evaluates the signum function and writes to output array', function test( t ) {
-	var expectedRe = data.expected_re;
-	var expectedIm = data.expected_im;
-	var returned;
-	var output;
+tape( 'the function evaluates the signum function of a single-precision floating-point complex number', function test( t ) {
 	var delta;
 	var tol;
-	var re = data.re;
-	var im = data.im;
+	var ere;
+	var eim;
+	var out;
+	var re;
+	var im;
 	var i;
 
+	re = data.re;
+	im = data.im;
+	ere = data.expected_re;
+	eim = data.expected_im;
+
 	for ( i = 0; i < re.length; i++ ) {
-		// Skip NaN cases for separate dedicated tests:
-		if ( isnanf( expectedRe[i] ) || isnanf( expectedIm[i] ) ) {
+		out = new Float32Array( 2 );
+		csignumf.assign( re[ i ], im[ i ], out, 1, 0 );
+		if ( isnanf( ere[i] ) || isnanf( eim[i] ) ) {
+			t.strictEqual( isnanf( out[ 0 ] ), true, 're is NaN' );
+			t.strictEqual( isnanf( out[ 1 ] ), true, 'im is NaN' );
 			continue;
-		}
-
-		output = new Float32Array( 2 );
-		returned = csignumf.assign( re[i], im[i], output, 1, 0 );
-
-		t.ok( returned instanceof Float32Array, 'returns a Float32Array' );
-		t.strictEqual( returned, output, 'returns same output array reference' );
-
-		if ( output[ 0 ] === expectedRe[ i ] && output[ 1 ] === expectedIm[ i ] ) {
-			t.strictEqual( output[ 0 ], expectedRe[ i ], 're: ' + re[ i ] + '. Expected: ' + expectedRe[ i ] );
-			t.strictEqual( output[ 1 ], expectedIm[ i ], 'im: ' + im[ i ] + '. Expected: ' + expectedIm[ i ] );
+		} else if ( out[ 0 ] === ere[ i ] && out[ 1 ] === eim[ i ] ) {
+			t.strictEqual( out[ 0 ], ere[ i ], 're: ' + re[ i ] + '. Expected: ' + ere[ i ] );
+			t.strictEqual( out[ 1 ], eim[ i ], 'im: ' + im[ i ] + '. Expected: ' + eim[ i ] );
 		} else {
-			delta = absf( output[ 0 ] - expectedRe[ i ] );
-			tol = EPS * absf( expectedRe[ i ] );
-			t.ok( delta <= tol, 'within tolerance. re: ' + re[ i ] + '. Expected: ' + expectedRe[ i ] + '. Actual: ' + output[ 0 ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
+			delta = absf( out[ 0 ] - ere[ i ] );
+			tol = EPS * absf( ere[ i ] );
+			t.ok( delta <= tol, 'within tolerance. re: ' + re[ i ] + '. im: ' + im[ i ] + '. Actual re: ' + out[ 0 ] + '. Expected re: '+ere[ i ]+ '. delta: ' + delta + '. tol: ' + tol + '.' );
 
-			delta = absf( output[ 1 ] - expectedIm[ i ] );
-			tol = EPS * absf( expectedIm[ i ] );
-			t.ok( delta <= tol, 'within tolerance. im: ' + im[ i ] + '. Expected: ' + expectedIm[ i ] + '. Actual: ' + output[ 1 ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
+			delta = absf( out[ 1 ] - eim[ i ] );
+			tol = EPS * absf( eim[ i ] );
+			t.ok( delta <= tol, 'within tolerance. im: ' + im[ i ] + '. im: ' + im[ i ] + '. Actual im: ' + out[ 1 ] + '. Expected im: '+ere[ i ]+ '. delta: ' + delta + '. tol: ' + tol + '.' );
 		}
 	}
 	t.end();
 });
 
-tape( 'the function returns NaNs if either input is NaN', function test( t ) {
-	var returned;
-	var outNaN;
+tape( 'if a real or imaginary component is `NaN`, the output component is `NaN`', function test( t ) {
+	var expected;
+	var out;
+	var v;
 
-	outNaN = new Float32Array( 2 );
-	returned = csignumf.assign( NaN, NaN, outNaN, 1, 0 );
+	out = new Float32Array( 2 );
+	expected = new Float32Array( [ NaN, NaN ] );
 
-	t.ok( returned instanceof Float32Array, 'returns a Float32Array' );
-	t.strictEqual( returned, outNaN, 'returns same output array reference' );
-	t.strictEqual( isnanf( outNaN[ 0 ] ), true, 'real is NaN' );
-	t.strictEqual( isnanf( outNaN[ 1 ] ), true, 'imag is NaN' );
+	v = csignumf.assign( NaN, 1.0, out, 1, 0 );
+	t.strictEqual( v, out, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( out, expected ), true, 'returns expected value' );
+
+	out = new Float32Array( 2 );
+	expected = new Float32Array( [ NaN, NaN ] );
+
+	v = csignumf.assign( 1.0, NaN, out, 1, 0 );
+	t.strictEqual( v, out, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( out, expected ), true, 'returns expected value' );
+
+	out = new Float32Array( 2 );
+	expected = new Float32Array( [ NaN, NaN ] );
+
+	v = csignumf.assign( NaN, 0.0, out, 1, 0 );
+	t.strictEqual( v, out, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( out, expected ), true, 'returns expected value' );
+
+	out = new Float32Array( 2 );
+	expected = new Float32Array( [ NaN, NaN ] );
+
+	v = csignumf.assign( 0.0, NaN, out, 1, 0 );
+	t.strictEqual( v, out, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( out, expected ), true, 'returns expected value' );
+
+	out = new Float32Array( 2 );
+	expected = new Float32Array( [ NaN, NaN ] );
+
+	v = csignumf.assign( NaN, -2.5, out, 1, 0 );
+	t.strictEqual( v, out, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( out, expected ), true, 'returns expected value' );
+
+	out = new Float32Array( 2 );
+	expected = new Float32Array( [ NaN, NaN ] );
+
+	v = csignumf.assign( -2.5, NaN, out, 1, 0 );
+	t.strictEqual( v, out, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( out, expected ), true, 'returns expected value' );
+
+	out = new Float32Array( 2 );
+	expected = new Float32Array( [ NaN, NaN ] );
+
+	v = csignumf.assign( NaN, NaN, out, 1, 0 );
+	t.strictEqual( v, out, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( out, expected ), true, 'returns expected value' );
 	t.end();
 });
 
-tape( 'the function returns +0 if input is +0 +0i', function test( t ) {
-	var outPosZero = new Float32Array( 2 );
-	csignumf.assign( +0.0, +0.0, outPosZero, 1, 0 );
+tape( 'the function returns `+0` if provided `+0`', function test( t ) {
+	var expected;
+	var out;
+	var v;
 
-	t.strictEqual( isPositiveZerof( outPosZero[ 0 ] ), true, 'real is +0' );
-	t.strictEqual( isPositiveZerof( outPosZero[ 1 ] ), true, 'imag is +0' );
+	out = new Float32Array( 2 );
+	expected = new Float32Array( [ +0.0, +0.0 ] );
+
+	v = csignumf.assign( +0.0, +0.0, out, 1, 0 );
+	t.strictEqual( v, out, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( out, expected ), true, 'returns expected value' );
 	t.end();
 });
 
-tape( 'the function returns -0 if input is -0 -0i', function test( t ) {
-	var outNegZero = new Float32Array( 2 );
-	csignumf.assign( -0.0, -0.0, outNegZero, 1, 0 );
+tape( 'the function returns `-0` if provided `-0`', function test( t ) {
+	var expected;
+	var out;
+	var v;
 
-	t.strictEqual( isNegativeZerof( outNegZero[ 0 ] ), true, 'real is -0' );
-	t.strictEqual( isNegativeZerof( outNegZero[ 1 ] ), true, 'imag is -0' );
+	out = new Float32Array( 2 );
+	expected = new Float32Array( [ -0.0, -0.0 ] );
+
+	v = csignumf.assign( -0.0, -0.0, out, 1, 0 );
+	t.strictEqual( v, out, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( out, expected ), true, 'returns expected value' );
 	t.end();
 });
 
-tape( 'the function returns NaNs if input is infinity', function test( t ) {
-	var outInf = new Float32Array( 2 );
-	csignumf.assign( PINF, PINF, outInf, 1, 0 );
+tape( 'the function returns a `NaN` if provided `infinity`', function test( t ) {
+	var expected;
+	var out;
+	var v;
 
-	t.strictEqual( isnanf( outInf[ 0 ] ), true, 'real is NaN' );
-	t.strictEqual( isnanf( outInf[ 1 ] ), true, 'imag is NaN' );
+	out = new Float32Array( 2 );
+	expected = new Float32Array( [ NaN, NaN ] );
+
+	v = csignumf.assign( PINF, PINF, out, 1, 0 );
+	t.strictEqual( v, out, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( out, expected ), true, 'returns expected value' );
 	t.end();
 });
 
-tape( 'the function returns NaNs if input is negative infinity', function test( t ) {
-	var outNegInf = new Float32Array( 2 );
-	csignumf.assign( NINF, NINF, outNegInf, 1, 0 );
+tape( 'the function returns a `NaN` if provided `-infinity`', function test( t ) {
+	var expected;
+	var out;
+	var v;
 
-	t.strictEqual( isnanf( outNegInf[ 0 ] ), true, 'real is NaN' );
-	t.strictEqual( isnanf( outNegInf[ 1 ] ), true, 'imag is NaN' );
+	out = new Float32Array( 2 );
+	expected = new Float32Array( [ NaN, NaN ] );
+
+	v = csignumf.assign( NINF, NINF, out, 1, 0 );
+	t.strictEqual( v, out, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( out, expected ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/test/test.assign.js
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/test/test.assign.js
@@ -1,0 +1,115 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var Float32Array = require( '@stdlib/array/float32' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
+var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
+var absf = require( '@stdlib/math/base/special/absf' );
+var EPS = require( '@stdlib/constants/float32/eps' );
+var csignumf = require( './../lib' );
+
+
+// FIXTURES //
+
+var data = require( './fixtures/julia/data.json' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof csignumf.assign, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function evaluates the signum function and writes to output array', function test( t ) {
+	var expectedRe = data.expected_re;
+	var expectedIm = data.expected_im;
+	var returned;
+	var output;
+	var delta;
+	var tol;
+	var re = data.re;
+	var im = data.im;
+	var i;
+
+	for ( i = 0; i < re.length; i++ ) {
+		// Skip NaN cases for separate dedicated tests:
+		if ( isnanf( expectedRe[i] ) || isnanf( expectedIm[i] ) ) {
+			continue;
+		}
+
+		output = new Float32Array( 2 );
+		returned = csignumf.assign( re[i], im[i], output, 1, 0 );
+
+		t.ok( returned instanceof Float32Array, 'returns a Float32Array' );
+		t.strictEqual( returned, output, 'returns same output array reference' );
+
+		if ( output[ 0 ] === expectedRe[ i ] && output[ 1 ] === expectedIm[ i ] ) {
+			t.strictEqual( output[ 0 ], expectedRe[ i ], 're: ' + re[ i ] + '. Expected: ' + expectedRe[ i ] );
+			t.strictEqual( output[ 1 ], expectedIm[ i ], 'im: ' + im[ i ] + '. Expected: ' + expectedIm[ i ] );
+		} else {
+			delta = absf( output[ 0 ] - expectedRe[ i ] );
+			tol = EPS * absf( expectedRe[ i ] );
+			t.ok( delta <= tol, 'within tolerance. re: ' + re[ i ] + '. Expected: ' + expectedRe[ i ] + '. Actual: ' + output[ 0 ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
+
+			delta = absf( output[ 1 ] - expectedIm[ i ] );
+			tol = EPS * absf( expectedIm[ i ] );
+			t.ok( delta <= tol, 'within tolerance. im: ' + im[ i ] + '. Expected: ' + expectedIm[ i ] + '. Actual: ' + output[ 1 ] + '. Δ: ' + delta + '. tol: ' + tol + '.' );
+		}
+	}
+	t.end();
+});
+
+tape( 'the function returns NaNs if either input is NaN', function test( t ) {
+	var returned;
+	var outNaN;
+
+	outNaN = new Float32Array( 2 );
+	returned = csignumf.assign( NaN, NaN, outNaN, 1, 0 );
+
+	t.ok( returned instanceof Float32Array, 'returns a Float32Array' );
+	t.strictEqual( returned, outNaN, 'returns same output array reference' );
+	t.strictEqual( isnanf( outNaN[ 0 ] ), true, 'real is NaN' );
+	t.strictEqual( isnanf( outNaN[ 1 ] ), true, 'imag is NaN' );
+	t.end();
+});
+
+tape( 'the function returns +0 if input is +0 +0i', function test( t ) {
+	var outPosZero = new Float32Array( 2 );
+	csignumf.assign( +0.0, +0.0, outPosZero, 1, 0 );
+
+	t.strictEqual( isPositiveZerof( outPosZero[ 0 ] ), true, 'real is +0' );
+	t.strictEqual( isPositiveZerof( outPosZero[ 1 ] ), true, 'imag is +0' );
+	t.end();
+});
+
+tape( 'the function returns -0 if input is -0 -0i', function test( t ) {
+	var outNegZero = new Float32Array( 2 );
+	csignumf.assign( -0.0, -0.0, outNegZero, 1, 0 );
+
+	t.strictEqual( isNegativeZerof( outNegZero[ 0 ] ), true, 'real is -0' );
+	t.strictEqual( isNegativeZerof( outNegZero[ 1 ] ), true, 'imag is -0' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/test/test.assign.js
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/test/test.assign.js
@@ -27,6 +27,8 @@ var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
 var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
 var absf = require( '@stdlib/math/base/special/absf' );
 var EPS = require( '@stdlib/constants/float32/eps' );
+var PINF = require( '@stdlib/constants/float32/pinf' );
+var NINF = require( '@stdlib/constants/float32/ninf' );
 var csignumf = require( './../lib' );
 
 
@@ -111,5 +113,23 @@ tape( 'the function returns -0 if input is -0 -0i', function test( t ) {
 
 	t.strictEqual( isNegativeZerof( outNegZero[ 0 ] ), true, 'real is -0' );
 	t.strictEqual( isNegativeZerof( outNegZero[ 1 ] ), true, 'imag is -0' );
+	t.end();
+});
+
+tape( 'the function returns NaNs if input is infinity', function test( t ) {
+	var outInf = new Float32Array( 2 );
+	csignumf.assign( PINF, PINF, outInf, 1, 0 );
+
+	t.strictEqual( isnanf( outInf[ 0 ] ), true, 'real is NaN' );
+	t.strictEqual( isnanf( outInf[ 1 ] ), true, 'imag is NaN' );
+	t.end();
+});
+
+tape( 'the function returns NaNs if input is negative infinity', function test( t ) {
+	var outNegInf = new Float32Array( 2 );
+	csignumf.assign( NINF, NINF, outNegInf, 1, 0 );
+
+	t.strictEqual( isnanf( outNegInf[ 0 ] ), true, 'real is NaN' );
+	t.strictEqual( isnanf( outNegInf[ 1 ] ), true, 'imag is NaN' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2018 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/test/test.strided.js
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/test/test.strided.js
@@ -1,0 +1,147 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var PINF = require( '@stdlib/constants/float32/pinf' );
+var NINF = require( '@stdlib/constants/float32/ninf' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var EPS = require( '@stdlib/constants/float32/eps' );
+var absf = require( '@stdlib/math/base/special/absf' );
+var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
+var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
+var Float32Array = require( '@stdlib/array/float32' );
+var csignumf = require( './../lib' );
+
+
+// FIXTURES //
+
+var data = require( './fixtures/julia/data.json' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof csignumf.strided, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function evaluates the signum function for complex numbers in strided arrays', function test( t ) {
+	var delta;
+	var out;
+	var tol;
+	var ere;
+	var eim;
+	var re;
+	var im;
+	var z;
+	var i;
+
+	re = data.re;
+	im = data.im;
+	ere = data.expected_re;
+	eim = data.expected_im;
+
+	for ( i = 0; i < re.length; i++ ) {
+		z = new Float32Array( 2 );
+		z[ 0 ] = re[ i ];
+		z[ 1 ] = im[ i ];
+
+		out = new Float32Array( 2 );
+		csignumf.strided( z, 1, 0, out, 1, 0 );
+
+		if ( isnanf( ere[ i ] ) || isnanf( eim[ i ] ) ) {
+			t.strictEqual( isnanf( out[ 0 ] ), true, 're is NaN' );
+			t.strictEqual( isnanf( out[ 1 ] ), true, 'im is NaN' );
+			continue;
+		}
+		if ( out[ 0 ] === ere[ i ] && out[ 1 ] === eim[ i ] ) {
+			t.strictEqual( out[ 0 ], ere[ i ], 're: '+re[ i ]+'. Expected: '+ere[ i ] );
+			t.strictEqual( out[ 1 ], eim[ i ], 'im: '+im[ i ]+'. Expected: '+eim[ i ] );
+		} else {
+			delta = absf( out[ 0 ] - ere[ i ] );
+			tol = EPS * absf( ere[ i ] );
+			t.ok(delta <= tol, 'within tolerance. re: '+re[ i ]+'. Expected: '+ere[ i ]+'. Actual: '+out[ 0 ]+'. Δ: '+delta+'. tol: '+tol+'.');
+
+			delta = absf( out[ 1 ] - eim[ i ] );
+			tol = EPS * absf( eim[ i ] );
+			t.ok(delta <= tol, 'within tolerance. im: '+im[ i ]+'. Expected: '+eim[ i ]+'. Actual: '+out[ 1 ]+'. Δ: '+delta+'. tol: '+tol+'.');
+		}
+	}
+	t.end();
+});
+
+tape( 'the function returns +0 if provided +0 +0i', function test( t ) {
+	var out = new Float32Array( 2 );
+	var z = new Float32Array( [ +0.0, +0.0 ] );
+
+	csignumf.strided( z, 1, 0, out, 1, 0 );
+
+	t.strictEqual( isPositiveZerof( out[ 0 ] ), true, 'real is +0' );
+	t.strictEqual( isPositiveZerof( out[ 1 ] ), true, 'imag is +0' );
+
+	t.end();
+});
+
+tape( 'the function returns -0 if provided -0 -0i', function test( t ) {
+	var out = new Float32Array( 2 );
+	var z = new Float32Array( [ -0.0, -0.0 ] );
+
+	csignumf.strided( z, 1, 0, out, 1, 0 );
+
+	t.strictEqual( isNegativeZerof( out[ 0 ] ), true, 'real is -0' );
+	t.strictEqual( isNegativeZerof( out[ 1 ] ), true, 'imag is -0' );
+
+	t.end();
+});
+
+tape( 'the function returns NaNs if provided NaNs', function test( t ) {
+	var out = new Float32Array( 2 );
+	var z = new Float32Array( [ NaN, NaN ] );
+
+	csignumf.strided( z, 1, 0, out, 1, 0 );
+
+	t.strictEqual( isnanf( out[ 0 ] ), true, 'real is NaN' );
+	t.strictEqual( isnanf( out[ 1 ] ), true, 'imag is NaN' );
+
+	t.end();
+});
+
+tape( 'the function returns NaNs if provided infinities', function test( t ) {
+	var out;
+	var z;
+
+	z = new Float32Array( [ PINF, PINF ] );
+	out = new Float32Array( 2 );
+	csignumf.strided( z, 1, 0, out, 1, 0 );
+
+	t.strictEqual( isnanf( out[ 0 ] ), true, 'real is NaN' );
+	t.strictEqual( isnanf( out[ 1 ] ), true, 'imag is NaN' );
+
+	z = new Float32Array( [ NINF, NINF ] );
+	csignumf.strided( z, 1, 0, out, 1, 0 );
+
+	t.strictEqual( isnanf( out[ 0 ] ), true, 'real is NaN' );
+	t.strictEqual( isnanf( out[ 1 ] ), true, 'imag is NaN' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/test/test.strided.js
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/test/test.strided.js
@@ -26,9 +26,8 @@ var NINF = require( '@stdlib/constants/float32/ninf' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
 var EPS = require( '@stdlib/constants/float32/eps' );
 var absf = require( '@stdlib/math/base/special/absf' );
-var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
-var isPositiveZerof = require( '@stdlib/math/base/assert/is-positive-zerof' );
 var Float32Array = require( '@stdlib/array/float32' );
+var isSameFloat32Array = require( '@stdlib/assert/is-same-float32array' );
 var csignumf = require( './../lib' );
 
 
@@ -45,12 +44,12 @@ tape( 'main export is a function', function test( t ) {
 	t.end();
 });
 
-tape( 'the function evaluates the signum function for complex numbers in strided arrays', function test( t ) {
+tape( 'the function evaluates the signum function of a single-precision floating-point complex number', function test( t ) {
 	var delta;
-	var out;
 	var tol;
 	var ere;
 	var eim;
+	var out;
 	var re;
 	var im;
 	var z;
@@ -62,86 +61,140 @@ tape( 'the function evaluates the signum function for complex numbers in strided
 	eim = data.expected_im;
 
 	for ( i = 0; i < re.length; i++ ) {
-		z = new Float32Array( 2 );
-		z[ 0 ] = re[ i ];
-		z[ 1 ] = im[ i ];
-
+		z = new Float32Array( [ re[ i ], im[ i ] ] );
 		out = new Float32Array( 2 );
+
 		csignumf.strided( z, 1, 0, out, 1, 0 );
 
 		if ( isnanf( ere[ i ] ) || isnanf( eim[ i ] ) ) {
 			t.strictEqual( isnanf( out[ 0 ] ), true, 're is NaN' );
 			t.strictEqual( isnanf( out[ 1 ] ), true, 'im is NaN' );
 			continue;
-		}
-		if ( out[ 0 ] === ere[ i ] && out[ 1 ] === eim[ i ] ) {
-			t.strictEqual( out[ 0 ], ere[ i ], 're: '+re[ i ]+'. Expected: '+ere[ i ] );
-			t.strictEqual( out[ 1 ], eim[ i ], 'im: '+im[ i ]+'. Expected: '+eim[ i ] );
+		} else if ( out[ 0 ] === ere[ i ] && out[ 1 ] === eim[ i ] ) {
+			t.strictEqual( out[ 0 ], ere[ i ], 're: ' + re[ i ] + '. Expected: ' + ere[ i ] );
+			t.strictEqual( out[ 1 ], eim[ i ], 'im: ' + im[ i ] + '. Expected: ' + eim[ i ] );
 		} else {
 			delta = absf( out[ 0 ] - ere[ i ] );
 			tol = EPS * absf( ere[ i ] );
-			t.ok(delta <= tol, 'within tolerance. re: '+re[ i ]+'. Expected: '+ere[ i ]+'. Actual: '+out[ 0 ]+'. Δ: '+delta+'. tol: '+tol+'.');
+			t.ok( delta <= tol, 'within tolerance. re: ' + re[ i ] + '. im: ' + im[ i ] + '. Actual re: ' + out[ 0 ] + '. Expected re: '+ere[ i ]+ '. delta: ' + delta + '. tol: ' + tol + '.' );
 
 			delta = absf( out[ 1 ] - eim[ i ] );
 			tol = EPS * absf( eim[ i ] );
-			t.ok(delta <= tol, 'within tolerance. im: '+im[ i ]+'. Expected: '+eim[ i ]+'. Actual: '+out[ 1 ]+'. Δ: '+delta+'. tol: '+tol+'.');
+			t.ok( delta <= tol, 'within tolerance. im: ' + im[ i ] + '. Actual im: ' + out[ 1 ] + '. Expected im: '+eim[ i ]+ '. delta: ' + delta + '. tol: ' + tol + '.' );
 		}
 	}
 	t.end();
 });
 
-tape( 'the function returns +0 if provided +0 +0i', function test( t ) {
-	var out = new Float32Array( 2 );
-	var z = new Float32Array( [ +0.0, +0.0 ] );
-
-	csignumf.strided( z, 1, 0, out, 1, 0 );
-
-	t.strictEqual( isPositiveZerof( out[ 0 ] ), true, 'real is +0' );
-	t.strictEqual( isPositiveZerof( out[ 1 ] ), true, 'imag is +0' );
-
-	t.end();
-});
-
-tape( 'the function returns -0 if provided -0 -0i', function test( t ) {
-	var out = new Float32Array( 2 );
-	var z = new Float32Array( [ -0.0, -0.0 ] );
-
-	csignumf.strided( z, 1, 0, out, 1, 0 );
-
-	t.strictEqual( isNegativeZerof( out[ 0 ] ), true, 'real is -0' );
-	t.strictEqual( isNegativeZerof( out[ 1 ] ), true, 'imag is -0' );
-
-	t.end();
-});
-
-tape( 'the function returns NaNs if provided NaNs', function test( t ) {
-	var out = new Float32Array( 2 );
-	var z = new Float32Array( [ NaN, NaN ] );
-
-	csignumf.strided( z, 1, 0, out, 1, 0 );
-
-	t.strictEqual( isnanf( out[ 0 ] ), true, 'real is NaN' );
-	t.strictEqual( isnanf( out[ 1 ] ), true, 'imag is NaN' );
-
-	t.end();
-});
-
-tape( 'the function returns NaNs if provided infinities', function test( t ) {
+tape( 'if a real or imaginary component is `NaN`, the output component is `NaN`', function test( t ) {
+	var expected;
 	var out;
 	var z;
+	var v;
+
+	z = new Float32Array( [ NaN, 1.0 ] );
+	out = new Float32Array( 2 );
+	expected = new Float32Array( [ NaN, NaN ] );
+
+	v = csignumf.strided( z, 1, 0, out, 1, 0 );
+	t.strictEqual( v, out, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( out, expected ), true, 'returns expected value' );
+
+	z = new Float32Array( [ 1.0, NaN ] );
+	out = new Float32Array( 2 );
+	expected = new Float32Array( [ NaN, NaN ] );
+
+	v = csignumf.strided( z, 1, 0, out, 1, 0 );
+	t.strictEqual( v, out, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( out, expected ), true, 'returns expected value' );
+
+	z = new Float32Array( [ NaN, 0.0 ] );
+	out = new Float32Array( 2 );
+	expected = new Float32Array( [ NaN, NaN ] );
+
+	v = csignumf.strided( z, 1, 0, out, 1, 0 );
+	t.strictEqual( v, out, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( out, expected ), true, 'returns expected value' );
+
+	z = new Float32Array( [ 0.0, NaN ] );
+	out = new Float32Array( 2 );
+	expected = new Float32Array( [ NaN, NaN ] );
+
+	v = csignumf.strided( z, 1, 0, out, 1, 0 );
+	t.strictEqual( v, out, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( out, expected ), true, 'returns expected value' );
+
+	z = new Float32Array( [ NaN, -2.5 ] );
+	out = new Float32Array( 2 );
+	expected = new Float32Array( [ NaN, NaN ] );
+
+	v = csignumf.strided( z, 1, 0, out, 1, 0 );
+	t.strictEqual( v, out, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( out, expected ), true, 'returns expected value' );
+
+	z = new Float32Array( [ -2.5, NaN ] );
+	out = new Float32Array( 2 );
+	expected = new Float32Array( [ NaN, NaN ] );
+
+	v = csignumf.strided( z, 1, 0, out, 1, 0 );
+	t.strictEqual( v, out, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( out, expected ), true, 'returns expected value' );
+
+	z = new Float32Array( [ NaN, NaN ] );
+	out = new Float32Array( 2 );
+	expected = new Float32Array( [ NaN, NaN ] );
+
+	v = csignumf.strided( z, 1, 0, out, 1, 0 );
+	t.strictEqual( v, out, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( out, expected ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `-0` if provided `-0`', function test( t ) {
+	var expected;
+	var out;
+	var z;
+	var v;
+
+	z = new Float32Array( [ -0.0, -0.0 ] );
+	out = new Float32Array( 2 );
+	expected = new Float32Array( [ -0.0, -0.0 ] );
+
+	v = csignumf.strided( z, 1, 0, out, 1, 0 );
+	t.strictEqual( v, out, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( out, expected ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns a `NaN` if provided `infinity`', function test( t ) {
+	var expected;
+	var out;
+	var z;
+	var v;
 
 	z = new Float32Array( [ PINF, PINF ] );
 	out = new Float32Array( 2 );
-	csignumf.strided( z, 1, 0, out, 1, 0 );
+	expected = new Float32Array( [ NaN, NaN ] );
 
-	t.strictEqual( isnanf( out[ 0 ] ), true, 'real is NaN' );
-	t.strictEqual( isnanf( out[ 1 ] ), true, 'imag is NaN' );
+	v = csignumf.strided( z, 1, 0, out, 1, 0 );
+	t.strictEqual( v, out, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( out, expected ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns a `NaN` if provided `-infinity`', function test( t ) {
+	var expected;
+	var out;
+	var z;
+	var v;
 
 	z = new Float32Array( [ NINF, NINF ] );
-	csignumf.strided( z, 1, 0, out, 1, 0 );
+	out = new Float32Array( 2 );
+	expected = new Float32Array( [ NaN, NaN ] );
+	v = csignumf.strided( z, 1, 0, out, 1, 0 );
 
-	t.strictEqual( isnanf( out[ 0 ] ), true, 'real is NaN' );
-	t.strictEqual( isnanf( out[ 1 ] ), true, 'imag is NaN' );
-
+	t.strictEqual( v, out, 'returns expected value' );
+	t.strictEqual( isSameFloat32Array( out, expected ), true, 'returns expected value' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/ndarray/base/zeros/README.md
+++ b/lib/node_modules/@stdlib/ndarray/base/zeros/README.md
@@ -57,7 +57,7 @@ var dt = arr.dtype;
 
 The function accepts the following arguments:
 
--   **dtype**: underlying [data type][@stdlib/ndarray/dtypes]. Must be a numeric [data type][@stdlib/ndarray/dtypes] or "generic". 
+-   **dtype**: underlying [data type][@stdlib/ndarray/dtypes]. Must be a numeric [data type][@stdlib/ndarray/dtypes] or "generic".
 -   **shape**: array shape.
 -   **order**: specifies whether an [ndarray][@stdlib/ndarray/base/ctor] is `'row-major'` (C-style) or `'column-major'` (Fortran-style).
 


### PR DESCRIPTION
Resolves #6507 

## Description

> What is the purpose of this pull request?

This pull request:  introduces additional functionality and documentation for the `@stdlib/math/base/special/csignumf` package. Specifically, it:

- Implements two new methods:
  - `csignumf.assign(re, im, out, strideOut, offsetOut)` for assigning the result of the signum function to an output array.
  - `csignumf.strided(z, sz, oz, out, so, oo)` for evaluating the signum function on strided array data.
- Adds corresponding test files:
  - `test.assign.js`
  - `test.strided.js`
- Adds performance benchmarks:
  - `benchmark.assign.js`
  - `benchmark.strided.js`
- Updates the documentation to include usage examples and interface descriptions for the new methods.
## Related Issues

No

> Does this pull request have any related issues?

This pull request:

-   resolves #6507 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Output of

`➜ make test TEST_FILTER=".*/@stdlib/math/base/special/csignumf.*"`

_Last Few lines_
![image](https://github.com/user-attachments/assets/120cea24-0b3c-4358-9c5f-8baf822d20d1)

`➜ make benchmark BENCHMARKS_FILTER=".*/@stdlib/math/base/special/csignumf.*"`
    [Click here for complete benchmark.log](https://github.com/user-attachments/files/20707160/benchmark.log)

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
