### PR TITLE
refactor!: modify C implementation to accept `float` instead of `int32` in `math/base/special/lucasf`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/lucasf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/lucasf/README.md
@@ -164,19 +164,19 @@ logEachMap( 'lucasf(%d) = %0.1f', x, lucasf );
 Computes the nth [Lucas number][lucas-number] as a single-precision floating-point number.
 
 ```c
-float out = stdlib_base_lucasf( 0 );
+float out = stdlib_base_lucasf( 0.0f );
 // returns 2.0f
 
-out = stdlib_base_lucasf( 1 );
+out = stdlib_base_lucasf( 1.0f );
 // returns 1.0f
 ```
 
 The function accepts the following arguments:
 
--   **n**: `[in] int32_t` input value.
+-   **n**: `[in] float` input value.
 
 ```c
-float stdlib_base_lucasf( const int32_t n );
+float stdlib_base_lucasf( const float n );
 ```
 
 </section>
@@ -200,15 +200,14 @@ float stdlib_base_lucasf( const int32_t n );
 ```c
 #include "stdlib/math/base/special/lucasf.h"
 #include <stdio.h>
-#include <stdint.h>
 
 int main( void ) {
-    int32_t i;
+    float i;
     float v;
 
-    for ( i = 0; i < 35; i++ ) {
+    for ( i = 0.0f; i < 35.0f; i++ ) {
         v = stdlib_base_lucasf( i );
-        printf( "lucasf(%d) = %f\n", i, v );
+        printf( "lucasf(%f) = %f\n", i, v );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/math/base/special/lucasf/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/lucasf/benchmark/c/native/benchmark.c
@@ -91,14 +91,14 @@ static float rand_float( void ) {
 * @return elapsed time in seconds
 */
 static double benchmark( void ) {
-	int32_t x[ 100 ];
+	float x[ 100 ];
 	double elapsed;
 	double t;
 	float y;
 	int i;
 
 	for ( i = 0; i < 100; i++ ) {
-		x[ i ] = (int32_t)( 34.0f*rand_float() );
+		x[ i ] = ( 34.0f*rand_float() );
 	}
 
 	t = tic();

--- a/lib/node_modules/@stdlib/math/base/special/lucasf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/lucasf/examples/c/example.c
@@ -18,14 +18,13 @@
 
 #include "stdlib/math/base/special/lucasf.h"
 #include <stdio.h>
-#include <stdint.h>
 
 int main( void ) {
-	int32_t i;
+	float i;
 	float v;
 
-	for ( i = 0; i < 35; i++ ) {
+	for ( i = 0.0f; i < 35.0f; i++ ) {
 		v = stdlib_base_lucasf( i );
-		printf( "lucasf(%d) = %f\n", i, v );
+		printf( "lucasf(%f) = %f\n", i, v );
 	}
 }

--- a/lib/node_modules/@stdlib/math/base/special/lucasf/include/stdlib/math/base/special/lucasf.h
+++ b/lib/node_modules/@stdlib/math/base/special/lucasf/include/stdlib/math/base/special/lucasf.h
@@ -19,8 +19,6 @@
 #ifndef STDLIB_MATH_BASE_SPECIAL_LUCASF_H
 #define STDLIB_MATH_BASE_SPECIAL_LUCASF_H
 
-#include <stdint.h>
-
 /*
 * If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
 */
@@ -31,7 +29,7 @@ extern "C" {
 /**
 * Computes the nth Lucas number as a single-precision floating-point number.
 */
-float stdlib_base_lucasf( const int32_t n );
+float stdlib_base_lucasf( const float n );
 
 #ifdef __cplusplus
 }

--- a/lib/node_modules/@stdlib/math/base/special/lucasf/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/lucasf/lib/main.js
@@ -21,7 +21,7 @@
 // MODULES //
 
 var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
-var isIntegerf = require( '@stdlib/math/base/assert/is-integerf' );
+var isNonNegativeIntegerf = require( '@stdlib/math/base/assert/is-nonnegative-integerf' );
 var MAX_LUCAS = require( '@stdlib/constants/float32/max-safe-nth-lucas' );
 var LUCAS = require( './lucas.json' );
 
@@ -77,8 +77,7 @@ var LUCAS = require( './lucas.json' );
 function lucasf( n ) {
 	if (
 		isnanf( n ) ||
-		isIntegerf( n ) === false ||
-		n < 0 ||
+		!isNonNegativeIntegerf( n ) ||
 		n > MAX_LUCAS
 	) {
 		return NaN;

--- a/lib/node_modules/@stdlib/math/base/special/lucasf/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/lucasf/manifest.json
@@ -37,7 +37,8 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/napi/unary",
-        "@stdlib/constants/float32/max-safe-nth-lucas"
+        "@stdlib/constants/float32/max-safe-nth-lucas",
+        "@stdlib/math/base/assert/is-nonnegative-integerf"
       ]
     },
     {
@@ -51,7 +52,8 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-        "@stdlib/constants/float32/max-safe-nth-lucas"
+        "@stdlib/constants/float32/max-safe-nth-lucas",
+        "@stdlib/math/base/assert/is-nonnegative-integerf"
       ]
     },
     {
@@ -65,7 +67,8 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-        "@stdlib/constants/float32/max-safe-nth-lucas"
+        "@stdlib/constants/float32/max-safe-nth-lucas",
+        "@stdlib/math/base/assert/is-nonnegative-integerf"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/lucasf/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/lucasf/src/addon.c
@@ -19,4 +19,4 @@
 #include "stdlib/math/base/special/lucasf.h"
 #include "stdlib/math/base/napi/unary.h"
 
-STDLIB_MATH_BASE_NAPI_MODULE_I_F( stdlib_base_lucasf )
+STDLIB_MATH_BASE_NAPI_MODULE_F_F( stdlib_base_lucasf )

--- a/lib/node_modules/@stdlib/math/base/special/lucasf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/lucasf/src/main.c
@@ -17,7 +17,10 @@
 */
 
 #include "stdlib/math/base/special/lucasf.h"
+#include "stdlib/math/base/assert/is_nonnegative_integerf.h"
 #include "stdlib/constants/float32/max_safe_nth_lucas.h"
+#include <stdint.h>
+#include <stdlib.h>
 
 static const int32_t lucas_value[ 35 ] = {
 	2,
@@ -64,16 +67,16 @@ static const int32_t lucas_value[ 35 ] = {
 * @return      output value
 *
 * @example
-* float out = stdlib_base_lucasf( 1 );
+* float out = stdlib_base_lucasf( 1.0f );
 * // returns 1.0f
 *
 * @example
-* float out = stdlib_base_lucasf( -1 );
+* float out = stdlib_base_lucasf( -1.0f );
 * // returns NaN
 */
-float stdlib_base_lucasf( const int32_t n ) {
-	if ( n < 0 || n > STDLIB_CONSTANT_FLOAT32_MAX_SAFE_NTH_LUCAS ) {
+float stdlib_base_lucasf( const float n ) {
+	if ( !stdlib_base_is_nonnegative_integerf( n ) || n > STDLIB_CONSTANT_FLOAT32_MAX_SAFE_NTH_LUCAS ) {
 		return 0.0f / 0.0f; // NaN
 	}
-	return lucas_value[ n ];
+	return lucas_value[ (size_t)n ];
 }


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: passed
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: passed
  - task: lint_c_examples status: passed
  - task: lint_c_benchmarks status: passed
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: na
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Resolves None.

## Description

> What is the purpose of this pull request?

This pull request:

-   modifies the C implementation to accept `float` instead of `int32` in [`math/base/special/lucasf`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/lucasf)

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
