### PR TITLE
fix: use correct data type of `searchElement` in C implementation

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/sindex-of/include/stdlib/blas/ext/base/sindex_of.h
+++ b/lib/node_modules/@stdlib/blas/ext/base/sindex-of/include/stdlib/blas/ext/base/sindex_of.h
@@ -31,12 +31,12 @@ extern "C" {
 /**
 * Returns the first index of a specified search element in a single-precision floating-point strided array.
 */
-CBLAS_INT API_SUFFIX(stdlib_strided_sindex_of)( const CBLAS_INT N, const CBLAS_INT searchElement, const float *X, const CBLAS_INT strideX );
+CBLAS_INT API_SUFFIX(stdlib_strided_sindex_of)( const CBLAS_INT N, const float searchElement, const float *X, const CBLAS_INT strideX );
 
 /**
 * Returns the first index of a specified search element in a single-precision floating-point strided array using alternative indexing semantics.
 */
-CBLAS_INT API_SUFFIX(stdlib_strided_sindex_of_ndarray)( const CBLAS_INT N, const CBLAS_INT searchElement, const float *X, const CBLAS_INT strideX, const CBLAS_INT offsetX );
+CBLAS_INT API_SUFFIX(stdlib_strided_sindex_of_ndarray)( const CBLAS_INT N, const float searchElement, const float *X, const CBLAS_INT strideX, const CBLAS_INT offsetX );
 
 #ifdef __cplusplus
 }

--- a/lib/node_modules/@stdlib/blas/ext/base/sindex-of/src/main.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/sindex-of/src/main.c
@@ -29,7 +29,7 @@
 * @param strideX       stride length
 * @return              index
 */
-CBLAS_INT API_SUFFIX(stdlib_strided_sindex_of)( const CBLAS_INT N, const CBLAS_INT searchElement, const float *X, const CBLAS_INT strideX ) {
+CBLAS_INT API_SUFFIX(stdlib_strided_sindex_of)( const CBLAS_INT N, const float searchElement, const float *X, const CBLAS_INT strideX ) {
 	CBLAS_INT ox = stdlib_strided_stride2offset( N, strideX );
 	return API_SUFFIX(stdlib_strided_sindex_of_ndarray)( N, searchElement, X, strideX, ox );
 }
@@ -44,7 +44,7 @@ CBLAS_INT API_SUFFIX(stdlib_strided_sindex_of)( const CBLAS_INT N, const CBLAS_I
 * @param offsetX       starting index
 * @return              index
 */
-CBLAS_INT API_SUFFIX(stdlib_strided_sindex_of_ndarray)( const CBLAS_INT N, const CBLAS_INT searchElement, const float *X, const CBLAS_INT strideX, const CBLAS_INT offsetX ) {
+CBLAS_INT API_SUFFIX(stdlib_strided_sindex_of_ndarray)( const CBLAS_INT N, const float searchElement, const float *X, const CBLAS_INT strideX, const CBLAS_INT offsetX ) {
 	CBLAS_INT ix;
 	CBLAS_INT i;
 


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: missing_dependencies
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: na
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Resolves none.

## Description

> What is the purpose of this pull request?

This pull request:

-   fixes use of of incorrect data type in `C` implementation.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves none. 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
