### PR TITLE
chore: fix EditorConfig lint errors (issue #8215)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/eslint/rules/line-closing-bracket-spacing/examples/index.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/line-closing-bracket-spacing/examples/index.js
@@ -45,22 +45,22 @@ var result = linter.verify( code, {
 });
 console.log( result );
 /* =>
-    [
-        {
-            'ruleId': 'line-closing-bracket-spacing',
-            'severity': 2,
-            'message': 'No spaces allowed between a closing parenthesis or bracket and a nested object or array expression at the beginning of a line',
-            'line': 3,
-            'column': 3,
-            'nodeType': 'CallExpression'
-        },
-        {
-            'ruleId': 'line-closing-bracket-spacing',
-            'severity': 2,
-            'message': 'No spaces allowed between a closing parenthesis or bracket and a nested object or array expression at the beginning of a line',
-            'line': 6,
-            'column': 13,
-            'nodeType': 'ArrayExpression'
-        }
-    ]
+	[
+		{
+			'ruleId': 'line-closing-bracket-spacing',
+			'severity': 2,
+			'message': 'No spaces allowed between a closing parenthesis or bracket and a nested object or array expression at the beginning of a line',
+			'line': 3,
+			'column': 3,
+			'nodeType': 'CallExpression'
+		},
+		{
+			'ruleId': 'line-closing-bracket-spacing',
+			'severity': 2,
+			'message': 'No spaces allowed between a closing parenthesis or bracket and a nested object or array expression at the beginning of a line',
+			'line': 6,
+			'column': 13,
+			'nodeType': 'ArrayExpression'
+		}
+	]
 */


### PR DESCRIPTION
Resolves #8215.

## Description

This pull request:

-   This PR fixes the EditorConfig lint errors in lib/node_modules/@stdlib/_tools/eslint/rules/line-closing-bracket-spacing/examples/index.js (lines 48–65) by using tabs instead of spaces, so editorconfig-checker passes

## Related Issues

This pull request:

-   resolves #8215 

## Questions

No.

## Other

No.

## Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
