### PR TITLE
test: update type expectations in `stats/base/cumax` tests to match generic return type

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/cumax/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/base/cumax/docs/types/test.ts
@@ -27,7 +27,7 @@ import cumax = require( './index' );
 	const x = new Float64Array( 10 );
 	const y = new Float64Array( 10 );
 
-	cumax( x.length, x, 1, y, 1 ); // $ExpectType NumericArray
+	cumax( x.length, x, 1, y, 1 ); // $ExpectType Float64Array
 	cumax( x.length, new AccessorArray( x ), 1, new AccessorArray( y ), 1 ); // $ExpectType AccessorArray<number>
 }
 
@@ -125,7 +125,7 @@ import cumax = require( './index' );
 	const x = new Float64Array( 10 );
 	const y = new Float64Array( 10 );
 
-	cumax.ndarray( x.length, x, 1, 0, y, 1, 0 ); // $ExpectType NumericArray
+	cumax.ndarray( x.length, x, 1, 0, y, 1, 0 ); // $ExpectType Float64Array
 	cumax.ndarray( x.length, new AccessorArray( x ), 1, 0, new AccessorArray( y ), 1, 0 ); // $ExpectType AccessorArray<number>
 }
 


### PR DESCRIPTION
…type

---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: na
  - task: lint_typescript_tests status: passed
  - task: lint_license_headers status: passed ---

Resolves [#7604](https://github.com/stdlib-js/stdlib/issues/7604)

## Description

> What is the purpose of this pull request?

-   This pull request fixes a type assertion issue in the [`@stdlib/stats/base/cumax`](https://github.com/stdlib-js/stdlib/blob/develop/lib/node_modules/%40stdlib/stats/base/cumax/docs/types/test.ts) TypeScript test file.

Previously, the output type was broadly assumed as NumericArray, but with the new generic behavior, when Float64Array is passed as input (e.g., in parameter y), the return type is also Float64Array.

The test currently expects NumericArray, causing the expect-type check to fail. This PR updates the expected type to match the actual inferred return type.

## Related Issues

> Does this pull request have any related issues?

This pull request:

- Resolves bug [#7604](https://github.com/stdlib-js/stdlib/issues/7604)
- Related issues are: #7608 , #7606 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
