### PR TITLE
docs: replace `integer` by `uinteger` in JSDocs

### DIFF
--- a/lib/node_modules/@stdlib/number/uint16/base/add/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint16/base/add/lib/main.js
@@ -29,9 +29,9 @@ var MASK = 0xFFFF;
 /**
 * Computes the sum of two unsigned 16-bit integers `x` and `y`.
 *
-* @param {integer} x - first input value
-* @param {integer} y - second input value
-* @returns {integer} sum
+* @param {uinteger} x - first input value
+* @param {uinteger} y - second input value
+* @returns {uinteger} sum
 *
 * @example
 * var v = add( 1, 5 );

--- a/lib/node_modules/@stdlib/number/uint16/base/add/lib/native.js
+++ b/lib/node_modules/@stdlib/number/uint16/base/add/lib/native.js
@@ -29,9 +29,9 @@ var addon = require( './../src/addon.node' );
 * Computes the sum of two unsigned 16-bit integers `x` and `y`.
 *
 * @private
-* @param {integer} x - first input value
-* @param {integer} y - second input value
-* @returns {integer} sum
+* @param {uinteger} x - first input value
+* @param {uinteger} y - second input value
+* @returns {uinteger} sum
 *
 * @example
 * var v = add( 1, 5 );

--- a/lib/node_modules/@stdlib/number/uint16/base/mul/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint16/base/mul/lib/main.js
@@ -34,9 +34,9 @@ var MASK = 0xFFFF;
 /**
 * Multiplies two unsigned 16-bit integers `x` and `y`.
 *
-* @param {integer} x - first input value
-* @param {integer} y - second input value
-* @returns {integer} result
+* @param {uinteger} x - first input value
+* @param {uinteger} y - second input value
+* @returns {uinteger} result
 *
 * @example
 * var v = mul( 5, 1 );

--- a/lib/node_modules/@stdlib/number/uint16/base/mul/lib/native.js
+++ b/lib/node_modules/@stdlib/number/uint16/base/mul/lib/native.js
@@ -29,9 +29,9 @@ var addon = require( './../src/addon.node' );
 * Multiplies two unsigned 16-bit integers `x` and `y`.
 *
 * @private
-* @param {integer} x - first input value
-* @param {integer} y - second input value
-* @returns {integer} result
+* @param {uinteger} x - first input value
+* @param {uinteger} y - second input value
+* @returns {uinteger} result
 *
 * @example
 * var v = mul( 5, 1 );

--- a/lib/node_modules/@stdlib/number/uint16/base/sub/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint16/base/sub/lib/main.js
@@ -29,9 +29,9 @@ var MASK = 0xFFFF;
 /**
 * Subtracts two unsigned 16-bit integers `x` and `y`.
 *
-* @param {integer} x - first input value
-* @param {integer} y - second input value
-* @returns {integer} result
+* @param {uinteger} x - first input value
+* @param {uinteger} y - second input value
+* @returns {uinteger} result
 *
 * @example
 * var v = sub( 5, 1 );

--- a/lib/node_modules/@stdlib/number/uint16/base/sub/lib/native.js
+++ b/lib/node_modules/@stdlib/number/uint16/base/sub/lib/native.js
@@ -29,9 +29,9 @@ var addon = require( './../src/addon.node' );
 * Subtracts two unsigned 16-bit integers `x` and `y`.
 *
 * @private
-* @param {integer} x - first input value
-* @param {integer} y - second input value
-* @returns {integer} result
+* @param {uinteger} x - first input value
+* @param {uinteger} y - second input value
+* @returns {uinteger} result
 *
 * @example
 * var v = sub( 5, 1 );

--- a/lib/node_modules/@stdlib/number/uint32/base/sub/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint32/base/sub/lib/main.js
@@ -29,9 +29,9 @@
 * -   `-`: subtraction is exact as IEEE-754 integer subtraction of two unsigned 32-bit integers fits inside 53-bit range.
 * -   `>>> 0`: keep the low 32 bits.
 *
-* @param {integer} x - first input value
-* @param {integer} y - second input value
-* @returns {integer} result
+* @param {uinteger} x - first input value
+* @param {uinteger} y - second input value
+* @returns {uinteger} result
 *
 * @example
 * var v = sub( 5>>>0, 1>>>0 );

--- a/lib/node_modules/@stdlib/number/uint32/base/sub/lib/native.js
+++ b/lib/node_modules/@stdlib/number/uint32/base/sub/lib/native.js
@@ -29,9 +29,9 @@ var addon = require( './../src/addon.node' );
 * Subtracts two unsigned 32-bit integers `x` and `y`.
 *
 * @private
-* @param {integer} x - first input value
-* @param {integer} y - second input value
-* @returns {integer} result
+* @param {uinteger} x - first input value
+* @param {uinteger} y - second input value
+* @returns {uinteger} result
 *
 * @example
 * var v = sub( 5>>>0, 1>>>0 );

--- a/lib/node_modules/@stdlib/number/uint8/base/add/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint8/base/add/lib/main.js
@@ -29,9 +29,9 @@ var MASK = 0xFF;
 /**
 * Computes the sum of two unsigned 8-bit integers `x` and `y`.
 *
-* @param {integer} x - first input value
-* @param {integer} y - second input value
-* @returns {integer} sum
+* @param {uinteger} x - first input value
+* @param {uinteger} y - second input value
+* @returns {uinteger} sum
 *
 * @example
 * var v = add( 1, 5 );

--- a/lib/node_modules/@stdlib/number/uint8/base/add/lib/native.js
+++ b/lib/node_modules/@stdlib/number/uint8/base/add/lib/native.js
@@ -29,9 +29,9 @@ var addon = require( './../src/addon.node' );
 * Computes the sum of two unsigned 8-bit integers `x` and `y`.
 *
 * @private
-* @param {integer} x - first input value
-* @param {integer} y - second input value
-* @returns {integer} sum
+* @param {uinteger} x - first input value
+* @param {uinteger} y - second input value
+* @returns {uinteger} sum
 *
 * @example
 * var v = add( 1, 5 );

--- a/lib/node_modules/@stdlib/number/uint8/base/mul/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint8/base/mul/lib/main.js
@@ -29,9 +29,9 @@ var MASK = 0xFF;
 /**
 * Multiplies two unsigned 8-bit integers `x` and `y`.
 *
-* @param {integer} x - first input value
-* @param {integer} y - second input value
-* @returns {integer} result
+* @param {uinteger} x - first input value
+* @param {uinteger} y - second input value
+* @returns {uinteger} result
 *
 * @example
 * var v = mul( 5, 1 );

--- a/lib/node_modules/@stdlib/number/uint8/base/mul/lib/native.js
+++ b/lib/node_modules/@stdlib/number/uint8/base/mul/lib/native.js
@@ -29,9 +29,9 @@ var addon = require( './../src/addon.node' );
 * Multiplies two unsigned 8-bit integers `x` and `y`.
 *
 * @private
-* @param {integer} x - first input value
-* @param {integer} y - second input value
-* @returns {integer} result
+* @param {uinteger} x - first input value
+* @param {uinteger} y - second input value
+* @returns {uinteger} result
 *
 * @example
 * var v = mul( 5, 1 );

--- a/lib/node_modules/@stdlib/number/uint8/base/sub/lib/main.js
+++ b/lib/node_modules/@stdlib/number/uint8/base/sub/lib/main.js
@@ -29,9 +29,9 @@ var MASK = 0xFF;
 /**
 * Subtracts two unsigned 8-bit integers `x` and `y`.
 *
-* @param {integer} x - first input value
-* @param {integer} y - second input value
-* @returns {integer} result
+* @param {uinteger} x - first input value
+* @param {uinteger} y - second input value
+* @returns {uinteger} result
 *
 * @example
 * var v = sub( 5, 1 );

--- a/lib/node_modules/@stdlib/number/uint8/base/sub/lib/native.js
+++ b/lib/node_modules/@stdlib/number/uint8/base/sub/lib/native.js
@@ -29,9 +29,9 @@ var addon = require( './../src/addon.node' );
 * Subtracts two unsigned 8-bit integers `x` and `y`.
 *
 * @private
-* @param {integer} x - first input value
-* @param {integer} y - second input value
-* @returns {integer} result
+* @param {uinteger} x - first input value
+* @param {uinteger} y - second input value
+* @returns {uinteger} result
 *
 * @example
 * var v = sub( 5, 1 );


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: na
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Resolves None.

## Description

> What is the purpose of this pull request?

This pull request:

-   replaces `integer` by `uinteger` in JSDocs, in `@stdlib/number/uint32`, `@stdlib/number/uint16` and `@stdlib/number/uint8`.

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
