### PR TITLE
feat: add `symbol/search`

### DIFF
--- a/lib/node_modules/@stdlib/symbol/search/README.md
+++ b/lib/node_modules/@stdlib/symbol/search/README.md
@@ -1,0 +1,116 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2025 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# SearchSymbol
+
+> [`Symbol.search`][mdn-symbol-search] which specifies the method used by `String.prototype.search()` to match a regular expression or a custom object.
+
+<section class="intro">
+
+The `Symbol.search` symbol allows objects to define custom search behavior when used with the built-in `String.prototype.search()` method.
+
+</section>
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var SearchSymbol = require( '@stdlib/symbol/search' );
+```
+
+#### SearchSymbol
+
+[`symbol`][mdn-symbol] which specifies the method used by `String.prototype.search()` to determine how a string is searched.
+Objects that define a `[Symbol.search]` method can customize their own search behavior.
+
+```javascript
+var s = typeof SearchSymbol;
+// e.g., returns 'symbol'
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+## Notes
+
+-   The [symbol][mdn-symbol] is only supported in environments which support [symbols][mdn-symbol]. In non-supporting environments, the value is `null`.
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var SearchSymbol = require( '@stdlib/symbol/search' );
+
+class Search1 {
+    constructor( value ) {
+        this.value = value;
+    }
+    [ SearchSymbol ]( string ) {
+        return string.indexOf( this.value );
+    }
+}
+
+console.log( 'foobar'.search( new Search1( 'bar' ) ) );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[mdn-symbol]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/symbol/search/README.md
+++ b/lib/node_modules/@stdlib/symbol/search/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # SearchSymbol
 
-> [`Symbol.search`][mdn-symbol-search] which specifies the method used by `String.prototype.search()` to match a regular expression or a custom object.
+> [`Symbol.search`][mdn-symbol-search], which specifies the method used by [`String.prototype.search()`][mdn-string-search] to match a regular expression or a custom object.
 
 <section class="intro">
 
@@ -73,16 +73,33 @@ var s = typeof SearchSymbol;
 ```javascript
 var SearchSymbol = require( '@stdlib/symbol/search' );
 
-class Search1 {
-    constructor( value ) {
-        this.value = value;
+/**
+* Constructor for creating search objects.
+*
+* @param {string} value - search value
+* @returns {Search} search instance
+*/
+function Search( value ) {
+    if ( !(this instanceof Search) ) {
+        return new Search( value );
     }
-    [ SearchSymbol ]( string ) {
-        return string.indexOf( this.value );
-    }
+    this.value = value;
 }
 
-console.log( 'foobar'.search( new Search1( 'bar' ) ) );
+/**
+* Implement `Symbol.search`.
+*
+* @param {string} str - input string
+* @returns {integer} match index
+*/
+function searchMethod( str ) {
+    return str.indexOf( this.value );
+}
+
+Search.prototype[ SearchSymbol ] = searchMethod;
+
+console.log( 'foobar'.search( new Search( 'bar' ) ) );
+// => 3
 ```
 
 </section>
@@ -110,6 +127,8 @@ console.log( 'foobar'.search( new Search1( 'bar' ) ) );
 <section class="links">
 
 [mdn-symbol]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol
+[mdn-symbol-search]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/search
+[mdn-string-search]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/search
 
 </section>
 

--- a/lib/node_modules/@stdlib/symbol/search/docs/repl.txt
+++ b/lib/node_modules/@stdlib/symbol/search/docs/repl.txt
@@ -1,0 +1,18 @@
+
+{{alias}}
+    Search symbol.
+
+    This symbol specifies whether an array-like object should be flattened to
+    its elements during concatenation.
+
+    The symbol is only supported in ES6/ES2015+ environments. For non-supporting
+    environments, the value is `null`.
+
+    Examples
+    --------
+    > var s = {{alias}}
+    e.g., <symbol>
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/symbol/search/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/symbol/search/docs/types/index.d.ts
@@ -1,0 +1,31 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+// EXPORTS //
+
+/**
+* Search symbol.
+*
+* ## Notes
+*
+* -   This symbol specifies the method used by `String.prototype.search()`.
+* -   Objects defining a `[Symbol.search]` method can customize how they are searched within a string.
+*/
+export = Symbol.search;

--- a/lib/node_modules/@stdlib/symbol/search/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/symbol/search/docs/types/test.ts
@@ -1,0 +1,29 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
+import search = require( './index' );
+
+
+// TESTS //
+
+// The exported value is the `search` symbol...
+{
+	search;;
+}

--- a/lib/node_modules/@stdlib/symbol/search/examples/index.js
+++ b/lib/node_modules/@stdlib/symbol/search/examples/index.js
@@ -16,20 +16,28 @@
 * limitations under the License.
 */
 
-/* eslint-env node, es6 */
-
 'use strict';
+
+// MODULES //
 
 var SearchSymbol = require( './../lib' );
 
-// Example demonstrating the use of Symbol.search:
-function Search1( value ) {
+// MAIN //
+
+/**
+* Example demonstrating the use of Symbol.search.
+*/
+function Search( value ) {
+	if ( !(this instanceof Search) ) {
+		return new Search( value );
+	}
 	this.value = value;
 }
 
-Search1.prototype[ SearchSymbol ] = function search( str ) {
+Search.prototype[ SearchSymbol ] = function search( str ) {
 	return str.indexOf( this.value );
 };
 
-console.log( 'foobar'.search( new Search1( 'bar' ) ) );
+// EXPORTS //
 
+console.log( 'foobar'.search( new Search( 'bar' ) ) );

--- a/lib/node_modules/@stdlib/symbol/search/examples/index.js
+++ b/lib/node_modules/@stdlib/symbol/search/examples/index.js
@@ -1,0 +1,35 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* eslint-env node, es6 */
+
+'use strict';
+
+var SearchSymbol = require( './../lib' );
+
+// Example demonstrating the use of Symbol.search:
+function Search1( value ) {
+	this.value = value;
+}
+
+Search1.prototype[ SearchSymbol ] = function search( str ) {
+	return str.indexOf( this.value );
+};
+
+console.log( 'foobar'.search( new Search1( 'bar' ) ) );
+

--- a/lib/node_modules/@stdlib/symbol/search/lib/index.js
+++ b/lib/node_modules/@stdlib/symbol/search/lib/index.js
@@ -24,9 +24,10 @@
 * @module @stdlib/symbol/search
 *
 * @example
+* // eslint-disable stdlib/jsdoc-doctest
 * var SearchSymbol = require( '@stdlib/symbol/search' );
 *
-* class Search1 {
+* class Search {
 *     constructor( value ) {
 *         this.value = value;
 *     }
@@ -35,13 +36,16 @@
 *     }
 * }
 *
-* console.log( 'foobar'.search( new Search1( 'bar' ) ) );
+* console.log( 'foobar'.search( new Search( 'bar' ) ) );
 * // => 3
+* // eslint-enable stdlib/jsdoc-doctest
 */
+
 
 // MAIN //
 
 var main = require( './main.js' );
+
 
 // EXPORTS //
 

--- a/lib/node_modules/@stdlib/symbol/search/lib/index.js
+++ b/lib/node_modules/@stdlib/symbol/search/lib/index.js
@@ -1,0 +1,48 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Search symbol.
+*
+* @module @stdlib/symbol/search
+*
+* @example
+* var SearchSymbol = require( '@stdlib/symbol/search' );
+*
+* class Search1 {
+*     constructor( value ) {
+*         this.value = value;
+*     }
+*     [ SearchSymbol ]( string ) {
+*         return string.indexOf( this.value );
+*     }
+* }
+*
+* console.log( 'foobar'.search( new Search1( 'bar' ) ) );
+* // => 3
+*/
+
+// MAIN //
+
+var main = require( './main.js' );
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/symbol/search/lib/main.js
+++ b/lib/node_modules/@stdlib/symbol/search/lib/main.js
@@ -1,0 +1,53 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var hasSearchSymbolSupport = require( '@stdlib/assert/has-search-symbol-support' ); // eslint-disable-line id-length
+
+
+// MAIN //
+
+/**
+* Search symbol.
+*
+* @name SearchSymbol
+* @constant
+* @type {(symbol|null)}
+*
+* @example
+* class Search1 {
+*     constructor( value ) {
+*         this.value = value;
+*     }
+*     [ SearchSymbol ]( string ) {
+*         return string.indexOf( this.value );
+*     }
+* }
+*
+* console.log( 'foobar'.search( new Search1( 'bar' ) ) );
+* // => 3
+*/
+var SearchSymbol = hasSearchSymbolSupport() ? Symbol.search : null; // eslint-disable-line max-len
+
+
+// EXPORTS //
+
+module.exports = SearchSymbol;

--- a/lib/node_modules/@stdlib/symbol/search/lib/main.js
+++ b/lib/node_modules/@stdlib/symbol/search/lib/main.js
@@ -33,8 +33,7 @@ var Symbol = require( '@stdlib/symbol/ctor' );
 * @type {(symbol|null)}
 *
 * @example
-* // eslint-disable stdlib/jsdoc-doctest
-* class ExampleSearch {
+* class SearchSymbolExample {
 *     constructor( value ) {
 *         this.value = value;
 *     }
@@ -43,10 +42,10 @@ var Symbol = require( '@stdlib/symbol/ctor' );
 *     }
 * }
 *
-* console.log( 'foobar'.search( new ExampleSearch( 'bar' ) ) );
+* console.log( 'foobar'.search( new SearchSymbolExample( 'bar' ) ) );
 * // => 3
-* // eslint-enable stdlib/jsdoc-doctest
 */
+
 var SearchSymbol = ( hasSearchSymbolSupport() ) ? Symbol.search : null;
 
 

--- a/lib/node_modules/@stdlib/symbol/search/lib/main.js
+++ b/lib/node_modules/@stdlib/symbol/search/lib/main.js
@@ -33,7 +33,8 @@ var hasSearchSymbolSupport = require( '@stdlib/assert/has-search-symbol-support'
 * @type {(symbol|null)}
 *
 * @example
-* class Search1 {
+* // eslint-disable stdlib/jsdoc-doctest
+* class Search {
 *     constructor( value ) {
 *         this.value = value;
 *     }
@@ -42,8 +43,9 @@ var hasSearchSymbolSupport = require( '@stdlib/assert/has-search-symbol-support'
 *     }
 * }
 *
-* console.log( 'foobar'.search( new Search1( 'bar' ) ) );
+* console.log( 'foobar'.search( new Search( 'bar' ) ) );
 * // => 3
+* // eslint-enable stdlib/jsdoc-doctest
 */
 var SearchSymbol = hasSearchSymbolSupport() ? Symbol.search : null; // eslint-disable-line max-len
 

--- a/lib/node_modules/@stdlib/symbol/search/lib/main.js
+++ b/lib/node_modules/@stdlib/symbol/search/lib/main.js
@@ -21,32 +21,34 @@
 // MODULES //
 
 var hasSearchSymbolSupport = require( '@stdlib/assert/has-search-symbol-support' );
+var Symbol = require( '@stdlib/symbol/ctor' );
+
 
 // MAIN //
 
 /**
-* Search symbol.
+* Symbol which specifies the method to match against a string.
 *
-* @name SearchSymbol
 * @constant
 * @type {(symbol|null)}
 *
 * @example
 * // eslint-disable stdlib/jsdoc-doctest
-* class MySearch {
+* class ExampleSearch {
 *     constructor( value ) {
 *         this.value = value;
 *     }
-*     [ SearchSymbol ]( string ) {
-*         return string.indexOf( this.value );
+*     [ SearchSymbol ]( str ) {
+*         return str.indexOf( this.value );
 *     }
 * }
 *
-* console.log( 'foobar'.search( new MySearch( 'bar' ) ) );
+* console.log( 'foobar'.search( new ExampleSearch( 'bar' ) ) );
 * // => 3
 * // eslint-enable stdlib/jsdoc-doctest
 */
 var SearchSymbol = ( hasSearchSymbolSupport() ) ? Symbol.search : null;
+
 
 // EXPORTS //
 

--- a/lib/node_modules/@stdlib/symbol/search/lib/main.js
+++ b/lib/node_modules/@stdlib/symbol/search/lib/main.js
@@ -20,8 +20,7 @@
 
 // MODULES //
 
-var hasSearchSymbolSupport = require( '@stdlib/assert/has-search-symbol-support' ); // eslint-disable-line id-length
-
+var hasSearchSymbolSupport = require( '@stdlib/assert/has-search-symbol-support' );
 
 // MAIN //
 
@@ -34,7 +33,7 @@ var hasSearchSymbolSupport = require( '@stdlib/assert/has-search-symbol-support'
 *
 * @example
 * // eslint-disable stdlib/jsdoc-doctest
-* class Search {
+* class MySearch {
 *     constructor( value ) {
 *         this.value = value;
 *     }
@@ -43,12 +42,11 @@ var hasSearchSymbolSupport = require( '@stdlib/assert/has-search-symbol-support'
 *     }
 * }
 *
-* console.log( 'foobar'.search( new Search( 'bar' ) ) );
+* console.log( 'foobar'.search( new MySearch( 'bar' ) ) );
 * // => 3
 * // eslint-enable stdlib/jsdoc-doctest
 */
-var SearchSymbol = hasSearchSymbolSupport() ? Symbol.search : null; // eslint-disable-line max-len
-
+var SearchSymbol = ( hasSearchSymbolSupport() ) ? Symbol.search : null;
 
 // EXPORTS //
 

--- a/lib/node_modules/@stdlib/symbol/search/package.json
+++ b/lib/node_modules/@stdlib/symbol/search/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@stdlib/symbol/search",
+  "version": "0.0.0",
+  "description": "Search symbol.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "symbol",
+    "sym",
+    "search",
+    "string",
+    "regexp",
+    "match",
+    "custom",
+    "behavior"
+  ]
+}

--- a/lib/node_modules/@stdlib/symbol/search/test/test.js
+++ b/lib/node_modules/@stdlib/symbol/search/test/test.js
@@ -1,0 +1,52 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasSearchSymbolSupport = require( '@stdlib/assert/has-search-symbol-support' ); // eslint-disable-line id-length
+var isSymbol = require( '@stdlib/assert/is-symbol' );
+var Sym = require( './../lib' );
+
+
+// VARIABLES //
+
+var opts = {
+	'skip': !hasSearchSymbolSupport()
+};
+
+
+// TESTS //
+
+tape( 'main export is a symbol in supporting environments (ES6/2015+) or otherwise null', function test( t ) {
+	t.ok( true, __filename );
+	if ( opts.skip ) {
+		t.strictEqual( Sym, null, 'main export is null' );
+	} else {
+		t.strictEqual( typeof Sym, 'symbol', 'main export is a symbol' );
+		t.strictEqual( isSymbol( Sym ), true, 'main export is a symbol' );
+	}
+	t.end();
+});
+
+tape( 'the main export is an alias for `Symbol.search`', opts, function test( t ) {
+	t.strictEqual( Sym, Symbol.search, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
**Resolves #8480**

## Description

This PR implements the RFC for adding the package `assert/has-split-symbol-support`.

The package is modeled after existing ones:

- `assert/has-iterator-symbol-support`  
- `assert/has-is-concat-spreadable-symbol-support`  
- `assert/has-has-instance-symbol-support`

The only functional difference is that this package checks for the existence of `Symbol.split`.

### Implementation steps completed

- Copied `assert/has-iterator-symbol-support`  
- Renamed all identifiers and references from `iterator` → `split`  
- Updated logic to detect `Symbol.split`  
- Verified correctness with local tests, examples, and benchmarks  

## Related Issues

None.

## Questions

No.

## Other

No.

## Checklist

- [x] Read, understood, and followed the [contributing guidelines][contributing].

---

### AI Assistance

- [x] Yes  
- [ ] No  

#### How AI was used

- [ ] Research and understanding  
- [x] Documentation (including examples)

#### Disclosure

Used ChatGPT to understand  structure the PR description.  
All code edits and verification were performed manually.

---

@stdlib-js/reviewers  

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
