### PR TITLE
chore: fix JavaScript lint errors (issue #8195)

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-probability/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-probability/benchmark/benchmark.js
@@ -16,7 +16,7 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers, no-undefined, no-empty-function */
+/* eslint-disable no-undefined, no-empty-function */
 
 'use strict';
 

--- a/lib/node_modules/@stdlib/blas/base/isamax/test/test.ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/base/isamax/test/test.ndarray.native.js
@@ -66,13 +66,13 @@ tape( 'the function finds the index of the element with the maximum absolute val
 	idx = isamax( 4, x, 1, 0 );
 	t.strictEqual( idx, expected, 'returns expected value' );
 
-	x = new Float32Array( [
+	x = new Float32Array([
 		0.2,  // 1
 		-0.6, // 2
 		0.3,  // 3
 		5.0,
 		5.0
-	] );
+	]);
 	expected = 1;
 
 	idx = isamax( 3, x, 1, 0 );
@@ -86,11 +86,11 @@ tape( 'if provided an `N` parameter less than `1`, the function returns `-1`', o
 	var idx;
 	var x;
 
-	x = new Float32Array( [
+	x = new Float32Array([
 		1.0,
 		2.0,
 		3.0
-	] );
+	]);
 	expected = -1;
 
 	idx = isamax( 0, x, 1, 0 );
@@ -104,11 +104,11 @@ tape( 'if provided an `N` parameter equal to `1`, the function returns `0`', opt
 	var idx;
 	var x;
 
-	x = new Float32Array( [
+	x = new Float32Array([
 		1.0,
 		2.0,
 		3.0
-	] );
+	]);
 	expected = 0;
 
 	idx = isamax( 1, x, 1, 1 );

--- a/lib/node_modules/@stdlib/plot/ctor/lib/props/x-axis-orient/orientations.json
+++ b/lib/node_modules/@stdlib/plot/ctor/lib/props/x-axis-orient/orientations.json
@@ -1,4 +1,4 @@
 [
-	"bottom",
-	"top"
+  "bottom",
+  "top"
 ]


### PR DESCRIPTION
Resolves #8195.

## Description

This pull request fixed linting errors in:

-  lib/node_modules/@stdlib/blas/base/isamax/test/test.ndarray.native.js 
   by removing extra spaces.

- lib/node_modules/@stdlib/assert/is-probability/benchmark/benchmark.js
   Removed unused ESLint disable directive 


## Related Issues

This pull request:

-   resolves #8195

## Questions

No.

## Other

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
