### PR TITLE
chore: fix JavaScript lint errors (issue #8260)

### DIFF
--- a/lib/node_modules/@stdlib/utils/try-require/test/fixtures/object.js
+++ b/lib/node_modules/@stdlib/utils/try-require/test/fixtures/object.js
@@ -22,4 +22,4 @@ var obj = {
 	'beep': 'boop'
 };
 
-throw obj; // eslint-disable-line no-throw-literal
+throw obj;


### PR DESCRIPTION
Resolves #8260

## Description

This pull request:

Removes an unused ESLint disable directive from lib/node_modules/@stdlib/utils/try-require/test/fixtures/object.js

## Related Issues

This pull request has the following related issues:

-   #8260 

## Questions

No.

## Other

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
