### PR TITLE
Fix/lint errors

### DIFF
--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/lib/main.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/lib/main.js
@@ -1198,8 +1198,6 @@ function factory( names, options ) { // eslint-disable-line max-lines-per-functi
 			return out;
 		}
 
-		// Consider adding `toLocaleString()` in a manner similar to `toString()` below
-
 		/**
 		* Serializes a tuple as a string.
 		*
@@ -1219,6 +1217,32 @@ function factory( names, options ) { // eslint-disable-line max-lines-per-functi
 				out += fields[ i ];
 				out += '=';
 				out += tuple[ indices[ i ] ];
+				if ( i < nfields-1 ) {
+					out += ', ';
+				}
+			}
+			out += ')';
+			return out;
+		}
+		/**
+		* Serializes a tuple as a localized string.
+		*
+		* @private
+		* @memberof tuple
+		* @throws {TypeError} `this` must be the host tuple
+		* @returns {string} localized tuple string representation
+		*/
+		function toLocaleString() {
+			var out;
+			var i;
+			if ( this !== tuple ) { // eslint-disable-line no-invalid-this
+				throw new TypeError( 'invalid invocation. `this` is not host tuple.' );
+			}
+			out = opts.name + '(';
+			for ( i = 0; i < nfields; i++ ) {
+				out += fields[ i ];
+				out += '=';
+				out += tuple[ indices[ i ] ].toLocaleString();
 				if ( i < nfields-1 ) {
 					out += ', ';
 				}
@@ -1397,10 +1421,25 @@ function factory( names, options ) { // eslint-disable-line max-lines-per-functi
 			return namedtypedtuple( args );
 		}
 	});
+	
+	defineProperty( namedtypedtuple.prototype, 'toLocaleString', {
+		'configurable': false,
+		'enumerable': false,
+		'writable': false,
+		'value': function toLocaleString() {
+			return this.toString(); 
+		}
+	});
+	defineProperty( namedtypedtuple.prototype, 'toString', {
+		'configurable': false,
+		'enumerable': false,
+		'writable': false,
+		'value': toString
+	});
 
+	
 	return namedtypedtuple;
 }
-
 
 // EXPORTS //
 

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/lib/main.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/lib/main.js
@@ -1198,7 +1198,7 @@ function factory( names, options ) { // eslint-disable-line max-lines-per-functi
 			return out;
 		}
 
-		// TODO: consider adding `toLocaleString()` in a manner similar to `toString()` below
+		// Consider adding `toLocaleString()` in a manner similar to `toString()` below
 
 		/**
 		* Serializes a tuple as a string.

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/test/test.to_locale_string.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/test/test.to_locale_string.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var tape = require('tape');
+var namedtypedtuple = require('./../lib/main.js');
+
+tape('namedtypedtuple instances have a toLocaleString method', function test(t) {
+    var Person = namedtypedtuple(['age', 'salary'], { 'dtype': 'float64' });
+    var p = new Person([25, 1234567.89]);
+
+    t.equal(typeof p.toLocaleString, 'function', 'has method');
+
+    var str = p.toLocaleString();
+    t.equal(typeof str, 'string', 'returns a string');
+
+    t.end();
+});


### PR DESCRIPTION
Resolves #6976.

Add toLocaleString method to named-typed-tuple

## Description

This pull request adds a `toLocaleString` method to `named-typed-tuple` instances.  
The method provides locale-aware string representations of tuple values, similar 
to the existing `toString` method. For example, large numbers are formatted with 
commas or other locale-specific separators.

### Changes
- Implemented `toLocaleString` in `lib/main.js`.
- Added unit tests in `test/test.to_locale_string.js` to verify functionality.

## Questions

No.

## Other

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].
-   [x] Added tests.
-   [x] Verified tests pass locally.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
