### PR TITLE
chore: fix JavaScript lint errors (issue #8310)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/pkgs/tree/lib/sync.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/tree/lib/sync.js
@@ -42,7 +42,7 @@ var defaults = require( './config.json' );
 * @returns {Object} tree
 *
 * @example
-* var tree = pkgTree();
+* var out = pkgTree();
 * // returns {...}
 */
 function pkgTree( options ) {


### PR DESCRIPTION
Resolves #8310 

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes a linting error in lib/node_modules/@stdlib/_tools/pkgs/tree/lib/sync.js.
The issue was caused by a variable name conflict in the JSDoc example (tree shadowed the imported module).
Renamed the example variable to out to resolve the conflict and pass linting.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8310 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
