### PR TITLE
chore: address commit comments for commit `3b9d924`

### DIFF
--- a/.github/workflows/check_tracking_issue_closure.yml
+++ b/.github/workflows/check_tracking_issue_closure.yml
@@ -69,5 +69,5 @@ jobs:
         run: |
           . "$GITHUB_WORKSPACE/.github/workflows/scripts/check_tracking_issue_closure" 1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.STDLIB_BOT_PAT_REPO_WRITE }}
           DEBUG: ${{ inputs.debug || 'false' }}

--- a/.github/workflows/check_tracking_issue_closure.yml
+++ b/.github/workflows/check_tracking_issue_closure.yml
@@ -69,5 +69,5 @@ jobs:
         run: |
           . "$GITHUB_WORKSPACE/.github/workflows/scripts/check_tracking_issue_closure" 1
         env:
-          GITHUB_TOKEN: ${{ secrets.STDLIB_BOT_PAT_REPO_WRITE }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEBUG: ${{ inputs.debug || 'false' }}

--- a/lib/node_modules/@stdlib/array/from-scalar/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/from-scalar/docs/types/index.d.ts
@@ -190,7 +190,7 @@ declare function scalar2array( value: number, dtype: 'uint8' ): Uint8Array;
 * @returns output array
 *
 * @example
-* var x = scalar2array( 1, uint8c' );
+* var x = scalar2array( 1, 'uint8c' );
 * // returns <Uint8ClampedArray>[]
 */
 declare function scalar2array( value: number, dtype: 'uint8c' ): Uint8ClampedArray;


### PR DESCRIPTION
Resolves #8055 .

## Description

> What is the purpose of this pull request?

This pull request fixes a documentation typo in the TypeScript declaration file
`lib/node_modules/@stdlib/array/from-scalar/docs/types/index.d.ts`.

Specifically:
- Added the missing single quotes around `uint8` in the JSDoc example.
- Corrected the closing brace from `}` to `)`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #8055 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
