### PR TITLE
feat: add `assert/has-replace-symbol-support`

### DIFF
--- a/lib/node_modules/@stdlib/assert/has-replace-symbol-support/README.md
+++ b/lib/node_modules/@stdlib/assert/has-replace-symbol-support/README.md
@@ -18,7 +18,7 @@ limitations under the License.
 
 -->
 
-# Has Instance Symbol Support
+# hasReplaceSymbolSupport
 
 > Detect native [`Symbol.replace`][mdn-replace-symbol] support.
 

--- a/lib/node_modules/@stdlib/assert/has-replace-symbol-support/README.md
+++ b/lib/node_modules/@stdlib/assert/has-replace-symbol-support/README.md
@@ -1,0 +1,129 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2025 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# Has Instance Symbol Support
+
+> Detect native [`Symbol.replace`][mdn-replace-symbol] support.
+
+<section class="usage">
+
+## Usage
+
+<!-- eslint-disable id-length -->
+
+```javascript
+var hasReplaceSymbolSupport = require( '@stdlib/assert/has-replace-symbol-support' );
+```
+
+#### hasReplaceSymbolSupport()
+
+Detects if a runtime environment supports [`Symbol.replace`][mdn-replace-symbol].
+
+<!-- eslint-disable id-length -->
+
+```javascript
+var bool = hasReplaceSymbolSupport();
+// returns <boolean>
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint-disable id-length -->
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var hasReplaceSymbolSupport = require( '@stdlib/assert/has-replace-symbol-support' );
+
+var bool = hasReplaceSymbolSupport();
+if ( bool ) {
+    console.log( 'Environment has Symbol.replace support.' );
+} else {
+    console.log( 'Environment lacks Symbol.replace support.' );
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+* * *
+
+<section class="cli">
+
+## CLI
+
+<section class="usage">
+
+### Usage
+
+```text
+Usage: has-replace-symbol-support [options]
+
+Options:
+
+  -h,    --help                Print this message.
+  -V,    --version             Print the package version.
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+### Examples
+
+```bash
+$ has-replace-symbol-support
+<boolean>
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.cli -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[mdn-replace-symbol]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/replace
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/assert/has-replace-symbol-support/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/has-replace-symbol-support/benchmark/benchmark.js
@@ -1,0 +1,49 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var pkg = require( './../package.json' ).name;
+var hasReplaceSymbolSupport = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var bool;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		// Note: the following *could* be optimized away via loop-invariant code motion. If so, the entire loop will disappear.
+		bool = hasReplaceSymbolSupport();
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/assert/has-replace-symbol-support/bin/cli
+++ b/lib/node_modules/@stdlib/assert/has-replace-symbol-support/bin/cli
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var readFileSync = require( '@stdlib/fs/read-file' ).sync;
+var CLI = require( '@stdlib/cli/ctor' );
+var detect = require( './../lib' );
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var flags;
+	var cli;
+
+	// Create a command-line interface:
+	cli = new CLI({
+		'pkg': require( './../package.json' ),
+		'options': require( './../etc/cli_opts.json' ),
+		'help': readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+			'encoding': 'utf8'
+		})
+	});
+
+	// Get any provided command-line options:
+	flags = cli.flags();
+	if ( flags.help || flags.version ) {
+		return;
+	}
+
+	console.log( detect() ); // eslint-disable-line no-console
+}
+
+main();

--- a/lib/node_modules/@stdlib/assert/has-replace-symbol-support/docs/repl.txt
+++ b/lib/node_modules/@stdlib/assert/has-replace-symbol-support/docs/repl.txt
@@ -1,0 +1,18 @@
+
+{{alias}}()
+    Tests for native `Symbol.replace` support.
+
+    Returns
+    -------
+    bool: boolean
+        Boolean indicating if an environment has native `Symbol.replace`
+        support.
+
+    Examples
+    --------
+    > var bool = {{alias}}()
+    <boolean>
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/assert/has-replace-symbol-support/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/has-replace-symbol-support/docs/types/index.d.ts
@@ -1,0 +1,35 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Tests for native `Symbol.replace` support.
+*
+* @returns boolean indicating if an environment has `Symbol.replace` support
+*
+* @example
+* var bool = hasReplaceSymbolSupport();
+* // returns <boolean>
+*/
+declare function hasReplaceSymbolSupport(): boolean;
+
+
+// EXPORTS //
+
+export = hasReplaceSymbolSupport;

--- a/lib/node_modules/@stdlib/assert/has-replace-symbol-support/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/assert/has-replace-symbol-support/docs/types/test.ts
@@ -1,0 +1,33 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import hasReplaceSymbolSupport = require( './index' );
+
+
+// TESTS //
+
+// The function returns a boolean...
+{
+	hasReplaceSymbolSupport(); // $ExpectType boolean
+}
+
+// The compiler throws an error if the function is provided arguments...
+{
+	hasReplaceSymbolSupport( true ); // $ExpectError
+	hasReplaceSymbolSupport( [], 123 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/assert/has-replace-symbol-support/docs/usage.txt
+++ b/lib/node_modules/@stdlib/assert/has-replace-symbol-support/docs/usage.txt
@@ -1,0 +1,8 @@
+
+Usage: has-replace-symbol-support [options]
+
+Options:
+
+  -h,    --help                Print this message.
+  -V,    --version             Print the package version.
+

--- a/lib/node_modules/@stdlib/assert/has-replace-symbol-support/etc/cli_opts.json
+++ b/lib/node_modules/@stdlib/assert/has-replace-symbol-support/etc/cli_opts.json
@@ -1,0 +1,14 @@
+{
+	"boolean": [
+		"help",
+		"version"
+	],
+	"alias": {
+		"help": [
+			"h"
+		],
+		"version": [
+			"V"
+		]
+	}
+}

--- a/lib/node_modules/@stdlib/assert/has-replace-symbol-support/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/has-replace-symbol-support/examples/index.js
@@ -1,0 +1,28 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var hasReplaceSymbolSupport = require( './../lib' );
+
+var bool = hasReplaceSymbolSupport();
+if ( bool ) {
+	console.log( 'Environment has Symbol.replace support.' );
+} else {
+	console.log( 'Environment lacks Symbol.replace support.' );
+}

--- a/lib/node_modules/@stdlib/assert/has-replace-symbol-support/lib/index.js
+++ b/lib/node_modules/@stdlib/assert/has-replace-symbol-support/lib/index.js
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Test for native `Symbol.replace` support.
+*
+* @module @stdlib/assert/has-replace-symbol-support
+*
+* @example
+* var hasReplaceSymbolSupport = require( '@stdlib/assert/has-replace-symbol-support' );
+*
+* var bool = hasReplaceSymbolSupport();
+* // returns <boolean>
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/assert/has-replace-symbol-support/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/has-replace-symbol-support/lib/main.js
@@ -1,0 +1,50 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var Symbol = require( '@stdlib/symbol/ctor' );
+
+
+// MAIN //
+
+/**
+* Tests for native `Symbol.replace` support.
+*
+* @returns {boolean} boolean indicating if an environment has `Symbol.replace` support
+*
+* @example
+* var bool = hasReplaceSymbolSupport();
+* // returns <boolean>
+*/
+function hasReplaceSymbolSupport() {
+	return (
+		typeof Symbol === 'function' &&
+		typeof Symbol( 'foo' ) === 'symbol' &&
+		hasOwnProp( Symbol, 'replace' ) &&
+		typeof Symbol.replace === 'symbol'
+	);
+}
+
+
+// EXPORTS //
+
+module.exports = hasReplaceSymbolSupport;

--- a/lib/node_modules/@stdlib/assert/has-replace-symbol-support/package.json
+++ b/lib/node_modules/@stdlib/assert/has-replace-symbol-support/package.json
@@ -1,0 +1,75 @@
+{
+  "name": "@stdlib/assert/has-replace-symbol-support",
+  "version": "0.0.0",
+  "description": "Detect native Symbol.replace support.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "bin": {
+    "has-replace-symbol-support": "./bin/cli"
+  },
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdutils",
+    "stdutil",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "detect",
+    "feature",
+    "symbol",
+    "instance",
+    "replace",
+    "es2015",
+    "es6",
+    "support",
+    "has",
+    "native",
+    "issupported",
+    "cli"
+  ]
+}

--- a/lib/node_modules/@stdlib/assert/has-replace-symbol-support/package.json
+++ b/lib/node_modules/@stdlib/assert/has-replace-symbol-support/package.json
@@ -62,7 +62,6 @@
     "detect",
     "feature",
     "symbol",
-    "instance",
     "replace",
     "es2015",
     "es6",

--- a/lib/node_modules/@stdlib/assert/has-replace-symbol-support/test/test.cli.js
+++ b/lib/node_modules/@stdlib/assert/has-replace-symbol-support/test/test.cli.js
@@ -1,0 +1,163 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var exec = require( 'child_process' ).exec;
+var tape = require( 'tape' );
+var IS_BROWSER = require( '@stdlib/assert/is-browser' );
+var IS_WINDOWS = require( '@stdlib/assert/is-windows' );
+var EXEC_PATH = require( '@stdlib/process/exec-path' );
+var readFileSync = require( '@stdlib/fs/read-file' ).sync;
+
+
+// VARIABLES //
+
+var fpath = resolve( __dirname, '..', 'bin', 'cli' );
+var opts = {
+	'skip': IS_BROWSER || IS_WINDOWS
+};
+
+
+// FIXTURES //
+
+var PKG_VERSION = require( './../package.json' ).version;
+
+
+// TESTS //
+
+tape( 'command-line interface', function test( t ) {
+	t.ok( true, __filename );
+	t.end();
+});
+
+tape( 'when invoked with a `--help` flag, the command-line interface prints the help text to `stderr`', opts, function test( t ) {
+	var expected;
+	var cmd;
+
+	expected = readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+		'encoding': 'utf8'
+	});
+	cmd = [
+		EXEC_PATH,
+		fpath,
+		'--help'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), expected+'\n', 'expected value' );
+		}
+		t.end();
+	}
+});
+
+tape( 'when invoked with a `-h` flag, the command-line interface prints the help text to `stderr`', opts, function test( t ) {
+	var expected;
+	var cmd;
+
+	expected = readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+		'encoding': 'utf8'
+	});
+	cmd = [
+		EXEC_PATH,
+		fpath,
+		'-h'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), expected+'\n', 'expected value' );
+		}
+		t.end();
+	}
+});
+
+tape( 'when invoked with a `--version` flag, the command-line interface prints the version to `stderr`', opts, function test( t ) {
+	var cmd = [
+		EXEC_PATH,
+		fpath,
+		'--version'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), PKG_VERSION+'\n', 'expected value' );
+		}
+		t.end();
+	}
+});
+
+tape( 'when invoked with a `-V` flag, the command-line interface prints the version to `stderr`', opts, function test( t ) {
+	var cmd = [
+		EXEC_PATH,
+		fpath,
+		'-V'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), PKG_VERSION+'\n', 'expected value' );
+		}
+		t.end();
+	}
+});
+
+tape( 'the command-line interface prints either `true` or `false` to `stdout` indicating whether an environment provides native `Symbol.replace` support', opts, function test( t ) {
+	var cmd = [
+		EXEC_PATH,
+		fpath
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		var str;
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			str = stdout.toString();
+			t.strictEqual( str === 'true\n' || str === 'false\n', true, 'prints either `true` or `false` to `stdout`' );
+			t.strictEqual( stderr.toString(), '', 'does not print to `stderr`' );
+		}
+		t.end();
+	}
+});

--- a/lib/node_modules/@stdlib/assert/has-replace-symbol-support/test/test.js
+++ b/lib/node_modules/@stdlib/assert/has-replace-symbol-support/test/test.js
@@ -1,0 +1,66 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var proxyquire = require( 'proxyquire' );
+var Symbol = require( '@stdlib/symbol/ctor' );
+var detect = require( './../lib' );
+
+
+// VARIABLES //
+
+var hasReplaceSymbol = ( typeof Symbol === 'function' && typeof Symbol.replace === 'symbol' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof detect, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'feature detection result is a boolean', function test( t ) {
+	t.strictEqual( typeof detect(), 'boolean', 'returns expected value' );
+	t.end();
+});
+
+tape( 'if `Symbol.replace` is supported, detection result is `true`', function test( t ) {
+	if ( hasReplaceSymbol ) {
+		t.strictEqual( detect(), true, 'returns expected value' );
+	} else {
+		t.strictEqual( detect(), false, 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function guards against a `Symbol` global variable which does not produce `symbols`', function test( t ) {
+	var detect = proxyquire( './../lib/main.js', {
+		'@stdlib/symbol/ctor': mock
+	});
+	t.strictEqual( detect(), false, 'returns expected value' );
+	t.end();
+
+	function mock() {
+		return {};
+	}
+});


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: passed
  - task: lint_package_json status: passed
  - task: lint_repl_help status: passed
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: passed
  - task: lint_javascript_examples status: passed
  - task: lint_javascript_tests status: passed
  - task: lint_javascript_benchmarks status: passed
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: passed
  - task: lint_license_headers status: passed ---

Resolves #8465.

## Description

> What is the purpose of this pull request?

This pull request adds a new package: @stdlib/assert/has-replace-symbol-support

-   The package provides a utility function to determine whether the current JavaScript environment supports `Symbol.replace` method.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

- #8465 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
