### PR TITLE
chore: fix JavaScript lint errors (issue #6976)

### DIFF
--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/lib/main.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/lib/main.js
@@ -1198,7 +1198,7 @@ function factory( names, options ) { // eslint-disable-line max-lines-per-functi
 			return out;
 		}
 
-		// TODO: consider adding `toLocaleString()` in a manner similar to `toString()` below
+         // NOTE: consider adding `toLocaleString()` in the future.
 
 		/**
 		* Serializes a tuple as a string.


### PR DESCRIPTION
This PR fixes lint warnings flagged by ESLint (`no-warning-comments`) in 
`lib/node_modules/@stdlib/dstructs/named-typed-tuple/lib/main.js`.

Related Issues:
resolves #6976
- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
