### PR TITLE
chore: fix JavaScript lint errors (issue #<6956>)

### DIFF
--- a/lib/node_modules/@stdlib/plot/components/svg/clip-path/lib/main.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/clip-path/lib/main.js
@@ -131,10 +131,10 @@ function ClipPath( options ) {
 		var args;
 		var i;
 		debug( 'Received a render event. Re-emitting...' );
-		args = new Array( arguments.length+1 );
-		args[ 0 ] = 'render';
-		for ( i = 0; i < arguments.length; i++ ) {
-			args[ i+1 ] = arguments[ i ];
+		args = [];
+		args[0]='render';
+		for( i=0;i<arguments.length;i++){
+            args.push(arguments[i]);
 		}
 		self.emit.apply( self, args );
 	}

--- a/lib/node_modules/@stdlib/stats/base/dists/bernoulli/ctor/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/bernoulli/ctor/lib/main.js
@@ -354,7 +354,7 @@ setReadOnly( Bernoulli.prototype, 'pmf', bernoulliPMF );
 * var bernoulli = new Bernoulli( 0.2 );
 *
 * var v = bernoulli.quantile( 0.9 );
-* // returns 1
+* // returns 1.0
 */
 setReadOnly( Bernoulli.prototype, 'quantile', bernoulliQuantile );
 


### PR DESCRIPTION
Resolves #6956.

## Description

> What is the purpose of this pull request?

This pull request:

- Replaces the use of `new Array()` with array literal and `push()` to conform to the `stdlib/no-new-array` ESLint rule.
- Fixes a linting error in `lib/node_modules/@stdlib/plot/components/svg/clip-path/lib/main.js` to ensure code style consistency and maintainability.

## Related Issues

> Does this pull request have any related issues?

This pull request:

- Resolves #6956

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines][contributing].

---

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
