### PR TITLE
chore: fix JavaScript lint errors (issue #7553)

### DIFF
--- a/lib/node_modules/@stdlib/bench/harness/lib/runner/create_stream.js
+++ b/lib/node_modules/@stdlib/bench/harness/lib/runner/create_stream.js
@@ -22,7 +22,7 @@
 
 // MODULES //
 
-TransformStream = require( '@stdlib/streams/node/transform' );
+var StdlibTransformStream = require( '@stdlib/streams/node/transform' );
 var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
 var nextTick = require( './../utils/next_tick.js' );
 
@@ -56,7 +56,7 @@ function createStream( options ) {
 	} else {
 		opts = {};
 	}
-	stream = new TransformStream( opts );
+	stream = new StdlibTransformStream( opts );
 	if ( opts.objectMode ) {
 		id = 0;
 		this.on( '_push', onPush );

--- a/lib/node_modules/@stdlib/bench/harness/lib/runner/create_stream.js
+++ b/lib/node_modules/@stdlib/bench/harness/lib/runner/create_stream.js
@@ -22,7 +22,7 @@
 
 // MODULES //
 
-var TransformStream = require( '@stdlib/streams/node/transform' );
+TransformStream = require( '@stdlib/streams/node/transform' );
 var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
 var nextTick = require( './../utils/next_tick.js' );
 

--- a/lib/node_modules/@stdlib/bench/harness/lib/runner/create_stream.js
+++ b/lib/node_modules/@stdlib/bench/harness/lib/runner/create_stream.js
@@ -22,7 +22,7 @@
 
 // MODULES //
 
-var StdlibTransformStream = require( '@stdlib/streams/node/transform' );
+var TransformStream = require( '@stdlib/streams/node/transform' ); // eslint-disable-line stdlib/no-redeclare
 var isString = require( '@stdlib/assert/is-string' ).isPrimitive;
 var nextTick = require( './../utils/next_tick.js' );
 
@@ -56,7 +56,7 @@ function createStream( options ) {
 	} else {
 		opts = {};
 	}
-	stream = new StdlibTransformStream( opts );
+	stream = new TransformStream( opts );
 	if ( opts.objectMode ) {
 		id = 0;
 		this.on( '_push', onPush );


### PR DESCRIPTION
Resolves #7553.

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes a JavaScript lint error where TransformStream was being reported as "already defined" by renaming the imported variable to StdlibTransformStream. This avoids conflicts with potential global or built-in TransformStream objects.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #7553

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
