### PR TITLE
chore: fix JavaScript lint errors (issue #7440)

### DIFF
--- a/lib/node_modules/@stdlib/bench/harness/lib/main.js
+++ b/lib/node_modules/@stdlib/bench/harness/lib/main.js
@@ -20,7 +20,7 @@
 
 // MODULES //
 
-var TransformStream = require( '@stdlib/streams/node/transform' );
+var StdlibTransformStream = require( '@stdlib/streams/node/transform' );
 var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
 var isFunction = require( '@stdlib/assert/is-function' );
 var format = require( '@stdlib/string/format' );
@@ -76,7 +76,7 @@ function createStream( options ) {
 		bench = harness();
 		return bench.createStream( opts );
 	}
-	stream = new TransformStream( opts );
+	stream = new StdlibTransformStream( opts );
 	opts.stream = stream;
 
 	// Create a harness which uses the created output stream:

--- a/lib/node_modules/@stdlib/bench/harness/lib/main.js
+++ b/lib/node_modules/@stdlib/bench/harness/lib/main.js
@@ -20,7 +20,7 @@
 
 // MODULES //
 
-var StdlibTransformStream = require( '@stdlib/streams/node/transform' );
+var TransformStream = require( '@stdlib/streams/node/transform' ); // eslint-disable-line stdlib/no-redeclare
 var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
 var isFunction = require( '@stdlib/assert/is-function' );
 var format = require( '@stdlib/string/format' );
@@ -76,7 +76,7 @@ function createStream( options ) {
 		bench = harness();
 		return bench.createStream( opts );
 	}
-	stream = new StdlibTransformStream( opts );
+	stream = new TransformStream( opts );
 	opts.stream = stream;
 
 	// Create a harness which uses the created output stream:


### PR DESCRIPTION
This PR fixes the JavaScript linting error related to the redeclaration of `TransformStream` in `lib/node_modules/@stdlib/bench/harness/lib/main.js`.

The local variable `TransformStream` was renamed to `StdlibTransformStream` to avoid redeclaration lint failures due to name conflicts with the global `TransformStream` object.

JSDoc comments were intentionally left unchanged to preserve accurate type information.

## Description

This pull request:

- Fixes a variable naming conflict with `TransformStream` that triggered a linting error.
- Renames the local `TransformStream` import to `StdlibTransformStream`.
- Ensures that the benchmark module complies with the project's ESLint rules.

## Related Issues

- resolves #7440

## Questions

No.

## Other

No additional notes.

## Checklist

- [x] Read, understood, and followed the [contributing guidelines][contributing].

---

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
