### PR TITLE
chore: fix C lint errors (issue #8196)

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/minmax-view-buffer-index/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/minmax-view-buffer-index/benchmark/c/benchmark.c
@@ -96,10 +96,10 @@ static double benchmark( void ) {
 	int i;
 
 	int64_t out[ 2 ];
-	int64_t shape[] = { 10, 10, 10 };
-	int64_t strides[] = { 100, 10, 1 };
-	int64_t offset = 1000;
-	int64_t ndims = 3;
+	const int64_t shape[] = { 10, 10, 10 };
+	const int64_t strides[] = { 100, 10, 1 };
+	const int64_t offset = 1000;
+	const int64_t ndims = 3;
 
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {

--- a/lib/node_modules/@stdlib/ndarray/base/minmax-view-buffer-index/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/ndarray/base/minmax-view-buffer-index/benchmark/c/benchmark.c
@@ -97,13 +97,13 @@ static double benchmark( void ) {
 
 	int64_t out[ 2 ];
 	const int64_t shape[] = { 10, 10, 10 };
-	const int64_t strides[] = { 100, 10, 1 };
+	int64_t strides[] = { 100, 10, 1 };
 	const int64_t offset = 1000;
 	const int64_t ndims = 3;
 
 	t = tic();
 	for ( i = 0; i < ITERATIONS; i++ ) {
-		strides[ 0 ] *= ( rand_double() < 0.5 ) ? 1 : -1;
+		strides[ 0 ] = ( i%2 ) ? 100 : -100;
 		stdlib_ndarray_minmax_view_buffer_index( ndims, shape, strides, offset, out );
 		if ( out[ 0 ] > 1e10 ) {
 			printf( "unexpected result\n" );


### PR DESCRIPTION
Resolves #8196.

## Description

> What is the purpose of this pull request?

This pull request:

-   fix C lint errors, according to https://github.com/stdlib-js/stdlib/blob/develop/lib/node_modules/%40stdlib/ndarray/base/minmax-view-buffer-index/src/main.c#L50

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #8196

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
