### PR TITLE
chore: fix javascript lint error(issue #7019)

### DIFF
--- a/lib/node_modules/@stdlib/plot/components/svg/marks/lib/main.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/marks/lib/main.js
@@ -111,7 +111,12 @@ function Marks( options ) {
 		var args;
 		var i;
 		debug( 'Received a render event. Re-emitting...' );
-		args = new Array( arguments.length+1 );
+	
+		args = [];
+		for(let i = 0; i < arguments.lenght+1; i++){
+			args.push(0);
+		}
+
 		args[ 0 ] = 'render';
 		for ( i = 0; i < arguments.length; i++ ) {
 			args[ i+1 ] = arguments[ i ];


### PR DESCRIPTION
Resolves #{7019}.

## Description

> solved 7019 issue 

This pull request:

-   This PR fixes the linting error in lib/node_modules/@stdlib/plot/components/svg/marks/lib/main.js where new Array() was used.

According to the stdlib/no-new-array rule, using new Array() can create sparse arrays, which we want to avoid.

Changes Made

Replaced new Array() constructor with an array literal ([]).

Used .push() to add elements instead of explicitly setting .length.

Related Issues

Resolves #7019



This pull request:

-   resolves #{7019} 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
