### PR TITLE
chore: fix EditorConfig lint errors (issue #7774)

### DIFF
--- a/lib/node_modules/@stdlib/strided/napi/binary/manifest.json
+++ b/lib/node_modules/@stdlib/strided/napi/binary/manifest.json
@@ -1,43 +1,43 @@
 {
-	"options": {},
-	"fields": [
-		{
-			"field": "src",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "include",
-			"resolve": true,
-			"relative": true
-		},
-		{
-			"field": "libraries",
-			"resolve": false,
-			"relative": false
-		},
-		{
-			"field": "libpath",
-			"resolve": true,
-			"relative": false
-		}
-	],
-	"confs": [
-		{
-			"src": [
-				"./src/main.c"
-			],
-			"include": [
-				"./include"
-			],
-			"libraries": [],
-			"libpath": [],
-			"dependencies": [
-				"@stdlib/strided/base/function-object",
-				"@stdlib/strided/base/binary",
-				"@stdlib/strided/dtypes",
-				"@stdlib/strided/napi/addon-arguments"
-			]
-		}
-	]
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/strided/base/function-object",
+        "@stdlib/strided/base/binary",
+        "@stdlib/strided/dtypes",
+        "@stdlib/strided/napi/addon-arguments"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Resolves #7774 

## Description

Fixes indentation error by replacing Tabs with Spaces

## Related Issues

#7774 

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
