### PR TITLE
chore: fix EditorConfig lint errors (issue #7502)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/release/package-json/lib/defaults.json
+++ b/lib/node_modules/@stdlib/_tools/release/package-json/lib/defaults.json
@@ -1,3 +1,3 @@
 {
-	"devDependencies": []
+  "devDependencies": []
 }


### PR DESCRIPTION
Resolves #7502.

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes an EditorConfig lint error in the file `lib/node_modules/@stdlib/_tools/release/package-json/lib/defaults.json`.
-   Replaces tab characters with 2 spaces as required by the `.editorconfig` rules for JSON files:
    ```ini
    [*.{json,json.txt}]
    indent_style = space
    indent_size = 2
    ```

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #7502 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
