### PR TITLE
test: use `ulpdiff` for floating-point comparisons

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/tanf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/tanf/test/test.js
@@ -22,10 +22,9 @@
 
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var absf = require( '@stdlib/math/base/special/absf' );
 var f32 = require( '@stdlib/number/float64/base/to-float32' );
+var ulpdiff = require( '@stdlib/number/float32/base/ulp-difference' );
 var PI = require( '@stdlib/constants/float32/pi' );
-var EPS = require( '@stdlib/constants/float32/eps' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
 var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
@@ -61,8 +60,6 @@ tape( 'main export is a function', function test( t ) {
 
 tape( 'the function computes the tangent (huge negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -74,21 +71,13 @@ tape( 'the function computes the tangent (huge negative values)', function test(
 		x[ i ] = f32( x[ i ] );
 		expected[ i ] = f32( expected[ i ] );
 		y = tanf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (huge positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -100,21 +89,13 @@ tape( 'the function computes the tangent (huge positive values)', function test(
 		x[ i ] = f32( x[ i ] );
 		expected[ i ] = f32( expected[ i ] );
 		y = tanf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (very large positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -126,21 +107,13 @@ tape( 'the function computes the tangent (very large positive values)', function
 		x[ i ] = f32( x[ i ] );
 		expected[ i ] = f32( expected[ i ] );
 		y = tanf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (very large negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -152,21 +125,13 @@ tape( 'the function computes the tangent (very large negative values)', function
 		x[ i ] = f32( x[ i ] );
 		expected[ i ] = f32( expected[ i ] );
 		y = tanf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (large positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -178,21 +143,13 @@ tape( 'the function computes the tangent (large positive values)', function test
 		x[ i ] = f32( x[ i ] );
 		expected[ i ] = f32( expected[ i ] );
 		y = tanf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (large negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -204,21 +161,13 @@ tape( 'the function computes the tangent (large negative values)', function test
 		x[ i ] = f32( x[ i ] );
 		expected[ i ] = f32( expected[ i ] );
 		y = tanf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (medium positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -230,21 +179,13 @@ tape( 'the function computes the tangent (medium positive values)', function tes
 		x[ i ] = f32( x[ i ] );
 		expected[ i ] = f32( expected[ i ] );
 		y = tanf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (medium negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -256,21 +197,13 @@ tape( 'the function computes the tangent (medium negative values)', function tes
 		x[ i ] = f32( x[ i ] );
 		expected[ i ] = f32( expected[ i ] );
 		y = tanf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (small positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -282,21 +215,13 @@ tape( 'the function computes the tangent (small positive values)', function test
 		x[ i ] = f32( x[ i ] );
 		expected[ i ] = f32( expected[ i ] );
 		y = tanf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (small negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -308,21 +233,13 @@ tape( 'the function computes the tangent (small negative values)', function test
 		x[ i ] = f32( x[ i ] );
 		expected[ i ] = f32( expected[ i ] );
 		y = tanf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (smaller values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -334,21 +251,13 @@ tape( 'the function computes the tangent (smaller values)', function test( t ) {
 		x[ i ] = f32( x[ i ] );
 		expected[ i ] = f32( expected[ i ] );
 		y = tanf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (tiny positive values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -360,21 +269,13 @@ tape( 'the function computes the tangent (tiny positive values)', function test(
 		x[ i ] = f32( x[ i ] );
 		expected[ i ] = f32( expected[ i ] );
 		y = tanf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (tiny negative values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -386,21 +287,13 @@ tape( 'the function computes the tangent (tiny negative values)', function test(
 		x[ i ] = f32( x[ i ] );
 		expected[ i ] = f32( expected[ i ] );
 		y = tanf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (subnormal values)', function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -412,13 +305,7 @@ tape( 'the function computes the tangent (subnormal values)', function test( t )
 		x[ i ] = f32( x[ i ] );
 		expected[ i ] = f32( expected[ i ] );
 		y = tanf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 
 	t.end();

--- a/lib/node_modules/@stdlib/math/base/special/tanf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/tanf/test/test.native.js
@@ -23,10 +23,9 @@
 var resolve = require( 'path' ).resolve;
 var tape = require( 'tape' );
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var absf = require( '@stdlib/math/base/special/absf' );
 var f32 = require( '@stdlib/number/float64/base/to-float32' );
+var ulpdiff = require( '@stdlib/number/float32/base/ulp-difference' );
 var PI = require( '@stdlib/constants/float32/pi' );
-var EPS = require( '@stdlib/constants/float32/eps' );
 var PINF = require( '@stdlib/constants/float32/pinf' );
 var NINF = require( '@stdlib/constants/float32/ninf' );
 var isNegativeZerof = require( '@stdlib/math/base/assert/is-negative-zerof' );
@@ -70,8 +69,6 @@ tape( 'main export is a function', opts, function test( t ) {
 
 tape( 'the function computes the tangent (huge negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -83,21 +80,13 @@ tape( 'the function computes the tangent (huge negative values)', opts, function
 		x[ i ] = f32( x[ i ] );
 		expected[ i ] = f32( expected[ i ] );
 		y = tanf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (huge positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -109,21 +98,13 @@ tape( 'the function computes the tangent (huge positive values)', opts, function
 		x[ i ] = f32( x[ i ] );
 		expected[ i ] = f32( expected[ i ] );
 		y = tanf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (very large positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -135,21 +116,13 @@ tape( 'the function computes the tangent (very large positive values)', opts, fu
 		x[ i ] = f32( x[ i ] );
 		expected[ i ] = f32( expected[ i ] );
 		y = tanf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (very large negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -161,21 +134,13 @@ tape( 'the function computes the tangent (very large negative values)', opts, fu
 		x[ i ] = f32( x[ i ] );
 		expected[ i ] = f32( expected[ i ] );
 		y = tanf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (large positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -187,21 +152,13 @@ tape( 'the function computes the tangent (large positive values)', opts, functio
 		x[ i ] = f32( x[ i ] );
 		expected[ i ] = f32( expected[ i ] );
 		y = tanf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (large negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -213,21 +170,13 @@ tape( 'the function computes the tangent (large negative values)', opts, functio
 		x[ i ] = f32( x[ i ] );
 		expected[ i ] = f32( expected[ i ] );
 		y = tanf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (medium positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -239,21 +188,13 @@ tape( 'the function computes the tangent (medium positive values)', opts, functi
 		x[ i ] = f32( x[ i ] );
 		expected[ i ] = f32( expected[ i ] );
 		y = tanf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (medium negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -265,21 +206,13 @@ tape( 'the function computes the tangent (medium negative values)', opts, functi
 		x[ i ] = f32( x[ i ] );
 		expected[ i ] = f32( expected[ i ] );
 		y = tanf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (small positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -291,21 +224,13 @@ tape( 'the function computes the tangent (small positive values)', opts, functio
 		x[ i ] = f32( x[ i ] );
 		expected[ i ] = f32( expected[ i ] );
 		y = tanf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (small negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -317,21 +242,13 @@ tape( 'the function computes the tangent (small negative values)', opts, functio
 		x[ i ] = f32( x[ i ] );
 		expected[ i ] = f32( expected[ i ] );
 		y = tanf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (smaller values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -343,21 +260,13 @@ tape( 'the function computes the tangent (smaller values)', opts, function test(
 		x[ i ] = f32( x[ i ] );
 		expected[ i ] = f32( expected[ i ] );
 		y = tanf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( ulpdiff( y, expected[ i ] ) <= 1, true, 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (tiny positive values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -369,21 +278,13 @@ tape( 'the function computes the tangent (tiny positive values)', opts, function
 		x[ i ] = f32( x[ i ] );
 		expected[ i ] = f32( expected[ i ] );
 		y = tanf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (tiny negative values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -395,21 +296,13 @@ tape( 'the function computes the tangent (tiny negative values)', opts, function
 		x[ i ] = f32( x[ i ] );
 		expected[ i ] = f32( expected[ i ] );
 		y = tanf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 	t.end();
 });
 
 tape( 'the function computes the tangent (subnormal values)', opts, function test( t ) {
 	var expected;
-	var delta;
-	var tol;
 	var x;
 	var y;
 	var i;
@@ -421,13 +314,7 @@ tape( 'the function computes the tangent (subnormal values)', opts, function tes
 		x[ i ] = f32( x[ i ] );
 		expected[ i ] = f32( expected[ i ] );
 		y = tanf( x[ i ] );
-		if ( y === expected[ i ] ) {
-			t.strictEqual( y, expected[ i ], 'x: '+x[i]+'. E: '+expected[i] );
-		} else {
-			delta = absf( y - expected[ i ] );
-			tol = EPS * absf( expected[ i ] );
-			t.ok( delta <= tol, 'within tolerance. x: '+x[i]+'. y: '+y+'. E: '+expected[i]+'. tol: '+tol+'. Δ: '+delta+'.' );
-		}
+		t.strictEqual( y, expected[ i ], 'returns expected value' );
 	}
 
 	t.end();


### PR DESCRIPTION
Resolves None

## Description

> What is the purpose of this pull request?

This pull request:

-  Uses `@stdlib/number/float32/base/ulp-difference` for floating-point test comparisons.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolve none.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
