### PR TITLE
chore: fix C lint errors (issue #7395)

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/min-view-buffer-index/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/min-view-buffer-index/benchmark/c/benchmark.c
@@ -96,7 +96,7 @@ static double benchmark( void ) {
 	double t;
 	int i;
 
-	int64_t shape[] = { 10, 10, 10 };
+	const int64_t shape[] = { 10, 10, 10 };
 	int64_t strides[] = { 100, 10, 1 };
 	int64_t offset = 1000;
 	int64_t ndims = 3;


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: passed
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: na
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Resolves #7395 .

## Description

> What is the purpose of this pull request?

This pull request:

-   Declared the `shape` array as `const` in `benchmark.c`

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #7395 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
