### PR TITLE
chore: fix JavaScript lint errors (issue #8508)

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-row-major/examples/index.js
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-row-major/examples/index.js
@@ -25,7 +25,7 @@ var shape = [ 10, 10, 10 ];
 
 var strides = shape2strides( shape, 'row-major' );
 console.log( 'Strides: %s', strides.join( ',' ) );
-// => Strides: 100,10,1
+// => 'Strides: 100,10,1'
 
 var bool = isRowMajor( strides );
 console.log( bool );
@@ -33,7 +33,7 @@ console.log( bool );
 
 strides = shape2strides( shape, 'column-major' );
 console.log( 'Strides: %s', strides.join( ',' ) );
-// => Strides: 1,10,100
+// => 'Strides: 1,10,100'
 
 bool = isRowMajor( strides );
 console.log( bool );


### PR DESCRIPTION
Resolves #8508.

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes JavaScript lint errors in `lib/node_modules/@stdlib/ndarray/base/assert/is-row-major/examples/index.js` by wrapping expected output strings in single quotes to comply with the `stdlib/doctest` ESLint rule.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8508

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [] Code generation (e.g., when writing an implementation or fixing a bug)
-   [] Documentation (including examples)
-   [ ] Test/benchmark generation
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

I consulted ChatGPT for confirming the correct formatting to resolve the `stdlib/doctest` lint errors. The code changes and commit were made manually.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
