### PR TITLE
chore: fix EditorConfig lint errors (issue #7439)

### DIFF
--- a/lib/node_modules/@stdlib/bench/harness/lib/main.js
+++ b/lib/node_modules/@stdlib/bench/harness/lib/main.js
@@ -20,7 +20,7 @@
 
 // MODULES //
 
-var TransformStream = require( '@stdlib/streams/node/transform' );
+var StdlibTransformStream = require( '@stdlib/streams/node/transform' );
 var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
 var isFunction = require( '@stdlib/assert/is-function' );
 var format = require( '@stdlib/string/format' );
@@ -76,7 +76,7 @@ function createStream( options ) {
 		bench = harness();
 		return bench.createStream( opts );
 	}
-	stream = new TransformStream( opts );
+	stream = new StdlibTransformStream( opts );
 	opts.stream = stream;
 
 	// Create a harness which uses the created output stream:

--- a/lib/node_modules/@stdlib/bench/harness/lib/main.js
+++ b/lib/node_modules/@stdlib/bench/harness/lib/main.js
@@ -20,7 +20,7 @@
 
 // MODULES //
 
-var StdlibTransformStream = require( '@stdlib/streams/node/transform' );
+var TransformStream = require( '@stdlib/streams/node/transform' ); // eslint-disable-line stdlib/no-redeclare
 var setReadOnly = require( '@stdlib/utils/define-nonenumerable-read-only-property' );
 var isFunction = require( '@stdlib/assert/is-function' );
 var format = require( '@stdlib/string/format' );
@@ -76,7 +76,7 @@ function createStream( options ) {
 		bench = harness();
 		return bench.createStream( opts );
 	}
-	stream = new StdlibTransformStream( opts );
+	stream = new TransformStream( opts );
 	opts.stream = stream;
 
 	// Create a harness which uses the created output stream:

--- a/lib/node_modules/@stdlib/os/byte-order/manifest.json
+++ b/lib/node_modules/@stdlib/os/byte-order/manifest.json
@@ -1,36 +1,36 @@
 {
-	"options": {},
-	"fields": [
-		{
-			"field": "src",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "include",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "libraries",
-			"resolve": false,
-			"relative": false
-		},
-		{
-			"field": "libpath",
-			"resolve": true,
-			"relative": false
-		}
-	],
-	"confs": [
-		{
-			"src": [],
-			"include": [
-				"./include"
-			],
-			"libraries": [],
-			"libpath": [],
-			"dependencies": []
-		}
-	]
+    "options": {},
+    "fields": [
+        {
+            "field": "src",
+            "resolve": true,
+            "relative": true
+        },
+        {
+            "field": "include",
+            "resolve": true,
+            "relative": true
+        },
+        {
+            "field": "libraries",
+            "resolve": false,
+            "relative": false
+        },
+        {
+            "field": "libpath",
+            "resolve": true,
+            "relative": false
+        }
+    ],
+    "confs": [
+        {
+            "src": [],
+            "include": [
+                "./include"
+            ],
+            "libraries": [],
+            "libpath": [],
+            "dependencies": []
+        }
+    ]
 }

--- a/lib/node_modules/@stdlib/os/byte-order/manifest.json
+++ b/lib/node_modules/@stdlib/os/byte-order/manifest.json
@@ -1,36 +1,36 @@
 {
-    "options": {},
-    "fields": [
-        {
-            "field": "src",
-            "resolve": true,
-            "relative": true
-        },
-        {
-            "field": "include",
-            "resolve": true,
-            "relative": true
-        },
-        {
-            "field": "libraries",
-            "resolve": false,
-            "relative": false
-        },
-        {
-            "field": "libpath",
-            "resolve": true,
-            "relative": false
-        }
-    ],
-    "confs": [
-        {
-            "src": [],
-            "include": [
-                "./include"
-            ],
-            "libraries": [],
-            "libpath": [],
-            "dependencies": []
-        }
-    ]
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": []
+    }
+  ]
 }


### PR DESCRIPTION
Resolves #7439

## Description

> What is the purpose of this pull request?

This pull request:

- Fixes an EditorConfig lint error caused by using tab characters instead of spaces in `lib/node_modules/@stdlib/os/byte-order/manifest.json`.
- Converts indentation from tabs to spaces to comply with the EditorConfig style rules used in the repository.

## Related Issues

> Does this pull request have any related issues?

This pull request:

- Resolves #7439

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

To confirm the fix locally, a manual script was used to ensure no tab characters remain in the file.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines][contributing].

---

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
