### PR TITLE
chore: fix JavaScript lint errors (issue #8061)

### DIFF
--- a/lib/node_modules/@stdlib/utils/properties/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/utils/properties/benchmark/benchmark.js
@@ -28,30 +28,40 @@ var pkg = require( './../package.json' ).name;
 var properties = require( './../lib' );
 
 
+// FUNCTIONS //
+
+/**
+* Constructor function for creating benchmark test objects.
+*
+* @private
+* @constructor
+* @returns {Foo} Foo instance
+*/
+function Foo() {
+	this.a = 'beep';
+	this.b = 'boop';
+	this.c = [ 1, 2, 3 ];
+	this.d = {};
+	this.e = null;
+	this.f = randu();
+	defineProperty( this, 'g', {
+		'value': 'bar',
+		'configurable': true,
+		'writable': true,
+		'enumerable': false
+	});
+	return this;
+}
+
+Foo.prototype.h = [ 'foo' ];
+
+
 // MAIN //
 
 bench( pkg, function benchmark( b ) {
 	var out;
 	var obj;
 	var i;
-
-	function Foo() {
-		this.a = 'beep';
-		this.b = 'boop';
-		this.c = [ 1, 2, 3 ];
-		this.d = {};
-		this.e = null;
-		this.f = randu();
-		defineProperty( this, 'g', {
-			'value': 'bar',
-			'configurable': true,
-			'writable': true,
-			'enumerable': false
-		});
-		return this;
-	}
-
-	Foo.prototype.h = [ 'foo' ];
 
 	obj = new Foo();
 


### PR DESCRIPTION
## Summary

This PR fixes a JavaScript lint error reported by the automated lint workflow.

## Changes

- Move `Foo` constructor function from inside the benchmark function to module scope
- Add appropriate JSDoc documentation for the moved function
- Maintain prototype assignment at module scope

## Details

The lint error was:
```
/home/runner/work/stdlib/stdlib/lib/node_modules/@stdlib/utils/properties/benchmark/benchmark.js
  38:2  error  Function 'Foo' should be moved to module scope  stdlib/no-unnecessary-nested-functions
```

The function has been moved to module scope as required by the `stdlib/no-unnecessary-nested-functions` rule.

## Related Issues

Resolves #8061

## Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
- [x] Searched for related issues and pull requests
- [x] The pull request is associated with an issue
- [x] Tests pass locally
- [x] Documentation is updated as appropriate

## Notes

This is my contribution to help maintain the high code quality standards of the stdlib project. The fix is straightforward - moving the function to module scope while preserving all functionality.