### PR TITLE
feat: add C implementation for studentized range quantile

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/README.md
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/README.md
@@ -128,6 +128,106 @@ for ( i = 0; i < 10; i++ ) {
 
 <!-- /.examples -->
 
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/stats/base/dists/studentized_range/quantile.h"
+```
+
+#### stdlib_base_dists_studentized_range_quantile( p, r, v, nranges )
+
+Evaluates the quantile function for a studentized range distribution.
+
+```c
+double out = stdlib_base_dists_studentized_range_quantile( 0.5, 3.0, 2.0, 1 );
+// returns ~1.908
+```
+
+The function accepts the following arguments:
+
+-   **p**: `[in] double` input probability.
+-   **r**: `[in] double` sample size for range (must be >= 2).
+-   **v**: `[in] double` degrees of freedom (must be >= 2).
+-   **nranges**: `[in] int32_t` number of groups whose maximum range is considered.
+
+```c
+double stdlib_base_dists_studentized_range_quantile( const double p, const double r, const double v, const int32_t nranges );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/stats/base/dists/studentized_range/quantile.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+static double random_double( void ) {
+    int r = rand();
+    return (double)r / ( (double)RAND_MAX + 1.0 );
+}
+
+int main( void ) {
+    double p;
+    double r;
+    double v;
+    double y;
+    int i;
+
+    r = 3.0;
+    v = 5.0;
+
+    for ( i = 0; i < 25; i++ ) {
+        p = random_double();
+        y = stdlib_base_dists_studentized_range_quantile( p, r, v, 1 );
+        printf( "p: %lf, r: %lf, v: %lf, Q(p;r,v): %lf\n", p, r, v, y );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
 <!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
 
 <section class="related">

--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/benchmark/benchmark.native.js
@@ -1,0 +1,65 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var quantile = tryRequire( resolve( __dirname, '..', 'lib', 'native.js' ) );
+var opts = {
+	'skip': ( quantile instanceof Error )
+};
+
+
+// MAIN //
+
+bench( pkg+'::native', opts, function benchmark( b ) {
+	var r;
+	var v;
+	var p;
+	var y;
+	var i;
+
+	r = 3.0;
+	v = 5.0;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		p = randu();
+		y = quantile( p, r, v );
+		if ( isnan( y ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnan( y ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/benchmark/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/benchmark/c/Makefile
@@ -1,0 +1,44 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2025 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# TARGETS #
+
+# Run benchmark.
+#
+# This target runs a benchmark.
+
+benchmark: benchmark.out
+	-$< | $( BENCHMARK_FILTER )
+
+.PHONY: benchmark
+
+# Generate a benchmark executable.
+#
+# This target generates a benchmark executable.
+
+benchmark.out: benchmark.c
+	$(QUIET) $(CC) $(CFLAGS) -o $@ $(INCLUDE) -I $(ROOT_DIR)/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/include $< $(LIBPATH) $(LIBRARIES)
+
+# Clean.
+#
+# This target removes generated files.
+
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/benchmark/c/benchmark.c
@@ -1,0 +1,129 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/studentized_range/quantile.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <sys/time.h>
+
+#define NAME "quantile"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+static void print_version( void ) {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+static void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total );
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+static void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+static double tic( void ) {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a pseudorandom double on the interval [0,1].
+*
+* @return pseudorandom double
+*/
+static double rand_double( void ) {
+	int r = rand();
+	return (double)r / ( (double)RAND_MAX + 1.0 );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+static double benchmark( void ) {
+	double elapsed;
+	double p;
+	double y;
+	double t;
+	int i;
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		p = rand_double();
+		y = stdlib_base_dists_studentized_range_quantile( p, 3.0, 5.0, 1 );
+		if ( y != y ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( y != y ) {
+		printf( "should not return NaN\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/binding.gyp
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/binding.gyp
@@ -1,0 +1,21 @@
+{
+  "targets": [
+    {
+      "target_name": "addon",
+      "sources": [
+        "src/addon.cpp",
+        "src/quantile.c"
+      ],
+      "include_dirs": [
+        "include",
+        "<!@(node -p \"require('@stdlib/utils-library-manifest').include()\")"
+      ],
+      "libraries": [
+        "<!@(node -p \"require('@stdlib/utils-library-manifest').libraries()\")"
+      ],
+      "ldflags": [
+        "<!@(node -p \"require('@stdlib/utils-library-manifest').ldflags()\")"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/examples/c/Makefile
@@ -1,0 +1,44 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2025 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# TARGETS #
+
+# Run example.
+#
+# This target runs the example.
+
+run: example.out
+	-$<
+
+.PHONY: run
+
+# Generate an example executable.
+#
+# This target generates an example executable.
+
+example.out: example.c
+	$(QUIET) $(CC) $(CFLAGS) -o $@ $(INCLUDE) -I $(ROOT_DIR)/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/include $< $(LIBPATH) $(LIBRARIES)
+
+# Clean.
+#
+# This target removes generated files.
+
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/examples/c/example.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/examples/c/example.c
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/studentized_range/quantile.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+static double random_double( void ) {
+	int r = rand();
+	return (double)r / ( (double)RAND_MAX + 1.0 );
+}
+
+int main( void ) {
+	double p;
+	double r;
+	double v;
+	double y;
+	int i;
+
+	r = 3.0;
+	v = 5.0;
+
+	for ( i = 0; i < 25; i++ ) {
+		p = random_double();
+		y = stdlib_base_dists_studentized_range_quantile( p, r, v, 1 );
+		printf( "p: %lf, r: %lf, v: %lf, Q(p;r,v): %lf\n", p, r, v, y );
+	}
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/include.gypi
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/include.gypi
@@ -1,0 +1,5 @@
+{
+  "includes": [
+    "binding.gyp"
+  ]
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/include/stdlib/stats/base/dists/studentized_range/quantile.h
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/include/stdlib/stats/base/dists/studentized_range/quantile.h
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_STATS_BASE_DISTS_STUDENTIZED_RANGE_QUANTILE_H
+#define STDLIB_STATS_BASE_DISTS_STUDENTIZED_RANGE_QUANTILE_H
+
+#include <stdint.h>
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Evaluates the quantile function for a studentized range distribution.
+*/
+double stdlib_base_dists_studentized_range_quantile( const double p, const double r, const double v, const int32_t nranges );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_STATS_BASE_DISTS_STUDENTIZED_RANGE_QUANTILE_H

--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/lib/native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/lib/native.js
@@ -1,0 +1,60 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Evaluates the quantile function for a studentized range distribution.
+*
+* @private
+* @param {Probability} p - input probability
+* @param {PositiveNumber} r - sample size for range (must be >= 2)
+* @param {PositiveNumber} v - degrees of freedom (must be >= 2)
+* @param {PositiveInteger} [nranges=1] - number of groups whose maximum range is considered
+* @returns {number} evaluated quantile function
+*
+* @example
+* var y = quantile( 0.5, 3.0, 2.0 );
+* // returns ~1.908
+*
+* @example
+* var y = quantile( 0.9, 17.0, 2.0 );
+* // returns ~11.237
+*
+* @example
+* var y = quantile( 0.5, 3.0, 2.0, 2 );
+* // returns ~2.549
+*/
+function quantile( p, r, v, nranges ) {
+	if ( nranges === void 0 ) {
+		return addon( p, r, v, 1 );
+	}
+	return addon( p, r, v, nranges );
+}
+
+
+// EXPORTS //
+
+module.exports = quantile;

--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/manifest.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/manifest.json
@@ -1,0 +1,45 @@
+{
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [
+        "./src/quantile.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/stats/base/dists/studentized-range/cdf",
+        "@stdlib/math/base/assert/is-nan",
+        "@stdlib/math/base/special/abs",
+        "@stdlib/math/base/special/ln",
+        "@stdlib/math/base/special/sqrt",
+        "@stdlib/constants/float64/pinf"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/src/addon.cpp
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/src/addon.cpp
@@ -1,0 +1,116 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/studentized_range/quantile.h"
+#include <node_api.h>
+#include <stdint.h>
+#include <assert.h>
+
+/**
+* Add-on namespace.
+*/
+namespace stdlib_stats_base_dists_studentized_range_quantile {
+
+	/**
+	* Evaluates the quantile function for a studentized range distribution.
+	*
+	* @param env    environment under which the function is invoked
+	* @param info   callback data
+	* @return       function result
+	*/
+	napi_value node_quantile( napi_env env, napi_callback_info info ) {
+		napi_status status;
+
+		size_t argc = 4;
+		napi_value argv[ 4 ];
+		status = napi_get_cb_info( env, info, &argc, argv, nullptr, nullptr );
+		assert( status == napi_ok );
+
+		if ( argc < 3 ) {
+			napi_throw_error( env, nullptr, "invalid invocation. Must provide at least 3 arguments." );
+			return nullptr;
+		}
+
+		napi_valuetype vtype0;
+		status = napi_typeof( env, argv[ 0 ], &vtype0 );
+		assert( status == napi_ok );
+		if ( vtype0 != napi_number ) {
+			napi_throw_type_error( env, nullptr, "invalid argument. First argument must be a number." );
+			return nullptr;
+		}
+
+		napi_valuetype vtype1;
+		status = napi_typeof( env, argv[ 1 ], &vtype1 );
+		assert( status == napi_ok );
+		if ( vtype1 != napi_number ) {
+			napi_throw_type_error( env, nullptr, "invalid argument. Second argument must be a number." );
+			return nullptr;
+		}
+
+		napi_valuetype vtype2;
+		status = napi_typeof( env, argv[ 2 ], &vtype2 );
+		assert( status == napi_ok );
+		if ( vtype2 != napi_number ) {
+			napi_throw_type_error( env, nullptr, "invalid argument. Third argument must be a number." );
+			return nullptr;
+		}
+
+		double p;
+		status = napi_get_value_double( env, argv[ 0 ], &p );
+		assert( status == napi_ok );
+
+		double r;
+		status = napi_get_value_double( env, argv[ 1 ], &r );
+		assert( status == napi_ok );
+
+		double v;
+		status = napi_get_value_double( env, argv[ 2 ], &v );
+		assert( status == napi_ok );
+
+		int32_t nranges = 1;
+		if ( argc == 4 ) {
+			napi_valuetype vtype3;
+			status = napi_typeof( env, argv[ 3 ], &vtype3 );
+			assert( status == napi_ok );
+			if ( vtype3 != napi_number ) {
+				napi_throw_type_error( env, nullptr, "invalid argument. Fourth argument must be a number." );
+				return nullptr;
+			}
+			status = napi_get_value_int32( env, argv[ 3 ], &nranges );
+			assert( status == napi_ok );
+		}
+
+		napi_value v_out;
+		double out = stdlib_base_dists_studentized_range_quantile( p, r, v, nranges );
+		status = napi_create_double( env, out, &v_out );
+		assert( status == napi_ok );
+
+		return v_out;
+	}
+
+	napi_value Init( napi_env env, napi_value exports ) {
+		napi_status status;
+		napi_value fcn;
+		status = napi_create_function( env, "exports", NAPI_AUTO_LENGTH, node_quantile, NULL, &fcn );
+		assert( status == napi_ok );
+		return fcn;
+	}
+
+	NODE_API_MODULE( NODE_GYP_MODULE_NAME, Init )
+
+} // end namespace stdlib_stats_base_dists_studentized_range_quantile

--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/src/quantile.c
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/src/quantile.c
@@ -1,0 +1,273 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/stats/base/dists/studentized_range/quantile.h"
+#include "stdlib/stats/base/dists/studentized_range/cdf.h"
+#include "stdlib/math/base/assert/is_nan.h"
+#include "stdlib/math/base/special/abs.h"
+#include "stdlib/math/base/special/ln.h"
+#include "stdlib/math/base/special/sqrt.h"
+#include "stdlib/constants/float64/pinf.h"
+#include <stdint.h>
+
+// Constants for PCUT and JMAX
+static const double PCUT = 1.0e-8;
+static const int32_t JMAX = 28;
+
+// Constants for qtrngo
+static const double VMAX = 120.0;
+static const double c1 = 0.8843;
+static const double c2 = 0.2368;
+static const double c3 = 1.214;
+static const double c4 = 1.208;
+static const double c5 = 1.4142;
+
+// Coefficients for apnorminv - P close to 0.5
+static const double a0 = 3.3871328727963666080;
+static const double a1 = 1.3314166789178437745e2;
+static const double a2 = 1.9715909503065514427e3;
+static const double a3 = 1.3731693765509461125e4;
+static const double a4 = 4.5921953931549871457e4;
+static const double a5 = 6.7265770927008700853e4;
+static const double a6 = 3.3430575583588128105e4;
+static const double a7 = 2.5090809287301226727e3;
+static const double b1 = 4.2313330701600911252e1;
+static const double b2 = 6.8718700749205790830e2;
+static const double b3 = 5.3941960214247511077e3;
+static const double b4 = 2.1213794301586595867e4;
+static const double b5 = 3.9307895800092710610e4;
+static const double b6 = 2.8729085735721942674e4;
+static const double b7 = 5.2264952788528545610e3;
+
+// Coefficients for apnorminv - P not close to 0, 0.5 or 1
+static const double c0_apn = 1.42343711074968357734;
+static const double c1_apn = 4.63033784615654529590;
+static const double c2_apn = 5.76949722146069140550;
+static const double c3_apn = 3.64784832476320460504;
+static const double c4_apn = 1.27045825245236838258;
+static const double c5_apn = 2.41780725177450611770e-1;
+static const double c6_apn = 2.27238449892691845833e-2;
+static const double c7_apn = 7.74545014278341407640e-4;
+static const double d1 = 2.05319162663775882187;
+static const double d2 = 1.67638483018380384940;
+static const double d3 = 6.89767334985100004550e-1;
+static const double d4 = 1.48103976427480074590e-1;
+static const double d5 = 1.51986665636164571966e-2;
+static const double d6 = 5.47593808499534494600e-4;
+static const double d7 = 1.05075007164441684324e-9;
+
+// Coefficients for apnorminv - P near 0 or 1
+static const double e0 = 6.65790464350110377720;
+static const double e1 = 5.46378491116411436990;
+static const double e2 = 1.78482653991729133580;
+static const double e3 = 2.96560571828504891230e-1;
+static const double e4 = 2.65321895265761230930e-2;
+static const double e5 = 1.24266094738807843860e-3;
+static const double e6 = 2.71155556874348757815e-5;
+static const double e7 = 2.01033439929228813265e-7;
+static const double f1 = 5.99832206555887937690e-1;
+static const double f2 = 1.36929880922735805310e-1;
+static const double f3 = 1.48753612908506148525e-2;
+static const double f4 = 7.86869131145613259100e-4;
+static const double f5 = 1.84631831751005468180e-5;
+static const double f6 = 1.42151175831644588870e-7;
+static const double f7 = 2.04426310338993978564e-15;
+
+/**
+* Returns the normal deviate Z corresponding to a given lower tail area of p.
+*
+* @private
+* @param p    lower tail area
+* @return     normal deviate
+*/
+static double apnorminv( const double p ) {
+	double ppnd;
+	double q;
+	double r;
+
+	q = p - 0.5;
+	if ( stdlib_base_abs( q ) <= 0.425 ) {
+		r = 0.180625 - ( q * q );
+		ppnd = q * (((((((a7 * r + a6) * r + a5) * r + a4) * r + a3) * r + a2) * r + a1) * r + a0) /
+			(((((((b7 * r + b6) * r + b5) * r + b4) * r + b3) * r + b2) * r + b1) * r + 1.0);
+	} else {
+		if ( q < 0.0 ) {
+			r = p;
+		} else {
+			r = 1.0 - p;
+		}
+		if ( r <= 0.0 ) {
+			ppnd = 0.0;
+		} else {
+			r = stdlib_base_sqrt( -stdlib_base_ln( r ) );
+			if ( r <= 5.0 ) {
+				r -= 1.6;
+				ppnd = (((((((c7_apn * r + c6_apn) * r + c5_apn) * r + c4_apn) * r + c3_apn) * r + c2_apn) * r + c1_apn) * r + c0_apn) /
+					(((((((d7 * r + d6) * r + d5) * r + d4) * r + d3) * r + d2) * r + d1) * r + 1.0);
+			} else {
+				r -= 5.0;
+				ppnd = (((((((e7 * r + e6) * r + e5) * r + e4) * r + e3) * r + e2) * r + e1) * r + e0) /
+					(((((((f7 * r + f6) * r + f5) * r + f4) * r + f3) * r + f2) * r + f1) * r + 1.0);
+			}
+			if ( q < 0.0 ) {
+				ppnd = -ppnd;
+			}
+		}
+	}
+	return ppnd;
+}
+
+/**
+* Calculates an initial percentile from the studentized range distribution.
+*
+* @private
+* @param p    quantile
+* @param v    degrees of freedom
+* @param r    number of samples
+* @return     initial percentile
+*/
+static double qtrngo( const double p, const double v, const double r ) {
+	double t;
+	double q;
+
+	t = apnorminv( 0.5 + ( 0.5 * p ) );
+	if ( v < VMAX ) {
+		t += ( ( t * t * t ) + t ) / v / 4.0;
+	}
+	q = c1 - ( c2 * t );
+	if ( v < VMAX ) {
+		q -= ( c3 / v ) + ( c4 * t / v );
+	}
+	return t * ( ( q * stdlib_base_ln( r - 1.0 ) ) + c5 );
+}
+
+/**
+* Evaluates the quantile function for a studentized range distribution.
+*
+* ## References
+*
+* -   Ferreira, D. F., Demetrico, C. G. B., Manly, B. F. J., and Machado, A. de A. 2007. "Quantis da distribuição do máximo da amplitude estudentizada." _Rev. Mat. Est._, São Paulo, 25 (1): 117-135.
+*
+* @param p          input probability
+* @param r          sample size for range (must be >= 2)
+* @param v          degrees of freedom (must be >= 2)
+* @param nranges    number of groups whose maximum range is considered
+* @return           evaluated quantile function
+*
+* @example
+* double y = stdlib_base_dists_studentized_range_quantile( 0.5, 3.0, 2.0, 1 );
+* // returns ~1.908
+*/
+double stdlib_base_dists_studentized_range_quantile( const double p, const double r, const double v, const int32_t nranges ) {
+	double aux;
+	double e1;
+	double e2;
+	double q1;
+	double q2;
+	double p1;
+	double p2;
+	int32_t j;
+
+	// Validate inputs
+	if (
+		stdlib_base_is_nan( r ) ||
+		stdlib_base_is_nan( v ) ||
+		r < 2.0 ||
+		v < 2.0
+	) {
+		return 0.0 / 0.0; // NaN
+	}
+	if ( stdlib_base_is_nan( p ) || p < 0.0 || p > 1.0 ) {
+		return 0.0 / 0.0; // NaN
+	}
+	if ( p == 0.0 ) {
+		return 0.0;
+	}
+	if ( p == 1.0 ) {
+		return STDLIB_CONSTANT_FLOAT64_PINF;
+	}
+	if ( nranges < 1 ) {
+		return 0.0 / 0.0; // NaN
+	}
+
+	// Initial guess
+	q1 = qtrngo( p, v, r );
+
+	// Find lower bound
+	while ( 1 ) {
+		p1 = stdlib_base_dists_studentized_range_cdf( q1, r, v, nranges );
+		if ( p1 > p ) {
+			q1 -= 0.4;
+		}
+		if ( q1 < 0.0 ) {
+			q1 = 0.1;
+		}
+		if ( p1 < p ) {
+			break;
+		}
+	}
+
+	aux = q1;
+	if ( stdlib_base_abs( p1 - p ) < PCUT ) {
+		return 0.0 / 0.0; // NaN
+	}
+
+	// Find upper bound
+	q2 = q1 + 0.5;
+	while ( 1 ) {
+		p2 = stdlib_base_dists_studentized_range_cdf( q2, r, v, nranges );
+		if ( p2 < p ) {
+			q2 += 0.4;
+		}
+		if ( q2 < 0.0 ) {
+			q2 = 1.0;
+		}
+		if ( p2 > p ) {
+			break;
+		}
+	}
+
+	if ( q2 < q1 ) {
+		q2 = q1 + 0.01;
+	}
+
+	// Iterative refinement using regula falsi method
+	j = 2;
+	while ( j <= JMAX ) {
+		p2 = stdlib_base_dists_studentized_range_cdf( q2, r, v, nranges );
+		e1 = p1 - p;
+		e2 = p2 - p;
+		if ( e2 - e1 != 0.0 ) {
+			aux = ( ( e2 * q1 ) - ( e1 * q2 ) ) / ( e2 - e1 );
+		}
+		if ( stdlib_base_abs( e1 ) < stdlib_base_abs( e2 ) ) {
+			if ( stdlib_base_abs( p1 - p ) < PCUT * 5.0 ) {
+				j = JMAX + 2;
+			}
+			q1 = aux;
+			p1 = stdlib_base_dists_studentized_range_cdf( q1, r, v, nranges );
+		} else {
+			q1 = q2;
+			p1 = p2;
+			q2 = aux;
+		}
+		j += 1;
+	}
+
+	return aux;
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/test/test.native.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/studentized-range/quantile/test/test.native.js
@@ -1,0 +1,158 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var abs = require( '@stdlib/math/base/special/abs' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var quantile = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( quantile instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof quantile, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'if provided `NaN` for any parameter, the function returns `NaN`', opts, function test( t ) {
+	var y;
+
+	y = quantile( NaN, 3.0, 2.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = quantile( 0.5, NaN, 2.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = quantile( 0.5, 3.0, NaN );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	t.end();
+});
+
+tape( 'if provided a number outside `[0,1]` for `p` and valid `r` and `v`, the function returns `NaN`', opts, function test( t ) {
+	var y;
+
+	y = quantile( -0.1, 3.0, 2.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = quantile( 1.1, 3.0, 2.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	t.end();
+});
+
+tape( 'if provided `r < 2`, the function returns `NaN`', opts, function test( t ) {
+	var y;
+
+	y = quantile( 0.5, 1.5, 2.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = quantile( 0.5, -1.0, 2.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	t.end();
+});
+
+tape( 'if provided `v < 2`, the function returns `NaN`', opts, function test( t ) {
+	var y;
+
+	y = quantile( 0.5, 3.0, 1.5 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	y = quantile( 0.5, 3.0, -1.0 );
+	t.equal( isnan( y ), true, 'returns NaN' );
+
+	t.end();
+});
+
+tape( 'if provided `p = 0`, the function returns `0`', opts, function test( t ) {
+	var y = quantile( 0.0, 3.0, 2.0 );
+	t.equal( y, 0.0, 'returns 0' );
+	t.end();
+});
+
+tape( 'if provided `p = 1`, the function returns `+infinity`', opts, function test( t ) {
+	var y = quantile( 1.0, 3.0, 2.0 );
+	t.equal( y, PINF, 'returns +infinity' );
+	t.end();
+});
+
+tape( 'the function evaluates the quantile function', opts, function test( t ) {
+	var delta;
+	var tol;
+	var y;
+
+	// Test case: p = 0.5, r = 3, v = 2
+	y = quantile( 0.5, 3.0, 2.0 );
+	t.equal( typeof y, 'number', 'returns a number' );
+	t.equal( y > 0, true, 'returns positive value' );
+
+	// Test case: p = 0.9, r = 17, v = 2
+	y = quantile( 0.9, 17.0, 2.0 );
+	t.equal( typeof y, 'number', 'returns a number' );
+	t.equal( y > 0, true, 'returns positive value' );
+
+	// Test with nranges parameter
+	y = quantile( 0.5, 3.0, 2.0, 2 );
+	t.equal( typeof y, 'number', 'returns a number' );
+	t.equal( y > 0, true, 'returns positive value' );
+
+	// Test monotonicity: quantile should increase with p
+	var y1 = quantile( 0.3, 5.0, 10.0 );
+	var y2 = quantile( 0.7, 5.0, 10.0 );
+	t.equal( y2 > y1, true, 'quantile increases with p' );
+
+	t.end();
+});
+
+tape( 'the function returns values consistent with the JavaScript implementation', opts, function test( t ) {
+	var jsQuantile = require( './../lib/main.js' );
+	var delta;
+	var tol;
+	var y1;
+	var y2;
+
+	// Test several values
+	y1 = quantile( 0.5, 3.0, 5.0 );
+	y2 = jsQuantile( 0.5, 3.0, 5.0 );
+	tol = 1e-6;
+	delta = abs( y1 - y2 );
+	t.equal( delta < tol, true, 'native and JS implementations are close for p=0.5, r=3, v=5' );
+
+	y1 = quantile( 0.8, 4.0, 10.0 );
+	y2 = jsQuantile( 0.8, 4.0, 10.0 );
+	delta = abs( y1 - y2 );
+	t.equal( delta < tol, true, 'native and JS implementations are close for p=0.8, r=4, v=10' );
+
+	t.end();
+});


### PR DESCRIPTION
Resolves #3888.

## Description

> What is the purpose of this pull request?

This pull request:


-   Adds a C implementation for the studentized-range quantile function (`@stdlib/stats/base/dists/studentized-range/quantile`)
-   Implements the C quantile function with helper routines for normal inverse CDF approximation and iterative root-finding using regula falsi method
-   Adds N-API Node.js addon bindings to expose the C implementation to JavaScript
-   Includes native wrapper (`lib/native.js`) that seamlessly integrates with the existing JS implementation
-   Adds comprehensive native test suite (`test/test.native.js`) for validating the C implementation
-   Includes C benchmarks and examples for performance testing
-   Updates README with C API documentation and usage examples
-   Fixes header file to include `<stdint.h>` for proper `int32_t` type definition


## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #{{TODO: add related issue number}}

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [X] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [X] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [X] Code generation (e.g., when writing an implementation or fixing a bug)
-   [X] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [X] Research and understanding

#### Disclosure

I used GitHub Copilot to implement this C functionality, helping with understanding the repository structure and stdlib conventions for native implementations

I manually checked and verified all JavaScript tests pass locally (245 tests) and that the conventions were followed.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
