### PR TITLE
chore: fix JavaScript lint errors (issue #6704)

### DIFF
--- a/lib/node_modules/@stdlib/utils/async/inmap/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/async/inmap/lib/main.js
@@ -48,35 +48,28 @@ var factory = require( './factory.js' );
 * @returns {void}
 *
 * @example
-* var readFile = require( '@stdlib/fs/read-file' );
+* var nextTick = require( '@stdlib/utils/next-tick' );
+* var inmapAsync = require( '@stdlib/utils/async/inmap' );
 *
-* function done( error, results ) {
-*     if ( error ) {
-*         throw error;
-*     }
-*     console.log( results );
+* var arr = [ 1, 2, 3, 4 ];
+*
+* function iterator( val, next ) {
+* nextTick( cb );
+* function cb() {
+* // Return the value multiplied by 2...
+* next( null, val*2 );
+* }
 * }
 *
-* function read( file, next ) {
-*     var opts = {
-*         'encoding': 'utf8'
-*     };
-*     readFile( file, opts, onFile );
-*
-*     function onFile( error, data ) {
+* function done( error, result ) {
 *         if ( error ) {
-*             return next( error );
+*                     throw error;
 *         }
-*         next( null, data );
-*     }
+*         console.log( result );
+*         // => [ 2, 4, 6, 8 ]
 * }
 *
-* var files = [
-*     './beep.js',
-*     './boop.js'
-* ];
-*
-* inmapAsync( files, read, done );
+* inmapAsync( arr, iterator, done );
 */
 function inmapAsync( collection, options, fcn, done ) {
 	if ( arguments.length < 4 ) {


### PR DESCRIPTION
Resolves #6704.

## Description

> What is the purpose of this pull request?

This pull request:

-   fixes a `jsdoc-doctest` linting error in `@stdlib/utils/async/inmap` by refactoring the JSDoc example to be self-contained and runnable, removing its dependency on the filesystem.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #6704

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md