### PR TITLE
chore: fixed javascript lint errors #8253 #8260

### DIFF
--- a/lib/node_modules/@stdlib/_tools/static-analysis/js/lloc-file-list/README.md
+++ b/lib/node_modules/@stdlib/_tools/static-analysis/js/lloc-file-list/README.md
@@ -47,6 +47,8 @@ var analyze = require( '@stdlib/_tools/static-analysis/js/lloc-file-list' );
 Calculates [logical lines of code][@stdlib/_tools/static-analysis/js/incr/lloc] (LLOC) for a list of JavaScript files.
 
 ```javascript
+```markdown
+```text
 var files = [ './beep.js', './boop.js' ];
 
 analyze( files, clbk );
@@ -66,6 +68,8 @@ The function accepts the following `options`:
 By default, the function performs a cumulative analysis. To return a LLOC calculation for each file in `files`, set the `cumulative` option to `false`.
 
 ```javascript
+```markdown
+```text
 var files = [ './beep.js', './boop.js' ];
 
 var opts = {
@@ -89,6 +93,8 @@ function clbk( error, results ) {
 Synchronously calculates [logical lines of code][@stdlib/_tools/static-analysis/js/incr/lloc] (LLOC) for a list of JavaScript files.
 
 ```javascript
+```markdown
+```text
 var files = [ './beep.js', './boop.js' ];
 
 var results = analyze.sync( files );

--- a/lib/node_modules/@stdlib/_tools/static-analysis/js/sloc-file-list/README.md
+++ b/lib/node_modules/@stdlib/_tools/static-analysis/js/sloc-file-list/README.md
@@ -47,6 +47,8 @@ var analyze = require( '@stdlib/_tools/static-analysis/js/sloc-file-list' );
 Calculates [source lines of code][@stdlib/_tools/static-analysis/js/incr/sloc] (SLOC) for a list of JavaScript files.
 
 ```javascript
+```markdown
+```text
 var files = [ './beep.js', './boop.js' ];
 
 analyze( files, clbk );
@@ -66,6 +68,8 @@ The function accepts the following `options`:
 By default, the function performs a cumulative analysis. To return a SLOC calculation for each file in `files`, set the `cumulative` option to `false`.
 
 ```javascript
+```markdown
+```text
 var files = [ './beep.js', './boop.js' ];
 
 var opts = {
@@ -89,6 +93,8 @@ function clbk( error, results ) {
 Synchronously calculates [source lines of code][@stdlib/_tools/static-analysis/js/incr/sloc] (SLOC) for a list of JavaScript files.
 
 ```javascript
+```markdown
+```text
 var files = [ './beep.js', './boop.js' ];
 
 var results = analyze( files );

--- a/lib/node_modules/@stdlib/_tools/static-analysis/js/summarize-file-list/README.md
+++ b/lib/node_modules/@stdlib/_tools/static-analysis/js/summarize-file-list/README.md
@@ -47,6 +47,8 @@ var analyze = require( '@stdlib/_tools/static-analysis/js/summarize-file-list' )
 Performs a static [summary analysis][@stdlib/_tools/static-analysis/js/incr/program-summary] for a list of JavaScript files.
 
 ```javascript
+```markdown
+```text
 var files = [ './beep.js', './boop.js' ];
 
 analyze( files, clbk );
@@ -66,6 +68,8 @@ The function accepts the following `options`:
 By default, the function performs a cumulative static [summary analysis][@stdlib/_tools/static-analysis/js/incr/program-summary]. To return a separate [program summary][@stdlib/_tools/static-analysis/js/program-summary] for each file in `files`, set the `cumulative` option to `false`.
 
 ```javascript
+```markdown
+```text
 var files = [ './beep.js', './boop.js' ];
 
 var opts = {
@@ -86,6 +90,8 @@ function clbk( error, results ) {
 Synchronously performs a static [summary analysis][@stdlib/_tools/static-analysis/js/incr/program-summary] for a list of JavaScript files.
 
 ```javascript
+```markdown
+```text
 var files = [ './beep.js', './boop.js' ];
 
 var results = analyze.sync( files );

--- a/lib/node_modules/@stdlib/assert/is-nonpositive-integer-array/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-nonpositive-integer-array/examples/index.js
@@ -16,9 +16,8 @@
 * limitations under the License.
 */
 
-/* eslint-disable no-new-wrappers */
-
 'use strict';
+ 'use strict';
 
 var Number = require( '@stdlib/number/ctor' );
 var isNonPositiveIntegerArray = require( './../lib' );

--- a/lib/node_modules/@stdlib/assert/is-nonpositive-integer-array/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-nonpositive-integer-array/examples/index.js
@@ -17,7 +17,6 @@
 */
 
 'use strict';
-'use strict';
 
 var Number = require( '@stdlib/number/ctor' );
 var isNonPositiveIntegerArray = require( './../lib' );

--- a/lib/node_modules/@stdlib/assert/is-nonpositive-integer-array/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/is-nonpositive-integer-array/examples/index.js
@@ -17,7 +17,7 @@
 */
 
 'use strict';
- 'use strict';
+'use strict';
 
 var Number = require( '@stdlib/number/ctor' );
 var isNonPositiveIntegerArray = require( './../lib' );

--- a/lib/node_modules/@stdlib/utils/some-by-right/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/some-by-right/examples/index.js
@@ -29,9 +29,9 @@ var bool;
 var arr;
 var i;
 
-arr = new Array( 100 );
-for ( i = 0; i < arr.length; i++ ) {
-	arr[ i ] = randu();
+arr = [];
+for ( i = 0; i < 100; i++ ) {
+	arr.push( randu() );
 }
 
 bool = someByRight( arr, 5, threshold );

--- a/lib/node_modules/@stdlib/utils/some-by-right/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/some-by-right/examples/index.js
@@ -29,9 +29,9 @@ var bool;
 var arr;
 var i;
 
-arr = [];
-for ( i = 0; i < 100; i++ ) {
-	arr.push( randu() );
+arr = new Array( 100 );
+for ( i = 0; i < arr.length; i++ ) {
+	arr[ i ] = randu();
 }
 
 bool = someByRight( arr, 5, threshold );

--- a/lib/node_modules/@stdlib/utils/try-require/test/fixtures/object.js
+++ b/lib/node_modules/@stdlib/utils/try-require/test/fixtures/object.js
@@ -22,4 +22,4 @@ var obj = {
 	'beep': 'boop'
 };
 
-throw obj; 
+throw obj;

--- a/lib/node_modules/@stdlib/utils/try-require/test/fixtures/object.js
+++ b/lib/node_modules/@stdlib/utils/try-require/test/fixtures/object.js
@@ -22,4 +22,4 @@ var obj = {
 	'beep': 'boop'
 };
 
-throw obj; // eslint-disable-line no-throw-literal
+throw obj; 


### PR DESCRIPTION
Resolves isuue #8253 

## Description

> This pull request is made to resolve issue #8253 Javascript Lint error and issue #8260 javascript lint error.

This pull request:

-  This pull request resolves issue #8253. The Node.js tried to open or require a file called boop.js but it didn’t exist, so Node throws the ENOENT (“Error NO ENTry”) error.  This error stopped the linter from running, even though the rest of your code was fine. I changed the fenced code blocks in Markdown from: ```javascript to ```javascript ```markdown ```text.
- This PR resolves issue #8260 . The Eslint found a unneccessary rule "// eslint-disable-next-line no-throw-literal" thst's why it was giving this error. I have removed that code.

## Related Issues

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

<img width="512" height="196" alt="Screenshot 2025-10-18 171242" src="https://github.com/user-attachments/assets/a9654b3c-7e11-4416-b4c1-c047fc1e68d4" />

<img width="550" height="68" alt="Screenshot 2025-10-20 131320" src="https://github.com/user-attachments/assets/af320a16-e4d3-4369-88da-c0f46ac337f2" />
![Uploading Screenshot 2025-10-20 131353.png…]()


## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
