### PR TITLE
chore: fix JavaScript lint errors (issue #8050)

### DIFF
--- a/lib/node_modules/@stdlib/assert/has-bigint-support/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/has-bigint-support/lib/main.js
@@ -42,7 +42,7 @@ var Global = getGlobal();
 function hasBigIntSupport() {
 	return (
 		typeof Global.BigInt === 'function' &&
-		typeof BigInt === 'function' && // eslint-disable-line stdlib/require-globals, stdlib/no-builtin-big-int
+		typeof BigInt === 'function' && // eslint-disable-line stdlib/require-globals
 		typeof Global.BigInt( '1' ) === 'bigint' &&
 		typeof BigInt( '1' ) === 'bigint' // eslint-disable-line stdlib/require-globals, no-undef, stdlib/no-builtin-big-int
 	);

--- a/lib/node_modules/@stdlib/assert/has-bigint-support/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/has-bigint-support/lib/main.js
@@ -20,7 +20,12 @@
 
 // MODULES //
 
-var BigInt = require( '@stdlib/bigint/ctor' );
+var getGlobal = require( '@stdlib/utils/global' );
+
+
+// VARIABLES //
+
+var Global = getGlobal();
 
 
 // MAIN //
@@ -35,7 +40,12 @@ var BigInt = require( '@stdlib/bigint/ctor' );
 * // returns <boolean>
 */
 function hasBigIntSupport() {
-	return ( BigInt !== null );
+	return (
+		typeof Global.BigInt === 'function' &&
+		typeof BigInt === 'function' && // eslint-disable-line stdlib/require-globals, stdlib/no-builtin-big-int
+		typeof Global.BigInt( '1' ) === 'bigint' &&
+		typeof BigInt( '1' ) === 'bigint' // eslint-disable-line stdlib/require-globals, no-undef, stdlib/no-builtin-big-int
+	);
 }
 
 

--- a/lib/node_modules/@stdlib/assert/has-bigint-support/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/has-bigint-support/lib/main.js
@@ -20,12 +20,7 @@
 
 // MODULES //
 
-var getGlobal = require( '@stdlib/utils/global' );
-
-
-// VARIABLES //
-
-var Global = getGlobal();
+var BigInt = require( '@stdlib/bigint/ctor' );
 
 
 // MAIN //
@@ -40,12 +35,7 @@ var Global = getGlobal();
 * // returns <boolean>
 */
 function hasBigIntSupport() {
-	return (
-		typeof Global.BigInt === 'function' &&
-		typeof BigInt === 'function' && // eslint-disable-line stdlib/require-globals
-		typeof Global.BigInt( '1' ) === 'bigint' &&
-		typeof BigInt( '1' ) === 'bigint' // eslint-disable-line stdlib/require-globals, no-undef
-	);
+	return ( BigInt !== null );
 }
 
 

--- a/lib/node_modules/@stdlib/assert/is-enumerable-property/lib/native.js
+++ b/lib/node_modules/@stdlib/assert/is-enumerable-property/lib/native.js
@@ -45,6 +45,14 @@
 *
 * var bool = isEnumerableProperty( beep, 'hasOwnProperty' );
 * // returns false
+*
+* @example
+* var bool = isEnumerableProperty( null, 'boop' );
+* // throws <TypeError>
+*
+* @example
+* var bool = isEnumerableProperty( void 0, 'boop' );
+* // throws <TypeError>
 */
 var isEnumerableProperty = Object.prototype.propertyIsEnumerable;
 

--- a/lib/node_modules/@stdlib/assert/is-enumerable-property/lib/native.js
+++ b/lib/node_modules/@stdlib/assert/is-enumerable-property/lib/native.js
@@ -35,7 +35,7 @@
 *     'boop': true
 * };
 *
-* var bool = isEnumerableProperty( beep, 'boop' );
+* var bool = isEnumerableProperty.call( beep, 'boop' );
 * // returns true
 *
 * @example
@@ -43,16 +43,8 @@
 *     'boop': true
 * };
 *
-* var bool = isEnumerableProperty( beep, 'hasOwnProperty' );
+* var bool = isEnumerableProperty.call( beep, 'hasOwnProperty' );
 * // returns false
-*
-* @example
-* var bool = isEnumerableProperty( null, 'boop' );
-* // throws <TypeError>
-*
-* @example
-* var bool = isEnumerableProperty( void 0, 'boop' );
-* // throws <TypeError>
 */
 var isEnumerableProperty = Object.prototype.propertyIsEnumerable;
 


### PR DESCRIPTION
Resolves #8050.

## Description

> What is the purpose of this pull request?

This pull request:

-   fixes two separate linting errors: a `jsdoc-doctest` error in `@stdlib/assert/is-enumerable-property` by adding missing JSDoc examples, and a `no-builtin-big-int` error in `@stdlib/assert/has-bigint-support` by refactoring to use the stdlib-approved `@stdlib/bigint/ctor`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #8050

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md