### PR TITLE
refactor!: modify C implementation to accept `double` instead of `int32` in `math/base/special/bernoulli`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/bernoulli/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/bernoulli/README.md
@@ -154,19 +154,19 @@ for ( i = 0; i < 280; i++ ) {
 Computes the nth [Bernoulli number][bernoulli-number].
 
 ```c
-double out = stdlib_base_bernoulli( 0 );
+double out = stdlib_base_bernoulli( 0.0 );
 // returns 1.0
 
-out = stdlib_base_bernoulli( 1 );
+out = stdlib_base_bernoulli( 1.0 );
 // returns 0.5
 ```
 
 The function accepts the following arguments:
 
--   **n**: `[in] int32_t` input value.
+-   **n**: `[in] double` input value.
 
 ```c
-double stdlib_base_bernoulli( const int32_t n );
+double stdlib_base_bernoulli( const double n );
 ```
 
 </section>
@@ -190,15 +190,14 @@ double stdlib_base_bernoulli( const int32_t n );
 ```c
 #include "stdlib/math/base/special/bernoulli.h"
 #include <stdio.h>
-#include <stdint.h>
 
 int main( void ) {
-    int32_t i;
+    double i;
     double v;
 
-    for ( i = 0; i < 130; i++ ) {
+    for ( i = 0.0; i < 130.0; i++ ) {
         v = stdlib_base_bernoulli( i );
-        printf( "bernoulli(%d) = %lf\n", i, v );
+        printf( "bernoulli(%lf) = %lf\n", i, v );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/math/base/special/bernoulli/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/bernoulli/benchmark/c/native/benchmark.c
@@ -102,7 +102,7 @@ static double benchmark( void ) {
 
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		y = stdlib_base_bernoulli( (int)( x[ i % 100 ] ) );
+		y = stdlib_base_bernoulli( ( x[ i % 100 ] ) );
 		if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;

--- a/lib/node_modules/@stdlib/math/base/special/bernoulli/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/bernoulli/examples/c/example.c
@@ -18,14 +18,13 @@
 
 #include "stdlib/math/base/special/bernoulli.h"
 #include <stdio.h>
-#include <stdint.h>
 
 int main( void ) {
-	int32_t i;
+	double i;
 	double v;
 
-	for ( i = 0; i < 130; i++ ) {
+	for ( i = 0.0; i < 130.0; i++ ) {
 		v = stdlib_base_bernoulli( i );
-		printf( "bernoulli(%d) = %lf\n", i, v );
+		printf( "bernoulli(%lf) = %lf\n", i, v );
 	}
 }

--- a/lib/node_modules/@stdlib/math/base/special/bernoulli/include/stdlib/math/base/special/bernoulli.h
+++ b/lib/node_modules/@stdlib/math/base/special/bernoulli/include/stdlib/math/base/special/bernoulli.h
@@ -19,8 +19,6 @@
 #ifndef STDLIB_MATH_BASE_SPECIAL_BERNOULLI_H
 #define STDLIB_MATH_BASE_SPECIAL_BERNOULLI_H
 
-#include <stdint.h>
-
 /*
 * If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
 */
@@ -31,7 +29,7 @@ extern "C" {
 /**
 * Computes the nth Bernoulli number.
 */
-double stdlib_base_bernoulli( const int32_t n );
+double stdlib_base_bernoulli( const double n );
 
 #ifdef __cplusplus
 }

--- a/lib/node_modules/@stdlib/math/base/special/bernoulli/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/bernoulli/lib/main.js
@@ -92,7 +92,7 @@ function bernoulli( n ) {
 		return 0.0;
 	}
 	if ( n > MAX_BERNOULLI ) {
-		return ( (n/2)&1 ) ? PINF : NINF;
+		return ( isOdd( n/2.0 ) ) ? PINF : NINF;
 	}
 	return BERNOULLI[ n/2 ];
 }

--- a/lib/node_modules/@stdlib/math/base/special/bernoulli/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/bernoulli/manifest.json
@@ -39,7 +39,8 @@
         "@stdlib/math/base/napi/unary",
         "@stdlib/math/base/assert/is-odd",
         "@stdlib/constants/float64/ninf",
-        "@stdlib/constants/float64/pinf"
+        "@stdlib/constants/float64/pinf",
+        "@stdlib/math/base/assert/is-nonnegative-integer"
       ]
     },
     {
@@ -55,7 +56,8 @@
       "dependencies": [
         "@stdlib/math/base/assert/is-odd",
         "@stdlib/constants/float64/ninf",
-        "@stdlib/constants/float64/pinf"
+        "@stdlib/constants/float64/pinf",
+        "@stdlib/math/base/assert/is-nonnegative-integer"
       ]
     },
     {
@@ -71,7 +73,8 @@
       "dependencies": [
         "@stdlib/math/base/assert/is-odd",
         "@stdlib/constants/float64/ninf",
-        "@stdlib/constants/float64/pinf"
+        "@stdlib/constants/float64/pinf",
+        "@stdlib/math/base/assert/is-nonnegative-integer"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/bernoulli/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/bernoulli/src/addon.c
@@ -19,4 +19,4 @@
 #include "stdlib/math/base/special/bernoulli.h"
 #include "stdlib/math/base/napi/unary.h"
 
-STDLIB_MATH_BASE_NAPI_MODULE_I_D( stdlib_base_bernoulli )
+STDLIB_MATH_BASE_NAPI_MODULE_D_D( stdlib_base_bernoulli )

--- a/lib/node_modules/@stdlib/math/base/special/bernoulli/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/bernoulli/src/main.c
@@ -181,7 +181,7 @@ double stdlib_base_bernoulli( const double n ) {
 		return 0.0;
 	}
 	if ( n > MAX_BERNOULLI ) {
-		return ( (size_t)( n / 2 ) & 1 ) ? STDLIB_CONSTANT_FLOAT64_PINF : STDLIB_CONSTANT_FLOAT64_NINF;
+		return ( stdlib_base_is_odd( n/2.0 ) ) ? STDLIB_CONSTANT_FLOAT64_PINF : STDLIB_CONSTANT_FLOAT64_NINF;
 	}
 	return bernoulli_value[ (size_t)( n / 2 ) ];
 }

--- a/lib/node_modules/@stdlib/math/base/special/bernoulli/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/bernoulli/src/main.c
@@ -16,10 +16,13 @@
 * limitations under the License.
 */
 
+#include "stdlib/math/base/assert/is_nonnegative_integer.h"
 #include "stdlib/math/base/assert/is_odd.h"
 #include "stdlib/constants/float64/ninf.h"
 #include "stdlib/constants/float64/pinf.h"
 #include "stdlib/math/base/special/bernoulli.h"
+#include <stdint.h>
+#include <stdlib.h>
 
 static const double bernoulli_value[ 130 ] = {
 	1.00000000000000000000000000000000000000000,
@@ -164,11 +167,11 @@ int32_t MAX_BERNOULLI = 258;
 * @return     output value
 *
 * @example
-* double out = stdlib_base_bernoulli( 0 );
-* // returns 1
+* double out = stdlib_base_bernoulli( 0.0 );
+* // returns 1.0
 */
-double stdlib_base_bernoulli( const int32_t n ) {
-	if ( n < 0 ) {
+double stdlib_base_bernoulli( const double n ) {
+	if ( !stdlib_base_is_nonnegative_integer( n ) ) {
 		return 0.0 / 0.0; // NaN
 	}
 	if ( n == 1 ) {
@@ -178,7 +181,7 @@ double stdlib_base_bernoulli( const int32_t n ) {
 		return 0.0;
 	}
 	if ( n > MAX_BERNOULLI ) {
-		return ( ( n / 2 ) & 1 ) ? STDLIB_CONSTANT_FLOAT64_PINF : STDLIB_CONSTANT_FLOAT64_NINF;
+		return ( (size_t)( n / 2 ) & 1 ) ? STDLIB_CONSTANT_FLOAT64_PINF : STDLIB_CONSTANT_FLOAT64_NINF;
 	}
-	return bernoulli_value[ n / 2 ];
+	return bernoulli_value[ (size_t)( n / 2 ) ];
 }

--- a/lib/node_modules/@stdlib/math/base/special/bernoulli/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/bernoulli/src/main.c
@@ -174,7 +174,7 @@ double stdlib_base_bernoulli( const double n ) {
 	if ( !stdlib_base_is_nonnegative_integer( n ) ) {
 		return 0.0 / 0.0; // NaN
 	}
-	if ( n == 1 ) {
+	if ( n == 1.0 ) {
 		return 0.5;
 	}
 	if ( stdlib_base_is_odd( n ) ) {
@@ -183,5 +183,5 @@ double stdlib_base_bernoulli( const double n ) {
 	if ( n > MAX_BERNOULLI ) {
 		return ( stdlib_base_is_odd( n/2.0 ) ) ? STDLIB_CONSTANT_FLOAT64_PINF : STDLIB_CONSTANT_FLOAT64_NINF;
 	}
-	return bernoulli_value[ (size_t)( n / 2 ) ];
+	return bernoulli_value[ (size_t)( n / 2.0 ) ];
 }


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: passed
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: passed
  - task: lint_c_examples status: passed
  - task: lint_c_benchmarks status: passed
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: na
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Resolves None.

## Description

> What is the purpose of this pull request?

This pull request:

-   modifies the C implementation to accept `double` instead of `int32` in [`math/base/special/bernoulli`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/bernoulli)

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
