### PR TITLE
chore: address commit comments for commit 75a786a (issue #7452)

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/README.md
@@ -56,7 +56,7 @@ var pdf = require( '@stdlib/stats/base/dists/lognormal/pdf' );
 
 #### pdf( x, mu, sigma )
 
-Evaluates the [probability density function][pdf] (PDF) for a [lognormal][lognormal-distribution] distribution with parameters `mu` (location parameter) and `sigma` (scale parameter).
+Evaluates the [probability density function][pdf] (PDF) of a [lognormal][lognormal-distribution] distribution with parameters `mu` (location parameter) and `sigma` (scale parameter).
 
 ```javascript
 var y = pdf( 2.0, 0.0, 1.0 );

--- a/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/lognormal/pdf/README.md
@@ -56,7 +56,7 @@ var pdf = require( '@stdlib/stats/base/dists/lognormal/pdf' );
 
 #### pdf( x, mu, sigma )
 
-Evaluates the [probability density function][pdf] (PDF) of a [lognormal][lognormal-distribution] distribution with parameters `mu` (location parameter) and `sigma` (scale parameter).
+Evaluates the [probability density function][pdf] (PDF) for a [lognormal][lognormal-distribution] distribution with parameters `mu` (location parameter) and `sigma` (scale parameter).
 
 ```javascript
 var y = pdf( 2.0, 0.0, 1.0 );
@@ -167,7 +167,7 @@ for ( i = 0; i < 10; i++ ) {
 
 #### stdlib_base_dists_lognormal_pdf( x, mu, sigma )
 
-Evaluates the [probability density function][pdf] (PDF) of a [lognormal][lognormal-distribution] distribution with parameters input value `x`, location parameter `mu` and scale parameter `sigma`.
+Evaluates the [probability density function][pdf] (PDF) of a [lognormal][lognormal-distribution] distribution with location parameter `mu` and scale parameter `sigma`.
 
 ```c
 double y = stdlib_base_dists_lognormal_pdf( 2.0, 0.0, 1.0 );


### PR DESCRIPTION
Resolves #7452

## Description

> What is the purpose of this pull request?

This pull request:

- Updates the description in the `README.md` file for the `lognormal/pdf` function to address the reviewer comment on commit [`75a786a`](https://github.com/stdlib-js/stdlib/commit/75a786a2b83991e7f7bb5e26a9af1263bba83556).  
- Specifically, it replaces the sentence:
  
  > Evaluates the [probability density function][pdf] (PDF) for a [lognormal][lognormal-distribution] distribution with parameters `mu` (location parameter) and `sigma` (scale parameter).

  with the suggested wording:
  
  > Evaluates the [probability density function][pdf] (PDF) of a [lognormal][lognormal-distribution] distribution with location parameter mu and scale parameter sigma.

## Related Issues

> Does this pull request have any related issues?

This pull request:

- resolves #7452

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
