### PR TITLE
chore: fix JavaScript lint errors (issue #8169)

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-nonpositive-number/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-nonpositive-number/benchmark/benchmark.js
@@ -16,7 +16,7 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers, no-undefined, no-empty-function */
+/* eslint-disable no-undefined, no-empty-function */
 
 'use strict';
 

--- a/lib/node_modules/@stdlib/utils/async/reduce-right/lib/limit.js
+++ b/lib/node_modules/@stdlib/utils/async/reduce-right/lib/limit.js
@@ -95,6 +95,7 @@ function limit( collection, acc, opts, fcn, done ) {
 		acc = result;
 		clbk();
 	}
+
 	/**
 	* Callback to invoke a provided function for the next element in a collection.
 	*

--- a/lib/node_modules/@stdlib/utils/async/reduce-right/lib/limit.js
+++ b/lib/node_modules/@stdlib/utils/async/reduce-right/lib/limit.js
@@ -75,6 +75,27 @@ function limit( collection, acc, opts, fcn, done ) {
 		}
 	}
 	/**
+	* Callback invoked once a provided function finishes processing a collection element.
+	*
+	* @private
+	* @param {*} [error] - error
+	* @param {*} [result] - accumulation result
+	* @returns {void}
+	*/
+	function cb( error, result ) {
+		if ( flg ) {
+			// Prevent further processing of collection elements:
+			return;
+		}
+		if ( error ) {
+			flg = true;
+			return clbk( error );
+		}
+		debug( 'Accumulator: %s', JSON.stringify( result ) );
+		acc = result;
+		clbk();
+	}
+	/**
 	* Callback to invoke a provided function for the next element in a collection.
 	*
 	* @private
@@ -88,27 +109,6 @@ function limit( collection, acc, opts, fcn, done ) {
 			fcn.call( opts.thisArg, acc, collection[ idx ], idx, cb );
 		} else {
 			fcn.call( opts.thisArg, acc, collection[ idx ], idx, collection, cb ); // eslint-disable-line max-len
-		}
-		/**
-		* Callback invoked once a provided function finishes processing a collection element.
-		*
-		* @private
-		* @param {*} [error] - error
-		* @param {*} [result] - accumulation result
-		* @returns {void}
-		*/
-		function cb( error, result ) {
-			if ( flg ) {
-				// Prevent further processing of collection elements:
-				return;
-			}
-			if ( error ) {
-				flg = true;
-				return clbk( error );
-			}
-			debug( 'Accumulator: %s', JSON.stringify( result ) );
-			acc = result;
-			clbk();
 		}
 	}
 


### PR DESCRIPTION
Resolves #8169.

## Description

This pull request fixes the linting issues reported in #8169:

-  Moved cb function to outer scope in utils/async/reduce-right/lib/limit.js to comply with stdlib/no-unnecessary-nested-functions.
- Removed unused eslint-disable directive in assert/is-nonpositive-number/benchmark/benchmark.js

## Related Issues

This pull request:

-   resolves #8169 

## Questions

No.

## Other

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
