### PR TITLE
feat: add `number/float32/base/assert/is-almost-equal-value`

### DIFF
--- a/lib/node_modules/@stdlib/number/float32/base/assert/is-almost-equal-value/README.md
+++ b/lib/node_modules/@stdlib/number/float32/base/assert/is-almost-equal-value/README.md
@@ -1,0 +1,134 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2025 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# isAlmostEqualValue
+
+> Test if two single-precision floating-point numbers are approximately equal within a specified number of ULPs (units in the last place).
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var isAlmostEqualValue = require( '@stdlib/number/float32/base/assert/is-almost-equal-value' );
+```
+
+#### isAlmostEqualValue( a, b, maxULP )
+
+Tests if two single-precision floating-point numbers are approximately equal within a specified number of ULPs (units in the last place).
+
+```javascript
+var EPS = require( '@stdlib/constants/float32/eps' );
+
+var bool = isAlmostEqualValue( 1.0, 1.0+EPS, 1 );
+// returns true
+
+bool = isAlmostEqualValue( 1.0, 1.0+EPS, 0 );
+// returns false
+```
+
+The function returns `false` if either input value is `NaN`.
+
+```javascript
+var bool = isAlmostEqualValue( NaN, 1.0, 1 );
+// returns false
+
+bool = isAlmostEqualValue( 1.0, NaN, 1 );
+// returns false
+
+bool = isAlmostEqualValue( NaN, NaN, 1 );
+// returns false
+```
+
+The function does not distinguish between `-0` and `+0`, treating them as equal.
+
+```javascript
+var bool = isAlmostEqualValue( 0.0, -0.0, 0 );
+// returns true
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var EPS = require( '@stdlib/constants/float32/eps' );
+var isAlmostEqualValue = require( '@stdlib/number/float32/base/assert/is-almost-equal-value' );
+
+var bool = isAlmostEqualValue( 1.0, 1.0+EPS, 1 );
+console.log( bool );
+// => true
+
+bool = isAlmostEqualValue( 1.0+EPS, 1.0, 1 );
+console.log( bool );
+// => true
+
+bool = isAlmostEqualValue( 1.0, 1.0+EPS+EPS, 1 );
+console.log( bool );
+// => false
+
+bool = isAlmostEqualValue( 1.0, 1.0+EPS, 0 );
+console.log( bool );
+// => false
+
+bool = isAlmostEqualValue( -0.0, 0.0, 0 );
+console.log( bool );
+// => true
+
+bool = isAlmostEqualValue( 1.0, NaN, 1 );
+console.log( bool );
+// => false
+
+bool = isAlmostEqualValue( NaN, NaN, 1 );
+console.log( bool );
+// => false
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/number/float32/base/assert/is-almost-equal-value/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/number/float32/base/assert/is-almost-equal-value/benchmark/benchmark.js
@@ -1,0 +1,60 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var pkg = require( './../package.json' ).name;
+var isAlmostEqualValue = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var values;
+	var bool;
+	var v;
+	var i;
+
+	values = [
+		5.0,
+		3.14,
+		NaN,
+		-0.0,
+		0.0,
+		-1.0
+	];
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		v = values[ i%values.length ];
+		bool = isAlmostEqualValue( v, v, 1 );
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/number/float32/base/assert/is-almost-equal-value/docs/repl.txt
+++ b/lib/node_modules/@stdlib/number/float32/base/assert/is-almost-equal-value/docs/repl.txt
@@ -1,0 +1,45 @@
+
+{{alias}}( a, b, maxULP )
+    Tests if two single-precision floating-point numbers are approximately equal
+    within a specified number of ULPs (units in the last place).
+
+    The function returns `false` if either input value is `NaN`.
+
+    The function does not distinguish between `-0` and `+0`, treating them as
+    equal.
+
+    Parameters
+    ----------
+    a: number
+        First input value.
+
+    b: number
+        Second input value.
+
+    maxULP: number
+        Maximum allowed ULP difference.
+
+    Returns
+    -------
+    bool: boolean
+        Boolean indicating whether two single-precision floating-point numbers
+        are approximately equal within a specified number of ULPs.
+
+    Examples
+    --------
+    > var bool = {{alias}}( 1, 1+{{alias:@stdlib/constants/float32/eps}}, 1 )
+    true
+    > bool = {{alias}}( 1+{{alias:@stdlib/constants/float32/eps}}, 1, 1 )
+    true
+    > bool = {{alias}}( 1, 1+{{alias:@stdlib/constants/float32/eps}}*2, 1 )
+    false
+    > bool = {{alias}}( 0.0, -0.0, 0 )
+    true
+    > bool = {{alias}}( NaN, 1.0, 1 )
+    false
+    > bool = {{alias}}( NaN, NaN, 0 )
+    false
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/number/float32/base/assert/is-almost-equal-value/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/number/float32/base/assert/is-almost-equal-value/docs/types/index.d.ts
@@ -1,0 +1,63 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Tests if two single-precision floating-point numbers are approximately equal within a specified number of ULPs (units in the last place).
+*
+* ## Notes
+*
+* -   The function returns `false` if either input value is `NaN`.
+* -   The function does not distinguish between `-0` and `+0`, treating them as equal.
+*
+* @param a - first input value
+* @param b - second input value
+* @param maxULP - maximum allowed ULP difference
+* @returns boolean indicating whether two single-precision floating-point numbers are approximately equal within a specified number of ULPs
+*
+* @example
+* var EPS = require( '@stdlib/constants/float32/eps' );
+*
+* var bool = isAlmostEqualValue( 1.0, 1.0+EPS, 1 );
+* // returns true
+*
+* var bool = isAlmostEqualValue( 1.0+EPS, 1.0, 1 );
+* // returns true
+*
+* bool = isAlmostEqualValue( 1.0, 1.0+EPS+EPS, 1 );
+* // returns false
+*
+* bool = isAlmostEqualValue( 1.0, 1.0+EPS, 0 );
+* // returns false
+*
+* bool = isAlmostEqualValue( 0.0, -0.0, 0 );
+* // returns true
+*
+* bool = isAlmostEqualValue( 1.0, NaN, 1 );
+* // returns false
+*
+* bool = isAlmostEqualValue( NaN, NaN, 1 );
+* // returns false
+*/
+declare function isAlmostEqualValue( a: number, b: number, maxULP: number ): boolean;
+
+
+// EXPORTS //
+
+export = isAlmostEqualValue;

--- a/lib/node_modules/@stdlib/number/float32/base/assert/is-almost-equal-value/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/number/float32/base/assert/is-almost-equal-value/docs/types/test.ts
@@ -1,0 +1,71 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import isAlmostEqualValue = require( './index' );
+
+
+// TESTS //
+
+// The function returns a boolean...
+{
+	isAlmostEqualValue( 3.14, 3.14, 1 ); // $ExpectType boolean
+}
+
+// The compiler throws an error if the function is not provided a first argument which is a number...
+{
+	isAlmostEqualValue( '5', 3.14, 1 ); // $ExpectError
+	isAlmostEqualValue( true, 3.14, 1 ); // $ExpectError
+	isAlmostEqualValue( false, 3.14, 1 ); // $ExpectError
+	isAlmostEqualValue( null, 3.14, 1 ); // $ExpectError
+	isAlmostEqualValue( void 0, 3.14, 1 ); // $ExpectError
+	isAlmostEqualValue( [], 3.14, 1 ); // $ExpectError
+	isAlmostEqualValue( {}, 3.14, 1 ); // $ExpectError
+	isAlmostEqualValue( ( x: number ): number => x, 3.14, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is not provided a second argument which is a number...
+{
+	isAlmostEqualValue( 3.14, '5', 1 ); // $ExpectError
+	isAlmostEqualValue( 3.14, true, 1 ); // $ExpectError
+	isAlmostEqualValue( 3.14, false, 1 ); // $ExpectError
+	isAlmostEqualValue( 3.14, null, 1 ); // $ExpectError
+	isAlmostEqualValue( 3.14, void 0, 1 ); // $ExpectError
+	isAlmostEqualValue( 3.14, [], 1 ); // $ExpectError
+	isAlmostEqualValue( 3.14, {}, 1 ); // $ExpectError
+	isAlmostEqualValue( 3.14, ( x: number ): number => x, 1 ); // $ExpectError
+}
+
+// The compiler throws an error if the function is not provided a third argument which is a number...
+{
+	isAlmostEqualValue( 3.14, 3.14, '5' ); // $ExpectError
+	isAlmostEqualValue( 3.14, 3.14, true ); // $ExpectError
+	isAlmostEqualValue( 3.14, 3.14, false ); // $ExpectError
+	isAlmostEqualValue( 3.14, 3.14, null ); // $ExpectError
+	isAlmostEqualValue( 3.14, 3.14, void 0 ); // $ExpectError
+	isAlmostEqualValue( 3.14, 3.14, [] ); // $ExpectError
+	isAlmostEqualValue( 3.14, 3.14, {} ); // $ExpectError
+	isAlmostEqualValue( 3.14, 3.14, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	isAlmostEqualValue(); // $ExpectError
+	isAlmostEqualValue( 3.14 ); // $ExpectError
+	isAlmostEqualValue( 3.14, 3.14 ); // $ExpectError
+	isAlmostEqualValue( 3.14, 3.14, 1, 2 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/number/float32/base/assert/is-almost-equal-value/examples/index.js
+++ b/lib/node_modules/@stdlib/number/float32/base/assert/is-almost-equal-value/examples/index.js
@@ -1,0 +1,50 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var EPS = require( '@stdlib/constants/float32/eps' );
+var isAlmostEqualValue = require( './../lib' );
+
+var bool = isAlmostEqualValue( 1.0, 1.0+EPS, 1 );
+console.log( bool );
+// => true
+
+bool = isAlmostEqualValue( 1.0+EPS, 1.0, 1 );
+console.log( bool );
+// => true
+
+bool = isAlmostEqualValue( 1.0, 1.0+EPS+EPS, 1 );
+console.log( bool );
+// => false
+
+bool = isAlmostEqualValue( 1.0, 1.0+EPS, 0 );
+console.log( bool );
+// => false
+
+bool = isAlmostEqualValue( -0.0, 0.0, 0 );
+console.log( bool );
+// => true
+
+bool = isAlmostEqualValue( 1.0, NaN, 1 );
+console.log( bool );
+// => false
+
+bool = isAlmostEqualValue( NaN, NaN, 1 );
+console.log( bool );
+// => false

--- a/lib/node_modules/@stdlib/number/float32/base/assert/is-almost-equal-value/lib/index.js
+++ b/lib/node_modules/@stdlib/number/float32/base/assert/is-almost-equal-value/lib/index.js
@@ -1,0 +1,49 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Test if two single-precision floating-point numbers are approximately equal within a specified number of ULPs (units in the last place).
+*
+* @module @stdlib/number/float32/base/assert/is-almost-equal-value
+*
+* @example
+* var isAlmostEqualValue = require( '@stdlib/number/float32/base/assert/is-almost-equal-value' );
+*
+* var bool = isAlmostEqualValue( 3.14, 3.14 );
+* // returns true
+*
+* bool = isAlmostEqualValue( -0.0, -0.0 );
+* // returns true
+*
+* bool = isAlmostEqualValue( -0.0, 0.0 );
+* // returns false
+*
+* bool = isAlmostEqualValue( NaN, NaN );
+* // returns true
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/number/float32/base/assert/is-almost-equal-value/lib/main.js
+++ b/lib/node_modules/@stdlib/number/float32/base/assert/is-almost-equal-value/lib/main.js
@@ -1,0 +1,72 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var ulpdiff = require( '@stdlib/number/float32/base/ulp-difference' );
+
+
+// MAIN //
+
+/**
+* Tests if two single-precision floating-point numbers are approximately equal within a specified number of ULPs (units in the last place).
+*
+* ## Notes
+*
+* -   The function returns `false` if either input value is `NaN`.
+* -   The function does not distinguish between `-0` and `+0`, treating them as equal.
+*
+* @param {number} a - first input value
+* @param {number} b - second input value
+* @param {number} maxULP - maximum allowed ULP difference
+* @returns {boolean} boolean indicating whether two single-precision floating-point numbers are approximately equal within a specified number of ULPs
+*
+* @example
+* var EPS = require( '@stdlib/constants/float32/eps' );
+*
+* var bool = isAlmostEqualValue( 1.0, 1.0+EPS, 1 );
+* // returns true
+*
+* var bool = isAlmostEqualValue( 1.0+EPS, 1.0, 1 );
+* // returns true
+*
+* bool = isAlmostEqualValue( 1.0, 1.0+EPS+EPS, 1 );
+* // returns false
+*
+* bool = isAlmostEqualValue( 1.0, 1.0+EPS, 0 );
+* // returns false
+*
+* bool = isAlmostEqualValue( 0.0, -0.0, 0 );
+* // returns true
+*
+* bool = isAlmostEqualValue( 1.0, NaN, 1 );
+* // returns false
+*
+* bool = isAlmostEqualValue( NaN, NaN, 1 );
+* // returns false
+*/
+function isAlmostEqualValue( a, b, maxULP ) {
+	return ulpdiff( a, b ) <= maxULP;
+}
+
+
+// EXPORTS //
+
+module.exports = isAlmostEqualValue;

--- a/lib/node_modules/@stdlib/number/float32/base/assert/is-almost-equal-value/lib/main.js
+++ b/lib/node_modules/@stdlib/number/float32/base/assert/is-almost-equal-value/lib/main.js
@@ -63,7 +63,7 @@ var ulpdiff = require( '@stdlib/number/float32/base/ulp-difference' );
 * // returns false
 */
 function isAlmostEqualValue( a, b, maxULP ) {
-	return ulpdiff( a, b ) <= maxULP;
+	return ulpdiff( f32( a ), f32( b ) ) <= maxULP;
 }
 
 

--- a/lib/node_modules/@stdlib/number/float32/base/assert/is-almost-equal-value/lib/main.js
+++ b/lib/node_modules/@stdlib/number/float32/base/assert/is-almost-equal-value/lib/main.js
@@ -20,6 +20,7 @@
 
 // MODULES //
 
+var f32 = require( '@stdlib/number/float64/base/to-float32' );
 var ulpdiff = require( '@stdlib/number/float32/base/ulp-difference' );
 
 

--- a/lib/node_modules/@stdlib/number/float32/base/assert/is-almost-equal-value/package.json
+++ b/lib/node_modules/@stdlib/number/float32/base/assert/is-almost-equal-value/package.json
@@ -1,0 +1,75 @@
+{
+  "name": "@stdlib/number/float32/base/assert/is-almost-equal-value",
+  "version": "0.0.0",
+  "description": "Test if two single-precision floating-point numbers are approximately equal within a specified number of ULPs (units in the last place).",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdassert",
+    "assertion",
+    "assert",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "equal",
+    "same",
+    "strict",
+    "is",
+    "issame",
+    "isequal",
+    "isalmostequal",
+    "type",
+    "check",
+    "valid",
+    "validate",
+    "test",
+    "float",
+    "single-precision"
+  ]
+}

--- a/lib/node_modules/@stdlib/number/float32/base/assert/is-almost-equal-value/test/test.js
+++ b/lib/node_modules/@stdlib/number/float32/base/assert/is-almost-equal-value/test/test.js
@@ -1,0 +1,82 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var EPS = require( '@stdlib/constants/float32/eps' );
+var isAlmostEqualValue = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof isAlmostEqualValue, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `false` if provided `NaN` as either input value', function test( t ) {
+	t.strictEqual( isAlmostEqualValue( NaN, 3.14, 0 ), false, 'returns expected value' );
+	t.strictEqual( isAlmostEqualValue( 3.14, NaN, 0 ), false, 'returns expected value' );
+	t.strictEqual( isAlmostEqualValue( NaN, NaN, 0 ), false, 'returns expected value' );
+	t.strictEqual( isAlmostEqualValue( NaN, NaN, 1 ), false, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `true` if provided two single-precision floating-point numbers which are the same value irrespective of the specified number of ULPs', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		5.0,
+		3.14,
+		-3.14,
+		0.0,
+		-0.0
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.strictEqual( isAlmostEqualValue( values[ i ], values[ i ], 0 ), true, 'returns expected value' );
+		t.strictEqual( isAlmostEqualValue( values[ i ], values[ i ], 1 ), true, 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function returns `true` if provided two single-precision floating-point numbers which are approximately equal within a specified number of ULPs', function test( t ) {
+	t.strictEqual( isAlmostEqualValue( 1.0, 1.0+EPS, 1 ), true, 'returns expected value' );
+	t.strictEqual( isAlmostEqualValue( 1.0+EPS, 1.0, 1 ), true, 'returns expected value' );
+	t.strictEqual( isAlmostEqualValue( 1.0, 1.0+EPS+EPS, 2 ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `false` if provided two single-precision floating-point numbers which are not approximately equal within a specified number of ULPs', function test( t ) {
+	t.strictEqual( isAlmostEqualValue( 1.0, 1.0+EPS, 0 ), false, 'returns expected value' );
+	t.strictEqual( isAlmostEqualValue( 1.0+EPS, 1.0, 0 ), false, 'returns expected value' );
+	t.strictEqual( isAlmostEqualValue( 1.0, 1.0+EPS+EPS, 1 ), false, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function returns `true` if signed zeros are provided as input values irrespective of the specified number of ULPs', function test( t ) {
+	t.strictEqual( isAlmostEqualValue( 0.0, -0.0, 0 ), true, 'returns expected value' );
+	t.strictEqual( isAlmostEqualValue( -0.0, 0.0, 0 ), true, 'returns expected value' );
+	t.strictEqual( isAlmostEqualValue( 0.0, -0.0, 1 ), true, 'returns expected value' );
+	t.strictEqual( isAlmostEqualValue( -0.0, 0.0, 1 ), true, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
Resolves None

## Description

> What is the purpose of this pull request?

This pull request:

-  Adds the implementation for `number/float32/base/assert/is-almost-equal-value`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolve none.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
