### PR TITLE
chore: fix EditorConfig lint errors (issue #7623)

### DIFF
--- a/lib/node_modules/@stdlib/math/strided/special/dmskramp/manifest.json
+++ b/lib/node_modules/@stdlib/math/strided/special/dmskramp/manifest.json
@@ -1,75 +1,75 @@
 {
-    "options": {
-        "task": "build"
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
     },
-    "fields": [
-        {
-            "field": "src",
-            "resolve": true,
-            "relative": true
-        },
-        {
-            "field": "include",
-            "resolve": true,
-            "relative": true
-        },
-        {
-            "field": "libraries",
-            "resolve": false,
-            "relative": false
-        },
-        {
-            "field": "libpath",
-            "resolve": true,
-            "relative": false
-        }
-    ],
-    "confs": [
-        {
-            "task": "build",
-            "src": [
-                "./src/dmskramp.c"
-            ],
-            "include": [
-                "./include"
-            ],
-            "libraries": [],
-            "libpath": [],
-            "dependencies": [
-                "@stdlib/math/base/special/ramp",
-                "@stdlib/strided/base/dmskmap",
-                "@stdlib/strided/napi/dmskmap"
-            ]
-        },
-        {
-            "task": "examples",
-            "src": [
-                "./src/dmskramp.c"
-            ],
-            "include": [
-                "./include"
-            ],
-            "libraries": [],
-            "libpath": [],
-            "dependencies": [
-                "@stdlib/math/base/special/ramp",
-                "@stdlib/strided/base/dmskmap"
-            ]
-        },
-        {
-            "task": "benchmark",
-            "src": [
-                "./src/dmskramp.c"
-            ],
-            "include": [
-                "./include"
-            ],
-            "libraries": [],
-            "libpath": [],
-            "dependencies": [
-                "@stdlib/math/base/special/ramp",
-                "@stdlib/strided/base/dmskmap"
-            ]
-        }
-    ]
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/dmskramp.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/ramp",
+        "@stdlib/strided/base/dmskmap",
+        "@stdlib/strided/napi/dmskmap"
+      ]
+    },
+    {
+      "task": "examples",
+      "src": [
+        "./src/dmskramp.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/ramp",
+        "@stdlib/strided/base/dmskmap"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/dmskramp.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/ramp",
+        "@stdlib/strided/base/dmskmap"
+      ]
+    }
+  ]
 }

--- a/lib/node_modules/@stdlib/math/strided/special/dmskramp/manifest.json
+++ b/lib/node_modules/@stdlib/math/strided/special/dmskramp/manifest.json
@@ -1,75 +1,75 @@
 {
-	"options": {
-		"task": "build"
-	},
-	"fields": [
-		{
-			"field": "src",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "include",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "libraries",
-			"resolve": false,
-			"relative": false
-		},
-		{
-			"field": "libpath",
-			"resolve": true,
-			"relative": false
-		}
-	],
-	"confs": [
-		{
-			"task": "build",
-			"src": [
-				"./src/dmskramp.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [],
-			"libpath": [],
-			"dependencies": [
-				"@stdlib/math/base/special/ramp",
-				"@stdlib/strided/base/dmskmap",
-				"@stdlib/strided/napi/dmskmap"
-			]
-		},
-		{
-			"task": "examples",
-			"src": [
-				"./src/dmskramp.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [],
-			"libpath": [],
-			"dependencies": [
-				"@stdlib/math/base/special/ramp",
-				"@stdlib/strided/base/dmskmap"
-			]
-		},
-		{
-			"task": "benchmark",
-			"src": [
-				"./src/dmskramp.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [],
-			"libpath": [],
-			"dependencies": [
-				"@stdlib/math/base/special/ramp",
-				"@stdlib/strided/base/dmskmap"
-			]
-		}
-	]
+    "options": {
+        "task": "build"
+    },
+    "fields": [
+        {
+            "field": "src",
+            "resolve": true,
+            "relative": true
+        },
+        {
+            "field": "include",
+            "resolve": true,
+            "relative": true
+        },
+        {
+            "field": "libraries",
+            "resolve": false,
+            "relative": false
+        },
+        {
+            "field": "libpath",
+            "resolve": true,
+            "relative": false
+        }
+    ],
+    "confs": [
+        {
+            "task": "build",
+            "src": [
+                "./src/dmskramp.c"
+            ],
+            "include": [
+                "./include"
+            ],
+            "libraries": [],
+            "libpath": [],
+            "dependencies": [
+                "@stdlib/math/base/special/ramp",
+                "@stdlib/strided/base/dmskmap",
+                "@stdlib/strided/napi/dmskmap"
+            ]
+        },
+        {
+            "task": "examples",
+            "src": [
+                "./src/dmskramp.c"
+            ],
+            "include": [
+                "./include"
+            ],
+            "libraries": [],
+            "libpath": [],
+            "dependencies": [
+                "@stdlib/math/base/special/ramp",
+                "@stdlib/strided/base/dmskmap"
+            ]
+        },
+        {
+            "task": "benchmark",
+            "src": [
+                "./src/dmskramp.c"
+            ],
+            "include": [
+                "./include"
+            ],
+            "libraries": [],
+            "libpath": [],
+            "dependencies": [
+                "@stdlib/math/base/special/ramp",
+                "@stdlib/strided/base/dmskmap"
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
Resolves #7623 

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes EditorConfig linting errors in `lib/node_modules/@stdlib/math/strided/special/dmskramp/manifest.json` by converting tab indentation to spaces

## Related Issues

> Does this pull request have any related issues?

This pull request:

-  resolves #7623 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Changes Made
- Converted tab characters to spaces in `manifest.json` to comply with EditorConfig rules

### Verification
- Ran local EditorConfig checks to ensure no linting errors remain
- Verified no tab characters exist in the modified file

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
