### PR TITLE
chore: fix JavaScript lint errors (issue #7782)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/pkgs/deps/lib/resolve.sync.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/deps/lib/resolve.sync.js
@@ -50,7 +50,7 @@ function resolve( entries, builtins ) {
 	var k;
 
 	len = entries.length;
-	cache = Array.from({ length:len });
+	cache = [];
 
 	opts = {
 		'walk': true,
@@ -63,10 +63,10 @@ function resolve( entries, builtins ) {
 		pkg = entries[ i ].pkg;
 		k = i + 1;
 
-		cache[ i ] = {
+		cache.push({
 			'pkg': entries[ i ].pkg,
 			'dir': entries[ i ].dir
-		};
+		});
 		debug( 'Resolving package: %s (%d of %d)...', pkg, k, len );
 		results = pkgDeps( entries[ i ].entries, opts );
 		if ( results instanceof Error ) {

--- a/lib/node_modules/@stdlib/_tools/pkgs/deps/lib/resolve.sync.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/deps/lib/resolve.sync.js
@@ -50,7 +50,7 @@ function resolve( entries, builtins ) {
 	var k;
 
 	len = entries.length;
-	cache = new Array( len );
+	cache = Array.from({ length:len });
 
 	opts = {
 		'walk': true,


### PR DESCRIPTION
Resolves #7782.

## Description

This pull request fixes a JavaScript lint error in `resolve.sync.js`.  
Specifically, it replaces the disallowed `new Array(len)` constructor with `Array.from({ length: len })` to comply with the project's linting rules.

## Related Issues

This pull request:

- resolves #7782

## Questions

No questions for reviewers.

## Other

No other information.

## Checklist

- [x] Read, understood, and followed the [contributing guidelines][contributing].

---

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
