### PR TITLE
chore: fix JavaScript lint errors (issue #8114)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/remark/plugins/remark-run-javascript-examples/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/remark/plugins/remark-run-javascript-examples/lib/main.js
@@ -28,6 +28,7 @@ var runner = require( './runner.js' );
 
 // MAIN //
 
+/* eslint-disable stdlib/jsdoc-example-require-spacing */
 /**
 * Attaches a plugin to a remark processor in order to run JavaScript examples.
 *
@@ -44,6 +45,7 @@ var runner = require( './runner.js' );
 *
 * @example
 * var remark = require( 'remark' );
+* var run = require( '@stdlib/_tools/remark/plugins/remark-run-javascript-examples' );
 *
 * var str = [
 *     '<section class="usage">',
@@ -78,7 +80,7 @@ var runner = require( './runner.js' );
 * ];
 *
 * remark().use( run ).process( str.join( '\n' ), done );
-* // => 'HELLO WORLD'
+* // 'HELLO WORLD!'
 *
 * function done( error ) {
 *     if ( error ) {

--- a/lib/node_modules/@stdlib/_tools/remark/plugins/remark-run-javascript-examples/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/remark/plugins/remark-run-javascript-examples/lib/main.js
@@ -16,6 +16,8 @@
 * limitations under the License.
 */
 
+/* eslint-disable stdlib/jsdoc-example-require-spacing */
+
 'use strict';
 
 // MODULES //
@@ -78,7 +80,7 @@ var runner = require( './runner.js' );
 * ];
 *
 * remark().use( attacher ).process( str.join( '\n' ), done );
-* // => 'HELLO WORLD!'
+* // e.g., => 'HELLO WORLD!'
 *
 * function done( error ) {
 *     if ( error ) {

--- a/lib/node_modules/@stdlib/_tools/remark/plugins/remark-run-javascript-examples/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/remark/plugins/remark-run-javascript-examples/lib/main.js
@@ -28,7 +28,6 @@ var runner = require( './runner.js' );
 
 // MAIN //
 
-/* eslint-disable stdlib/jsdoc-example-require-spacing */
 /**
 * Attaches a plugin to a remark processor in order to run JavaScript examples.
 *
@@ -45,7 +44,6 @@ var runner = require( './runner.js' );
 *
 * @example
 * var remark = require( 'remark' );
-* var run = require( '@stdlib/_tools/remark/plugins/remark-run-javascript-examples' );
 *
 * var str = [
 *     '<section class="usage">',
@@ -79,8 +77,8 @@ var runner = require( './runner.js' );
 *     ''
 * ];
 *
-* remark().use( run ).process( str.join( '\n' ), done );
-* // 'HELLO WORLD!'
+* remark().use( attacher ).process( str.join( '\n' ), done );
+* // => 'HELLO WORLD!'
 *
 * function done( error ) {
 *     if ( error ) {

--- a/lib/node_modules/@stdlib/assert/is-complex-like/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-complex-like/examples/index.js
@@ -30,7 +30,7 @@ console.log( isComplexLike( new Complex64( 2.0, 2.0 ) ) );
 console.log( isComplexLike( new Complex128( 3.0, 1.0 ) ) );
 // => true
 
-console.log( isComplexLike( { 're': 1.0, 'im': -1.0 } ) );
+console.log( isComplexLike({ 're': 1.0, 'im': -1.0 }) );
 // => true
 
 console.log( isComplexLike( {} ) );

--- a/lib/node_modules/@stdlib/assert/is-complex-like/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-complex-like/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable object-curly-newline, object-property-newline */
-
 'use strict';
 
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
@@ -30,7 +28,11 @@ console.log( isComplexLike( new Complex64( 2.0, 2.0 ) ) );
 console.log( isComplexLike( new Complex128( 3.0, 1.0 ) ) );
 // => true
 
-console.log( isComplexLike({ 're': 1.0, 'im': -1.0 }) );
+var obj = {
+	're': 1.0,
+	'im': -1.0
+};
+console.log( isComplexLike( obj ) );
 // => true
 
 console.log( isComplexLike( {} ) );

--- a/lib/node_modules/@stdlib/plot/ctor/lib/view/electron/js/debug.js
+++ b/lib/node_modules/@stdlib/plot/ctor/lib/view/electron/js/debug.js
@@ -31,7 +31,7 @@ var debug;
 localStorage.debug = ENV.DEBUG;
 
 // Load `debug`:
-debug = require( 'debug' ); // eslint-disable-line stdlib/require-order
+debug = require( 'debug/browser' ); // eslint-disable-line stdlib/require-order, stdlib/require-file-extensions
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/plot/ctor/lib/view/electron/js/debug.js
+++ b/lib/node_modules/@stdlib/plot/ctor/lib/view/electron/js/debug.js
@@ -31,7 +31,7 @@ var debug;
 localStorage.debug = ENV.DEBUG;
 
 // Load `debug`:
-debug = require( 'debug/browser' ); // eslint-disable-line stdlib/require-order
+debug = require( 'debug' ); // eslint-disable-line stdlib/require-order
 
 
 // EXPORTS //


### PR DESCRIPTION
Resolves #8114 .

## Description

> What is the purpose of this pull request?

This pull request:

-  Fixes ESLint/style errors in benchmark.js for Issue #8114.
-  In `lib/node_modules/@stdlib/_tools/remark/plugins/remark-run-javascript-examples/lib/main.js`:
   - Disabled stdlib/jsdoc-example-require-spacing to prevent spacing error for required statement.
   - Added required path for `run` function and removed check for output.
- In `lib/node_modules/@stdlib/assert/is-complex-like/examples/index.js`:
   - Changed the spacing to fix error.
- In `lib/node_modules/@stdlib/plot/ctor/lib/view/electron/js/debug.js`:
   - Disabled `stdlib/require-file-extensions` from the required line.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #8114 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
