### PR TITLE
bench: fix types in C benchmarks

### DIFF
--- a/lib/node_modules/@stdlib/number/uint16/base/add/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/uint16/base/add/benchmark/c/benchmark.c
@@ -101,7 +101,7 @@ static uint16_t add( const uint16_t x, const uint16_t y ) {
 static double benchmark( void ) {
 	uint16_t x[ 100 ];
 	double elapsed;
-	double y;
+	uint16_t y;
 	double t;
 	int i;
 

--- a/lib/node_modules/@stdlib/number/uint16/base/add/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/number/uint16/base/add/benchmark/c/native/benchmark.c
@@ -93,7 +93,7 @@ static double rand_double( void ) {
 static double benchmark( void ) {
 	uint16_t x[ 100 ];
 	double elapsed;
-	double y;
+	uint16_t y;
 	double t;
 	int i;
 

--- a/lib/node_modules/@stdlib/number/uint16/base/mul/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/uint16/base/mul/benchmark/c/benchmark.c
@@ -101,7 +101,7 @@ static uint16_t mul( const uint16_t x, const uint16_t y ) {
 static double benchmark( void ) {
 	uint16_t x[ 100 ];
 	double elapsed;
-	double y;
+	uint16_t y;
 	double t;
 	int i;
 

--- a/lib/node_modules/@stdlib/number/uint16/base/mul/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/number/uint16/base/mul/benchmark/c/native/benchmark.c
@@ -93,7 +93,7 @@ static double rand_double( void ) {
 static double benchmark( void ) {
 	uint16_t x[ 100 ];
 	double elapsed;
-	double y;
+	uint16_t y;
 	double t;
 	int i;
 

--- a/lib/node_modules/@stdlib/number/uint16/base/sub/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/uint16/base/sub/benchmark/c/benchmark.c
@@ -101,7 +101,7 @@ static uint16_t sub( const uint16_t x, const uint16_t y ) {
 static double benchmark( void ) {
 	uint16_t x[ 100 ];
 	double elapsed;
-	double y;
+	uint16_t y;
 	double t;
 	int i;
 

--- a/lib/node_modules/@stdlib/number/uint16/base/sub/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/number/uint16/base/sub/benchmark/c/native/benchmark.c
@@ -93,7 +93,7 @@ static double rand_double( void ) {
 static double benchmark( void ) {
 	uint16_t x[ 100 ];
 	double elapsed;
-	double y;
+	uint16_t y;
 	double t;
 	int i;
 

--- a/lib/node_modules/@stdlib/number/uint32/base/sub/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/uint32/base/sub/benchmark/c/benchmark.c
@@ -101,7 +101,7 @@ static uint32_t sub( const uint32_t x, const uint32_t y ) {
 static double benchmark( void ) {
 	uint32_t x[ 100 ];
 	double elapsed;
-	double y;
+	uint32_t y;
 	double t;
 	int i;
 

--- a/lib/node_modules/@stdlib/number/uint32/base/sub/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/number/uint32/base/sub/benchmark/c/native/benchmark.c
@@ -93,7 +93,7 @@ static double rand_double( void ) {
 static double benchmark( void ) {
 	uint32_t x[ 100 ];
 	double elapsed;
-	double y;
+	uint32_t y;
 	double t;
 	int i;
 

--- a/lib/node_modules/@stdlib/number/uint8/base/add/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/uint8/base/add/benchmark/c/benchmark.c
@@ -101,7 +101,7 @@ static uint8_t add( const uint8_t x, const uint8_t y ) {
 static double benchmark( void ) {
 	uint8_t x[ 100 ];
 	double elapsed;
-	double y;
+	uint8_t y;
 	double t;
 	int i;
 

--- a/lib/node_modules/@stdlib/number/uint8/base/add/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/number/uint8/base/add/benchmark/c/native/benchmark.c
@@ -93,7 +93,7 @@ static double rand_double( void ) {
 static double benchmark( void ) {
 	uint8_t x[ 100 ];
 	double elapsed;
-	double y;
+	uint8_t y;
 	double t;
 	int i;
 

--- a/lib/node_modules/@stdlib/number/uint8/base/mul/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/uint8/base/mul/benchmark/c/benchmark.c
@@ -101,7 +101,7 @@ static uint8_t mul( const uint8_t x, const uint8_t y ) {
 static double benchmark( void ) {
 	uint8_t x[ 100 ];
 	double elapsed;
-	double y;
+	uint8_t y;
 	double t;
 	int i;
 

--- a/lib/node_modules/@stdlib/number/uint8/base/mul/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/number/uint8/base/mul/benchmark/c/native/benchmark.c
@@ -93,7 +93,7 @@ static double rand_double( void ) {
 static double benchmark( void ) {
 	uint8_t x[ 100 ];
 	double elapsed;
-	double y;
+	uint8_t y;
 	double t;
 	int i;
 

--- a/lib/node_modules/@stdlib/number/uint8/base/sub/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/uint8/base/sub/benchmark/c/benchmark.c
@@ -101,7 +101,7 @@ static uint8_t sub( const uint8_t x, const uint8_t y ) {
 static double benchmark( void ) {
 	uint8_t x[ 100 ];
 	double elapsed;
-	double y;
+	uint8_t y;
 	double t;
 	int i;
 

--- a/lib/node_modules/@stdlib/number/uint8/base/sub/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/number/uint8/base/sub/benchmark/c/native/benchmark.c
@@ -93,7 +93,7 @@ static double rand_double( void ) {
 static double benchmark( void ) {
 	uint8_t x[ 100 ];
 	double elapsed;
-	double y;
+	uint8_t y;
 	double t;
 	int i;
 


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: passed
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: na
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Resolves None.

## Description

> What is the purpose of this pull request?

This pull request:

-   uses the appropriate data type instead of `double` in C benchmarks, for `@stdlib/number/uint32`, `@stdlib/number/uint16` and `@stdlib/number/uint8`. 

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

This problem was present in multiple packages, so I included all of them in this PR, instead of opening multiple PRs.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
