### PR TITLE
feat: add `assert/has-search-symbol-support`

### DIFF
--- a/lib/node_modules/@stdlib/assert/has-search-symbol-support/README.md
+++ b/lib/node_modules/@stdlib/assert/has-search-symbol-support/README.md
@@ -1,0 +1,132 @@
+````markdown
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2025 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# Search Symbol Support
+
+> Detect native [`Symbol.search`][mdn-search-symbol] support.
+
+<section class="usage">
+
+## Usage
+
+<!-- eslint-disable id-length -->
+
+```javascript
+var hasSearchSymbolSupport = require( '@stdlib/assert/has-search-symbol-support' );
+```
+
+#### hasSearchSymbolSupport()
+
+Detects if a runtime environment supports [`Symbol.search`][mdn-search-symbol].
+
+<!-- eslint-disable id-length -->
+
+```javascript
+var bool = hasSearchSymbolSupport();
+// returns <boolean>
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint-disable id-length -->
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var hasSearchSymbolSupport = require( '@stdlib/assert/has-search-symbol-support' );
+
+var bool = hasSearchSymbolSupport();
+if ( bool ) {
+    console.log( 'Environment has Symbol.search support.' );
+} else {
+    console.log( 'Environment lacks Symbol.search support.' );
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+* * *
+
+<section class="cli">
+
+## CLI
+
+<section class="usage">
+
+### Usage
+
+```text
+Usage: has-search-symbol-support [options]
+
+Options:
+
+  -h,    --help                Print this message.
+  -V,    --version             Print the package version.
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+### Examples
+
+```bash
+$ has-search-symbol-support
+<boolean>
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.cli -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[mdn-search-symbol]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/search
+
+</section>
+
+<!-- /.links -->
+
+````

--- a/lib/node_modules/@stdlib/assert/has-search-symbol-support/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/has-search-symbol-support/benchmark/benchmark.js
@@ -1,0 +1,49 @@
+/**
+ * @license Apache-2.0
+ *
+ * Copyright (c) 2025 The Stdlib Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var pkg = require( './../package.json' ).name;
+var hasSearchSymbol = require( './../lib' ); // eslint-disable-line id-length
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+    var bool;
+    var i;
+
+    b.tic();
+    for ( i = 0; i < b.iterations; i++ ) {
+        // Note: the following *could* be optimized away via loop-invariant code motion. If so, the entire loop will disappear.
+        bool = hasSearchSymbol();
+        if ( typeof bool !== 'boolean' ) {
+            b.fail( 'should return a boolean' );
+        }
+    }
+    b.toc();
+    if ( !isBoolean( bool ) ) {
+        b.fail( 'should return a boolean' );
+    }
+    b.pass( 'benchmark finished' );
+    b.end();
+});

--- a/lib/node_modules/@stdlib/assert/has-search-symbol-support/bin/cli
+++ b/lib/node_modules/@stdlib/assert/has-search-symbol-support/bin/cli
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var readFileSync = require( '@stdlib/fs/read-file' ).sync;
+var CLI = require( '@stdlib/cli/ctor' );
+var detect = require( './../lib' );
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+    var flags;
+    var cli;
+
+    // Create a command-line interface:
+    cli = new CLI({
+        'pkg': require( './../package.json' ),
+        'options': require( './../etc/cli_opts.json' ),
+        'help': readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+            'encoding': 'utf8'
+        })
+    });
+
+    // Get any provided command-line options:
+    flags = cli.flags();
+    if ( flags.help || flags.version ) {
+        return;
+    }
+
+    console.log( detect() ); // eslint-disable-line no-console
+}
+
+main();

--- a/lib/node_modules/@stdlib/assert/has-search-symbol-support/docs/repl.txt
+++ b/lib/node_modules/@stdlib/assert/has-search-symbol-support/docs/repl.txt
@@ -1,0 +1,18 @@
+
+{{alias}}()
+    Tests for native `Symbol.search` support.
+
+    Returns
+    -------
+    bool: boolean
+        Boolean indicating if an environment has native
+        `Symbol.search` support.
+
+    Examples
+    --------
+    > var bool = {{alias}}()
+    <boolean>
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/assert/has-search-symbol-support/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/has-search-symbol-support/docs/types/index.d.ts
@@ -1,0 +1,35 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Tests for native `Symbol.search` support.
+*
+* @returns boolean indicating if an environment has `Symbol.search` support
+*
+* @example
+* var bool = hasSearchSymbolSupport();
+* // returns <boolean>
+*/
+declare function hasSearchSymbolSupport(): boolean;
+
+
+// EXPORTS //
+
+export = hasSearchSymbolSupport;

--- a/lib/node_modules/@stdlib/assert/has-search-symbol-support/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/assert/has-search-symbol-support/docs/types/test.ts
@@ -1,0 +1,33 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import hasSearchSymbolSupport = require( './index' );
+
+
+// TESTS //
+
+// The function returns a boolean...
+{
+	hasSearchSymbolSupport(); // $ExpectType boolean
+}
+
+// The compiler throws an error if the function is provided arguments...
+{
+	hasSearchSymbolSupport( true ); // $ExpectError
+	hasSearchSymbolSupport( [], 123 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/assert/has-search-symbol-support/docs/usage.txt
+++ b/lib/node_modules/@stdlib/assert/has-search-symbol-support/docs/usage.txt
@@ -1,0 +1,10 @@
+```
+
+Usage: has-search-symbol-support [options]
+
+Options:
+
+  -h,    --help                Print this message.
+  -V,    --version             Print the package version.
+
+```

--- a/lib/node_modules/@stdlib/assert/has-search-symbol-support/etc/cli_opts.json
+++ b/lib/node_modules/@stdlib/assert/has-search-symbol-support/etc/cli_opts.json
@@ -1,0 +1,14 @@
+{
+	"boolean": [
+		"help",
+		"version"
+	],
+	"alias": {
+		"help": [
+			"h"
+		],
+		"version": [
+			"V"
+		]
+	}
+}

--- a/lib/node_modules/@stdlib/assert/has-search-symbol-support/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/has-search-symbol-support/examples/index.js
@@ -1,0 +1,28 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var hasSearchSymbolSupport = require( './../lib' ); // eslint-disable-line id-length
+
+var bool = hasSearchSymbolSupport();
+if ( bool ) {
+    console.log( 'Environment has Symbol.search support.' );
+} else {
+    console.log( 'Environment lacks Symbol.search support.' );
+}

--- a/lib/node_modules/@stdlib/assert/has-search-symbol-support/lib/index.js
+++ b/lib/node_modules/@stdlib/assert/has-search-symbol-support/lib/index.js
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Test for native `Symbol.search` support.
+*
+* @module @stdlib/assert/has-search-symbol-support
+*
+* @example
+* var hasSearchSymbolSupport = require( '@stdlib/assert/has-search-symbol-support' );
+*
+* var bool = hasSearchSymbolSupport();
+* // returns <boolean>
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/assert/has-search-symbol-support/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/has-search-symbol-support/lib/main.js
@@ -1,0 +1,50 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var Symbol = require( '@stdlib/symbol/ctor' );
+
+
+// MAIN //
+
+/**
+* Tests for native `Symbol.search` support.
+*
+* @returns {boolean} boolean indicating if an environment has `Symbol.search` support
+*
+* @example
+* var bool = hasSearchSymbolSupport();
+* // returns <boolean>
+*/
+function hasSearchSymbolSupport() { // eslint-disable-line id-length
+    return (
+        typeof Symbol === 'function' &&
+        typeof Symbol( 'foo' ) === 'symbol' &&
+        hasOwnProp( Symbol, 'search' ) &&
+        typeof Symbol.search === 'symbol'
+    );
+}
+
+
+// EXPORTS //
+
+module.exports = hasSearchSymbolSupport;

--- a/lib/node_modules/@stdlib/assert/has-search-symbol-support/package.json
+++ b/lib/node_modules/@stdlib/assert/has-search-symbol-support/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@stdlib/assert/has-search-symbol-support",
+  "version": "0.0.0",
+  "description": "Detect native Symbol.search support.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "bin": {
+    "has-search-symbol-support": "./bin/cli"
+  },
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdutils",
+    "stdutil",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "detect",
+    "feature",
+    "symbol",
+    "search",
+    "es2015",
+    "es6",
+    "support",
+    "has",
+    "native",
+    "issupported",
+    "cli"
+  ]
+}

--- a/lib/node_modules/@stdlib/assert/has-search-symbol-support/test/test.cli.js
+++ b/lib/node_modules/@stdlib/assert/has-search-symbol-support/test/test.cli.js
@@ -1,0 +1,163 @@
+/**
+ * @license Apache-2.0
+ *
+ * Copyright (c) 2025 The Stdlib Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var exec = require( 'child_process' ).exec;
+var tape = require( 'tape' );
+var IS_BROWSER = require( '@stdlib/assert/is-browser' );
+var IS_WINDOWS = require( '@stdlib/assert/is-windows' );
+var EXEC_PATH = require( '@stdlib/process/exec-path' );
+var readFileSync = require( '@stdlib/fs/read-file' ).sync;
+
+
+// VARIABLES //
+
+var fpath = resolve( __dirname, '..', 'bin', 'cli' );
+var opts = {
+	'skip': IS_BROWSER || IS_WINDOWS
+};
+
+
+// FIXTURES //
+
+var PKG_VERSION = require( './../package.json' ).version;
+
+
+// TESTS //
+
+tape( 'command-line interface', function test( t ) {
+	t.ok( true, __filename );
+	t.end();
+});
+
+tape( 'when invoked with a `--help` flag, the command-line interface prints the help text to `stderr`', opts, function test( t ) {
+	var expected;
+	var cmd;
+
+	expected = readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+		'encoding': 'utf8'
+	});
+	cmd = [
+		EXEC_PATH,
+		fpath,
+		'--help'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), expected+'\n', 'expected value' );
+		}
+		t.end();
+	}
+});
+
+tape( 'when invoked with a `-h` flag, the command-line interface prints the help text to `stderr`', opts, function test( t ) {
+	var expected;
+	var cmd;
+
+	expected = readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+		'encoding': 'utf8'
+	});
+	cmd = [
+		EXEC_PATH,
+		fpath,
+		'-h'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), expected+'\n', 'expected value' );
+		}
+		t.end();
+	}
+});
+
+tape( 'when invoked with a `--version` flag, the command-line interface prints the version to `stderr`', opts, function test( t ) {
+	var cmd = [
+		EXEC_PATH,
+		fpath,
+		'--version'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), PKG_VERSION+'\n', 'expected value' );
+		}
+		t.end();
+	}
+});
+
+tape( 'when invoked with a `-V` flag, the command-line interface prints the version to `stderr`', opts, function test( t ) {
+	var cmd = [
+		EXEC_PATH,
+		fpath,
+		'-V'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), PKG_VERSION+'\n', 'expected value' );
+		}
+		t.end();
+	}
+});
+
+tape( 'the command-line interface prints either `true` or `false` to `stdout` indicating whether an environment provides native `Symbol.search` support', opts, function test( t ) {
+	var cmd = [
+		EXEC_PATH,
+		fpath
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		var str;
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			str = stdout.toString();
+			t.strictEqual( str === 'true\n' || str === 'false\n', true, 'prints either `true` or `false` to `stdout`' );
+			t.strictEqual( stderr.toString(), '', 'does not print to `stderr`' );
+		}
+		t.end();
+	}
+});

--- a/lib/node_modules/@stdlib/assert/has-search-symbol-support/test/test.js
+++ b/lib/node_modules/@stdlib/assert/has-search-symbol-support/test/test.js
@@ -1,0 +1,66 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var proxyquire = require( 'proxyquire' );
+var Symbol = require( '@stdlib/symbol/ctor' );
+var detect = require( './../lib' );
+
+
+// VARIABLES //
+
+var hasSearchSymbol = ( typeof Symbol === 'function' && typeof Symbol.search === 'symbol' ); // eslint-disable-line id-length
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof detect, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'feature detection result is a boolean', function test( t ) {
+	t.strictEqual( typeof detect(), 'boolean', 'returns expected value' );
+	t.end();
+});
+
+tape( 'if `Symbol.search` is supported, detection result is `true`', function test( t ) {
+	if ( hasSearchSymbol ) {
+		t.strictEqual( detect(), true, 'returns expected value' );
+	} else {
+		t.strictEqual( detect(), false, 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function guards against a `Symbol` global variable which does not produce `symbols`', function test( t ) {
+	var detect = proxyquire( './../lib/main.js', {
+		'@stdlib/symbol/ctor': mock
+	});
+	t.strictEqual( detect(), false, 'returns expected value' );
+	t.end();
+
+	function mock() {
+		return {};
+	}
+});

--- a/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/README.md
+++ b/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/README.md
@@ -1,0 +1,129 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2025 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# ToPrimitive Symbol Support
+
+> Detect native [`Symbol.toPrimitive`][mdn-to-primitive-symbol] support.
+
+<section class="usage">
+
+## Usage
+
+<!-- eslint-disable id-length -->
+
+```javascript
+var hasToPrimitiveSymbolSupport = require( '@stdlib/assert/has-to-primitive-symbol-support' );
+```
+
+#### hasToPrimitiveSymbolSupport()
+
+Detects if a runtime environment supports [`Symbol.toPrimitive`][mdn-to-primitive-symbol].
+
+<!-- eslint-disable id-length -->
+
+```javascript
+var bool = hasToPrimitiveSymbolSupport();
+// returns <boolean>
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint-disable id-length -->
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var hasToPrimitiveSymbolSupport = require( '@stdlib/assert/has-to-primitive-symbol-support' );
+
+var bool = hasToPrimitiveSymbolSupport();
+if ( bool ) {
+  console.log( 'Environment has Symbol.toPrimitive support.' );
+} else {
+  console.log( 'Environment lacks Symbol.toPrimitive support.' );
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+* * *
+
+<section class="cli">
+
+## CLI
+
+<section class="usage">
+
+### Usage
+
+```text
+Usage: has-to-primitive-symbol-support [options]
+
+Options:
+
+  -h,    --help                Print this message.
+  -V,    --version             Print the package version.
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+### Examples
+
+```bash
+$ has-to-primitive-symbol-support
+<boolean>
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.cli -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[mdn-to-primitive-symbol]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/benchmark/benchmark.js
@@ -1,0 +1,49 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var pkg = require( './../package.json' ).name;
+var hasIsConcatSpreadableSymbolSupport = require( './../lib' ); // eslint-disable-line id-length
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var bool;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		// Note: the following *could* be optimized away via loop-invariant code motion. If so, the entire loop will disappear.
+		bool = hasIsConcatSpreadableSymbolSupport();
+		if ( typeof bool !== 'boolean' ) {
+			b.fail( 'should return a boolean' );
+		}
+	}
+	b.toc();
+	if ( !isBoolean( bool ) ) {
+		b.fail( 'should return a boolean' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/benchmark/benchmark.js
@@ -24,7 +24,6 @@ var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var pkg = require( './../package.json' ).name;
 var hasToPrimitiveSymbolSupport = require( './../lib' ); // eslint-disable-line id-length
-var hasToPrimitiveSymbolSupport = require( './../lib' ); // eslint-disable-line id-length
 
 
 // MAIN //
@@ -35,8 +34,8 @@ bench( pkg, function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-	// Note: the following *could* be optimized away via loop-invariant code motion. If so, the entire loop will disappear.
-	bool = hasToPrimitiveSymbolSupport();
+		// Note: the following *could* be optimized away via loop-invariant code motion. If so, the entire loop will disappear.
+		bool = hasToPrimitiveSymbolSupport();
 		if ( typeof bool !== 'boolean' ) {
 			b.fail( 'should return a boolean' );
 		}

--- a/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/benchmark/benchmark.js
@@ -23,7 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var pkg = require( './../package.json' ).name;
-var hasIsConcatSpreadableSymbolSupport = require( './../lib' ); // eslint-disable-line id-length
+var hasToPrimitiveSymbolSupport = require( './../lib' ); // eslint-disable-line id-length
 
 
 // MAIN //
@@ -35,7 +35,7 @@ bench( pkg, function benchmark( b ) {
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
 		// Note: the following *could* be optimized away via loop-invariant code motion. If so, the entire loop will disappear.
-		bool = hasIsConcatSpreadableSymbolSupport();
+		bool = hasToPrimitiveSymbolSupport();
 		if ( typeof bool !== 'boolean' ) {
 			b.fail( 'should return a boolean' );
 		}

--- a/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/benchmark/benchmark.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var pkg = require( './../package.json' ).name;
 var hasToPrimitiveSymbolSupport = require( './../lib' ); // eslint-disable-line id-length
+var hasToPrimitiveSymbolSupport = require( './../lib' ); // eslint-disable-line id-length
 
 
 // MAIN //
@@ -34,8 +35,8 @@ bench( pkg, function benchmark( b ) {
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {
-		// Note: the following *could* be optimized away via loop-invariant code motion. If so, the entire loop will disappear.
-		bool = hasToPrimitiveSymbolSupport();
+	// Note: the following *could* be optimized away via loop-invariant code motion. If so, the entire loop will disappear.
+	bool = hasToPrimitiveSymbolSupport();
 		if ( typeof bool !== 'boolean' ) {
 			b.fail( 'should return a boolean' );
 		}

--- a/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/bin/cli
+++ b/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/bin/cli
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var readFileSync = require( '@stdlib/fs/read-file' ).sync;
+var CLI = require( '@stdlib/cli/ctor' );
+var detect = require( './../lib' );
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var flags;
+	var cli;
+
+	// Create a command-line interface:
+	cli = new CLI({
+		'pkg': require( './../package.json' ),
+		'options': require( './../etc/cli_opts.json' ),
+		'help': readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+			'encoding': 'utf8'
+		})
+	});
+
+	// Get any provided command-line options:
+	flags = cli.flags();
+	if ( flags.help || flags.version ) {
+		return;
+	}
+
+	console.log( detect() ); // eslint-disable-line no-console
+}
+
+main();

--- a/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/docs/repl.txt
+++ b/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/docs/repl.txt
@@ -1,0 +1,18 @@
+
+{{alias}}()
+    Tests for native `Symbol.isConcatSpreadable` support.
+
+    Returns
+    -------
+    bool: boolean
+        Boolean indicating if an environment has native
+        `Symbol.isConcatSpreadable` support.
+
+    Examples
+    --------
+    > var bool = {{alias}}()
+    <boolean>
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/docs/repl.txt
+++ b/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/docs/repl.txt
@@ -1,12 +1,13 @@
 
 {{alias}}()
     Tests for native `Symbol.toPrimitive` support.
+    Tests for native `Symbol.toPrimitive` support.
 
     Returns
     -------
     bool: boolean
-        Boolean indicating if an environment has native `Symbol.toPrimitive`
-        support.
+        Boolean indicating if an environment has native
+        `Symbol.toPrimitive` support.
 
     Examples
     --------

--- a/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/docs/repl.txt
+++ b/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/docs/repl.txt
@@ -1,12 +1,12 @@
 
 {{alias}}()
-    Tests for native `Symbol.isConcatSpreadable` support.
+    Tests for native `Symbol.toPrimitive` support.
 
     Returns
     -------
     bool: boolean
-        Boolean indicating if an environment has native
-        `Symbol.isConcatSpreadable` support.
+        Boolean indicating if an environment has native `Symbol.toPrimitive`
+        support.
 
     Examples
     --------

--- a/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/docs/types/index.d.ts
@@ -1,0 +1,35 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Tests for native `Symbol.isConcatSpreadable` support.
+*
+* @returns boolean indicating if an environment has `Symbol.isConcatSpreadable` support
+*
+* @example
+* var bool = hasIsConcatSpreadableSymbolSupport();
+* // returns <boolean>
+*/
+declare function hasIsConcatSpreadableSymbolSupport(): boolean;
+
+
+// EXPORTS //
+
+export = hasIsConcatSpreadableSymbolSupport;

--- a/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/docs/types/index.d.ts
@@ -19,17 +19,17 @@
 // TypeScript Version: 4.1
 
 /**
-* Tests for native `Symbol.isConcatSpreadable` support.
+* Tests for native `Symbol.toPrimitive` support.
 *
-* @returns boolean indicating if an environment has `Symbol.isConcatSpreadable` support
+* @returns boolean indicating if an environment has `Symbol.toPrimitive` support
 *
 * @example
-* var bool = hasIsConcatSpreadableSymbolSupport();
+* var bool = hasToPrimitiveSymbolSupport();
 * // returns <boolean>
 */
-declare function hasIsConcatSpreadableSymbolSupport(): boolean;
+declare function hasToPrimitiveSymbolSupport(): boolean;
 
 
 // EXPORTS //
 
-export = hasIsConcatSpreadableSymbolSupport;
+export = hasToPrimitiveSymbolSupport;

--- a/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/docs/types/test.ts
@@ -1,0 +1,33 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import hasIsConcatSpreadableSymbolSupport = require( './index' );
+
+
+// TESTS //
+
+// The function returns a boolean...
+{
+	hasIsConcatSpreadableSymbolSupport(); // $ExpectType boolean
+}
+
+// The compiler throws an error if the function is provided arguments...
+{
+	hasIsConcatSpreadableSymbolSupport( true ); // $ExpectError
+	hasIsConcatSpreadableSymbolSupport( [], 123 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/docs/types/test.ts
@@ -16,18 +16,18 @@
 * limitations under the License.
 */
 
-import hasIsConcatSpreadableSymbolSupport = require( './index' );
+import hasToPrimitiveSymbolSupport = require( './index' );
 
 
 // TESTS //
 
 // The function returns a boolean...
 {
-	hasIsConcatSpreadableSymbolSupport(); // $ExpectType boolean
+	hasToPrimitiveSymbolSupport(); // $ExpectType boolean
 }
 
 // The compiler throws an error if the function is provided arguments...
 {
-	hasIsConcatSpreadableSymbolSupport( true ); // $ExpectError
-	hasIsConcatSpreadableSymbolSupport( [], 123 ); // $ExpectError
+	hasToPrimitiveSymbolSupport( true ); // $ExpectError
+	hasToPrimitiveSymbolSupport( [], 123 ); // $ExpectError
 }

--- a/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/docs/usage.txt
+++ b/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/docs/usage.txt
@@ -1,0 +1,8 @@
+
+Usage: has-to-primitive-symbol-support [options]
+
+Options:
+
+  -h,    --help                Print this message.
+  -V,    --version             Print the package version.
+

--- a/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/etc/cli_opts.json
+++ b/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/etc/cli_opts.json
@@ -1,0 +1,14 @@
+{
+	"boolean": [
+		"help",
+		"version"
+	],
+	"alias": {
+		"help": [
+			"h"
+		],
+		"version": [
+			"V"
+		]
+	}
+}

--- a/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/examples/index.js
@@ -1,0 +1,28 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var hasIsConcatSpreadableSymbolSupport = require( './../lib' ); // eslint-disable-line id-length
+
+var bool = hasIsConcatSpreadableSymbolSupport();
+if ( bool ) {
+	console.log( 'Environment has Symbol.isConcatSpreadable support.' );
+} else {
+	console.log( 'Environment lacks Symbol.isConcatSpreadable support.' );
+}

--- a/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/examples/index.js
+++ b/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/examples/index.js
@@ -18,11 +18,11 @@
 
 'use strict';
 
-var hasIsConcatSpreadableSymbolSupport = require( './../lib' ); // eslint-disable-line id-length
+var hasToPrimitiveSymbolSupport = require( './../lib' ); // eslint-disable-line id-length
 
-var bool = hasIsConcatSpreadableSymbolSupport();
+var bool = hasToPrimitiveSymbolSupport();
 if ( bool ) {
-	console.log( 'Environment has Symbol.isConcatSpreadable support.' );
+	console.log( 'Environment has Symbol.toPrimitive support.' );
 } else {
-	console.log( 'Environment lacks Symbol.isConcatSpreadable support.' );
+	console.log( 'Environment lacks Symbol.toPrimitive support.' );
 }

--- a/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/lib/index.js
+++ b/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/lib/index.js
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+ * Test for native `Symbol.toPrimitive` support.
+ *
+ * @module @stdlib/assert/has-to-primitive-symbol-support
+ *
+ * @example
+ * var hasToPrimitiveSymbolSupport = require( '@stdlib/assert/has-to-primitive-symbol-support' );
+ *
+ * var bool = hasToPrimitiveSymbolSupport();
+ * // returns <boolean>
+ */
+
+// MODULES //
+
+var main = require( '@stdlib/assert/has-to-primitive-symbol-support/lib/main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/lib/index.js
+++ b/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/lib/index.js
@@ -19,16 +19,16 @@
 'use strict';
 
 /**
- * Test for native `Symbol.toPrimitive` support.
- *
- * @module @stdlib/assert/has-to-primitive-symbol-support
- *
- * @example
- * var hasToPrimitiveSymbolSupport = require( '@stdlib/assert/has-to-primitive-symbol-support' );
- *
- * var bool = hasToPrimitiveSymbolSupport();
- * // returns <boolean>
- */
+* Test for native `Symbol.toPrimitive` support.
+*
+* @module @stdlib/assert/has-to-primitive-symbol-support
+*
+* @example
+* var hasToPrimitiveSymbolSupport = require( '@stdlib/assert/has-to-primitive-symbol-support' );
+*
+* var bool = hasToPrimitiveSymbolSupport();
+* // returns <boolean>
+*/
 
 // MODULES //
 

--- a/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/lib/index.js
+++ b/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/lib/index.js
@@ -32,7 +32,7 @@
 
 // MODULES //
 
-var main = require( '@stdlib/assert/has-to-primitive-symbol-support/lib/main.js' );
+var main = require( './main.js' );
 
 
 // EXPORTS //

--- a/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/lib/main.js
@@ -23,12 +23,11 @@
 var hasOwnProp = require( '@stdlib/assert/has-own-property' );
 var Symbol = require( '@stdlib/symbol/ctor' );
 
+
 // MAIN //
 
 /**
 * Tests for native `Symbol.toPrimitive` support.
-*
-* @module @stdlib/assert/has-to-primitive-symbol-support
 *
 * @returns {boolean} boolean indicating if an environment has `Symbol.toPrimitive` support
 *
@@ -44,6 +43,7 @@ function hasToPrimitiveSymbolSupport() {
 		typeof Symbol.toPrimitive === 'symbol'
 	);
 }
+
 
 // EXPORTS //
 

--- a/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/lib/main.js
@@ -1,0 +1,50 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var hasOwnProp = require( '@stdlib/assert/has-own-property' );
+var Symbol = require( '@stdlib/symbol/ctor' );
+
+
+// MAIN //
+
+/**
+* Tests for native `Symbol.toPrimitive` support.
+*
+* @returns {boolean} boolean indicating if an environment has `Symbol.toPrimitive` support
+*
+* @example
+* var bool = hasToPrimitiveSymbolSupport();
+* // returns <boolean>
+*/
+function hasToPrimitiveSymbolSupport() { // eslint-disable-line id-length
+	return (
+		typeof Symbol === 'function' &&
+		typeof Symbol( 'foo' ) === 'symbol' &&
+		hasOwnProp( Symbol, 'toPrimitive' ) &&
+		typeof Symbol.toPrimitive === 'symbol'
+	);
+}
+
+
+// EXPORTS //
+
+module.exports = hasToPrimitiveSymbolSupport;

--- a/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/lib/main.js
+++ b/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/lib/main.js
@@ -23,11 +23,12 @@
 var hasOwnProp = require( '@stdlib/assert/has-own-property' );
 var Symbol = require( '@stdlib/symbol/ctor' );
 
-
 // MAIN //
 
 /**
 * Tests for native `Symbol.toPrimitive` support.
+*
+* @module @stdlib/assert/has-to-primitive-symbol-support
 *
 * @returns {boolean} boolean indicating if an environment has `Symbol.toPrimitive` support
 *
@@ -35,7 +36,7 @@ var Symbol = require( '@stdlib/symbol/ctor' );
 * var bool = hasToPrimitiveSymbolSupport();
 * // returns <boolean>
 */
-function hasToPrimitiveSymbolSupport() { // eslint-disable-line id-length
+function hasToPrimitiveSymbolSupport() {
 	return (
 		typeof Symbol === 'function' &&
 		typeof Symbol( 'foo' ) === 'symbol' &&
@@ -43,7 +44,6 @@ function hasToPrimitiveSymbolSupport() { // eslint-disable-line id-length
 		typeof Symbol.toPrimitive === 'symbol'
 	);
 }
-
 
 // EXPORTS //
 

--- a/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/package.json
+++ b/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@stdlib/assert/has-to-primitive-symbol-support",
+  "version": "0.0.0",
+  "description": "Detect native Symbol.toPrimitive support.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "bin": {
+    "has-to-primitive-symbol-support": "./bin/cli"
+  },
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdutils",
+    "stdutil",
+    "utilities",
+    "utility",
+    "utils",
+    "util",
+    "detect",
+    "feature",
+    "symbol",
+    "to-primitive",
+    "es2015",
+    "es6",
+    "support",
+    "has",
+    "native",
+    "issupported",
+    "cli"
+  ]
+}

--- a/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/test/test.cli.js
+++ b/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/test/test.cli.js
@@ -1,0 +1,163 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var exec = require( 'child_process' ).exec;
+var tape = require( 'tape' );
+var IS_BROWSER = require( '@stdlib/assert/is-browser' );
+var IS_WINDOWS = require( '@stdlib/assert/is-windows' );
+var EXEC_PATH = require( '@stdlib/process/exec-path' );
+var readFileSync = require( '@stdlib/fs/read-file' ).sync;
+
+
+// VARIABLES //
+
+var fpath = resolve( __dirname, '..', 'bin', 'cli' );
+var opts = {
+	'skip': IS_BROWSER || IS_WINDOWS
+};
+
+
+// FIXTURES //
+
+var PKG_VERSION = require( './../package.json' ).version;
+
+
+// TESTS //
+
+tape( 'command-line interface', function test( t ) {
+	t.ok( true, __filename );
+	t.end();
+});
+
+tape( 'when invoked with a `--help` flag, the command-line interface prints the help text to `stderr`', opts, function test( t ) {
+	var expected;
+	var cmd;
+
+	expected = readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+		'encoding': 'utf8'
+	});
+	cmd = [
+		EXEC_PATH,
+		fpath,
+		'--help'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), expected+'\n', 'expected value' );
+		}
+		t.end();
+	}
+});
+
+tape( 'when invoked with a `-h` flag, the command-line interface prints the help text to `stderr`', opts, function test( t ) {
+	var expected;
+	var cmd;
+
+	expected = readFileSync( resolve( __dirname, '..', 'docs', 'usage.txt' ), {
+		'encoding': 'utf8'
+	});
+	cmd = [
+		EXEC_PATH,
+		fpath,
+		'-h'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), expected+'\n', 'expected value' );
+		}
+		t.end();
+	}
+});
+
+tape( 'when invoked with a `--version` flag, the command-line interface prints the version to `stderr`', opts, function test( t ) {
+	var cmd = [
+		EXEC_PATH,
+		fpath,
+		'--version'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), PKG_VERSION+'\n', 'expected value' );
+		}
+		t.end();
+	}
+});
+
+tape( 'when invoked with a `-V` flag, the command-line interface prints the version to `stderr`', opts, function test( t ) {
+	var cmd = [
+		EXEC_PATH,
+		fpath,
+		'-V'
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			t.strictEqual( stdout.toString(), '', 'does not print to `stdout`' );
+			t.strictEqual( stderr.toString(), PKG_VERSION+'\n', 'expected value' );
+		}
+		t.end();
+	}
+});
+
+tape( 'the command-line interface prints either `true` or `false` to `stdout` indicating whether an environment provides native `Symbol.toPrimitive` support', opts, function test( t ) {
+	var cmd = [
+		EXEC_PATH,
+		fpath
+	];
+
+	exec( cmd.join( ' ' ), done );
+
+	function done( error, stdout, stderr ) {
+		var str;
+		if ( error ) {
+			t.fail( error.message );
+		} else {
+			str = stdout.toString();
+			t.strictEqual( str === 'true\n' || str === 'false\n', true, 'prints either `true` or `false` to `stdout`' );
+			t.strictEqual( stderr.toString(), '', 'does not print to `stderr`' );
+		}
+		t.end();
+	}
+});

--- a/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/test/test.js
+++ b/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/test/test.js
@@ -1,0 +1,66 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var proxyquire = require( 'proxyquire' );
+var Symbol = require( '@stdlib/symbol/ctor' );
+var detect = require( '@stdlib/assert/has-to-primitive-symbol-support/lib' );
+
+
+// VARIABLES //
+
+var hasToPrimitiveSymbol = ( typeof Symbol === 'function' && typeof Symbol.toPrimitive === 'symbol' ); // eslint-disable-line id-length
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof detect, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'feature detection result is a boolean', function test( t ) {
+	t.strictEqual( typeof detect(), 'boolean', 'returns expected value' );
+	t.end();
+});
+
+tape( 'if `Symbol.toPrimitive` is supported, detection result is `true`', function test( t ) {
+	if ( hasToPrimitiveSymbol ) {
+		t.strictEqual( detect(), true, 'returns expected value' );
+	} else {
+		t.strictEqual( detect(), false, 'returns expected value' );
+	}
+	t.end();
+});
+
+tape( 'the function guards against a `Symbol` global variable which does not produce `symbols`', function test( t ) {
+	var detect = proxyquire( './../lib/main.js', {
+		'@stdlib/symbol/ctor': mock
+	});
+	t.strictEqual( detect(), false, 'returns expected value' );
+	t.end();
+
+	function mock() {
+		return {};
+	}
+});

--- a/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/test/test.js
+++ b/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/test/test.js
@@ -28,7 +28,7 @@ var detect = require( './../lib' );
 
 // VARIABLES //
 
-var hasToPrimitiveSymbol = ( typeof Symbol === 'function' && typeof Symbol.toPrimitive === 'symbol' ); // eslint-disable-line id-length
+var hasToPrimitiveSymbol = ( typeof Symbol === 'function' && typeof Symbol.toPrimitive === 'symbol' );
 
 
 // TESTS //

--- a/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/test/test.js
+++ b/lib/node_modules/@stdlib/assert/has-to-primitive-symbol-support/test/test.js
@@ -23,7 +23,7 @@
 var tape = require( 'tape' );
 var proxyquire = require( 'proxyquire' );
 var Symbol = require( '@stdlib/symbol/ctor' );
-var detect = require( '@stdlib/assert/has-to-primitive-symbol-support/lib' );
+var detect = require( './../lib' );
 
 
 // VARIABLES //


### PR DESCRIPTION
Resolves #8466.

## Description

> What is the purpose of this pull request?

This pull request adds a new package: **`@stdlib/assert/has-search-symbol-support`**.

The package detects native support for the built-in `Symbol.search`.  
It follows the same structure and design as related packages such as:
- `@stdlib/assert/has-iterator-symbol-support`
- `@stdlib/assert/has-is-concat-spreadable-symbol-support`
- `@stdlib/assert/has-has-instance-symbol-support`

### Summary of changes
- Added implementation in `lib/`.
- Added corresponding test, benchmark, and example files.
- Verified linting, testing, and benchmark results for consistency with existing symbol-support detection modules.

## Related Issues

> Does this pull request have any related issues?

- #8466

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

This implementation was created by following the steps outlined in the RFC:
1. Copied and refactored an existing symbol-support package.
2. Replaced all occurrences of the previous symbol name with `search`.
3. Verified the package via local tests, benchmarks, and examples.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

- [] Yes  
- [x ] No

If you answered "yes" above, how did you use AI assistance?

- [] Code generation (for boilerplate refactor)
- [] Documentation preparation (PR template assistance)

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

---

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
