### PR TITLE
refactor!: modify C implementation to accept `float` value instead of `int32` in `math/base/special/negalucasf`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/negalucasf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/negalucasf/README.md
@@ -191,19 +191,19 @@ for ( i = 0; i > -35; i-- ) {
 Computes the nth [negaLucas number][lucas-number] in single-precision floating-point format.
 
 ```c
-float out = stdlib_base_negalucasf( 0 );
+float out = stdlib_base_negalucasf( 0.0f );
 // returns 0.0f
 
-out = stdlib_base_negalucasf( -1 );
+out = stdlib_base_negalucasf( -1.0f );
 // returns -1.0f
 ```
 
 The function accepts the following arguments:
 
--   **n**: `[in] int32_t` input value.
+-   **n**: `[in] float` input value.
 
 ```c
-float stdlib_base_negalucasf( const int32_t n );
+float stdlib_base_negalucasf( const float n );
 ```
 
 </section>
@@ -227,15 +227,14 @@ float stdlib_base_negalucasf( const int32_t n );
 ```c
 #include "stdlib/math/base/special/negalucasf.h"
 #include <stdio.h>
-#include <stdint.h>
 
 int main( void ) {
-    int32_t i;
+    float i;
     float v;
 
-    for ( i = 0; i > -35; i-- ) {
+    for ( i = 0.0f; i > -35.0f; i-- ) {
         v = stdlib_base_negalucasf( i );
-        printf( "negalucasf(%d) = %f\n", i, v );
+        printf( "negalucasf(%f) = %f\n", i, v );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/math/base/special/negalucasf/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/negalucasf/benchmark/c/native/benchmark.c
@@ -30,7 +30,7 @@
 /**
 * Prints the TAP version.
 */
-void print_version() {
+static void print_version( void ) {
 	printf( "TAP version 13\n" );
 }
 

--- a/lib/node_modules/@stdlib/math/base/special/negalucasf/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/negalucasf/benchmark/c/native/benchmark.c
@@ -91,13 +91,13 @@ static float rand_float( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
-	int32_t x[ 100 ];
+	float x[ 100 ];
 	double t;
 	float y;
 	int i;
 
 	for ( i = 0; i < 100; i++ ) {
-		x[ i ] = (int32_t)( 34.0f * rand_float() );
+		x[ i ] = ( 34.0f * rand_float() );
 	}
 
 	t = tic();

--- a/lib/node_modules/@stdlib/math/base/special/negalucasf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/negalucasf/examples/c/example.c
@@ -18,14 +18,13 @@
 
 #include "stdlib/math/base/special/negalucasf.h"
 #include <stdio.h>
-#include <stdint.h>
 
 int main( void ) {
-	int32_t i;
+	float i;
 	float v;
 
-	for ( i = 0; i > -35; i-- ) {
+	for ( i = 0.0f; i > -35.0f; i-- ) {
 		v = stdlib_base_negalucasf( i );
-		printf( "negalucasf(%d) = %f\n", i, v );
+		printf( "negalucasf(%f) = %f\n", i, v );
 	}
 }

--- a/lib/node_modules/@stdlib/math/base/special/negalucasf/include/stdlib/math/base/special/negalucasf.h
+++ b/lib/node_modules/@stdlib/math/base/special/negalucasf/include/stdlib/math/base/special/negalucasf.h
@@ -19,8 +19,6 @@
 #ifndef STDLIB_MATH_BASE_SPECIAL_NEGALUCASF_H
 #define STDLIB_MATH_BASE_SPECIAL_NEGALUCASF_H
 
-#include <stdint.h>
-
 /*
 * If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
 */
@@ -31,7 +29,7 @@ extern "C" {
 /**
 * Computes the nth negaLucas number in single-precision floating-point format.
 */
-float stdlib_base_negalucasf( const int32_t n );
+float stdlib_base_negalucasf( const float n );
 
 #ifdef __cplusplus
 }

--- a/lib/node_modules/@stdlib/math/base/special/negalucasf/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/negalucasf/manifest.json
@@ -37,8 +37,9 @@
       "libpath": [],
       "dependencies": [
         "@stdlib/math/base/napi/unary",
-        "@stdlib/math/base/special/labs",
-        "@stdlib/constants/float32/max-safe-nth-lucas"
+        "@stdlib/math/base/special/absf",
+        "@stdlib/constants/float32/max-safe-nth-lucas",
+        "@stdlib/math/base/assert/is-integerf"
       ]
     },
     {
@@ -52,8 +53,9 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-        "@stdlib/math/base/special/labs",
-        "@stdlib/constants/float32/max-safe-nth-lucas"
+        "@stdlib/math/base/special/absf",
+        "@stdlib/constants/float32/max-safe-nth-lucas",
+        "@stdlib/math/base/assert/is-integerf"
       ]
     },
     {
@@ -67,8 +69,9 @@
       "libraries": [],
       "libpath": [],
       "dependencies": [
-        "@stdlib/math/base/special/labs",
-        "@stdlib/constants/float32/max-safe-nth-lucas"
+        "@stdlib/math/base/special/absf",
+        "@stdlib/constants/float32/max-safe-nth-lucas",
+        "@stdlib/math/base/assert/is-integerf"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/negalucasf/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/negalucasf/src/addon.c
@@ -19,4 +19,4 @@
 #include "stdlib/math/base/special/negalucasf.h"
 #include "stdlib/math/base/napi/unary.h"
 
-STDLIB_MATH_BASE_NAPI_MODULE_I_F( stdlib_base_negalucasf )
+STDLIB_MATH_BASE_NAPI_MODULE_F_F( stdlib_base_negalucasf )

--- a/lib/node_modules/@stdlib/math/base/special/negalucasf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/negalucasf/src/main.c
@@ -16,9 +16,12 @@
 * limitations under the License.
 */
 
+#include "stdlib/math/base/assert/is_integerf.h"
 #include "stdlib/math/base/special/negalucasf.h"
-#include "stdlib/math/base/special/labs.h"
+#include "stdlib/math/base/special/absf.h"
 #include "stdlib/constants/float32/max_safe_nth_lucas.h"
+#include <stdint.h>
+#include <stdlib.h>
 
 static const int32_t negalucasf_value[ 35 ] = {
 	2,
@@ -65,17 +68,17 @@ static const int32_t negalucasf_value[ 35 ] = {
 * @return      output value
 *
 * @example
-* float out = stdlib_base_negalucasf( -1 );
-* // returns -1
+* float out = stdlib_base_negalucasf( -1.0f );
+* // returns -1.0f
 *
 * @example
-* float out = stdlib_base_negalucasf( 1 );
+* float out = stdlib_base_negalucasf( 1.0f );
 * // returns NaN
 */
-float stdlib_base_negalucasf( const int32_t n ) {
-	int32_t an = stdlib_base_labs( n );
-	if ( n > 0 || an > STDLIB_CONSTANT_FLOAT32_MAX_SAFE_NTH_LUCAS ) {
+float stdlib_base_negalucasf( const float n ) {
+	float an = stdlib_base_absf( n );
+	if ( !stdlib_base_is_integerf( n ) || n > 0.0f || an > STDLIB_CONSTANT_FLOAT32_MAX_SAFE_NTH_LUCAS ) {
 		return 0.0f / 0.0f; // NaN
 	}
-	return negalucasf_value[ an ];
+	return negalucasf_value[ (size_t)an ];
 }

--- a/lib/node_modules/@stdlib/math/base/special/negalucasf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/negalucasf/src/main.c
@@ -16,8 +16,8 @@
 * limitations under the License.
 */
 
-#include "stdlib/math/base/assert/is_integerf.h"
 #include "stdlib/math/base/special/negalucasf.h"
+#include "stdlib/math/base/assert/is_integerf.h"
 #include "stdlib/math/base/special/absf.h"
 #include "stdlib/constants/float32/max_safe_nth_lucas.h"
 #include <stdint.h>


### PR DESCRIPTION
Resolves None.

## Description

> What is the purpose of this pull request?

This pull request:

-   modifies the C implementation to accept `float` value instead of `int32` in [`math/base/special/negalucasf`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/negalucasf)

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md