### PR TITLE
refactor!: modify C implementation to accept `double` instead of `int32` in `math/base/special/nonfibonacci`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/nonfibonacci/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/nonfibonacci/README.md
@@ -154,19 +154,19 @@ for ( i = 1; i < 100; i++ ) {
 Computes the nth non-Fibonacci number.
 
 ```c
-double out = stdlib_base_nonfibonacci( 1 );
-// returns 4
+double out = stdlib_base_nonfibonacci( 1.0 );
+// returns 4.0
 
-out = stdlib_base_nonfibonacci( 2 );
-// returns 6
+out = stdlib_base_nonfibonacci( 2.0 );
+// returns 6.0
 ```
 
 The function accepts the following arguments:
 
--   **x**: `[in] int32_t` input value.
+-   **x**: `[in] double` input value.
 
 ```c
-double stdlib_base_nonfibonacci( const int32_t x );
+double stdlib_base_nonfibonacci( const double x );
 ```
 
 </section>
@@ -190,12 +190,14 @@ double stdlib_base_nonfibonacci( const int32_t x );
 ```c
 #include "stdlib/math/base/special/nonfibonacci.h"
 #include <stdio.h>
-#include <stdlib.h>
+
 int main( void ) {
-    int i;
-    for ( i = 1; i < 12; i++ ) {
-        double result = stdlib_base_nonfibonacci( i );
-        printf( "x: %i => result: %lf", i, result );
+    double i;
+    double v;
+
+    for ( i = 1.0; i < 12.0; i++ ) {
+        v = stdlib_base_nonfibonacci( i );
+        printf( "nonfibonacci(%lf) = %lf\n", i, v );
     }
 }
 ```

--- a/lib/node_modules/@stdlib/math/base/special/nonfibonacci/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/nonfibonacci/benchmark/c/native/benchmark.c
@@ -90,13 +90,13 @@ static double rand_double( void ) {
 */
 static double benchmark( void ) {
 	double elapsed;
+	double x[ 100 ];
 	double t;
 	double y;
-	int x[ 100 ];
 	int i;
 
 	for ( i = 0; i < 100; i++ ) {
-		x[ i ] = (int)floor( (100.0*rand_double()) + 1.0 );
+		x[ i ] = floor( (100.0*rand_double()) + 1.0 );
 	}
 
 	t = tic();

--- a/lib/node_modules/@stdlib/math/base/special/nonfibonacci/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/nonfibonacci/examples/c/example.c
@@ -20,9 +20,11 @@
 #include <stdio.h>
 
 int main( void ) {
-	int i;
-	for ( i = 1; i < 12; i++ ) {
-		double result = stdlib_base_nonfibonacci( i );
-		printf( "x: %i => result: %lf\n", i, result );
+	double i;
+	double v;
+
+	for ( i = 1.0; i < 12.0; i++ ) {
+		v = stdlib_base_nonfibonacci( i );
+		printf( "nonfibonacci(%lf) = %lf\n", i, v );
 	}
 }

--- a/lib/node_modules/@stdlib/math/base/special/nonfibonacci/include/stdlib/math/base/special/nonfibonacci.h
+++ b/lib/node_modules/@stdlib/math/base/special/nonfibonacci/include/stdlib/math/base/special/nonfibonacci.h
@@ -19,8 +19,6 @@
 #ifndef STDLIB_MATH_BASE_SPECIAL_NONFIBONACCI_H
 #define STDLIB_MATH_BASE_SPECIAL_NONFIBONACCI_H
 
-#include <stdint.h>
-
 /*
 * If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
 */
@@ -31,7 +29,7 @@ extern "C" {
 /**
 * Computes the nth non-Fibonacci number.
 */
-double stdlib_base_nonfibonacci( const int32_t n );
+double stdlib_base_nonfibonacci( const double n );
 
 #ifdef __cplusplus
 }

--- a/lib/node_modules/@stdlib/math/base/special/nonfibonacci/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/nonfibonacci/manifest.json
@@ -40,7 +40,8 @@
         "@stdlib/constants/float64/nan",
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/ln",
-        "@stdlib/math/base/assert/is-integer"
+        "@stdlib/math/base/assert/is-integer",
+        "@stdlib/constants/float64/pinf"
       ]
     },
     {
@@ -57,7 +58,8 @@
         "@stdlib/constants/float64/nan",
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/ln",
-        "@stdlib/math/base/assert/is-integer"
+        "@stdlib/math/base/assert/is-integer",
+        "@stdlib/constants/float64/pinf"
       ]
     },
     {
@@ -74,7 +76,8 @@
         "@stdlib/constants/float64/nan",
         "@stdlib/math/base/special/floor",
         "@stdlib/math/base/special/ln",
-        "@stdlib/math/base/assert/is-integer"
+        "@stdlib/math/base/assert/is-integer",
+        "@stdlib/constants/float64/pinf"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/nonfibonacci/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/nonfibonacci/manifest.json
@@ -39,7 +39,8 @@
         "@stdlib/math/base/napi/unary",
         "@stdlib/constants/float64/nan",
         "@stdlib/math/base/special/floor",
-        "@stdlib/math/base/special/ln"
+        "@stdlib/math/base/special/ln",
+        "@stdlib/math/base/assert/is-integer"
       ]
     },
     {
@@ -55,7 +56,8 @@
       "dependencies": [
         "@stdlib/constants/float64/nan",
         "@stdlib/math/base/special/floor",
-        "@stdlib/math/base/special/ln"
+        "@stdlib/math/base/special/ln",
+        "@stdlib/math/base/assert/is-integer"
       ]
     },
     {
@@ -71,7 +73,8 @@
       "dependencies": [
         "@stdlib/constants/float64/nan",
         "@stdlib/math/base/special/floor",
-        "@stdlib/math/base/special/ln"
+        "@stdlib/math/base/special/ln",
+        "@stdlib/math/base/assert/is-integer"
       ]
     }
   ]

--- a/lib/node_modules/@stdlib/math/base/special/nonfibonacci/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/nonfibonacci/src/addon.c
@@ -19,4 +19,4 @@
 #include "stdlib/math/base/special/nonfibonacci.h"
 #include "stdlib/math/base/napi/unary.h"
 
-STDLIB_MATH_BASE_NAPI_MODULE_I_D( stdlib_base_nonfibonacci )
+STDLIB_MATH_BASE_NAPI_MODULE_D_D( stdlib_base_nonfibonacci )

--- a/lib/node_modules/@stdlib/math/base/special/nonfibonacci/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/nonfibonacci/src/main.c
@@ -19,6 +19,7 @@
 #include "stdlib/math/base/special/nonfibonacci.h"
 #include "stdlib/math/base/assert/is_integer.h"
 #include "stdlib/constants/float64/nan.h"
+#include "stdlib/constants/float64/pinf.h"
 #include "stdlib/math/base/special/floor.h"
 #include "stdlib/math/base/special/ln.h"
 
@@ -53,7 +54,7 @@ double stdlib_base_nonfibonacci( const double n ) {
 	double b;
 
 	mut_n = n;
-	if ( !stdlib_base_is_integer( n ) || n < 1.0 ) {
+	if ( !stdlib_base_is_integer( n ) || n == STDLIB_CONSTANT_FLOAT64_PINF || n < 1.0 ) {
 		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 

--- a/lib/node_modules/@stdlib/math/base/special/nonfibonacci/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/nonfibonacci/src/main.c
@@ -17,10 +17,10 @@
 */
 
 #include "stdlib/math/base/special/nonfibonacci.h"
+#include "stdlib/math/base/assert/is_integer.h"
 #include "stdlib/constants/float64/nan.h"
 #include "stdlib/math/base/special/floor.h"
 #include "stdlib/math/base/special/ln.h"
-#include <stdint.h>
 
 static const double SQRT5 = 2.23606797749979;
 static const double LN_PHI = 0.48121182506;
@@ -32,31 +32,32 @@ static const double LN_PHI = 0.48121182506;
 * @return     output value
 *
 * @example
-* double y = stdlib_base_nonfibonacci( 2 );
+* double y = stdlib_base_nonfibonacci( 2.0 );
 * // returns 6.0
 *
 * @example
-* double y = stdlib_base_nonfibonacci( 1 );
+* double y = stdlib_base_nonfibonacci( 1.0 );
 * // returns 4.0
 *
 * @example
-* double y = stdlib_base_nonfibonacci( 3 );
+* double y = stdlib_base_nonfibonacci( 3.0 );
 * // returns 7.0
 *
 * @example
-* double y = stdlib_base_nonfibonacci( -1 );
+* double y = stdlib_base_nonfibonacci( -1.0 );
 * // returns NaN
 */
-double stdlib_base_nonfibonacci( const int32_t n ) {
+double stdlib_base_nonfibonacci( const double n ) {
+	double mut_n;
 	double a;
 	double b;
-	int32_t mut_n = n;
 
-	if ( n < 1 ) {
+	mut_n = n;
+	if ( !stdlib_base_is_integer( n ) || n < 1.0 ) {
 		return STDLIB_CONSTANT_FLOAT64_NAN;
 	}
 
-	mut_n += 1;
+	mut_n += 1.0;
 	a = stdlib_base_ln( mut_n * SQRT5 ) / LN_PHI;
 	b = stdlib_base_ln( (SQRT5 * (mut_n + a)) - 5.0 + (3.0 / mut_n) ) / LN_PHI;
 


### PR DESCRIPTION
Resolves None.

## Description

> What is the purpose of this pull request?

This pull request:

-   modifies the C implementation to accept `double` instead of `int32` in [`math/base/special/nonfibonacci`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/nonfibonacci)

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
