### PR TITLE
chore: fix JavaScript lint errors (issue #7553)

### DIFF
--- a/lib/node_modules/@stdlib/bench/harness/lib/runner/create_stream.js
+++ b/lib/node_modules/@stdlib/bench/harness/lib/runner/create_stream.js
@@ -22,7 +22,7 @@
 
 // MODULES //
 
-var TransformStream = require( '@stdlib/streams/node/transform' );
+TransformStream = require( '@stdlib/streams/node/transform' );
 var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
 var nextTick = require( './../utils/next_tick.js' );
 


### PR DESCRIPTION
Resolves #7553.

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes a JavaScript lint error where TransformStream was being reported as "already defined" by removing re-declaration

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #7553

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
