### PR TITLE
chore: fix JavaScript lint errors (issue #8213)

### DIFF
--- a/lib/node_modules/@stdlib/bench/harness/lib/log/index.js
+++ b/lib/node_modules/@stdlib/bench/harness/lib/log/index.js
@@ -20,7 +20,7 @@
 
 // MODULES //
 
-var Transform = require( '@stdlib/streams/node/transform' );
+var TransformStream = require( '@stdlib/streams/node/transform' ); // eslint-disable-line stdlib/no-redeclare
 var fromCodePoint = require( '@stdlib/string/from-code-point' );
 var log = require( './log.js' );
 
@@ -37,7 +37,7 @@ function createStream() {
 	var stream;
 	var line;
 
-	stream = new Transform({
+	stream = new TransformStream({
 		'transform': transform,
 		'flush': flush
 	});

--- a/lib/node_modules/@stdlib/bench/harness/lib/log/index.js
+++ b/lib/node_modules/@stdlib/bench/harness/lib/log/index.js
@@ -20,7 +20,7 @@
 
 // MODULES //
 
-var TransformStream = require( '@stdlib/streams/node/transform' );
+var Transform = require( '@stdlib/streams/node/transform' );
 var fromCodePoint = require( '@stdlib/string/from-code-point' );
 var log = require( './log.js' );
 
@@ -37,7 +37,7 @@ function createStream() {
 	var stream;
 	var line;
 
-	stream = new TransformStream({
+	stream = new Transform({
 		'transform': transform,
 		'flush': flush
 	});

--- a/lib/node_modules/@stdlib/stats/pcorrtest/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/pcorrtest/benchmark/benchmark.js
@@ -40,11 +40,11 @@ bench( pkg, function benchmark( b ) {
 	var i;
 
 	rho = 0.5;
-	x = new Array( 300 );
-	y = new Array( 300 );
+	x = [];
+	y = [];
 	for ( i = 0; i < 300; i++ ) {
-		x[ i ] = rnorm( 0.0, 1.0 );
-		y[ i ] = ( rho * x[ i ] ) + rnorm( 0.0, sqrt( 1.0 - (rho*rho) ) );
+		x.push( rnorm( 0.0, 1.0 ) );
+		y.push( ( rho * x[ i ] ) + rnorm( 0.0, sqrt( 1.0 - (rho*rho) ) ) );
 	}
 
 	b.tic();
@@ -74,11 +74,11 @@ bench( pkg+'::one-sided', function benchmark( b ) {
 	var i;
 
 	rho = 0.5;
-	x = new Array( 300 );
-	y = new Array( 300 );
+	x = [];
+	y = [];
 	for ( i = 0; i < 300; i++ ) {
-		x[ i ] = rnorm( 0.0, 1.0 );
-		y[ i ] = ( rho * x[ i ] ) + rnorm( 0.0, sqrt( 1.0 - (rho*rho) ) );
+		x.push( rnorm( 0.0, 1.0 ) );
+		y.push( ( rho * x[ i ] ) + rnorm( 0.0, sqrt( 1.0 - (rho*rho) ) ) );
 	}
 	opts = {
 		'alternative': 'less'
@@ -111,11 +111,11 @@ bench( pkg+':rho=0.5', function benchmark( b ) {
 	var i;
 
 	rho = 0.5;
-	x = new Array( 300 );
-	y = new Array( 300 );
+	x = [];
+	y = [];
 	for ( i = 0; i < 300; i++ ) {
-		x[ i ] = rnorm( 0.0, 1.0 );
-		y[ i ] = ( rho * x[ i ] ) + rnorm( 0.0, sqrt( 1.0 - (rho*rho) ) );
+		x.push( rnorm( 0.0, 1.0 ) );
+		y.push( ( rho * x[ i ] ) + rnorm( 0.0, sqrt( 1.0 - (rho*rho) ) ) );
 	}
 	opts = {
 		'rho': 0.5
@@ -148,11 +148,11 @@ bench( pkg+':print', function benchmark( b ) {
 	var i;
 
 	rho = 0.5;
-	x = new Array( 300 );
-	y = new Array( 300 );
+	x = [];
+	y = [];
 	for ( i = 0; i < 300; i++ ) {
-		x[ i ] = rnorm( 0.0, 1.0 );
-		y[ i ] = ( rho * x[ i ] ) + rnorm( 0.0, sqrt( 1.0 - (rho*rho) ) );
+		x.push( rnorm( 0.0, 1.0 ) );
+		y.push( ( rho * x[ i ] ) + rnorm( 0.0, sqrt( 1.0 - (rho*rho) ) ) );
 	}
 	result = pcorrtest( x, y );
 


### PR DESCRIPTION
Resolves #8213.

## Description

> What is the purpose of this pull request?

This pull request:

-   fixes two separate linting errors: a `no-redeclare` error in `@stdlib/bench/harness` by renaming a variable to avoid shadowing a global, and several `no-new-array` errors in `@stdlib/stats/pcorrtest` by refactoring array creation to use literals and `.push()`.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #8213

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md