### PR TITLE
feat: add `dtype` option support in `ndarray/flatten`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/flatten/README.md
+++ b/lib/node_modules/@stdlib/ndarray/flatten/README.md
@@ -72,7 +72,7 @@ The function accepts the following options:
 
 -   **depth**: maximum number of input [ndarray][@stdlib/ndarray/ctor] dimensions to flatten.
 
--   **dtype**: output ndarray [data type][@stdlib/ndarray/dtypes]. By default, the function an [ndarray][@stdlib/ndarray/ctor] having the same [data type][@stdlib/ndarray/dtypes] as a provided input [ndarray][@stdlib/ndarray/ctor].
+-   **dtype**: output ndarray [data type][@stdlib/ndarray/dtypes]. By default, the function returns an [ndarray][@stdlib/ndarray/ctor] having the same [data type][@stdlib/ndarray/dtypes] as a provided input [ndarray][@stdlib/ndarray/ctor].
 
 By default, the function flattens all dimensions of the input [ndarray][@stdlib/ndarray/ctor]. To flatten to a desired depth, specify the `depth` option.
 

--- a/lib/node_modules/@stdlib/ndarray/flatten/README.md
+++ b/lib/node_modules/@stdlib/ndarray/flatten/README.md
@@ -72,6 +72,8 @@ The function accepts the following options:
 
 -   **depth**: maximum number of input [ndarray][@stdlib/ndarray/ctor] dimensions to flatten.
 
+-   **dtype**: output ndarray [data type][@stdlib/ndarray/dtypes]. If not specified, the output ndarray [data type][@stdlib/ndarray/dtypes] is inferred from the input [ndarray][@stdlib/ndarray/ctor].
+
 By default, the function flattens all dimensions of the input [ndarray][@stdlib/ndarray/ctor]. To flatten to a desired depth, specify the `depth` option.
 
 ```javascript
@@ -106,6 +108,28 @@ var y = flatten( x, {
 
 var arr = ndarray2array( y );
 // returns [ 1.0, 3.0, 5.0, 2.0, 4.0, 6.0 ]
+```
+
+By default, the output ndarray [data type][@stdlib/ndarray/dtypes] is inferred from the input [ndarray][@stdlib/ndarray/ctor]. To return an ndarray with a different [data type][@stdlib/ndarray/dtypes], specify the `dtype` option.
+
+```javascript
+var array = require( '@stdlib/ndarray/array' );
+var dtype = require( '@stdlib/ndarray/dtype' );
+var ndarray2array = require( '@stdlib/ndarray/to-array' );
+
+var x = array( [ [ [ 1.0, 2.0 ] ], [ [ 3.0, 4.0 ] ], [ [ 5.0, 6.0 ] ] ] );
+// returns <ndarray>
+
+var y = flatten( x, {
+    'dtype': 'float32'
+});
+// returns <ndarray>
+
+var dt = dtype( y );
+// returns 'float32'
+
+var arr = ndarray2array( y );
+// returns [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ]
 ```
 
 </section>
@@ -163,6 +187,8 @@ console.log( ndarray2array( y ) );
 <section class="links">
 
 [@stdlib/ndarray/ctor]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/ndarray/ctor
+
+[@stdlib/ndarray/dtypes]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/ndarray/dtypes
 
 [@stdlib/ndarray/orders]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/ndarray/orders
 

--- a/lib/node_modules/@stdlib/ndarray/flatten/README.md
+++ b/lib/node_modules/@stdlib/ndarray/flatten/README.md
@@ -72,7 +72,7 @@ The function accepts the following options:
 
 -   **depth**: maximum number of input [ndarray][@stdlib/ndarray/ctor] dimensions to flatten.
 
--   **dtype**: output ndarray [data type][@stdlib/ndarray/dtypes]. If not specified, the output ndarray [data type][@stdlib/ndarray/dtypes] is inferred from the input [ndarray][@stdlib/ndarray/ctor].
+-   **dtype**: output ndarray [data type][@stdlib/ndarray/dtypes]. By default, the function an [ndarray][@stdlib/ndarray/ctor] having the same [data type][@stdlib/ndarray/dtypes] as a provided input [ndarray][@stdlib/ndarray/ctor].
 
 By default, the function flattens all dimensions of the input [ndarray][@stdlib/ndarray/ctor]. To flatten to a desired depth, specify the `depth` option.
 

--- a/lib/node_modules/@stdlib/ndarray/flatten/docs/repl.txt
+++ b/lib/node_modules/@stdlib/ndarray/flatten/docs/repl.txt
@@ -30,8 +30,8 @@
         Default: 'row-major'.
 
     options.dtype: string (optional)
-        Output ndarray data type. Overrides using the input array's inferred
-        data type.
+        Output ndarray data type. By default, the function returns an ndarray
+        having the same data type as the provided input ndarray.
 
     Returns
     -------

--- a/lib/node_modules/@stdlib/ndarray/flatten/docs/repl.txt
+++ b/lib/node_modules/@stdlib/ndarray/flatten/docs/repl.txt
@@ -29,6 +29,10 @@
 
         Default: 'row-major'.
 
+    options.dtype: string (optional)
+        Output ndarray data type. Overrides using the input array's inferred
+        data type.
+
     Returns
     -------
     out: ndarray

--- a/lib/node_modules/@stdlib/ndarray/flatten/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/flatten/docs/types/index.d.ts
@@ -56,7 +56,7 @@ interface Options {
 	*
 	* ## Notes
 	*
-	* -   This option overrides using the input ndarray's inferred data type.
+	* -   By default, the function returns an ndarray having the same data type as a provided input ndarray.
 	*/
 	dtype?: DataType;
 }

--- a/lib/node_modules/@stdlib/ndarray/flatten/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/flatten/docs/types/index.d.ts
@@ -20,7 +20,7 @@
 
 /// <reference types="@stdlib/types"/>
 
-import { ndarray, Order } from '@stdlib/types/ndarray';
+import { ndarray, Order, DataType } from '@stdlib/types/ndarray';
 
 /**
 * Interface defining function options.
@@ -50,6 +50,15 @@ interface Options {
 	* -   Default: 'row-major'.
 	*/
 	order?: Order | 'same' | 'any';
+
+	/**
+	* Output ndarray data type.
+	*
+	* ## Notes
+	*
+	* -   This option overrides using the input ndarray's inferred data type.
+	*/
+	dtype?: DataType;
 }
 
 /**

--- a/lib/node_modules/@stdlib/ndarray/flatten/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/ndarray/flatten/docs/types/test.ts
@@ -128,6 +128,30 @@ import flatten = require( './index' );
 	flatten( zeros( 'generic', [ 2, 2, 2 ], 'row-major' ), { 'order': ( x: number ): number => x } ); // $ExpectError
 }
 
+// The compiler throws an error if the function is provided a second argument with invalid `dtype` option...
+{
+	flatten( zeros( 'float64', [ 2, 2, 2 ], 'row-major' ), { 'dtype': '5' } ); // $ExpectError
+	flatten( zeros( 'float64', [ 2, 2, 2 ], 'row-major' ), { 'dtype': true } ); // $ExpectError
+	flatten( zeros( 'float64', [ 2, 2, 2 ], 'row-major' ), { 'dtype': false } ); // $ExpectError
+	flatten( zeros( 'float64', [ 2, 2, 2 ], 'row-major' ), { 'dtype': null } ); // $ExpectError
+	flatten( zeros( 'float64', [ 2, 2, 2 ], 'row-major' ), { 'dtype': [ 1 ] } ); // $ExpectError
+	flatten( zeros( 'float64', [ 2, 2, 2 ], 'row-major' ), { 'dtype': ( x: number ): number => x } ); // $ExpectError
+
+	flatten( zeros( 'complex128', [ 2, 2, 2 ], 'row-major' ), { 'dtype': '5' } ); // $ExpectError
+	flatten( zeros( 'complex128', [ 2, 2, 2 ], 'row-major' ), { 'dtype': true } ); // $ExpectError
+	flatten( zeros( 'complex128', [ 2, 2, 2 ], 'row-major' ), { 'dtype': false } ); // $ExpectError
+	flatten( zeros( 'complex128', [ 2, 2, 2 ], 'row-major' ), { 'dtype': null } ); // $ExpectError
+	flatten( zeros( 'complex128', [ 2, 2, 2 ], 'row-major' ), { 'dtype': [ 1 ] } ); // $ExpectError
+	flatten( zeros( 'complex128', [ 2, 2, 2 ], 'row-major' ), { 'dtype': ( x: number ): number => x } ); // $ExpectError
+
+	flatten( zeros( 'generic', [ 2, 2, 2 ], 'row-major' ), { 'dtype': '5' } ); // $ExpectError
+	flatten( zeros( 'generic', [ 2, 2, 2 ], 'row-major' ), { 'dtype': true } ); // $ExpectError
+	flatten( zeros( 'generic', [ 2, 2, 2 ], 'row-major' ), { 'dtype': false } ); // $ExpectError
+	flatten( zeros( 'generic', [ 2, 2, 2 ], 'row-major' ), { 'dtype': null } ); // $ExpectError
+	flatten( zeros( 'generic', [ 2, 2, 2 ], 'row-major' ), { 'dtype': [ 1 ] } ); // $ExpectError
+	flatten( zeros( 'generic', [ 2, 2, 2 ], 'row-major' ), { 'dtype': ( x: number ): number => x } ); // $ExpectError
+}
+
 // The compiler throws an error if the function is provided an unsupported number of arguments...
 {
 	const x = zeros( 'float64', [ 2, 2, 2 ], 'row-major' );

--- a/lib/node_modules/@stdlib/ndarray/flatten/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/flatten/lib/main.js
@@ -351,7 +351,7 @@ function flatten( x, options ) {
 
 	// Create a view on top of output ndarray having the same shape as the input ndarray:
 	st = ( xsh.length > 0 ) ? shape2strides( xsh, opts.order ) : [ 0 ];
-	view = ndarray( getDType( y ), getData( y ), xsh, st, 0, opts.order );
+	view = ndarray( opts.dtype, getData( y ), xsh, st, 0, opts.order );
 
 	// Copy elements to the output ndarray:
 	assign( [ x, view ] );

--- a/lib/node_modules/@stdlib/ndarray/flatten/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/flatten/lib/main.js
@@ -297,7 +297,8 @@ function flatten( x, options ) {
 	// Define default options:
 	opts = {
 		'depth': xsh.length, // by default, flatten to a one-dimensional ndarray
-		'order': ROW_MAJOR   // by default, flatten in lexicographic order (i.e., trailing dimensions first; e.g., if `x` is a matrix, flatten row-by-row)
+		'order': ROW_MAJOR,   // by default, flatten in lexicographic order (i.e., trailing dimensions first; e.g., if `x` is a matrix, flatten row-by-row)
+		'dtype': getDType( x )
 	};
 
 	// Resolve function options...
@@ -335,11 +336,16 @@ function flatten( x, options ) {
 				throw new TypeError( format( 'invalid option. `%s` option must be a recognized order. Option: `%s`.', 'order', options.order ) );
 			}
 		}
+		if ( hasOwnProp( options, 'dtype' ) ) {
+			// Delegate `dtype` validation to `emptyLike` during output array creation:
+			opts.dtype = options.dtype;
+		}
 	}
 	// Create an output ndarray having contiguous memory:
 	y = emptyLike( x, {
 		'shape': flattenShape( xsh, opts.depth ),
-		'order': opts.order
+		'order': opts.order,
+		'dtype': opts.dtype
 	});
 
 	// Create a view on top of output ndarray having the same shape as the input ndarray:

--- a/lib/node_modules/@stdlib/ndarray/flatten/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/flatten/lib/main.js
@@ -54,6 +54,7 @@ var COL_MAJOR = 'column-major';
 * @param {Options} [options] - function options
 * @param {NonNegativeInteger} [options.depth] - maximum number of dimensions to flatten
 * @param {string} [options.order='row-major'] - order in which input ndarray elements should be flattened
+* @param {*} [options.dtype] - output ndarray data type
 * @throws {TypeError} first argument must be an ndarray-like object
 * @throws {TypeError} options argument must be an object
 * @throws {TypeError} must provide valid options
@@ -296,8 +297,8 @@ function flatten( x, options ) {
 
 	// Define default options:
 	opts = {
-		'depth': xsh.length, // by default, flatten to a one-dimensional ndarray
-		'order': ROW_MAJOR,   // by default, flatten in lexicographic order (i.e., trailing dimensions first; e.g., if `x` is a matrix, flatten row-by-row)
+		'depth': xsh.length,    // by default, flatten to a one-dimensional ndarray
+		'order': ROW_MAJOR,     // by default, flatten in lexicographic order (i.e., trailing dimensions first; e.g., if `x` is a matrix, flatten row-by-row)
 		'dtype': getDType( x )
 	};
 

--- a/lib/node_modules/@stdlib/ndarray/flatten/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/flatten/test/test.js
@@ -219,12 +219,8 @@ tape( 'the function throws an error if provided an invalid `dtype` option', func
 			var opts = {
 				'dtype': value
 			};
-			flatten( zeros( [ 2 ] ), opts, scale );
+			flatten( zeros( [ 2 ] ), opts );
 		};
-	}
-
-	function scale( z ) {
-		return z * 10.0;
 	}
 });
 

--- a/lib/node_modules/@stdlib/ndarray/flatten/test/test.js
+++ b/lib/node_modules/@stdlib/ndarray/flatten/test/test.js
@@ -191,6 +191,43 @@ tape( 'the function throws an error if provided an invalid `order` option', func
 	}
 });
 
+tape( 'the function throws an error if provided an invalid `dtype` option', function test( t ) {
+	var values;
+	var i;
+
+	values = [
+		'foo',
+		'bar',
+		1,
+		NaN,
+		true,
+		false,
+		void 0,
+		null,
+		[],
+		{},
+		function noop() {}
+	];
+
+	for ( i = 0; i < values.length; i++ ) {
+		t.throws( badValue( values[i] ), TypeError, 'throws an error when provided '+ values[i] );
+	}
+	t.end();
+
+	function badValue( value ) {
+		return function badValue() {
+			var opts = {
+				'dtype': value
+			};
+			flatten( zeros( [ 2 ] ), opts, scale );
+		};
+	}
+
+	function scale( z ) {
+		return z * 10.0;
+	}
+});
+
 tape( 'by default, the function flattens all dimensions of a provided input ndarray in lexicographic order (row-major, contiguous)', function test( t ) {
 	var expected;
 	var xbuf;


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: passed
  - task: lint_package_json status: na
  - task: lint_repl_help status: passed
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: passed
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: passed
  - task: lint_license_headers status: passed ---

Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/79.

## Description

> What is the purpose of this pull request?

This pull request:

-   add `dtype` option support in `ndarray/fatten`

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves https://github.com/stdlib-js/metr-issue-tracker/issues/79 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
