### PR TITLE
chore: fix JavaScript lint warning (issue #6762)

### DIFF
--- a/lib/node_modules/@stdlib/utils/async/inmap/lib/limit.js
+++ b/lib/node_modules/@stdlib/utils/async/inmap/lib/limit.js
@@ -24,7 +24,7 @@ var logger = require( 'debug' );
 
 
 // VARIABLES //
-
+// cspell: ignore inmap 
 var debug = logger( 'inmap-async:limit' );
 
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

- Fixes a JavaScript lint warning in the `lib/node_modules/@stdlib/utils/async/inmap/lib/limit.js` file by adding a directive comment (`// cspell:ignore inmap`) to satisfy the spellchecker rule.

## Related Issues

> Does this pull request have any related issues?

This pull request:

- Resolves #6762

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
