### PR TITLE
test: add tests for `toJSON` method in `dstructs/named-typed-tuple`

### DIFF
--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/test/test.to_json.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/test/test.to_json.js
@@ -1,0 +1,125 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var isFunction = require( '@stdlib/assert/is-function' );
+var namedtypedtuple = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof namedtypedtuple, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'a tuple has a `toJSON` method', function test( t ) {
+	var Point;
+	var p;
+
+	Point = namedtypedtuple( [ 'x', 'y' ], {
+		'name': 'Point'
+	});
+	p = new Point( [ 10, 20 ] );
+
+	t.strictEqual( hasOwnProp( p, 'toJSON' ), true, 'returns expected value' );
+	t.strictEqual( isFunction( p.toJSON ), true, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method throws an error if invoked with a `this` context which is not a tuple instance', function test( t ) {
+	var values;
+	var Point;
+	var p;
+	var i;
+
+	Point = namedtypedtuple( [ 'x', 'y' ], {
+		'name': 'Point'
+	});
+	p = new Point( [ 10, 20 ] );
+
+	values = [
+		'5',
+		5,
+		NaN,
+		true,
+		false,
+		null,
+		void 0,
+		{},
+		[],
+		function noop() {},
+		{
+			'name': 'Bob'
+		}
+	];
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			return p.toJSON.call( value );
+		};
+	}
+});
+
+tape( 'the method serializes a tuple as JSON', function test( t ) {
+	var expected;
+	var actual;
+	var Point;
+	var p;
+
+	Point = namedtypedtuple( [ 'x', 'y' ] );
+	p = new Point( [ 10, 20 ] );
+
+	expected = {
+		'x': 10,
+		'y': 20
+	};
+	actual = p.toJSON();
+
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the method serializes a tuple with multiple fields as JSON', function test( t ) {
+	var expected;
+	var actual;
+	var Point;
+	var p;
+
+	Point = namedtypedtuple( [ 'price', 'quantity' ] );
+	p = new Point( [ 123456.789, 9876 ] );
+
+	expected = {
+		'price': 123456.789,
+		'quantity': 9876
+	};
+	actual = p.toJSON();
+
+	t.deepEqual( actual, expected, 'returns expected value' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/dstructs/named-typed-tuple/test/test.to_json.js
+++ b/lib/node_modules/@stdlib/dstructs/named-typed-tuple/test/test.to_json.js
@@ -104,22 +104,3 @@ tape( 'the method serializes a tuple as JSON', function test( t ) {
 	t.deepEqual( actual, expected, 'returns expected value' );
 	t.end();
 });
-
-tape( 'the method serializes a tuple with multiple fields as JSON', function test( t ) {
-	var expected;
-	var actual;
-	var Point;
-	var p;
-
-	Point = namedtypedtuple( [ 'price', 'quantity' ] );
-	p = new Point( [ 123456.789, 9876 ] );
-
-	expected = {
-		'price': 123456.789,
-		'quantity': 9876
-	};
-	actual = p.toJSON();
-
-	t.deepEqual( actual, expected, 'returns expected value' );
-	t.end();
-});


### PR DESCRIPTION
…tuple

---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: passed
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: na
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---



## Description

> What is the purpose of this pull request?

This pull request:

-   Add a test file for toJSON() method of dstructs/named-typed-tuple

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
