### PR TITLE
chore: fix C lint errors (issue #8443)

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/dasum/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/base/dasum/benchmark/c/benchmark.length.c
@@ -173,7 +173,7 @@ int main( void ) {
 	count = 0;
 	for ( i = MIN; i <= MAX; i++ ) {
 		len = pow( 10, i );
-		iter = ITERATIONS / pow( 10, i - 1 );
+		iter = ITERATIONS / pow( 10, i-1 );
 		for ( j = 0; j < REPEATS; j++ ) {
 			count += 1;
 			printf( "# c::%s:len=%d\n", NAME, len );

--- a/lib/node_modules/@stdlib/blas/base/dasum/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/base/dasum/benchmark/c/benchmark.length.c
@@ -74,7 +74,7 @@ static void print_results( int iterations, double elapsed ) {
 static double tic( void ) {
 	struct timeval now;
 	gettimeofday( &now, NULL );
-	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+	return (double)now.tv_sec + (double)now.tv_usec / 1.0e6;
 }
 
 /**
@@ -96,13 +96,13 @@ static double rand_double( void ) {
 */
 static double benchmark1( int iterations, int len ) {
 	double elapsed;
-	double x[ len ];
+	double *x = (double *)malloc( len * sizeof(double) );
 	double y;
 	double t;
 	int i;
 
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( rand_double()*20000.0 ) - 10000.0;
+		x[ i ] = ( rand_double() * 20000.0 ) - 10000.0;
 	}
 	y = 0.0;
 	t = tic();
@@ -117,6 +117,7 @@ static double benchmark1( int iterations, int len ) {
 	if ( y != y ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
 	return elapsed;
 }
 
@@ -129,13 +130,13 @@ static double benchmark1( int iterations, int len ) {
 */
 static double benchmark2( int iterations, int len ) {
 	double elapsed;
-	double x[ len ];
+	double *x = (double *)malloc( len * sizeof(double) );
 	double y;
 	double t;
 	int i;
 
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( rand_double()*20000.0 ) - 10000.0;
+		x[ i ] = ( rand_double() * 20000.0 ) - 10000.0;
 	}
 	y = 0.0;
 	t = tic();
@@ -150,6 +151,7 @@ static double benchmark2( int iterations, int len ) {
 	if ( y != y ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
 	return elapsed;
 }
 
@@ -171,7 +173,7 @@ int main( void ) {
 	count = 0;
 	for ( i = MIN; i <= MAX; i++ ) {
 		len = pow( 10, i );
-		iter = ITERATIONS / pow( 10, i-1 );
+		iter = ITERATIONS / pow( 10, i - 1 );
 		for ( j = 0; j < REPEATS; j++ ) {
 			count += 1;
 			printf( "# c::%s:len=%d\n", NAME, len );
@@ -188,4 +190,5 @@ int main( void ) {
 		}
 	}
 	print_summary( count, count );
+	
 }

--- a/lib/node_modules/@stdlib/blas/base/dasum/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/base/dasum/benchmark/c/benchmark.length.c
@@ -102,7 +102,7 @@ static double benchmark1( int iterations, int len ) {
 	int i;
 
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( rand_double() * 20000.0 ) - 10000.0;
+		x[ i ] = ( rand_double()*20000.0 ) - 10000.0;
 	}
 	y = 0.0;
 	t = tic();

--- a/lib/node_modules/@stdlib/blas/base/dasum/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/base/dasum/benchmark/c/benchmark.length.c
@@ -136,7 +136,7 @@ static double benchmark2( int iterations, int len ) {
 	int i;
 
 	for ( i = 0; i < len; i++ ) {
-		x[ i ] = ( rand_double() * 20000.0 ) - 10000.0;
+		x[ i ] = ( rand_double()*20000.0 ) - 10000.0;
 	}
 	y = 0.0;
 	t = tic();

--- a/lib/node_modules/@stdlib/blas/base/dasum/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/base/dasum/benchmark/c/benchmark.length.c
@@ -190,5 +190,4 @@ int main( void ) {
 		}
 	}
 	print_summary( count, count );
-
 }

--- a/lib/node_modules/@stdlib/blas/base/dasum/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/base/dasum/benchmark/c/benchmark.length.c
@@ -74,7 +74,7 @@ static void print_results( int iterations, double elapsed ) {
 static double tic( void ) {
 	struct timeval now;
 	gettimeofday( &now, NULL );
-	return (double)now.tv_sec + (double)now.tv_usec / 1.0e6;
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
 }
 
 /**

--- a/lib/node_modules/@stdlib/blas/base/dasum/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/base/dasum/benchmark/c/benchmark.length.c
@@ -190,5 +190,5 @@ int main( void ) {
 		}
 	}
 	print_summary( count, count );
-	
+
 }

--- a/lib/node_modules/@stdlib/blas/base/dasum/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/base/dasum/benchmark/c/benchmark.length.c
@@ -96,11 +96,12 @@ static double rand_double( void ) {
 */
 static double benchmark1( int iterations, int len ) {
 	double elapsed;
-	double *x = (double *)malloc( len * sizeof(double) );
+	double *x;
 	double y;
 	double t;
 	int i;
 
+	x = (double *) malloc( len * sizeof( double ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = ( rand_double()*20000.0 ) - 10000.0;
 	}
@@ -130,11 +131,12 @@ static double benchmark1( int iterations, int len ) {
 */
 static double benchmark2( int iterations, int len ) {
 	double elapsed;
-	double *x = (double *)malloc( len * sizeof(double) );
+	double *x;
 	double y;
 	double t;
 	int i;
 
+	x = (double *) malloc( len * sizeof( double ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = ( rand_double()*20000.0 ) - 10000.0;
 	}


### PR DESCRIPTION
Resolves #8443.

## Description

> What is the purpose of this pull request?

This pull request:

- Fixes C linting errors in the BLAS `dasum` benchmark files.
- Replaces uninitialized variable usage and VLA arrays with properly allocated arrays using `malloc`.
- Removes unnecessary `malloc` null checks to comply with stdlib benchmark style.
- Ensures all benchmark arrays are initialized and freed correctly to avoid warnings and memory leaks.
- Improves code consistency with other stdlib benchmark files.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

- #8443

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

- [ ] Yes
- [x] No

If you answered "yes" above, how did you use AI assistance?

- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

N/A

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md