### PR TITLE
docs: use correct types in `number/uint32/base/add`

### DIFF
--- a/lib/node_modules/@stdlib/number/uint32/base/add/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/uint32/base/add/benchmark/c/benchmark.c
@@ -101,7 +101,7 @@ static uint32_t add( const uint32_t x, const uint32_t y ) {
 static double benchmark( void ) {
 	uint32_t x[ 100 ];
 	double elapsed;
-	double y;
+	uint32_t y;
 	double t;
 	int i;
 

--- a/lib/node_modules/@stdlib/number/uint32/base/add/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/number/uint32/base/add/benchmark/c/native/benchmark.c
@@ -93,7 +93,7 @@ static double rand_double( void ) {
 static double benchmark( void ) {
 	uint32_t x[ 100 ];
 	double elapsed;
-	double y;
+	uint32_t y;
 	double t;
 	int i;
 

--- a/lib/node_modules/@stdlib/number/uint32/base/add/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint32/base/add/lib/main.js
@@ -29,9 +29,9 @@
 * -   `+`: summation is exact as IEEE-754 integer addition of two unsigned 32-bit integers fits inside 53-bit range.
 * -   `>>> 0`: keep the low 32 bits.
 *
-* @param {integer} x - first input value
-* @param {integer} y - second input value
-* @returns {integer} sum
+* @param {uinteger} x - first input value
+* @param {uinteger} y - second input value
+* @returns {uinteger} sum
 *
 * @example
 * var v = add( 1>>>0, 5>>>0 );

--- a/lib/node_modules/@stdlib/number/uint32/base/add/lib/native.js
+++ b/lib/node_modules/@stdlib/number/uint32/base/add/lib/native.js
@@ -29,9 +29,9 @@ var addon = require( './../src/addon.node' );
 * Computes the sum of two unsigned 32-bit integers `x` and `y`.
 *
 * @private
-* @param {integer} x - first input value
-* @param {integer} y - second input value
-* @returns {integer} sum
+* @param {uinteger} x - first input value
+* @param {uinteger} y - second input value
+* @returns {uinteger} sum
 *
 * @example
 * var v = add( 1>>>0, 5>>>0 );


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: passed
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: na
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Resolves None.

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces `integer` by `uinteger` in JSDoC comments.
-   updates C benchmarks to use `uint32` instead of `double`, in [`@stdlib/number/uint32/base/add`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/number/uint32/base/add).

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
