### PR TITLE
chore: remove unused ESLint directives

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-boolean-array/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-boolean-array/examples/index.js
@@ -13,10 +13,9 @@
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
-* limitations under the License.
+* limitations under t
+ License.
 */
-
-/* eslint-disable no-new-wrappers */
 
 'use strict';
 

--- a/lib/node_modules/@stdlib/assert/is-boolean-array/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-boolean-array/examples/index.js
@@ -13,8 +13,7 @@
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
-* limitations under t
- License.
+* limitations under the License.
 */
 
 'use strict';

--- a/lib/node_modules/@stdlib/assert/is-boolean/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-boolean/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Boolean = require( '@stdlib/boolean/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-composite/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-composite/examples/index.js
@@ -16,7 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
 
 'use strict';
 

--- a/lib/node_modules/@stdlib/assert/is-composite/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-composite/examples/index.js
@@ -16,7 +16,6 @@
 * limitations under the License.
 */
 
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );

--- a/lib/node_modules/@stdlib/assert/is-cube-number/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-cube-number/examples/index.js
@@ -13,10 +13,9 @@
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
-* limitations under the License.
+* limitations under t
+ License.
 */
-
-/* eslint-disable no-new-wrappers */
 
 'use strict';
 

--- a/lib/node_modules/@stdlib/assert/is-cube-number/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-cube-number/examples/index.js
@@ -13,8 +13,7 @@
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
-* limitations under t
- License.
+* limitations under the License.
 */
 
 'use strict';

--- a/lib/node_modules/@stdlib/assert/is-number/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-number/examples/index.js
@@ -16,8 +16,6 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );


### PR DESCRIPTION
Progresses #8244

## Description

This pull request:

removes unused ESLint disable directives (`/* eslint-disable no-new-wrappers */`) from several example files within the `@stdlib/assert` module.

These directives are unnecessary because the affected files:
- Do not use global wrapper constructors like `new Number()`, `new String()`, or `new Boolean()`.
- Or, when such constructors appear, they are locally shadowed (e.g., `var Number = require('@stdlib/number/ctor');`).

Removing these unused disables prevents random CI failures caused by the `--report-unused-disable-directives` ESLint flag.

### Files Updated (5)
lib/node_modules/@stdlib/assert/is-number/examples/index.js
lib/node_modules/@stdlib/assert/is-boolean-array/examples/index.js
lib/node_modules/@stdlib/assert/is-boolean/examples/index.js
lib/node_modules/@stdlib/assert/is-composite/examples/index.js
lib/node_modules/@stdlib/assert/is-cube-number/examples/index.js

## Related Issues

This pull request:

-   progresses #8244 

## Questions

No.

## Other

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
