### PR TITLE
chore: fix C lint errors (issue #8443)

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/dasum/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/base/dasum/benchmark/c/benchmark.length.c
@@ -16,12 +16,12 @@
 * limitations under the License.
 */
 
-#include "stdlib/blas/base/dasum.h"
-#include <stdlib.h>
-#include <stdio.h>
-#include <math.h>
-#include <time.h>
 #include <sys/time.h>
+#include "stdlib/blas/base/dasum.h"
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
 
 #define NAME "dasum"
 #define ITERATIONS 10000000
@@ -74,7 +74,7 @@ static void print_results( int iterations, double elapsed ) {
 static double tic( void ) {
 	struct timeval now;
 	gettimeofday( &now, NULL );
-	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+	return (double)now.tv_sec + (double)now.tv_usec / 1.0e6;
 }
 
 /**
@@ -96,13 +96,14 @@ static double rand_double( void ) {
 */
 static double benchmark1( int iterations, int len ) {
 	double elapsed;
-	double x[ len ];
+	double *x;
+	x = (double *)malloc( len * sizeof( double ) );
 	double y;
 	double t;
 	int i;
 
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( rand_double()*20000.0 ) - 10000.0;
+		x[ i ] = ( rand_double() * 20000.0 ) - 10000.0;
 	}
 	y = 0.0;
 	t = tic();
@@ -117,6 +118,7 @@ static double benchmark1( int iterations, int len ) {
 	if ( y != y ) {
 		printf( "should not return NaN\n" );
 	}
+	free(x);
 	return elapsed;
 }
 
@@ -129,19 +131,20 @@ static double benchmark1( int iterations, int len ) {
 */
 static double benchmark2( int iterations, int len ) {
 	double elapsed;
-	double x[ len ];
+	double *x;
+	x = (double *)malloc( len * sizeof( double ) );
 	double y;
 	double t;
 	int i;
 
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( rand_double()*20000.0 ) - 10000.0;
+		x[ i ] = ( rand_double() * 20000.0 ) - 10000.0;
 	}
 	y = 0.0;
 	t = tic();
 	for ( i = 0; i < iterations; i++ ) {
-		y = c_dasum_ndarray( len, x, 1, 0 );
-		if ( y != y ) {
+			y = c_dasum_ndarray( len, x, 1, 0 );
+					if ( y != y ) {
 			printf( "should not return NaN\n" );
 			break;
 		}
@@ -150,6 +153,7 @@ static double benchmark2( int iterations, int len ) {
 	if ( y != y ) {
 		printf( "should not return NaN\n" );
 	}
+	free(x);
 	return elapsed;
 }
 
@@ -171,7 +175,7 @@ int main( void ) {
 	count = 0;
 	for ( i = MIN; i <= MAX; i++ ) {
 		len = pow( 10, i );
-		iter = ITERATIONS / pow( 10, i-1 );
+		iter = ITERATIONS / pow( 10, i - 1 );
 		for ( j = 0; j < REPEATS; j++ ) {
 			count += 1;
 			printf( "# c::%s:len=%d\n", NAME, len );
@@ -188,4 +192,5 @@ int main( void ) {
 		}
 	}
 	print_summary( count, count );
+
 }


### PR DESCRIPTION
**Resolves #8443.**

## Description

> What is the purpose of this pull request?

This pull request fixes C lint errors in the `benchmark.length.c` file for the `@stdlib/blas/base/dasum` package by properly initializing the variable `x` using dynamic memory allocation.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8443

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].



---

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
