### PR TITLE
chore: fix JavaScript lint errors (issue #8508)

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/assert/is-row-major/examples/index.js
+++ b/lib/node_modules/@stdlib/ndarray/base/assert/is-row-major/examples/index.js
@@ -25,7 +25,7 @@ var shape = [ 10, 10, 10 ];
 
 var strides = shape2strides( shape, 'row-major' );
 console.log( 'Strides: %s', strides.join( ',' ) );
-// => Strides: 100,10,1
+// => 'Strides: 100,10,1'
 
 var bool = isRowMajor( strides );
 console.log( bool );
@@ -33,7 +33,7 @@ console.log( bool );
 
 strides = shape2strides( shape, 'column-major' );
 console.log( 'Strides: %s', strides.join( ',' ) );
-// => Strides: 1,10,100
+// => 'Strides: 1,10,100'
 
 bool = isRowMajor( strides );
 console.log( bool );


### PR DESCRIPTION
Resolves  #8508.

## Description

This pull request fixes the JavaScript lint errors related to issue #8508

This pull request:

- Fixed doctest lint errors in the example for is-row-major.

- Updated example output strings to comply with stdlib/doctest formatting rules.

- Ensured the example section adheres to stdlib’s linting and style conventions.

These changes ensure that the package passes linting and maintains code quality consistency across the project.

## Related Issues


## Questions

> Any questions for reviewers of this pull request?


No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Please let me know if anything needs to be adjusted to fit stdlib’s conventions.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [ ] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

- [x] Yes
- [ ] No

If you answered "yes" above, how did you use AI assistance?

- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [x] Documentation (including examples)
- [x] Research and understanding


#### Disclosure

> I used ChatGPT only to understand the contribution process and linting rules.
All code changes were authored manually by me.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
