### PR TITLE
chore: add `alias_prefix` to parent namespaces

### DIFF
--- a/lib/node_modules/@stdlib/complex/float32/base/package.json
+++ b/lib/node_modules/@stdlib/complex/float32/base/package.json
@@ -58,5 +58,10 @@
     "ns",
     "float32",
     "base"
-  ]
+  ],
+  "__stdlib__": {
+    "scaffold": {
+      "alias_prefix": "stdlib_base_complex64_"
+    }
+  }
 }

--- a/lib/node_modules/@stdlib/complex/float64/base/package.json
+++ b/lib/node_modules/@stdlib/complex/float64/base/package.json
@@ -58,5 +58,10 @@
     "ns",
     "float64",
     "base"
-  ]
+  ],
+  "__stdlib__": {
+    "scaffold": {
+      "alias_prefix": "stdlib_base_complex128_"
+    }
+  }
 }

--- a/lib/node_modules/@stdlib/number/float32/base/package.json
+++ b/lib/node_modules/@stdlib/number/float32/base/package.json
@@ -62,5 +62,10 @@
     "number",
     "32-bit",
     "ieee754"
-  ]
+  ],
+  "__stdlib__": {
+    "scaffold": {
+      "alias_prefix": "stdlib_base_float32_"
+    }
+  }
 }

--- a/lib/node_modules/@stdlib/number/float64/base/package.json
+++ b/lib/node_modules/@stdlib/number/float64/base/package.json
@@ -61,5 +61,10 @@
     "number",
     "64-bit",
     "ieee754"
-  ]
+  ],
+  "__stdlib__": {
+    "scaffold": {
+      "alias_prefix": "stdlib_base_float64_"
+    }
+  }
 }

--- a/lib/node_modules/@stdlib/number/int16/base/lib/index.js
+++ b/lib/node_modules/@stdlib/number/int16/base/lib/index.js
@@ -1,0 +1,51 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/*
+* When adding modules to the namespace, ensure that they are added in alphabetical order according to module name.
+*/
+
+// MODULES //
+
+var setReadOnly = require( '@stdlib/utils/define-read-only-property' );
+
+
+// MAIN //
+
+/**
+* Top-level namespace.
+*
+* @namespace ns
+*/
+var ns = {};
+
+/**
+* @name identity
+* @memberof ns
+* @readonly
+* @type {Function}
+* @see {@link module:@stdlib/number/int16/base/identity}
+*/
+setReadOnly( ns, 'identity', require( '@stdlib/number/int16/base/identity' ) );
+
+
+// EXPORTS //
+
+module.exports = ns;

--- a/lib/node_modules/@stdlib/number/int16/base/package.json
+++ b/lib/node_modules/@stdlib/number/int16/base/package.json
@@ -14,12 +14,7 @@
     }
   ],
   "main": "lib/index.js",
-  "directories": {
-    "doc": "./docs",
-    "example": "./examples",
-    "lib": "./lib",
-    "test": "./test"
-  },
+  "directories": {},
   "types": "./docs/types",
   "scripts": {},
   "homepage": "https://github.com/stdlib-js/stdlib",

--- a/lib/node_modules/@stdlib/number/int16/base/package.json
+++ b/lib/node_modules/@stdlib/number/int16/base/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@stdlib/math/base/special",
+  "name": "@stdlib/number/int16/base",
   "version": "0.0.0",
-  "description": "Base (i.e., lower-level) special math functions.",
+  "description": "Base utilities for signed 16-bit integers.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",
@@ -13,7 +13,7 @@
       "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
     }
   ],
-  "main": "./lib",
+  "main": "lib/index.js",
   "directories": {
     "doc": "./docs",
     "example": "./examples",
@@ -49,17 +49,20 @@
   ],
   "keywords": [
     "stdlib",
-    "stdmath",
-    "standard",
-    "library",
-    "std",
-    "lib",
-    "mathematics",
-    "math"
+    "stdtypes",
+    "types",
+    "base",
+    "namespace",
+    "ns",
+    "int16",
+    "signed",
+    "integer",
+    "int",
+    "16-bit"
   ],
   "__stdlib__": {
     "scaffold": {
-      "alias_prefix": "stdlib_base_"
+      "alias_prefix": "stdlib_base_int16_"
     }
   }
 }

--- a/lib/node_modules/@stdlib/number/int16/base/package.json
+++ b/lib/node_modules/@stdlib/number/int16/base/package.json
@@ -14,7 +14,10 @@
     }
   ],
   "main": "lib/index.js",
-  "directories": {},
+  "directories": {
+    "lib": "./lib",
+    "test": "./test"
+  },
   "types": "./docs/types",
   "scripts": {},
   "homepage": "https://github.com/stdlib-js/stdlib",

--- a/lib/node_modules/@stdlib/number/int16/base/test/test.js
+++ b/lib/node_modules/@stdlib/number/int16/base/test/test.js
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var objectKeys = require( '@stdlib/utils/keys' );
+var ns = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is an object', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof ns, 'object', 'main export is an object' );
+	t.end();
+});
+
+tape( 'the exported object contains key-value pairs', function test( t ) {
+	var keys = objectKeys( ns );
+	t.strictEqual( keys.length > 0, true, 'has keys' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/number/int32/base/package.json
+++ b/lib/node_modules/@stdlib/number/int32/base/package.json
@@ -59,5 +59,10 @@
     "integer",
     "int",
     "32-bit"
-  ]
+  ],
+  "__stdlib__": {
+    "scaffold": {
+      "alias_prefix": "stdlib_base_int32_"
+    }
+  }
 }

--- a/lib/node_modules/@stdlib/number/int8/base/lib/index.js
+++ b/lib/node_modules/@stdlib/number/int8/base/lib/index.js
@@ -1,0 +1,51 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/*
+* When adding modules to the namespace, ensure that they are added in alphabetical order according to module name.
+*/
+
+// MODULES //
+
+var setReadOnly = require( '@stdlib/utils/define-read-only-property' );
+
+
+// MAIN //
+
+/**
+* Top-level namespace.
+*
+* @namespace ns
+*/
+var ns = {};
+
+/**
+* @name identity
+* @memberof ns
+* @readonly
+* @type {Function}
+* @see {@link module:@stdlib/number/int8/base/identity}
+*/
+setReadOnly( ns, 'identity', require( '@stdlib/number/int8/base/identity' ) );
+
+
+// EXPORTS //
+
+module.exports = ns;

--- a/lib/node_modules/@stdlib/number/int8/base/package.json
+++ b/lib/node_modules/@stdlib/number/int8/base/package.json
@@ -14,12 +14,7 @@
     }
   ],
   "main": "lib/index.js",
-  "directories": {
-    "doc": "./docs",
-    "example": "./examples",
-    "lib": "./lib",
-    "test": "./test"
-  },
+  "directories": {},
   "types": "./docs/types",
   "scripts": {},
   "homepage": "https://github.com/stdlib-js/stdlib",

--- a/lib/node_modules/@stdlib/number/int8/base/package.json
+++ b/lib/node_modules/@stdlib/number/int8/base/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@stdlib/math/base/special",
+  "name": "@stdlib/number/int8/base",
   "version": "0.0.0",
-  "description": "Base (i.e., lower-level) special math functions.",
+  "description": "Base utilities for signed 8-bit integers.",
   "license": "Apache-2.0",
   "author": {
     "name": "The Stdlib Authors",
@@ -13,7 +13,7 @@
       "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
     }
   ],
-  "main": "./lib",
+  "main": "lib/index.js",
   "directories": {
     "doc": "./docs",
     "example": "./examples",
@@ -49,17 +49,20 @@
   ],
   "keywords": [
     "stdlib",
-    "stdmath",
-    "standard",
-    "library",
-    "std",
-    "lib",
-    "mathematics",
-    "math"
+    "stdtypes",
+    "types",
+    "base",
+    "namespace",
+    "ns",
+    "int8",
+    "signed",
+    "integer",
+    "int",
+    "8-bit"
   ],
   "__stdlib__": {
     "scaffold": {
-      "alias_prefix": "stdlib_base_"
+      "alias_prefix": "stdlib_base_int8_"
     }
   }
 }

--- a/lib/node_modules/@stdlib/number/int8/base/package.json
+++ b/lib/node_modules/@stdlib/number/int8/base/package.json
@@ -14,7 +14,10 @@
     }
   ],
   "main": "lib/index.js",
-  "directories": {},
+  "directories": {
+    "lib": "./lib",
+    "test": "./test"
+  },
   "types": "./docs/types",
   "scripts": {},
   "homepage": "https://github.com/stdlib-js/stdlib",

--- a/lib/node_modules/@stdlib/number/int8/base/test/test.js
+++ b/lib/node_modules/@stdlib/number/int8/base/test/test.js
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var objectKeys = require( '@stdlib/utils/keys' );
+var ns = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is an object', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof ns, 'object', 'main export is an object' );
+	t.end();
+});
+
+tape( 'the exported object contains key-value pairs', function test( t ) {
+	var keys = objectKeys( ns );
+	t.strictEqual( keys.length > 0, true, 'has keys' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/number/uint16/base/package.json
+++ b/lib/node_modules/@stdlib/number/uint16/base/package.json
@@ -59,5 +59,10 @@
     "integer",
     "int",
     "16-bit"
-  ]
+  ],
+  "__stdlib__": {
+    "scaffold": {
+      "alias_prefix": "stdlib_base_uint16_"
+    }
+  }
 }

--- a/lib/node_modules/@stdlib/number/uint32/base/package.json
+++ b/lib/node_modules/@stdlib/number/uint32/base/package.json
@@ -59,5 +59,10 @@
     "integer",
     "int",
     "32-bit"
-  ]
+  ],
+  "__stdlib__": {
+    "scaffold": {
+      "alias_prefix": "stdlib_base_uint32_"
+    }
+  }
 }

--- a/lib/node_modules/@stdlib/number/uint8/base/package.json
+++ b/lib/node_modules/@stdlib/number/uint8/base/package.json
@@ -59,5 +59,10 @@
     "integer",
     "int",
     "8-bit"
-  ]
+  ],
+  "__stdlib__": {
+    "scaffold": {
+      "alias_prefix": "stdlib_base_uint8_"
+    }
+  }
 }


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: passed
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Resolves None.

## Description

> What is the purpose of this pull request?

This pull request:

-   adds the `alias_prefix` field to parent namespaces, as discussed [here](https://github.com/stdlib-js/stdlib/pull/8139#discussion_r2519556645).

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

- [`@stdlib/number/int8/base`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/number/int8/base) and [`@stdlib/number/int16/base`](https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/number/int16/base) didn't had `index.js`, `test.js` and `package.json`, which I've added in this PR.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
