### PR TITLE
chore: fix C lint errors (issue #5432)

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/assign/src/k_i.c
+++ b/lib/node_modules/@stdlib/ndarray/base/assign/src/k_i.c
@@ -206,6 +206,7 @@ int8_t stdlib_ndarray_assign_k_i_0d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_k_i_1d( struct ndarray *arrays[], void *data ) {
+	// cppcheck-suppress constVariablePointer
 	STDLIB_NDARRAY_ASSIGN_1D_LOOP_CAST( int16_t, int32_t )
 	return 0;
 }
@@ -293,6 +294,7 @@ int8_t stdlib_ndarray_assign_k_i_1d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_k_i_2d( struct ndarray *arrays[], void *data ) {
+	// cppcheck-suppress constVariablePointer
 	STDLIB_NDARRAY_ASSIGN_2D_LOOP_CAST( int16_t, int32_t )
 	return 0;
 }
@@ -380,6 +382,7 @@ int8_t stdlib_ndarray_assign_k_i_2d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_k_i_2d_blocked( struct ndarray *arrays[], void *data ) {
+	// cppcheck-suppress constVariablePointer
 	STDLIB_NDARRAY_ASSIGN_2D_BLOCKED_LOOP_CAST( int16_t, int32_t )
 	return 0;
 }
@@ -467,6 +470,7 @@ int8_t stdlib_ndarray_assign_k_i_2d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_k_i_3d( struct ndarray *arrays[], void *data ) {
+	// cppcheck-suppress constVariablePointer
 	STDLIB_NDARRAY_ASSIGN_3D_LOOP_CAST( int16_t, int32_t )
 	return 0;
 }
@@ -554,6 +558,7 @@ int8_t stdlib_ndarray_assign_k_i_3d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_k_i_3d_blocked( struct ndarray *arrays[], void *data ) {
+	// cppcheck-suppress constVariablePointer
 	STDLIB_NDARRAY_ASSIGN_3D_BLOCKED_LOOP_CAST( int16_t, int32_t )
 	return 0;
 }
@@ -641,6 +646,7 @@ int8_t stdlib_ndarray_assign_k_i_3d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_k_i_4d( struct ndarray *arrays[], void *data ) {
+	// cppcheck-suppress constVariablePointer
 	STDLIB_NDARRAY_ASSIGN_4D_LOOP_CAST( int16_t, int32_t )
 	return 0;
 }
@@ -728,6 +734,7 @@ int8_t stdlib_ndarray_assign_k_i_4d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_k_i_4d_blocked( struct ndarray *arrays[], void *data ) {
+	// cppcheck-suppress constVariablePointer
 	STDLIB_NDARRAY_ASSIGN_4D_BLOCKED_LOOP_CAST( int16_t, int32_t )
 	return 0;
 }
@@ -815,6 +822,7 @@ int8_t stdlib_ndarray_assign_k_i_4d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_k_i_5d( struct ndarray *arrays[], void *data ) {
+	// cppcheck-suppress constVariablePointer
 	STDLIB_NDARRAY_ASSIGN_5D_LOOP_CAST( int16_t, int32_t )
 	return 0;
 }
@@ -902,6 +910,7 @@ int8_t stdlib_ndarray_assign_k_i_5d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_k_i_5d_blocked( struct ndarray *arrays[], void *data ) {
+	// cppcheck-suppress constVariablePointer
 	STDLIB_NDARRAY_ASSIGN_5D_BLOCKED_LOOP_CAST( int16_t, int32_t )
 	return 0;
 }
@@ -989,6 +998,7 @@ int8_t stdlib_ndarray_assign_k_i_5d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_k_i_6d( struct ndarray *arrays[], void *data ) {
+	// cppcheck-suppress constVariablePointer
 	STDLIB_NDARRAY_ASSIGN_6D_LOOP_CAST( int16_t, int32_t )
 	return 0;
 }
@@ -1076,6 +1086,7 @@ int8_t stdlib_ndarray_assign_k_i_6d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_k_i_6d_blocked( struct ndarray *arrays[], void *data ) {
+	// cppcheck-suppress constVariablePointer
 	STDLIB_NDARRAY_ASSIGN_6D_BLOCKED_LOOP_CAST( int16_t, int32_t )
 	return 0;
 }
@@ -1163,6 +1174,7 @@ int8_t stdlib_ndarray_assign_k_i_6d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_k_i_7d( struct ndarray *arrays[], void *data ) {
+	// cppcheck-suppress constVariablePointer
 	STDLIB_NDARRAY_ASSIGN_7D_LOOP_CAST( int16_t, int32_t )
 	return 0;
 }
@@ -1250,6 +1262,7 @@ int8_t stdlib_ndarray_assign_k_i_7d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_k_i_7d_blocked( struct ndarray *arrays[], void *data ) {
+	// cppcheck-suppress constVariablePointer
 	STDLIB_NDARRAY_ASSIGN_7D_BLOCKED_LOOP_CAST( int16_t, int32_t )
 	return 0;
 }
@@ -1337,6 +1350,7 @@ int8_t stdlib_ndarray_assign_k_i_7d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_k_i_8d( struct ndarray *arrays[], void *data ) {
+	// cppcheck-suppress constVariablePointer
 	STDLIB_NDARRAY_ASSIGN_8D_LOOP_CAST( int16_t, int32_t )
 	return 0;
 }
@@ -1424,6 +1438,7 @@ int8_t stdlib_ndarray_assign_k_i_8d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_k_i_8d_blocked( struct ndarray *arrays[], void *data ) {
+	// cppcheck-suppress constVariablePointer
 	STDLIB_NDARRAY_ASSIGN_8D_BLOCKED_LOOP_CAST( int16_t, int32_t )
 	return 0;
 }
@@ -1511,6 +1526,7 @@ int8_t stdlib_ndarray_assign_k_i_8d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_k_i_9d( struct ndarray *arrays[], void *data ) {
+	// cppcheck-suppress constVariablePointer
 	STDLIB_NDARRAY_ASSIGN_9D_LOOP_CAST( int16_t, int32_t )
 	return 0;
 }
@@ -1598,6 +1614,7 @@ int8_t stdlib_ndarray_assign_k_i_9d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_k_i_9d_blocked( struct ndarray *arrays[], void *data ) {
+	// cppcheck-suppress constVariablePointer
 	STDLIB_NDARRAY_ASSIGN_9D_BLOCKED_LOOP_CAST( int16_t, int32_t )
 	return 0;
 }
@@ -1685,6 +1702,7 @@ int8_t stdlib_ndarray_assign_k_i_9d_blocked( struct ndarray *arrays[], void *dat
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_k_i_10d( struct ndarray *arrays[], void *data ) {
+	// cppcheck-suppress constVariablePointer
 	STDLIB_NDARRAY_ASSIGN_10D_LOOP_CAST( int16_t, int32_t )
 	return 0;
 }
@@ -1772,6 +1790,7 @@ int8_t stdlib_ndarray_assign_k_i_10d( struct ndarray *arrays[], void *data ) {
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_k_i_10d_blocked( struct ndarray *arrays[], void *data ) {
+	// cppcheck-suppress constVariablePointer
 	STDLIB_NDARRAY_ASSIGN_10D_BLOCKED_LOOP_CAST( int16_t, int32_t )
 	return 0;
 }
@@ -1859,6 +1878,7 @@ int8_t stdlib_ndarray_assign_k_i_10d_blocked( struct ndarray *arrays[], void *da
 * stdlib_ndarray_free( y );
 */
 int8_t stdlib_ndarray_assign_k_i_nd( struct ndarray *arrays[], void *data ) {
+	// cppcheck-suppress constVariablePointer
 	STDLIB_NDARRAY_ASSIGN_ND_LOOP_CAST( int16_t, int32_t )
 	return 0;
 }


### PR DESCRIPTION
Resolves #5432.

## Description

> What is the purpose of this pull request?

This pull request:

-   fix C lint errors with `// cppcheck-suppress constVariablePointer` 

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #5432

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
