### PR TITLE
chore: address comments from commit d269f48

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/logcdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/logcdf/README.md
@@ -228,6 +228,8 @@ int main( void ) {
 
 </section>
 
+<!-- /.examples -->
+
 </section>
 
 <!-- /.c -->

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/logcdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/logcdf/README.md
@@ -139,10 +139,6 @@ for ( i = 0; i < 10; i++ ) {
 
 <!-- /.examples -->
 
-<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
-
-<section class="references">
-
 <!-- C interface documentation. -->
 
 * * *
@@ -209,7 +205,6 @@ double stdlib_base_dists_geometric_logcdf( const double x, const double p );
 #include "stdlib/stats/base/dists/geometric/logcdf.h"
 #include <stdlib.h>
 #include <stdio.h>
-#include <math.h>
 
 static double random_uniform( const double min, const double max ) {
     double v = (double)rand() / ( (double)RAND_MAX + 1.0 );
@@ -232,6 +227,14 @@ int main( void ) {
 ```
 
 </section>
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
 
 <!-- /.references -->
 

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/logcdf/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/logcdf/README.md
@@ -238,6 +238,8 @@ int main( void ) {
 
 <section class="references">
 
+</section>
+
 <!-- /.references -->
 
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->

--- a/lib/node_modules/@stdlib/stats/base/dists/geometric/logcdf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/geometric/logcdf/examples/c/example.c
@@ -19,7 +19,6 @@
 #include "stdlib/stats/base/dists/geometric/logcdf.h"
 #include <stdlib.h>
 #include <stdio.h>
-#include <math.h>
 
 static double random_uniform( const double min, const double max ) {
 	double v = (double)rand() / ( (double)RAND_MAX + 1.0 );

--- a/lib/node_modules/@stdlib/utils/async/inmap/lib/limit.js
+++ b/lib/node_modules/@stdlib/utils/async/inmap/lib/limit.js
@@ -24,7 +24,7 @@ var logger = require( 'debug' );
 
 
 // VARIABLES //
-// cspell: ignore inmap 
+
 var debug = logger( 'inmap-async:limit' );
 
 

--- a/lib/node_modules/@stdlib/utils/async/inmap/lib/limit.js
+++ b/lib/node_modules/@stdlib/utils/async/inmap/lib/limit.js
@@ -24,7 +24,7 @@ var logger = require( 'debug' );
 
 
 // VARIABLES //
-
+// cspell: ignore inmap 
 var debug = logger( 'inmap-async:limit' );
 
 


### PR DESCRIPTION
## Description

This pull request addresses the 4 comments left on commit `d269f48`:

1. Move lines 142-145 down to line 234 in `README.md`.
2. Remove unused headers in `README.md` and `example.c`.
3. Add missing closing `</section>` and trailing comment in `README.md`.

## Related Issues

This pull request:

- resolves #5715

## Questions

No questions for reviewers.

## Other

No additional information.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
