### PR TITLE
chore: fix EditorConfig lint errors (issue #7793)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/github/create-issue/test/fixtures/info.json
+++ b/lib/node_modules/@stdlib/_tools/github/create-issue/test/fixtures/info.json
@@ -1,5 +1,5 @@
 {
-	"limit": 5000,
-	"remaining": 4823,
-	"reset": 1454693201845
+  "name": "stdlib",
+  "version": "1.0.0",
+  "description": "..."
 }


### PR DESCRIPTION
This PR fixes EditorConfig lint errors in the file:  
lib/node_modules/@stdlib/_tools/github/create-issue/test/fixtures/info.json

- Replaced tabs with spaces on lines 2–4

Related Issues:  
resolves #7793

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
