### PR TITLE
test: use `ulpdiff` for floating-point comparisons

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/tan/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/tan/test/test.js
@@ -22,9 +22,8 @@
 
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var ulpdiff = require( '@stdlib/number/float64/base/ulp-difference' );
 var PI = require( '@stdlib/constants/float64/pi' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var isNegativeZero = require( '@stdlib/assert/is-negative-zero' );
@@ -60,8 +59,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the tangent (huge negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -71,21 +68,13 @@ tape( 'the function computes the tangent (huge negative values)', function test(
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (huge positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -95,21 +84,13 @@ tape( 'the function computes the tangent (huge positive values)', function test(
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (very large positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -119,21 +100,13 @@ tape( 'the function computes the tangent (very large positive values)', function
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (very large negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -143,21 +116,13 @@ tape( 'the function computes the tangent (very large negative values)', function
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (large positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -167,21 +132,13 @@ tape( 'the function computes the tangent (large positive values)', function test
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (large negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -191,21 +148,13 @@ tape( 'the function computes the tangent (large negative values)', function test
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (medium positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -215,21 +164,13 @@ tape( 'the function computes the tangent (medium positive values)', function tes
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (medium negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -239,21 +180,13 @@ tape( 'the function computes the tangent (medium negative values)', function tes
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (small positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -263,21 +196,13 @@ tape( 'the function computes the tangent (small positive values)', function test
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (small negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -287,21 +212,13 @@ tape( 'the function computes the tangent (small negative values)', function test
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (smaller values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -311,21 +228,13 @@ tape( 'the function computes the tangent (smaller values)', function test( t ) {
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (tiny positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -335,21 +244,13 @@ tape( 'the function computes the tangent (tiny positive values)', function test(
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (tiny negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -359,21 +260,13 @@ tape( 'the function computes the tangent (tiny negative values)', function test(
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (subnormal values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -383,13 +276,7 @@ tape( 'the function computes the tangent (subnormal values)', function test( t )
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 
 	t.end();
@@ -397,8 +284,6 @@ tape( 'the function computes the tangent (subnormal values)', function test( t )
 
 tape( 'if provided a multiple of `-pi/2`, the function does not return `-infinity`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -407,17 +292,12 @@ tape( 'if provided a multiple of `-pi/2`, the function does not return `-infinit
 	v = tan( x );
 	expected = -1.633123935319537e16;
 
-	delta = abs( v - expected );
-	tol = EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. x: '+x+'. v: '+v+'. E: '+expected+'. Δ: '+delta+'. tol: '+tol+'.' );
+	t.strictEqual( v, expected, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided a multiple of `pi/2`, the function does not return `+infinity`', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -426,10 +306,7 @@ tape( 'if provided a multiple of `pi/2`, the function does not return `+infinity
 	v = tan( x );
 	expected = 1.633123935319537e16;
 
-	delta = abs( v - expected );
-	tol = EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. x: '+x+'. v: '+v+'. E: '+expected+'. Δ: '+delta+'. tol: '+tol+'.' );
+	t.strictEqual( v, expected, 'returns expected value' );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/math/base/special/tan/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/tan/test/test.native.js
@@ -23,9 +23,8 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
-var abs = require( '@stdlib/math/base/special/abs' );
+var ulpdiff = require( '@stdlib/number/float64/base/ulp-difference' );
 var PI = require( '@stdlib/constants/float64/pi' );
-var EPS = require( '@stdlib/constants/float64/eps' );
 var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var isPositiveZero = require( '@stdlib/assert/is-positive-zero' );
@@ -69,8 +68,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the tangent (huge negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -80,21 +77,13 @@ tape( 'the function computes the tangent (huge negative values)', opts, function
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (huge positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -104,21 +93,13 @@ tape( 'the function computes the tangent (huge positive values)', opts, function
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (very large positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -128,21 +109,13 @@ tape( 'the function computes the tangent (very large positive values)', opts, fu
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (very large negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -152,21 +125,13 @@ tape( 'the function computes the tangent (very large negative values)', opts, fu
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (large positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -176,21 +141,13 @@ tape( 'the function computes the tangent (large positive values)', opts, functio
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (large negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -200,21 +157,13 @@ tape( 'the function computes the tangent (large negative values)', opts, functio
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (medium positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -224,21 +173,13 @@ tape( 'the function computes the tangent (medium positive values)', opts, functi
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (medium negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -248,21 +189,13 @@ tape( 'the function computes the tangent (medium negative values)', opts, functi
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (small positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -272,21 +205,13 @@ tape( 'the function computes the tangent (small positive values)', opts, functio
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (small negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -296,21 +221,13 @@ tape( 'the function computes the tangent (small negative values)', opts, functio
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (smaller values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -320,21 +237,13 @@ tape( 'the function computes the tangent (smaller values)', opts, function test(
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (tiny positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -344,21 +253,13 @@ tape( 'the function computes the tangent (tiny positive values)', opts, function
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (tiny negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -368,21 +269,13 @@ tape( 'the function computes the tangent (tiny negative values)', opts, function
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (subnormal values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -392,13 +285,7 @@ tape( 'the function computes the tangent (subnormal values)', opts, function tes
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = abs( y - expected[ i ] );
-			tol = EPS * abs( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 
 	t.end();
@@ -406,8 +293,6 @@ tape( 'the function computes the tangent (subnormal values)', opts, function tes
 
 tape( 'if provided a multiple of `-pi/2`, the function does not return `-infinity`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -416,17 +301,12 @@ tape( 'if provided a multiple of `-pi/2`, the function does not return `-infinit
 	v = tan( x );
 	expected = -1.633123935319537e16;
 
-	delta = abs( v - expected );
-	tol = EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. x: '+x+'. v: '+v+'. E: '+expected+'. Δ: '+delta+'. tol: '+tol+'.' );
+	t.strictEqual( v, expected, 'returns expected value' );
 	t.end();
 });
 
 tape( 'if provided a multiple of `pi/2`, the function does not return `+infinity`', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var v;
 
@@ -435,10 +315,7 @@ tape( 'if provided a multiple of `pi/2`, the function does not return `+infinity
 	v = tan( x );
 	expected = 1.633123935319537e16;
 
-	delta = abs( v - expected );
-	tol = EPS * abs( expected );
-
-	t.ok( delta <= tol, 'within tolerance. x: '+x+'. v: '+v+'. E: '+expected+'. Δ: '+delta+'. tol: '+tol+'.' );
+	t.strictEqual( v, expected, 'returns expected value' );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/math/base/special/tan/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/tan/test/test.native.js
@@ -141,6 +141,8 @@ tape( 'the function computes the tangent (large positive values)', opts, functio
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
 		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
@@ -157,6 +159,8 @@ tape( 'the function computes the tangent (large negative values)', opts, functio
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
 		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
@@ -173,6 +177,8 @@ tape( 'the function computes the tangent (medium positive values)', opts, functi
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
 		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
@@ -189,6 +195,8 @@ tape( 'the function computes the tangent (medium negative values)', opts, functi
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
 		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
@@ -205,6 +213,8 @@ tape( 'the function computes the tangent (small positive values)', opts, functio
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
 		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
@@ -221,6 +231,8 @@ tape( 'the function computes the tangent (small negative values)', opts, functio
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
 		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
@@ -237,6 +249,8 @@ tape( 'the function computes the tangent (smaller values)', opts, function test(
 
 	for ( i = 0; i < x.length; i++ ) {
 		y = tan( x[ i ] );
+
+		// NOTE: the tolerance here is larger than for the JavaScript implementation due to compiler optimizations which may be performed resulting in result divergence. For discussion, see https://github.com/stdlib-js/stdlib/pull/2298#discussion_r1624765205
 		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();


### PR DESCRIPTION
Resolves None

## Description

> What is the purpose of this pull request?

This pull request:

-  Uses `@stdlib/number/float64/base/ulp-difference` for floating-point test comparisons.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolve none.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
