### PR TITLE
refactor: move `onDrain` function to outer scope

### DIFF
--- a/lib/node_modules/@stdlib/repl/presentation/lib/commands/first.js
+++ b/lib/node_modules/@stdlib/repl/presentation/lib/commands/first.js
@@ -37,15 +37,15 @@ function command( pres ) {
 	*/
 	function onCommand() {
 		pres._repl.once( 'drain', onDrain ); // eslint-disable-line no-underscore-dangle
+	}
 
-		/**
-		* Callback invoked upon a `drain` event.
-		*
-		* @private
-		*/
-		function onDrain() {
-			pres.first().show();
-		}
+	/**
+	* Callback invoked upon a `drain` event.
+	*
+	* @private
+	*/
+	function onDrain() {
+		pres.first().show();
 	}
 }
 


### PR DESCRIPTION
Resolves #8100.

## Description

This pull request:
-   fixes a linting issue in `lib/node_modules/@stdlib/repl/presentation/lib/commands/first.js`.
-   Moved the nested `onDrain` function to the outer function scope.

## Related Issues

This pull request:

-   resolves #8100

## Questions

No.

## Other

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
