### PR TITLE
chore: fix EditorConfig lint errors (issue #7349)

### DIFF
--- a/lib/node_modules/@stdlib/number/float64/base/exponent/manifest.json
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/manifest.json
@@ -1,42 +1,42 @@
 {
-    "options": {},
-    "fields": [
-        {
-            "field": "src",
-            "resolve": true,
-            "relative": true
-        },
-        {
-            "field": "include",
-            "resolve": true,
-            "relative": true
-        },
-        {
-            "field": "libraries",
-            "resolve": false,
-            "relative": false
-        },
-        {
-            "field": "libpath",
-            "resolve": true,
-            "relative": false
-        }
-    ],
-    "confs": [
-        {
-            "src": [
-                "./src/exponent.c"
-            ],
-            "include": [
-                "./include"
-            ],
-            "libraries": [],
-            "libpath": [],
-            "dependencies": [
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [
+        "./src/exponent.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
         "@stdlib/constants/float64/exponent-bias",
         "@stdlib/constants/float64/high-word-exponent-mask",
-                "@stdlib/number/float64/base/get-high-word"
-            ]
-        }
-    ]
+        "@stdlib/number/float64/base/get-high-word"
+      ]
+    }
+  ]
 }

--- a/lib/node_modules/@stdlib/number/float64/base/exponent/manifest.json
+++ b/lib/node_modules/@stdlib/number/float64/base/exponent/manifest.json
@@ -1,42 +1,42 @@
 {
-	"options": {},
-	"fields": [
-		{
-			"field": "src",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "include",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "libraries",
-			"resolve": false,
-			"relative": false
-		},
-		{
-			"field": "libpath",
-			"resolve": true,
-			"relative": false
-		}
-	],
-	"confs": [
-		{
-			"src": [
-				"./src/exponent.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [],
-			"libpath": [],
-			"dependencies": [
+    "options": {},
+    "fields": [
+        {
+            "field": "src",
+            "resolve": true,
+            "relative": true
+        },
+        {
+            "field": "include",
+            "resolve": true,
+            "relative": true
+        },
+        {
+            "field": "libraries",
+            "resolve": false,
+            "relative": false
+        },
+        {
+            "field": "libpath",
+            "resolve": true,
+            "relative": false
+        }
+    ],
+    "confs": [
+        {
+            "src": [
+                "./src/exponent.c"
+            ],
+            "include": [
+                "./include"
+            ],
+            "libraries": [],
+            "libpath": [],
+            "dependencies": [
         "@stdlib/constants/float64/exponent-bias",
         "@stdlib/constants/float64/high-word-exponent-mask",
-				"@stdlib/number/float64/base/get-high-word"
-			]
-		}
-	]
+                "@stdlib/number/float64/base/get-high-word"
+            ]
+        }
+    ]
 }

--- a/lib/node_modules/@stdlib/random/streams/normal/lib/defaults.json
+++ b/lib/node_modules/@stdlib/random/streams/normal/lib/defaults.json
@@ -1,7 +1,7 @@
 {
-	"objectMode": false,
-	"encoding": null,
-	"sep": "\n",
-	"copy": true,
-	"siter": 1e308
+    "objectMode": false,
+    "encoding": null,
+    "sep": "\n",
+    "copy": true,
+    "siter": 1e308
 }

--- a/lib/node_modules/@stdlib/random/streams/normal/lib/defaults.json
+++ b/lib/node_modules/@stdlib/random/streams/normal/lib/defaults.json
@@ -1,7 +1,7 @@
 {
-    "objectMode": false,
-    "encoding": null,
-    "sep": "\n",
-    "copy": true,
-    "siter": 1e308
+  "objectMode": false,
+  "encoding": null,
+  "sep": "\n",
+  "copy": true,
+  "siter": 1e308
 }


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: na
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Resolves #7349 .

## Description

> What is the purpose of this pull request?

This pull request:

-   This pull request fixes EditorConfig linting errors by replacing tabs with spaces in affected JSON files.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #7349 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
