### PR TITLE
chore: fix JavaScript lint errors (issue #8208)

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-bigint/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-bigint/benchmark/benchmark.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* global BigInt */
-
 /* eslint-disable no-new-wrappers, no-empty-function, stdlib/require-globals */
 
 'use strict';
@@ -27,6 +25,7 @@
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var hasBigInts = require( '@stdlib/assert/has-bigint-support' );
+var BigInt = require( '@stdlib/bigint/ctor' );
 var pkg = require( './../package.json' ).name;
 var isBigInt = require( './../lib' );
 


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: passed
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Resolves #8208.

## Description

> What is the purpose of this pull request?

This pull request resolves JavaScript lint errors in the is-bigint benchmark file by replacing the built-in global `BigInt` with the project's required `@stdlib/bigint/ctor` version. This ensures compatibility with older Node.js runtimes.

The conflicting `/* global BigInt */` directive was also removed to prevent a redeclaration error.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #8208

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
