### PR TITLE
docs: lowercase 'binomial' in description

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/entropy/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/entropy/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Entropy
 
-> [Binomial][binomial-distribution] distribution [entropy][entropy].
+> [binomial][binomial-distribution] distribution [entropy][entropy].
 
 <!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
 

--- a/lib/node_modules/@stdlib/stats/base/dists/binomial/entropy/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/binomial/entropy/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # Entropy
 
-> [binomial][binomial-distribution] distribution [entropy][entropy].
+> [Binomial][binomial-distribution] distribution [entropy][entropy].
 
 <!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
 
@@ -166,7 +166,7 @@ logEachMap( 'n: %0.4f, p: %0.4f, H(X;n,p): %0.4f', n, p, entropy );
 
 #### stdlib_base_dists_binomial_entropy( n, p )
 
-Evaluates the [entropy][entropy] of a [Binomial][binomial-distribution] distribution with `n` the number of trials and `p` the success probability.
+Evaluates the [entropy][entropy] of a [binomial][binomial-distribution] distribution with `n` the number of trials and `p` the success probability.
 
 ```c
 double out = stdlib_base_dists_binomial_entropy( 20, 0.1 );


### PR DESCRIPTION
Resolves

Resolves #7758

Description

> What is the purpose of this pull request?

This pull request addresses a reviewer comment from commit [394df9c](https://github.com/stdlib-js/stdlib/commit/394df9c) by:

- Fixing a capitalization issue in the README file for the binomial distribution's entropy documentation.
- Specifically, changing **"Binomial"** to **"binomial"** to follow the standard lowercase naming convention used throughout the project.

Related Issues

> Does this pull request have any related issues?

- Resolves #7758
- Follows up on feedback from commit [394df9c](https://github.com/stdlib-js/stdlib/commit/394df9c)

Questions

> Any questions for reviewers of this pull request?

No.

Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No additional notes.

Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines][contributing].

---

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
