### PR TITLE
chore: fix JavaScript lint errors (issue #8140)

### DIFF
--- a/lib/node_modules/@stdlib/utils/async/map-values/lib/factory.js
+++ b/lib/node_modules/@stdlib/utils/async/map-values/lib/factory.js
@@ -50,6 +50,7 @@ var limit = require( './limit.js' );
 * @returns {Function} function which maps values from one object to a new object having the same keys
 *
 * @example
+* var join = require( 'path' ).join;
 * var stat = require( 'fs' ).stat;
 *
 * function getStats( file, next ) {
@@ -72,8 +73,8 @@ var limit = require( './limit.js' );
 *
 * // Create a dictionary of file names:
 * var files = {
-*     'file1': './beep.js',
-*     'file2': './boop.js'
+*     'file1': join( __dirname, '..', 'README.md' ),
+*     'file2': join( __dirname, '..', 'package.json' )
 * };
 *
 * // Define a callback which handles errors:

--- a/lib/node_modules/@stdlib/utils/async/map-values/lib/index.js
+++ b/lib/node_modules/@stdlib/utils/async/map-values/lib/index.js
@@ -25,6 +25,7 @@
 *
 * @example
 * var stat = require( 'fs' ).stat;
+* var join = require( 'path' ).join;
 * var mapValuesAsync = require( '@stdlib/utils/async/map-values' );
 *
 * function getStats( file, next ) {
@@ -48,8 +49,8 @@
 *
 * // Create a dictionary of file names:
 * var files = {
-*     'file1': './beep.js',
-*     'file2': './boop.js'
+*     'file1': join( __dirname, '..', 'README.md' ),
+*     'file2': join( __dirname, '..', 'package.json' )
 * };
 *
 * var opts = {

--- a/lib/node_modules/@stdlib/utils/async/map-values/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/async/map-values/lib/main.js
@@ -50,6 +50,7 @@ var factory = require( './factory.js' );
 * @returns {void}
 *
 * @example
+* var join = require( 'path' ).join;
 * var stat = require( 'fs' ).stat;
 *
 * function getStats( file, next ) {
@@ -73,8 +74,8 @@ var factory = require( './factory.js' );
 *
 * // Create a dictionary of file names:
 * var files = {
-*     'file1': './beep.js',
-*     'file2': './boop.js'
+*     'file1': join( __dirname, '..', 'README.md' ),
+*     'file2': join( __dirname, '..', 'package.json' )
 * };
 *
 * var opts = {


### PR DESCRIPTION
**Relates to #8140.**

## Description

This pull request:

* Fixes the ESLint/import-resolver `ENOENT` caused by `@example` blocks referencing non-existent files (`'./beep.js'`, `'./boop.js'`) in `@stdlib/utils/async/map-values`.
* Updates the `@example` blocks in:

  * `lib/node_modules/@stdlib/utils/async/map-values/lib/index.js`
  * `lib/node_modules/@stdlib/utils/async/map-values/lib/main.js`
  * `lib/node_modules/@stdlib/utils/async/map-values/lib/factory.js`
* Replaces placeholders with real, existing files and adds a cross-platform path join:

  ```js
  var join = require('path').join;
  var files = [
    join( __dirname, '..', 'README.md' ),
    join( __dirname, '..', 'package.json' )
  ];
  ```
* No runtime logic, public API, build tooling, or Make/workflow changes. This is an example-only adjustment to prevent the linter/import resolver from attempting to `stat` missing paths.

## Related Issues

This pull request:

* relates to #8140

## Questions

No.

## Other

### Scope & Intent

* This PR intentionally fixes the issue **only for** `@stdlib/utils/async/map-values` (the three files listed above).
* The CI failure in #8140 is triggered by **random file sampling**; similar placeholder paths may exist in other `utils/async/*` packages.
* Therefore this PR uses **Relates to** (not *Resolves*) until the same pattern is addressed in other packages.

### Why this approach (and not tooling changes)

* Keep the fix minimal and source-focused: do not modify Makefiles, workflows, or eslint recipes.
* Point examples at guaranteed-to-exist files within the package (`README.md`, `package.json`) to avoid import-resolver file-system lookups failing on non-existent placeholders.

### Local Verification

* Ran locally:

  ```bash
  make install-node-modules && make init
  make lint-javascript-files FILES="lib/node_modules/@stdlib/utils/async/map-values/lib/{index.js,main.js,factory.js}"
  # Optional: invoke the workflow helper script on a single file
  node .github/workflows/scripts/lint_javascript_files_error_log lib/node_modules/@stdlib/utils/async/map-values/lib/factory.js
  ```
* ✅ No `ENOENT` occurred and no new lint errors/warnings were introduced.

### Follow-up Plan

* If this approach is accepted, I will submit small, per-package PRs applying the same example-path fix to other `utils/async/*` modules that still reference non-existent example files. Optionally open a tracking issue to audit and replace placeholder paths across affected packages.


## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

---

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md