### PR TITLE
chore: fix JavaScript lint errors (issue #8515)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/pkgs/entry-points/lib/resolve.sync.js
+++ b/lib/node_modules/@stdlib/_tools/pkgs/entry-points/lib/resolve.sync.js
@@ -56,7 +56,7 @@ function getPkgs( pkgs, basedir ) {
 	len = pkgs.length;
 	debug( 'Resolving %d packages...', len );
 
-	out = new Array( len );
+	out = [];
 	for ( i = 0; i < len; i++ ) {
 		pkg = pkgs[ i ];
 		k = i + 1;
@@ -65,7 +65,7 @@ function getPkgs( pkgs, basedir ) {
 		opts = {
 			'basedir': basedir
 		};
-		out[ i ] = {};
+		out.push( {} );
 		out[ i ].pkg = pkg;
 
 		main = resolve( pkg, opts );

--- a/lib/node_modules/@stdlib/ndarray/slice-to/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/ndarray/slice-to/benchmark/benchmark.js
@@ -66,17 +66,17 @@ bench( pkg+'::0d,non-base', function benchmark( b ) {
 	var s;
 	var i;
 
-	/* eslint-disable object-curly-newline */
+	/* eslint-disable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	values = [
-		empty( [], { 'dtype': 'float64' }),
-		empty( [], { 'dtype': 'float32' }),
-		empty( [], { 'dtype': 'int32' }),
-		empty( [], { 'dtype': 'complex128' }),
-		empty( [], { 'dtype': 'generic' })
+		empty( [], { 'dtype': 'float64' } ),
+		empty( [], { 'dtype': 'float32' } ),
+		empty( [], { 'dtype': 'int32' } ),
+		empty( [], { 'dtype': 'complex128' } ),
+		empty( [], { 'dtype': 'generic' } )
 	];
 
-	/* eslint-enable object-curly-newline */
+	/* eslint-enable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	s = [];
 
@@ -131,17 +131,17 @@ bench( pkg+'::1d,non-base', function benchmark( b ) {
 	var s;
 	var i;
 
-	/* eslint-disable object-curly-newline */
+	/* eslint-disable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	values = [
-		empty( [ 2 ], { 'dtype': 'float64' }),
-		empty( [ 2 ], { 'dtype': 'float32' }),
-		empty( [ 2 ], { 'dtype': 'int32' }),
-		empty( [ 2 ], { 'dtype': 'complex128' }),
-		empty( [ 2 ], { 'dtype': 'generic' })
+		empty( [ 2 ], { 'dtype': 'float64' } ),
+		empty( [ 2 ], { 'dtype': 'float32' } ),
+		empty( [ 2 ], { 'dtype': 'int32' } ),
+		empty( [ 2 ], { 'dtype': 'complex128' } ),
+		empty( [ 2 ], { 'dtype': 'generic' } )
 	];
 
-	/* eslint-enable object-curly-newline */
+	/* eslint-enable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	s = [ 1 ];
 
@@ -201,17 +201,17 @@ bench( pkg+'::1d,non-base,out-of-bounds', function benchmark( b ) {
 	var s;
 	var i;
 
-	/* eslint-disable object-curly-newline */
+	/* eslint-disable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	values = [
-		empty( [ 2 ], { 'dtype': 'float64' }),
-		empty( [ 2 ], { 'dtype': 'float32' }),
-		empty( [ 2 ], { 'dtype': 'int32' }),
-		empty( [ 2 ], { 'dtype': 'complex128' }),
-		empty( [ 2 ], { 'dtype': 'generic' })
+		empty( [ 2 ], { 'dtype': 'float64' } ),
+		empty( [ 2 ], { 'dtype': 'float32' } ),
+		empty( [ 2 ], { 'dtype': 'int32' } ),
+		empty( [ 2 ], { 'dtype': 'complex128' } ),
+		empty( [ 2 ], { 'dtype': 'generic' } )
 	];
 
-	/* eslint-enable object-curly-newline */
+	/* eslint-enable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	s = [ -20 ];
 	opts = {
@@ -269,17 +269,17 @@ bench( pkg+'::2d,non-base', function benchmark( b ) {
 	var s;
 	var i;
 
-	/* eslint-disable object-curly-newline */
+	/* eslint-disable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	values = [
-		empty( [ 2, 2 ], { 'dtype': 'float64' }),
-		empty( [ 2, 2 ], { 'dtype': 'float32' }),
-		empty( [ 2, 2 ], { 'dtype': 'int32' }),
-		empty( [ 2, 2 ], { 'dtype': 'complex128' }),
-		empty( [ 2, 2 ], { 'dtype': 'generic' })
+		empty( [ 2, 2 ], { 'dtype': 'float64' } ),
+		empty( [ 2, 2 ], { 'dtype': 'float32' } ),
+		empty( [ 2, 2 ], { 'dtype': 'int32' } ),
+		empty( [ 2, 2 ], { 'dtype': 'complex128' } ),
+		empty( [ 2, 2 ], { 'dtype': 'generic' } )
 	];
 
-	/* eslint-enable object-curly-newline */
+	/* eslint-enable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	s = [ 1, 1 ];
 
@@ -339,17 +339,17 @@ bench( pkg+'::2d,non-base,out-of-bounds', function benchmark( b ) {
 	var s;
 	var i;
 
-	/* eslint-disable object-curly-newline */
+	/* eslint-disable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	values = [
-		empty( [ 2, 2 ], { 'dtype': 'float64' }),
-		empty( [ 2, 2 ], { 'dtype': 'float32' }),
-		empty( [ 2, 2 ], { 'dtype': 'int32' }),
-		empty( [ 2, 2 ], { 'dtype': 'complex128' }),
-		empty( [ 2, 2 ], { 'dtype': 'generic' })
+		empty( [ 2, 2 ], { 'dtype': 'float64' } ),
+		empty( [ 2, 2 ], { 'dtype': 'float32' } ),
+		empty( [ 2, 2 ], { 'dtype': 'int32' } ),
+		empty( [ 2, 2 ], { 'dtype': 'complex128' } ),
+		empty( [ 2, 2 ], { 'dtype': 'generic' } )
 	];
 
-	/* eslint-enable object-curly-newline */
+	/* eslint-enable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	s = [ -20, null ];
 	opts = {
@@ -407,17 +407,17 @@ bench( pkg+'::3d,non-base', function benchmark( b ) {
 	var s;
 	var i;
 
-	/* eslint-disable object-curly-newline */
+	/* eslint-disable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	values = [
-		empty( [ 2, 2, 2 ], { 'dtype': 'float64' }),
-		empty( [ 2, 2, 2 ], { 'dtype': 'float32' }),
-		empty( [ 2, 2, 2 ], { 'dtype': 'int32' }),
-		empty( [ 2, 2, 2 ], { 'dtype': 'complex128' }),
-		empty( [ 2, 2, 2 ], { 'dtype': 'generic' })
+		empty( [ 2, 2, 2 ], { 'dtype': 'float64' } ),
+		empty( [ 2, 2, 2 ], { 'dtype': 'float32' } ),
+		empty( [ 2, 2, 2 ], { 'dtype': 'int32' } ),
+		empty( [ 2, 2, 2 ], { 'dtype': 'complex128' } ),
+		empty( [ 2, 2, 2 ], { 'dtype': 'generic' } )
 	];
 
-	/* eslint-enable object-curly-newline */
+	/* eslint-enable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	s = [ 1, 1, 1 ];
 
@@ -477,17 +477,17 @@ bench( pkg+'::3d,non-base,out-of-bounds', function benchmark( b ) {
 	var s;
 	var i;
 
-	/* eslint-disable object-curly-newline */
+	/* eslint-disable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	values = [
-		empty( [ 2, 2, 2 ], { 'dtype': 'float64' }),
-		empty( [ 2, 2, 2 ], { 'dtype': 'float32' }),
-		empty( [ 2, 2, 2 ], { 'dtype': 'int32' }),
-		empty( [ 2, 2, 2 ], { 'dtype': 'complex128' }),
-		empty( [ 2, 2, 2 ], { 'dtype': 'generic' })
+		empty( [ 2, 2, 2 ], { 'dtype': 'float64' } ),
+		empty( [ 2, 2, 2 ], { 'dtype': 'float32' } ),
+		empty( [ 2, 2, 2 ], { 'dtype': 'int32' } ),
+		empty( [ 2, 2, 2 ], { 'dtype': 'complex128' } ),
+		empty( [ 2, 2, 2 ], { 'dtype': 'generic' } )
 	];
 
-	/* eslint-enable object-curly-newline */
+	/* eslint-enable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	s = [ 1, -20, null ];
 	opts = {
@@ -545,17 +545,17 @@ bench( pkg+'::4d,non-base', function benchmark( b ) {
 	var s;
 	var i;
 
-	/* eslint-disable object-curly-newline */
+	/* eslint-disable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	values = [
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'float64' }),
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'float32' }),
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'int32' }),
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'complex128' }),
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'generic' })
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'float64' } ),
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'float32' } ),
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'int32' } ),
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'complex128' } ),
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'generic' } )
 	];
 
-	/* eslint-enable object-curly-newline */
+	/* eslint-enable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	s = [ 1, 1, 1, 1 ];
 
@@ -615,17 +615,17 @@ bench( pkg+'::4d,non-base,out-of-bounds', function benchmark( b ) {
 	var s;
 	var i;
 
-	/* eslint-disable object-curly-newline */
+	/* eslint-disable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	values = [
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'float64' }),
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'float32' }),
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'int32' }),
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'complex128' }),
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'generic' })
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'float64' } ),
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'float32' } ),
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'int32' } ),
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'complex128' } ),
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'generic' } )
 	];
 
-	/* eslint-enable object-curly-newline */
+	/* eslint-enable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	s = [ 1, 1, -20, null ];
 	opts = {
@@ -683,17 +683,17 @@ bench( pkg+'::5d,non-base', function benchmark( b ) {
 	var s;
 	var i;
 
-	/* eslint-disable object-curly-newline */
+	/* eslint-disable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	values = [
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'float64' }),
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'float32' }),
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'int32' }),
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'complex128' }),
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'generic' })
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'float64' } ),
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'float32' } ),
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'int32' } ),
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'complex128' } ),
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'generic' } )
 	];
 
-	/* eslint-enable object-curly-newline */
+	/* eslint-enable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	s = [ 1, 1, 1, 1, 1 ];
 
@@ -753,17 +753,17 @@ bench( pkg+'::5d,non-base,out-of-bounds', function benchmark( b ) {
 	var s;
 	var i;
 
-	/* eslint-disable object-curly-newline */
+	/* eslint-disable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	values = [
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'float64' }),
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'float32' }),
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'int32' }),
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'complex128' }),
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'generic' })
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'float64' } ),
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'float32' } ),
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'int32' } ),
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'complex128' } ),
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'generic' } )
 	];
 
-	/* eslint-enable object-curly-newline */
+	/* eslint-enable object-curly-newline, stdlib/line-closing-bracket-spacing */
 
 	s = [ 1, 1, 1, -20, null ];
 	opts = {

--- a/lib/node_modules/@stdlib/ndarray/slice-to/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/ndarray/slice-to/benchmark/benchmark.js
@@ -69,11 +69,11 @@ bench( pkg+'::0d,non-base', function benchmark( b ) {
 	/* eslint-disable object-curly-newline */
 
 	values = [
-		empty( [], { 'dtype': 'float64' } ),
-		empty( [], { 'dtype': 'float32' } ),
-		empty( [], { 'dtype': 'int32' } ),
-		empty( [], { 'dtype': 'complex128' } ),
-		empty( [], { 'dtype': 'generic' } )
+		empty( [], { 'dtype': 'float64' }),
+		empty( [], { 'dtype': 'float32' }),
+		empty( [], { 'dtype': 'int32' }),
+		empty( [], { 'dtype': 'complex128' }),
+		empty( [], { 'dtype': 'generic' })
 	];
 
 	/* eslint-enable object-curly-newline */
@@ -134,11 +134,11 @@ bench( pkg+'::1d,non-base', function benchmark( b ) {
 	/* eslint-disable object-curly-newline */
 
 	values = [
-		empty( [ 2 ], { 'dtype': 'float64' } ),
-		empty( [ 2 ], { 'dtype': 'float32' } ),
-		empty( [ 2 ], { 'dtype': 'int32' } ),
-		empty( [ 2 ], { 'dtype': 'complex128' } ),
-		empty( [ 2 ], { 'dtype': 'generic' } )
+		empty( [ 2 ], { 'dtype': 'float64' }),
+		empty( [ 2 ], { 'dtype': 'float32' }),
+		empty( [ 2 ], { 'dtype': 'int32' }),
+		empty( [ 2 ], { 'dtype': 'complex128' }),
+		empty( [ 2 ], { 'dtype': 'generic' })
 	];
 
 	/* eslint-enable object-curly-newline */
@@ -204,11 +204,11 @@ bench( pkg+'::1d,non-base,out-of-bounds', function benchmark( b ) {
 	/* eslint-disable object-curly-newline */
 
 	values = [
-		empty( [ 2 ], { 'dtype': 'float64' } ),
-		empty( [ 2 ], { 'dtype': 'float32' } ),
-		empty( [ 2 ], { 'dtype': 'int32' } ),
-		empty( [ 2 ], { 'dtype': 'complex128' } ),
-		empty( [ 2 ], { 'dtype': 'generic' } )
+		empty( [ 2 ], { 'dtype': 'float64' }),
+		empty( [ 2 ], { 'dtype': 'float32' }),
+		empty( [ 2 ], { 'dtype': 'int32' }),
+		empty( [ 2 ], { 'dtype': 'complex128' }),
+		empty( [ 2 ], { 'dtype': 'generic' })
 	];
 
 	/* eslint-enable object-curly-newline */
@@ -272,11 +272,11 @@ bench( pkg+'::2d,non-base', function benchmark( b ) {
 	/* eslint-disable object-curly-newline */
 
 	values = [
-		empty( [ 2, 2 ], { 'dtype': 'float64' } ),
-		empty( [ 2, 2 ], { 'dtype': 'float32' } ),
-		empty( [ 2, 2 ], { 'dtype': 'int32' } ),
-		empty( [ 2, 2 ], { 'dtype': 'complex128' } ),
-		empty( [ 2, 2 ], { 'dtype': 'generic' } )
+		empty( [ 2, 2 ], { 'dtype': 'float64' }),
+		empty( [ 2, 2 ], { 'dtype': 'float32' }),
+		empty( [ 2, 2 ], { 'dtype': 'int32' }),
+		empty( [ 2, 2 ], { 'dtype': 'complex128' }),
+		empty( [ 2, 2 ], { 'dtype': 'generic' })
 	];
 
 	/* eslint-enable object-curly-newline */
@@ -342,11 +342,11 @@ bench( pkg+'::2d,non-base,out-of-bounds', function benchmark( b ) {
 	/* eslint-disable object-curly-newline */
 
 	values = [
-		empty( [ 2, 2 ], { 'dtype': 'float64' } ),
-		empty( [ 2, 2 ], { 'dtype': 'float32' } ),
-		empty( [ 2, 2 ], { 'dtype': 'int32' } ),
-		empty( [ 2, 2 ], { 'dtype': 'complex128' } ),
-		empty( [ 2, 2 ], { 'dtype': 'generic' } )
+		empty( [ 2, 2 ], { 'dtype': 'float64' }),
+		empty( [ 2, 2 ], { 'dtype': 'float32' }),
+		empty( [ 2, 2 ], { 'dtype': 'int32' }),
+		empty( [ 2, 2 ], { 'dtype': 'complex128' }),
+		empty( [ 2, 2 ], { 'dtype': 'generic' })
 	];
 
 	/* eslint-enable object-curly-newline */
@@ -410,11 +410,11 @@ bench( pkg+'::3d,non-base', function benchmark( b ) {
 	/* eslint-disable object-curly-newline */
 
 	values = [
-		empty( [ 2, 2, 2 ], { 'dtype': 'float64' } ),
-		empty( [ 2, 2, 2 ], { 'dtype': 'float32' } ),
-		empty( [ 2, 2, 2 ], { 'dtype': 'int32' } ),
-		empty( [ 2, 2, 2 ], { 'dtype': 'complex128' } ),
-		empty( [ 2, 2, 2 ], { 'dtype': 'generic' } )
+		empty( [ 2, 2, 2 ], { 'dtype': 'float64' }),
+		empty( [ 2, 2, 2 ], { 'dtype': 'float32' }),
+		empty( [ 2, 2, 2 ], { 'dtype': 'int32' }),
+		empty( [ 2, 2, 2 ], { 'dtype': 'complex128' }),
+		empty( [ 2, 2, 2 ], { 'dtype': 'generic' })
 	];
 
 	/* eslint-enable object-curly-newline */
@@ -480,11 +480,11 @@ bench( pkg+'::3d,non-base,out-of-bounds', function benchmark( b ) {
 	/* eslint-disable object-curly-newline */
 
 	values = [
-		empty( [ 2, 2, 2 ], { 'dtype': 'float64' } ),
-		empty( [ 2, 2, 2 ], { 'dtype': 'float32' } ),
-		empty( [ 2, 2, 2 ], { 'dtype': 'int32' } ),
-		empty( [ 2, 2, 2 ], { 'dtype': 'complex128' } ),
-		empty( [ 2, 2, 2 ], { 'dtype': 'generic' } )
+		empty( [ 2, 2, 2 ], { 'dtype': 'float64' }),
+		empty( [ 2, 2, 2 ], { 'dtype': 'float32' }),
+		empty( [ 2, 2, 2 ], { 'dtype': 'int32' }),
+		empty( [ 2, 2, 2 ], { 'dtype': 'complex128' }),
+		empty( [ 2, 2, 2 ], { 'dtype': 'generic' })
 	];
 
 	/* eslint-enable object-curly-newline */
@@ -548,11 +548,11 @@ bench( pkg+'::4d,non-base', function benchmark( b ) {
 	/* eslint-disable object-curly-newline */
 
 	values = [
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'float64' } ),
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'float32' } ),
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'int32' } ),
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'complex128' } ),
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'generic' } )
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'float64' }),
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'float32' }),
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'int32' }),
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'complex128' }),
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'generic' })
 	];
 
 	/* eslint-enable object-curly-newline */
@@ -618,11 +618,11 @@ bench( pkg+'::4d,non-base,out-of-bounds', function benchmark( b ) {
 	/* eslint-disable object-curly-newline */
 
 	values = [
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'float64' } ),
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'float32' } ),
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'int32' } ),
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'complex128' } ),
-		empty( [ 2, 2, 2, 2 ], { 'dtype': 'generic' } )
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'float64' }),
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'float32' }),
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'int32' }),
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'complex128' }),
+		empty( [ 2, 2, 2, 2 ], { 'dtype': 'generic' })
 	];
 
 	/* eslint-enable object-curly-newline */
@@ -686,11 +686,11 @@ bench( pkg+'::5d,non-base', function benchmark( b ) {
 	/* eslint-disable object-curly-newline */
 
 	values = [
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'float64' } ),
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'float32' } ),
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'int32' } ),
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'complex128' } ),
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'generic' } )
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'float64' }),
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'float32' }),
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'int32' }),
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'complex128' }),
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'generic' })
 	];
 
 	/* eslint-enable object-curly-newline */
@@ -756,11 +756,11 @@ bench( pkg+'::5d,non-base,out-of-bounds', function benchmark( b ) {
 	/* eslint-disable object-curly-newline */
 
 	values = [
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'float64' } ),
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'float32' } ),
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'int32' } ),
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'complex128' } ),
-		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'generic' } )
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'float64' }),
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'float32' }),
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'int32' }),
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'complex128' }),
+		empty( [ 2, 2, 2, 2, 2 ], { 'dtype': 'generic' })
 	];
 
 	/* eslint-enable object-curly-newline */


### PR DESCRIPTION
Resolves #8515.

## Description

> What is the purpose of this pull request?

This pull request fixes JavaScript lint errors reported by the linter in the following files:

- `lib/node_modules/@stdlib/_tools/pkgs/entry-points/lib/resolve.sync.js`
- `lib/node_modules/@stdlib/ndarray/slice-to/benchmark/benchmark.js`

The changes include code style and formatting adjustments (consistent spacing, indentation, variable declaration alignment, and quote usage) to comply with the project's ESLint configuration.  
No logic or behavior of the code was modified — all fixes are purely stylistic.

## Related Issues

> Does this pull request have any related issues?

This pull request resolves the following issue:

- #8515

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

All lint tests (`make lint`) and JavaScript-specific checks (`make lint-javascript-files`) were executed successfully after the fixes.  
Both files now conform fully to the project's coding standards.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

- [] Yes
- [ ] No

If you answered "yes" above, how did you use AI assistance?

- [] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

This PR was developed with assistance from ChatGPT for guidance on resolving ESLint issues and verifying proper PR formatting.  
All code edits were manually reviewed and validated to ensure correctness and consistency with stdlib’s style conventions.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
