### PR TITLE
Fixed Javacript liniting issue 

### DIFF
--- a/lib/node_modules/@stdlib/repl/presentation/lib/commands/first.js
+++ b/lib/node_modules/@stdlib/repl/presentation/lib/commands/first.js
@@ -36,17 +36,19 @@ function command( pres ) {
 	* @private
 	*/
 	function onCommand() {
-		pres._repl.once( 'drain', onDrain ); // eslint-disable-line no-underscore-dangle
-
-		/**
-		* Callback invoked upon a `drain` event.
-		*
-		* @private
-		*/
-		function onDrain() {
-			pres.first().show();
-		}
+		// bind `pres` so `onDrain` still has access to it:
+		pres._repl.once( 'drain', () => onDrain( pres ) ); // eslint-disable-line no-underscore-dangle
 	}
+}
+
+/**
+* Callback invoked upon a `drain` event.
+*
+* @private
+* @param {Presentation} pres - presentation instance
+*/
+function onDrain( pres ) {
+	pres.first().show();
 }
 
 

--- a/lib/node_modules/@stdlib/stats/base/dists/cosine/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/cosine/README.md
@@ -145,7 +145,7 @@ console.log( 'Skewness: %d', cosine.skewness( mu, s ) );
 // => 'Skewness: 0'
 
 console.log( 'Excess Kurtosis: %d', cosine.kurtosis( mu, s ) );
-// => 'Excess Kurtosis: -0.5937628755982807'
+// => 'Excess Kurtosis: -0.5937628755982794'
 ```
 
 </section>


### PR DESCRIPTION
Fixing the liniting issue

Resolves #8100 .

## Description

> What is the purpose of this pull request?

This pull request:

-  Previously, the onDrain callback was nested inside onCommand. This violated the project’s linting rule stdlib/no-unnecessary-nested-functions, which discourages unnecessary nested functions because they can:

Capture more variables than needed,

Hurt readability, and

Complicate linting/analysis.

Before (nested function):

function onCommand() {
  pres._repl.once('drain', onDrain);

  function onDrain() {
    pres.first().show();
  }
}


After (fixed):

function onCommand() {
  // bind `pres` so `onDrain` still has access to it
  pres._repl.once('drain', () => onDrain(pres));
}

function onDrain(pres) {
  pres.first().show();
}

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #6704 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

onDrain moved from a nested function inside onCommand to its own top-level private function.

Used an arrow function wrapper () => onDrain(pres) to pass pres as an argument, keeping the same behavior.

Satisfies linting by removing the unnecessary nested function.

Keeps onDrain reusable and cleaner to test/document.

Maintains the original behavior: waiting for the drain event before showing the first slide.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
