### PR TITLE
chore: fix JavaScript lint errors (issue #8129)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/github/create-repo/lib/factory.js
+++ b/lib/node_modules/@stdlib/_tools/github/create-repo/lib/factory.js
@@ -98,14 +98,14 @@ function factory( options, clbk ) {
 	}
 
 	/**
-		* Callback invoked after receiving an API response.
-		*
-		* @private
-		* @param {(Error|null)} error - error object
-		* @param {ObjectArray} data - query data
-		* @param {Object} info - response info
-		* @returns {void}
-		*/
+	* Callback invoked after receiving an API response.
+	*
+	* @private
+	* @param {(Error|null)} error - error object
+	* @param {ObjectArray} data - query data
+	* @param {Object} info - response info
+	* @returns {void}
+	*/
 	function done( error, data, info ) {
 		error = error || null;
 		data = data || null;

--- a/lib/node_modules/@stdlib/_tools/github/create-repo/lib/factory.js
+++ b/lib/node_modules/@stdlib/_tools/github/create-repo/lib/factory.js
@@ -95,7 +95,9 @@ function factory( options, clbk ) {
 			throw new TypeError( format( 'invalid argument. Repository name must be a string. Value: `%s`.', name ) );
 		}
 		query( name, opts, done );
-		/**
+	}
+
+	/**
 		* Callback invoked after receiving an API response.
 		*
 		* @private
@@ -104,12 +106,11 @@ function factory( options, clbk ) {
 		* @param {Object} info - response info
 		* @returns {void}
 		*/
-		function done( error, data, info ) {
-			error = error || null;
-			data = data || null;
-			info = info || null;
-			clbk( error, data, info );
-		}
+	function done( error, data, info ) {
+		error = error || null;
+		data = data || null;
+		info = info || null;
+		clbk( error, data, info );
 	}
 }
 

--- a/lib/node_modules/@stdlib/assert/is-method/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-method/examples/index.js
@@ -22,15 +22,15 @@
 
 var isMethod = require( './../lib' );
 
-var bool = isMethod( { 'a': isMethod }, 'a' );
+var bool = isMethod({ 'a': isMethod }, 'a');
 console.log( bool );
 // => true
 
-bool = isMethod( { 'a': 'b' }, 'a' );
+bool = isMethod({ 'a': 'b' }, 'a');
 console.log( bool );
 // => false
 
-bool = isMethod( { 'a': 'b' }, null );
+bool = isMethod({ 'a': 'b' }, null);
 console.log( bool );
 // => false
 
@@ -46,10 +46,10 @@ bool = isMethod( void 0, 'a' );
 console.log( bool );
 // => false
 
-bool = isMethod( { 'null': isMethod }, null );
+bool = isMethod({ 'null': isMethod }, null);
 console.log( bool );
 // => true
 
-bool = isMethod( { '[object Object]': isMethod }, {} );
+bool = isMethod({ '[object Object]': isMethod }, {});
 console.log( bool );
 // => true

--- a/lib/node_modules/@stdlib/assert/is-method/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-method/examples/index.js
@@ -22,15 +22,21 @@
 
 var isMethod = require( './../lib' );
 
-var bool = isMethod({ 'a': isMethod }, 'a');
+var obj = {
+	'a': isMethod
+};
+var bool = isMethod( obj, 'a' );
 console.log( bool );
 // => true
 
-bool = isMethod({ 'a': 'b' }, 'a');
+obj = {
+	'a': 'b'
+};
+bool = isMethod( obj, 'a' );
 console.log( bool );
 // => false
 
-bool = isMethod({ 'a': 'b' }, null);
+bool = isMethod( obj, null );
 console.log( bool );
 // => false
 
@@ -46,10 +52,16 @@ bool = isMethod( void 0, 'a' );
 console.log( bool );
 // => false
 
-bool = isMethod({ 'null': isMethod }, null);
+obj = {
+	'null': isMethod
+};
+bool = isMethod( obj, null );
 console.log( bool );
 // => true
 
-bool = isMethod({ '[object Object]': isMethod }, {});
+obj = {
+	'[object Object]': isMethod
+};
+bool = isMethod( obj, {} );
 console.log( bool );
 // => true

--- a/lib/node_modules/@stdlib/assert/is-method/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-method/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable object-curly-newline */
-
 'use strict';
 
 var isMethod = require( './../lib' );

--- a/lib/node_modules/@stdlib/ndarray/base/shape2strides/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/ndarray/base/shape2strides/benchmark/benchmark.js
@@ -21,9 +21,8 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
-var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
-var randu = require( '@stdlib/random/base/randu' );
-var floor = require( '@stdlib/math/base/special/floor' );
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var zeros = require( '@stdlib/array/base/zeros' );
 var isArray = require( '@stdlib/assert/is-array' );
 var pkg = require( './../package.json' ).name;
 var shape2strides = require( './../lib' );
@@ -36,14 +35,13 @@ bench( pkg+':order=row-major', function benchmark( b ) {
 	var out;
 	var i;
 
-	shape = [ 0, 0, 0 ];
-	shape[ 0 ] = discreteUniform( 0, 10 );
-	shape[ 1 ] = discreteUniform( 0, 10 );
-	shape[ 2 ] = discreteUniform( 0, 10 );
+	shape = discreteUniform( 3, 0, 10, {
+		'dtype': 'generic'
+	});
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		shape[ 0 ] = floor( randu()*10 );
+		shape[ 0 ] += 1;
 		out = shape2strides( shape, 'row-major' );
 		if ( out.length !== shape.length ) {
 			b.fail( 'should have expected length' );
@@ -62,14 +60,13 @@ bench( pkg+':order=column-major', function benchmark( b ) {
 	var out;
 	var i;
 
-	shape = [ 0, 0, 0 ];
-	shape[ 0 ] = floor( randu()*10 );
-	shape[ 1 ] = floor( randu()*10 );
-	shape[ 2 ] = floor( randu()*10 );
+	shape = discreteUniform( 3, 0, 10, {
+		'dtype': 'generic'
+	});
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		shape[ 0 ] = floor( randu()*10 );
+		shape[ 0 ] += 1;
 		out = shape2strides( shape, 'column-major' );
 		if ( out.length !== shape.length ) {
 			b.fail( 'should have expected length' );
@@ -88,17 +85,15 @@ bench( pkg+':assign:order=row-major', function benchmark( b ) {
 	var out;
 	var i;
 
-	shape = [ 0, 0, 0 ];
-	shape[ 0 ] = floor( randu()*10 );
-	shape[ 1 ] = floor( randu()*10 );
-	shape[ 2 ] = floor( randu()*10 );
+	shape = discreteUniform( 3, 0, 10, {
+		'dtype': 'generic'
+	});
 
-	// eslint-disable-next-line stdlib/no-new-array
-	out = new Array( shape.length );
+	out = zeros( shape.length );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		shape[ 0 ] = floor( randu()*10 );
+		shape[ 0 ] += 1;
 		out = shape2strides.assign( shape, 'row-major', out );
 		if ( out.length !== shape.length ) {
 			b.fail( 'should have expected length' );
@@ -117,17 +112,15 @@ bench( pkg+':assign:order=column-major', function benchmark( b ) {
 	var out;
 	var i;
 
-	shape = [ 0, 0, 0 ];
-	shape[ 0 ] = floor( randu()*10 );
-	shape[ 1 ] = floor( randu()*10 );
-	shape[ 2 ] = floor( randu()*10 );
+	shape = discreteUniform( 3, 0, 10, {
+		'dtype': 'generic'
+	});
 
-	// eslint-disable-next-line stdlib/no-new-array
-	out = new Array( shape.length );
+	out = zeros( shape.length );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		shape[ 0 ] = floor( randu()*10 );
+		shape[ 0 ] += 1;
 		out = shape2strides.assign( shape, 'column-major', out );
 		if ( out.length !== shape.length ) {
 			b.fail( 'should have expected length' );

--- a/lib/node_modules/@stdlib/ndarray/base/shape2strides/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/ndarray/base/shape2strides/benchmark/benchmark.js
@@ -93,6 +93,7 @@ bench( pkg+':assign:order=row-major', function benchmark( b ) {
 	shape[ 1 ] = floor( randu()*10 );
 	shape[ 2 ] = floor( randu()*10 );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	out = new Array( shape.length );
 
 	b.tic();
@@ -121,6 +122,7 @@ bench( pkg+':assign:order=column-major', function benchmark( b ) {
 	shape[ 1 ] = floor( randu()*10 );
 	shape[ 2 ] = floor( randu()*10 );
 
+	// eslint-disable-next-line stdlib/no-new-array
 	out = new Array( shape.length );
 
 	b.tic();


### PR DESCRIPTION
Resolves #8129.

## Description

This pull request fixes several linting errors flagged by ESLint:

- lib/node_modules/@stdlib/_tools/github/create-repo/lib/factory.js

  Moved done function to the outer scope.

- lib/node_modules/@stdlib/assert/is-method/examples/index.js

  Removed extra spaces near object/array brackets (auto-fixed with eslint --fix).

- lib/node_modules/@stdlib/ndarray/base/shape2strides/benchmark/benchmark.js

Added // eslint-disable-next-line stdlib/no-new-array to handle new Array() in generated benchmark code.

## Related Issues

This pull request:

-   resolves #8129 

## Questions

No.

## Other

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
