### PR TITLE
chore: fix JavaScript lint errors (issue #8068)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/pkgs/entry-points/lib/resolve_files.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/entry-points/lib/resolve_files.js
@@ -48,7 +48,7 @@ function resolveFiles( files, idx, clbk ) {
 	var i;
 
 	len = files.length;
-	out = new Array( len );
+	out = [];
 
 	debug( 'Resolving %d files...', len );
 	if ( len === 0 ) {

--- a/lib/node_modules/@stdlib/_tools/pkgs/entry-points/lib/resolve_files.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/entry-points/lib/resolve_files.js
@@ -22,6 +22,7 @@
 
 var logger = require( 'debug' );
 var exists = require( '@stdlib/fs/exists' );
+var filled = require( '@stdlib/array/base/filled' );
 var format = require( '@stdlib/string/format' );
 
 
@@ -48,7 +49,7 @@ function resolveFiles( files, idx, clbk ) {
 	var i;
 
 	len = files.length;
-	out = [];
+	out = filled( null, len );
 
 	debug( 'Resolving %d files...', len );
 	if ( len === 0 ) {
@@ -71,6 +72,7 @@ function resolveFiles( files, idx, clbk ) {
 		var k = i + 1;
 
 		return onExists;
+
 		/**
 		* Callback to be invoked upon determining if a file path exists.
 		*


### PR DESCRIPTION
Resolves #8068.

## Description

> What is the purpose of this pull request?

This pull request:

-   fixes a `stdlib/no-new-array` linting error in the `resolve_files.js` utility within the `@stdlib/_tools/pkgs/entry-points` package.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #8068

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md