### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/plot/components/svg/marks/lib/main.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/marks/lib/main.js
@@ -111,7 +111,8 @@ function Marks( options ) {
 		var args;
 		var i;
 		debug( 'Received a render event. Re-emitting...' );
-		args = new Array( arguments.length+1 );
+		args = [];
+        args.length = arguments.length + 1;
 		args[ 0 ] = 'render';
 		for ( i = 0; i < arguments.length; i++ ) {
 			args[ i+1 ] = arguments[ i ];

--- a/lib/node_modules/@stdlib/plot/components/svg/marks/lib/main.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/marks/lib/main.js
@@ -112,7 +112,7 @@ function Marks( options ) {
 		var i;
 		debug( 'Received a render event. Re-emitting...' );
 		args = [];
-        args.length = arguments.length + 1;
+		args.length = arguments.length + 1;
 		args[ 0 ] = 'render';
 		for ( i = 0; i < arguments.length; i++ ) {
 			args[ i+1 ] = arguments[ i ];

--- a/lib/node_modules/@stdlib/plot/components/svg/marks/lib/main.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/marks/lib/main.js
@@ -112,10 +112,9 @@ function Marks( options ) {
 		var i;
 		debug( 'Received a render event. Re-emitting...' );
 		args = [];
-		args.length = arguments.length + 1;
-		args[ 0 ] = 'render';
+		args.push( 'render' );
 		for ( i = 0; i < arguments.length; i++ ) {
-			args[ i+1 ] = arguments[ i ];
+			args.push( arguments[ i ] );
 		}
 		self.emit.apply( self, args );
 	}


### PR DESCRIPTION
Resolves #7019.

## Description

> What is the purpose of this pull request?

This pull request:

-   fixes JavaScript lint errors by replacing `new Array()` constructor with array literal syntax to comply with the `stdlib/no-new-array` ESLint rule in the svg marks component

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #7019 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Technical Details:**
- **File changed:** `lib/node_modules/@stdlib/plot/components/svg/marks/lib/main.js`
- **Line 114:** Replaced `args = new Array( arguments.length+1 );` with `args = []; args.length = arguments.length + 1;`
- **ESLint rule:** `stdlib/no-new-array`
- **Functionality:** Maintains identical behavior while following stdlib coding standards
- **Testing:** Verified with `make lint-javascript-files` command

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
