### PR TITLE
chore: fix JavaScript lint errors (issue #8282)

### DIFF
--- a/lib/node_modules/@stdlib/fs/read-file/examples/index.js
+++ b/lib/node_modules/@stdlib/fs/read-file/examples/index.js
@@ -18,6 +18,7 @@
 
 'use strict';
 
+var isError = require( '@stdlib/assert/is-error' );
 var readFile = require( './../lib' );
 
 /* Sync */
@@ -27,7 +28,7 @@ var file = readFile.sync( __filename, {
 });
 // returns <string>
 
-console.log( file instanceof Error );
+console.log( isError( file ) );
 // => false
 
 file = readFile.sync( 'beepboop', {
@@ -35,7 +36,7 @@ file = readFile.sync( 'beepboop', {
 });
 // returns <Error>
 
-console.log( file instanceof Error );
+console.log( isError( file ) );
 // => true
 
 /* Async */

--- a/lib/node_modules/@stdlib/fs/read-file/examples/index.js
+++ b/lib/node_modules/@stdlib/fs/read-file/examples/index.js
@@ -23,9 +23,7 @@ var readFile = require( './../lib' );
 
 /* Sync */
 
-var file = readFile.sync( __filename, {
-	'encoding': 'utf8'
-});
+var file = readFile.sync( __filename, 'utf8' );
 // returns <string>
 
 console.log( isError( file ) );

--- a/lib/node_modules/@stdlib/fs/read-file/examples/index.js
+++ b/lib/node_modules/@stdlib/fs/read-file/examples/index.js
@@ -22,7 +22,9 @@ var readFile = require( './../lib' );
 
 /* Sync */
 
-var file = readFile.sync( __filename, 'utf8' );
+var file = readFile.sync( __filename, {
+	'encoding': 'utf8'
+});
 // returns <string>
 
 console.log( file instanceof Error );


### PR DESCRIPTION
Resolves #8282

## Description

This pull request fixes a JavaScript doctest linting failure detected by CI. An example returned a Buffer in some environments while the doctest expected a string. The example has been updated so the sync read uses an options object with an explicit encoding, ensuring the example deterministically returns a string and the inline doctest matches the actual output.

Change summary:

- Updated `lib/node_modules/@stdlib/fs/read-file/examples/index.js` to call:
  - `readFile.sync(__filename, { 'encoding': 'utf8' })`
  so the example prints a string and the doctest expectation is correct.

How I verified:

- Ran the example locally and confirmed the output matches the doctest comments.

## Related Issues

- resolves #8282

## Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).

@stdlib-js/reviewers