### PR TITLE
chore: address commit comments for commit  `dd4ec1f ` (issue #7454)

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/gumbel/quantile/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/gumbel/quantile/README.md
@@ -1,5 +1,4 @@
 <!--
-
 @license Apache-2.0
 
 Copyright (c) 2018 The Stdlib Authors.
@@ -55,7 +54,7 @@ var quantile = require( '@stdlib/stats/base/dists/gumbel/quantile' );
 
 #### quantile( p, mu, beta )
 
-Evaluates the [quantile function][quantile-function] for a [Gumbel][gumbel-distribution] distribution with parameters `mu` (location parameter) and `beta` (scale parameter).
+Evaluates the [quantile function][quantile-function] for a [Gumbel][gumbel-distribution] distribution with parameters `mu` (location parameter), and `beta` (scale parameter).
 
 ```javascript
 var y = quantile( 0.8, 0.0, 1.0 );
@@ -148,6 +147,11 @@ for ( i = 0; i < 100; i++ ) {
 </section>
 
 <!-- /.examples -->
+
+<!-- Section for related `stdlib ` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
 
 <!-- C interface documentation. -->
 
@@ -246,7 +250,7 @@ int main( void ) {
 
 </section>
 
-<!-- /.c -->
+<!-- /.related -->
 
 <!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
 


### PR DESCRIPTION
Resolves #7457

## Description

Removed the extra empty line
Added an Oxford comma after “mu,”
Re‐introduced the empty “Related packages” section and its comment

## Related Issues

#7457

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
