### PR TITLE
chore: fix JavaScript lint errors (issue #8235) (remove all unused no-new-wrappers disables in @stdlib/assert examples)

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-boolean-array/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-boolean-array/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Boolean = require( '@stdlib/boolean/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-boolean/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-boolean/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Boolean = require( '@stdlib/boolean/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-composite/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-composite/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-cube-number/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-cube-number/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-even/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-even/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-finite-array/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-finite-array/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-finite/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-finite/examples/index.js
@@ -16,7 +16,7 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers, stdlib/no-redeclare */
+/* eslint-disable stdlib/no-redeclare */
 
 'use strict';
 

--- a/lib/node_modules/@stdlib/assert/is-infinite/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-infinite/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-integer/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-integer/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-nan-array/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-nan-array/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Float64Array = require( '@stdlib/array/float64' );

--- a/lib/node_modules/@stdlib/assert/is-nan/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-nan/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var hasSymbolSupport = require( '@stdlib/assert/has-symbol-support' );

--- a/lib/node_modules/@stdlib/assert/is-negative-integer-array/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-negative-integer-array/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-negative-integer/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-negative-integer/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-negative-number-array/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-negative-number-array/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-negative-number/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-negative-number/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-negative-zero/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-negative-zero/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-integer-array/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-integer-array/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-integer/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-integer/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-number-array/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-number-array/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-nonnegative-number/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-nonnegative-number/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-nonpositive-integer-array/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-nonpositive-integer-array/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-nonpositive-integer/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-nonpositive-integer/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-nonpositive-number-array/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-nonpositive-number-array/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-nonpositive-number/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-nonpositive-number/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-number-array/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-number-array/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-number/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-number/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-odd/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-odd/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-positive-integer-array/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-positive-integer-array/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-positive-integer/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-positive-integer/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-positive-number-array/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-positive-number-array/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-positive-number/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-positive-number/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-positive-zero/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-positive-zero/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-prime/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-prime/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-probability/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-probability/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-safe-integer-array/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-safe-integer-array/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-safe-integer/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-safe-integer/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-square-number/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-square-number/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-square-triangular-number/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-square-triangular-number/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-triangular-number/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-triangular-number/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );


### PR DESCRIPTION
Resolves #8235.

## Description

> What is the purpose of this pull request?

This pull request:

- Removes all unused file-level /* eslint-disable no-new-wrappers */ directives across @stdlib/assert/**/examples/index.js where the rule does not trigger (e.g., Number/Boolean are shadowed via @stdlib/*/ctor or no wrapper constructors are used at all). Also includes the specific fix for the CI‑flagged file in issue #8235 (lib/node_modules/@stdlib/assert/is-nonpositive-integer-array/examples/index.js) by removing its unused directive;

Rationale:

- The root cause of issue #8235: the CI lint runs ESLint with --report-unused-disable-directives. In several examples, a top‑level no-new-wrappers disable is present, but the rule never fires because the code either (a) does not use wrapper constructors or (b) uses locally shadowed constructors (e.g., var Number = require('@stdlib/number/ctor'); new Number(...)), which are not the global wrappers the rule targets. An unused disable becomes an error under this CI flag.
- The lint_random_files workflow lints a random subset of files on each run. Fixing only the one CI‑flagged file in issue #8235 would not prevent future failures when a different example containing the same unused disable is randomly selected. This PR proactively cleans all confirmed “unused” instances within @stdlib/assert examples to eliminate this class of failures.
- For files that genuinely rely on global wrappers (e.g., new String(...) without a local shadow, or deliberate new Number(...) use), their disables are left intact; only truly unused no-new-wrappers disables are removed. No runtime logic or example output is changed. The examples ESLint config already sets no-new-wrappers to “warn”, so removals do not introduce new errors.

Selection criteria:

- Remove the directive when:
      - no new Number/String/Boolean is used; or
      - new Number/Boolean is used but the corresponding constructor is locally shadowed via @stdlib/*/ctor, so no-new-wrappers does not apply.

- Keep the directive when:
      - the example intentionally uses a global wrapper (e.g., new String(...)) and no local shadow exists, meaning the rule would trigger without the disable.

- One special case:
      - is-finite/examples/index.js: the disable line contained no-new-wrappers, stdlib/no-redeclare; only no-new-wrappers was unused, so it was dropped and stdlib/no-redeclare retained.

Net effect:

- Removes unused no-new-wrappers disables from a set of assert example files; adjusts one combined directive; retains disables only where necessary. This resolves the current CI failure and prevents similar random lint failures in future runs.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #8235

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
