### PR TITLE
chore: fix JavaScript lint errors (issue #8225)

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/ctor/test/test.instance.set_nd.js
+++ b/lib/node_modules/@stdlib/ndarray/ctor/test/test.instance.set_nd.js
@@ -79,15 +79,14 @@ tape( 'an ndarray constructor returns an instance which has a `set` method which
 			var i;
 
 			args = [];
-			args.length = shape.length+1;
 			for ( i = 0; i < shape.length; i++ ) {
 				if ( i === dim ) {
-					args[ i ] = value;
+					args.push( value );
 				} else {
-					args[ i ] = 0;
+					args.push( 0 );
 				}
 			}
-			args[ i ] = 10.0;
+			args.push( 10.0 );
 			arr.set.apply( arr, args );
 		};
 	}

--- a/lib/node_modules/@stdlib/ndarray/ctor/test/test.instance.set_nd.js
+++ b/lib/node_modules/@stdlib/ndarray/ctor/test/test.instance.set_nd.js
@@ -75,9 +75,11 @@ tape( 'an ndarray constructor returns an instance which has a `set` method which
 
 	function badValue( value, dim ) {
 		return function badValue() {
-			var args = new Array( shape.length+1 );
+			var args;
 			var i;
 
+			args = [];
+			args.length = shape.length+1;
 			for ( i = 0; i < shape.length; i++ ) {
 				if ( i === dim ) {
 					args[ i ] = value;


### PR DESCRIPTION
## Description

Fixes JavaScript linting error in `@stdlib/ndarray/ctor` test file by replacing `new Array()` constructor with array literal.

## Changes

- Replaced `new Array(shape.length+1)` with array literal and explicit length assignment
- Resolves `stdlib/no-new-array` ESLint rule violation
- Maintains identical functionality while adhering to project coding standards

## Related Issues

Resolves the linting failure detected in CI workflow:
https://github.com/stdlib-js/stdlib/actions/runs/18392323945

## Testing

- ✅ Local linting passes (no errors detected)
- ✅ No functional changes - only coding style compliance
- ✅ Array behavior remains identical

## Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)
- [x] Linting passes locally
- [x] No functional changes - only coding style compliance
- [x] Commit message follows project conventions
- [x] Single focused change addressing one specific issue