### PR TITLE
feat: add `assert/is-almost-equal-complex64array`

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-almost-equal-complex64array/README.md
+++ b/lib/node_modules/@stdlib/assert/is-almost-equal-complex64array/README.md
@@ -1,0 +1,126 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2025 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# isAlmostEqualComplex64Array
+
+> Test if two arguments are both [Complex64Arrays][@stdlib/array/complex64] and contain respective elements which are [approximately equal][@stdlib/assert/is-almost-equal] within a specified number of ULPs (units in the last place).
+
+<section class="usage">
+
+## Usage
+
+<!-- eslint-disable id-length -->
+
+```javascript
+var isAlmostEqualComplex64Array = require( '@stdlib/assert/is-almost-equal-complex64array' );
+```
+
+#### isAlmostEqualComplex64Array( v1, v2, maxULP )
+
+Tests if two arguments are both [Complex64Arrays][@stdlib/array/complex64] and contain respective elements which are [approximately equal][@stdlib/assert/is-almost-equal] within a specified number of ULPs (units in the last place).
+
+<!-- eslint-disable id-length -->
+
+```javascript
+var EPS = require( '@stdlib/constants/float32/eps' );
+var Complex64Array = require( '@stdlib/array/complex64' );
+
+var x = new Complex64Array( [ 1.0, 2.0 ] );
+var y = new Complex64Array( [ 1.0+EPS, 2.0 ] );
+
+var bool = isAlmostEqualComplex64Array( x, y, 0 );
+// returns false
+
+bool = isAlmostEqualComplex64Array( x, y, 1 );
+// returns true
+
+bool = isAlmostEqualComplex64Array( x, [ 1.0, 2.0 ], 1 );
+// returns false
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   The function returns `false` if either input value is a `Complex64Array` containing `NaN`.
+-   The function does not distinguish between `-0` and `+0`, treating them as equal.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+<!-- eslint-disable id-length -->
+
+```javascript
+var Complex64Array = require( '@stdlib/array/complex64' );
+var isAlmostEqualComplex64Array = require( '@stdlib/assert/is-almost-equal-complex64array' );
+
+var x = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+var y = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+var out = isAlmostEqualComplex64Array( x, y, 0 );
+console.log( out );
+// => true
+
+x = new Complex64Array( [ -0.0, 0.0, -0.0, 0.0 ] );
+y = new Complex64Array( [ 0.0, -0.0, 0.0, -0.0 ] );
+out = isAlmostEqualComplex64Array( x, y, 1 );
+console.log( out );
+// => true
+
+x = new Complex64Array( [ NaN, NaN, NaN, NaN ] );
+y = new Complex64Array( [ NaN, NaN, NaN, NaN ] );
+out = isAlmostEqualComplex64Array( x, y, 0 );
+console.log( out );
+// => false
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[@stdlib/array/complex64]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/array/complex64
+
+[@stdlib/assert/is-almost-equal]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/assert/is-almost-equal
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/assert/is-almost-equal-complex64array/benchmark/benchmark.length.js
+++ b/lib/node_modules/@stdlib/assert/is-almost-equal-complex64array/benchmark/benchmark.length.js
@@ -1,0 +1,97 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var pow = require( '@stdlib/math/base/special/pow' );
+var zeroTo = require( '@stdlib/array/base/zero-to' );
+var Complex64Array = require( '@stdlib/array/complex64' );
+var pkg = require( './../package.json' ).name;
+var isAlmostEqualComplex64Array = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var x = new Complex64Array( zeroTo( len*2 ) );
+	var y = new Complex64Array( zeroTo( len*2 ) );
+	return benchmark;
+
+	/**
+	* Benchmark function.
+	*
+	* @private
+	* @param {Benchmark} b - benchmark instance
+	*/
+	function benchmark( b ) {
+		var bool;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			bool = isAlmostEqualComplex64Array( x, y, 1 );
+			if ( typeof bool !== 'boolean' ) {
+				b.fail( 'should return a boolean' );
+			}
+		}
+		b.toc();
+		if ( !isBoolean( bool ) ) {
+			b.fail( 'should return a boolean' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':len='+len, f );
+	}
+}
+
+main();

--- a/lib/node_modules/@stdlib/assert/is-almost-equal-complex64array/docs/repl.txt
+++ b/lib/node_modules/@stdlib/assert/is-almost-equal-complex64array/docs/repl.txt
@@ -1,0 +1,43 @@
+
+{{alias}}( v1, v2, maxULP )
+    Tests if two arguments are both Complex64Arrays and contain respective
+    elements which are approximately equal within a specified number of ULPs
+    (units in the last place).
+
+    The function returns `false` if either input value is a `Complex64Array`
+    containing `NaN`.
+
+    The function does not distinguish between `-0` and `+0`, treating them as
+    equal.
+
+    Parameters
+    ----------
+    v1: any
+        First input value.
+
+    v2: any
+        Second input value.
+
+    maxULP: integer
+        Maximum allowed ULP difference.
+
+    Returns
+    -------
+    bool: boolean
+        Boolean indicating whether two arguments are approximately equal.
+
+    Examples
+    --------
+    > var x = new {{alias:@stdlib/array/complex64}}( [ 1.0, 2.0, 3.0, 4.0 ] );
+    > var y = new {{alias:@stdlib/array/complex64}}( [ 1.0, 2.0, 3.0, 4.0 ] );
+    > var bool = {{alias}}( x, y, 0 )
+    true
+
+    > x = new {{alias:@stdlib/array/complex64}}( [ NaN, NaN, NaN, NaN ] );
+    > y = new {{alias:@stdlib/array/complex64}}( [ NaN, NaN, NaN, NaN ] );
+    > bool = {{alias}}( x, y, 1 )
+    false
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/assert/is-almost-equal-complex64array/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/is-almost-equal-complex64array/docs/types/index.d.ts
@@ -1,0 +1,57 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Tests if two arguments are both Complex64Arrays and contain respective elements which are approximately equal within a specified number of ULPs (units in the last place).
+*
+* ## Notes
+*
+* -   The function returns `false` if either input value is a `Complex64Array` containing `NaN`.
+* -   The function does not distinguish between `-0` and `+0`, treating them as equal.
+*
+* @param v1 - first input value
+* @param v2 - second input value
+* @param maxULP - maximum allowed ULP difference
+* @returns boolean indicating whether two arguments are approximately equal
+*
+* @example
+* var Complex64Array = require( '@stdlib/array/complex64' );
+*
+* var x = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var y = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+*
+* var out = isAlmostEqualComplex64Array( x, y, 0 );
+* // returns true
+*
+* @example
+* var Complex64Array = require( '@stdlib/array/complex64' );
+*
+* var x = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var y = new Complex64Array( [ 1.0, 2.0, 4.0, 4.0 ] );
+*
+* var out = isAlmostEqualComplex64Array( x, y, 1 );
+* // returns false
+*/
+declare function isAlmostEqualComplex64Array( v1: any, v2: any, maxULP: number ): boolean;
+
+
+// EXPORTS //
+
+export = isAlmostEqualComplex64Array;

--- a/lib/node_modules/@stdlib/assert/is-almost-equal-complex64array/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/assert/is-almost-equal-complex64array/docs/types/test.ts
@@ -1,0 +1,49 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import isAlmostEqualComplex64Array = require( './index' );
+
+
+// TESTS //
+
+// The function returns a boolean...
+{
+	isAlmostEqualComplex64Array( 3.14, 3.14, 1 ); // $ExpectType boolean
+	isAlmostEqualComplex64Array( null, null, 1 ); // $ExpectType boolean
+	isAlmostEqualComplex64Array( 'beep', 'boop', 1 ); // $ExpectType boolean
+}
+
+// The compiler throws an error if the function is provided a third argument which is not a number...
+{
+	isAlmostEqualComplex64Array( 3.14, 3.14, '1' ); // $ExpectError
+	isAlmostEqualComplex64Array( 3.14, 3.14, true ); // $ExpectError
+	isAlmostEqualComplex64Array( 3.14, 3.14, false ); // $ExpectError
+	isAlmostEqualComplex64Array( 3.14, 3.14, null ); // $ExpectError
+	isAlmostEqualComplex64Array( 3.14, 3.14, undefined ); // $ExpectError
+	isAlmostEqualComplex64Array( 3.14, 3.14, [] ); // $ExpectError
+	isAlmostEqualComplex64Array( 3.14, 3.14, {} ); // $ExpectError
+	isAlmostEqualComplex64Array( 3.14, 3.14, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	isAlmostEqualComplex64Array(); // $ExpectError
+	isAlmostEqualComplex64Array( 3.14 ); // $ExpectError
+	isAlmostEqualComplex64Array( 3.14, 3.14 ); // $ExpectError
+	isAlmostEqualComplex64Array( 'beep', 'beep', 2, {} ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/assert/is-almost-equal-complex64array/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-almost-equal-complex64array/examples/index.js
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var Complex64Array = require( '@stdlib/array/complex64' );
+var isAlmostEqualComplex64Array = require( './../lib' );
+
+var x = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+var y = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+var out = isAlmostEqualComplex64Array( x, y, 0 );
+console.log( out );
+// => true
+
+x = new Complex64Array( [ -0.0, 0.0, -0.0, 0.0 ] );
+y = new Complex64Array( [ 0.0, -0.0, 0.0, -0.0 ] );
+out = isAlmostEqualComplex64Array( x, y, 1 );
+console.log( out );
+// => true
+
+x = new Complex64Array( [ NaN, NaN, NaN, NaN ] );
+y = new Complex64Array( [ NaN, NaN, NaN, NaN ] );
+out = isAlmostEqualComplex64Array( x, y, 0 );
+console.log( out );
+// => false

--- a/lib/node_modules/@stdlib/assert/is-almost-equal-complex64array/lib/index.js
+++ b/lib/node_modules/@stdlib/assert/is-almost-equal-complex64array/lib/index.js
@@ -1,0 +1,54 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Test if two arguments are both Complex64Arrays and contain respective elements which are approximately equal within a specified number of ULPs (units in the last place).
+*
+* @module @stdlib/assert/is-almost-equal-complex64array
+*
+* @example
+* var Complex64Array = require( '@stdlib/array/complex64' );
+* var isAlmostEqualComplex64Array = require( '@stdlib/assert/is-almost-equal-complex64array' );
+*
+* var x = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var y = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+*
+* var out = isAlmostEqualComplex64Array( x, y, 0 );
+* // returns true
+*
+* @example
+* var Complex64Array = require( '@stdlib/array/complex64' );
+* var isAlmostEqualComplex64Array = require( '@stdlib/assert/is-almost-equal-complex64array' );
+*
+* var x = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var y = new Complex64Array( [ 1.0, 2.0, 4.0, 4.0 ] );
+*
+* var out = isAlmostEqualComplex64Array( x, y, 1 );
+* // returns false
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/assert/is-almost-equal-complex64array/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/is-almost-equal-complex64array/lib/main.js
@@ -1,0 +1,67 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isComplex64Array = require( '@stdlib/assert/is-complex64array' );
+var hasAlmostEqualValues = require( '@stdlib/array/base/assert/has-almost-equal-values' );
+
+
+// MAIN //
+
+/**
+* Tests if two arguments are both Complex64Arrays and contain respective elements which are approximately equal within a specified number of ULPs (units in the last place).
+*
+* ## Notes
+*
+* -   The function returns `false` if either input value is a `Complex64Array` containing `NaN`.
+* -   The function does not distinguish between `-0` and `+0`, treating them as equal.
+*
+* @param {*} v1 - first value
+* @param {*} v2 - second value
+* @param {NonNegativeInteger} maxULP - maximum allowed ULP difference
+* @returns {boolean} boolean indicating whether two arguments are approximately equal
+*
+* @example
+* var Complex64Array = require( '@stdlib/array/complex64' );
+*
+* var x = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var y = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+*
+* var out = isAlmostEqualComplex64Array( x, y, 0 );
+* // returns true
+*
+* @example
+* var Complex64Array = require( '@stdlib/array/complex64' );
+*
+* var x = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var y = new Complex64Array( [ 1.0, 2.0, 4.0, 4.0 ] );
+*
+* var out = isAlmostEqualComplex64Array( x, y, 1 );
+* // returns false
+*/
+function isAlmostEqualComplex64Array( v1, v2, maxULP ) {
+	return ( isComplex64Array( v1 ) && isComplex64Array( v2 ) && hasAlmostEqualValues( v1, v2, maxULP ) );  // eslint-disable-line max-len
+}
+
+
+// EXPORTS //
+
+module.exports = isAlmostEqualComplex64Array;

--- a/lib/node_modules/@stdlib/assert/is-almost-equal-complex64array/package.json
+++ b/lib/node_modules/@stdlib/assert/is-almost-equal-complex64array/package.json
@@ -1,0 +1,77 @@
+{
+  "name": "@stdlib/assert/is-almost-equal-complex64array",
+  "version": "0.0.0",
+  "description": "Test if two arguments are both Complex64Arrays and contain respective elements which are approximately equal within a specified number of ULPs (units in the last place).",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdassert",
+    "assertion",
+    "assert",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "equal",
+    "same",
+    "strict",
+    "is",
+    "issame",
+    "issamevalue",
+    "isequal",
+    "isstrictequal",
+    "type",
+    "check",
+    "valid",
+    "validate",
+    "test",
+    "typed",
+    "array",
+    "complex64"
+  ]
+}

--- a/lib/node_modules/@stdlib/assert/is-almost-equal-complex64array/test/test.js
+++ b/lib/node_modules/@stdlib/assert/is-almost-equal-complex64array/test/test.js
@@ -1,0 +1,114 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var typedarray = require( '@stdlib/array/typed' );
+var EPS = require( '@stdlib/constants/float32/eps' );
+var isAlmostEqualComplex64Array = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof isAlmostEqualComplex64Array, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns `true` if provided two Complex64Arrays having almost equal values', function test( t ) {
+	var x;
+	var y;
+
+	x = typedarray( [ 1.0, 2.0, 3.0, 4.0 ], 'complex64' );
+	t.strictEqual( isAlmostEqualComplex64Array( x, x, 0 ), true, 'returns expected value' );
+
+	x = typedarray( [ 1.0, 2.0, 3.0, 4.0 ], 'complex64' );
+	y = typedarray( [ 1.0, 2.0, 3.0, 4.0 ], 'complex64' );
+	t.strictEqual( isAlmostEqualComplex64Array( x, y, 0 ), true, 'returns expected value' );
+
+	x = typedarray( [ -0.0, 0.0, -0.0, 0.0 ], 'complex64' );
+	y = typedarray( [ -0.0, 0.0, -0.0, 0.0 ], 'complex64' );
+	t.strictEqual( isAlmostEqualComplex64Array( x, y, 0 ), true, 'returns expected value' );
+
+	x = typedarray( [ 1.0, 2.0, 3.0, 4.0 ], 'complex64' );
+	y = typedarray( [ 1.0+EPS, 2.0, 3.0, 4.0 ], 'complex64' );
+	t.strictEqual( isAlmostEqualComplex64Array( x, y, 1 ), true, 'returns expected value' );
+
+	t.end();
+});
+
+tape( 'the function returns `false` if not provided two Complex64Arrays having almost equal values', function test( t ) {
+	var x;
+	var y;
+	var i;
+
+	x = [
+		'',
+		'beep',
+		5,
+		3.14,
+		-3.14,
+		0.0,
+		-0.0,
+		true,
+		false,
+		null,
+		void 0,
+		[],
+		{},
+		function noop() {},
+		typedarray( 10, 'float32' ),
+		typedarray( 10, 'int32' ),
+		typedarray( 10, 'complex64' ),
+		typedarray( [ 1.0, 2.0, 3.0, 4.0 ], 'complex64' ),
+		typedarray( [ -0.0, -0.0, -0.0, -0.0 ], 'complex64' ),
+		typedarray( [ 1.0, 2.0, 3.0, 4.0 ], 'complex64' ),
+		typedarray( [ NaN, NaN, NaN, NaN ], 'complex64' )
+	];
+	y = [
+		'abc',
+		'boop',
+		-5,
+		-3.14,
+		3.14,
+		-0.0,
+		0.0,
+		false,
+		true,
+		void 0,
+		null,
+		[],
+		{},
+		function noop() {},
+		typedarray( 10, 'float32' ),
+		typedarray( 10, 'int32' ),
+		typedarray( 10, 'float32' ),
+		typedarray( [ 2.0, 4.0, 6.0, 8.0 ], 'complex64' ),
+		typedarray( [ 0.0, 0.0, 1.0, 1.0 ], 'complex64' ),
+		typedarray( [ 1.0+EPS+EPS, 2.0, 3.0, 4.0 ], 'complex64' ),
+		typedarray( [ NaN, NaN, NaN, NaN ], 'complex64' )
+	];
+	for ( i = 0; i < x.length; i++ ) {
+		t.strictEqual( isAlmostEqualComplex64Array( x[ i ], y[ i ], 1 ), false, 'returns expected value' );
+	}
+	t.end();
+});


### PR DESCRIPTION
Resolves None

## Description

> What is the purpose of this pull request?

This pull request:

-  Adds the implementation for `assert/is-almost-equal-complex64array`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolve none.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
