### PR TITLE
feat: add `symbol/split`

### DIFF
--- a/lib/node_modules/@stdlib/symbol/split/README.md
+++ b/lib/node_modules/@stdlib/symbol/split/README.md
@@ -1,0 +1,130 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2025 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# SplitSymbol
+
+>  [Symbol][mdn-symbol] which provides a method for splitting strings using the current object as the separator.
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var SplitSymbol = require( '@stdlib/symbol/split' );
+```
+
+### SplitSymbol
+
+[`Symbol`][mdn-symbol] which provides a method for splitting strings using the current object as the separator.
+
+```javascript
+var s = typeof SplitSymbol;
+// e.g., returns 'symbol'
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+## Notes
+
+-   The [symbol][mdn-symbol] is only supported in environments which support [symbols][mdn-symbol]. In non-supporting environments, the value is `null`.
+-   When calling `String.prototype.split` and the `separator` argument is an object with a `[SplitSymbol]()` method, this method is called with the target string and a limit as arguments, and its result is used as the returned array of substrings. If the `[SplitSymbol]` property is `null` or `absent`, the default splitting behavior is used.
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var defineProperty = require( '@stdlib/utils/define-property' );
+var SplitSymbol = require( '@stdlib/symbol/split' );
+
+function split( str ) {
+    return [ str, 'CUSTOM' ];
+}
+
+var obj = {};
+
+defineProperty( obj, SplitSymbol, {
+    'configurable': true,
+    'value': null
+});
+
+var str = 'a-b-c';
+console.log( str.split( obj ) ); 
+
+defineProperty( obj, SplitSymbol, {
+    'configurable': true,
+    'value': split
+});
+console.log( str.split( obj ) ); 
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[mdn-symbol]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/symbol/split/docs/repl.txt
+++ b/lib/node_modules/@stdlib/symbol/split/docs/repl.txt
@@ -1,0 +1,16 @@
+{{alias}}
+    Split symbol.
+
+    This symbol provides a method for splitting strings using the current
+    object as the separator.
+
+    The symbol is only supported in ES6/ES2015+ environments. For non-supporting
+    environments, the value is `null`.
+
+    Examples
+    --------
+    > var s = {{alias}}
+    e.g., <symbol>
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/symbol/split/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/symbol/split/docs/types/index.d.ts
@@ -1,0 +1,31 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+// EXPORTS //
+
+/**
+* Split symbol.
+*
+* ## Notes
+*
+* -   This symbol provides a method for splitting strings using the current object as the separator.
+* -   The symbol is only supported in ES6/ES2015+ environments. For non-supporting environments, the value is `null`.
+*/
+export = Symbol.split;

--- a/lib/node_modules/@stdlib/symbol/split/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/symbol/split/docs/types/test.ts
@@ -1,0 +1,29 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
+import SplitSymbol = require( './index' );
+
+
+// TESTS //
+
+// The exported value is the `replace` symbol...
+{
+	SplitSymbol;
+}

--- a/lib/node_modules/@stdlib/symbol/split/examples/index.js
+++ b/lib/node_modules/@stdlib/symbol/split/examples/index.js
@@ -1,0 +1,42 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var defineProperty = require( '@stdlib/utils/define-property' );
+var SplitSymbol = require( './../lib' );
+
+function split( str ) {
+    return [ str, 'CUSTOM' ];
+}
+
+var obj = {};
+
+defineProperty( obj, SplitSymbol, {
+    'configurable': true,
+    'value': null
+});
+
+var str = 'a-b-c';
+console.log( str.split( obj ) ); 
+
+defineProperty( obj, SplitSymbol, {
+    'configurable': true,
+    'value': split
+});
+console.log( str.split( obj ) ); 

--- a/lib/node_modules/@stdlib/symbol/split/lib/index.js
+++ b/lib/node_modules/@stdlib/symbol/split/lib/index.js
@@ -1,0 +1,44 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Symbol which provides a method for replacing substrings matched by the current object.
+*
+* @module @stdlib/symbol/split
+*
+* @example
+* var SplitSymbol = require( '@stdlib/symbol/split' );
+*
+* function split( str ) {
+*     return [ str, 'CUSTOM' ];
+* }
+*
+* var obj = {};
+* obj[ SplitSymbol ] = split;
+*/
+
+// MAIN //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/symbol/split/lib/main.js
+++ b/lib/node_modules/@stdlib/symbol/split/lib/main.js
@@ -1,0 +1,48 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var hasSplitSymbolSupport = require( '@stdlib/assert/has-split-symbol-support' );
+
+
+// MAIN //
+
+/**
+* Split symbol.
+*
+* @name SplitSymbol
+* @constant
+* @type {(symbol|null)}
+*
+* @example
+* function split( str ) {
+*     return [ str, 'CUSTOM' ];
+* }
+*
+* var obj = {};
+* obj[ SplitSymbol ] = split;
+*/
+var SplitSymbol = ( hasSplitSymbolSupport() ) ? Symbol.split : null;
+
+
+// EXPORTS //
+
+module.exports = SplitSymbol;

--- a/lib/node_modules/@stdlib/symbol/split/package.json
+++ b/lib/node_modules/@stdlib/symbol/split/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@stdlib/symbol/split",
+  "version": "0.0.0",
+  "description": "Split symbol.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "symbol",
+    "spl",
+    "string",
+    "split"
+  ]
+}

--- a/lib/node_modules/@stdlib/symbol/split/test/test.js
+++ b/lib/node_modules/@stdlib/symbol/split/test/test.js
@@ -1,0 +1,52 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasSplitSymbolSupport = require( '@stdlib/assert/has-split-symbol-support' );
+var isSymbol = require( '@stdlib/assert/is-symbol' );
+var Sym = require( './../lib' );
+
+
+// VARIABLES //
+
+var opts = {
+	'skip': !hasSplitSymbolSupport()
+};
+
+
+// TESTS //
+
+tape( 'main export is a symbol in supporting environments (ES6/2015+) or otherwise null', function test( t ) {
+	t.ok( true, __filename );
+	if ( opts.skip ) {
+		t.strictEqual( Sym, null, 'main export is null' );
+	} else {
+		t.strictEqual( typeof Sym, 'symbol', 'main export is a symbol' );
+		t.strictEqual( isSymbol( Sym ), true, 'main export is a symbol' );
+	}
+	t.end();
+});
+
+tape( 'the main export is an alias for `Symbol.split`', opts, function test( t ) {
+	t.strictEqual( Sym, Symbol.split, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
Resolves #8488.

## Description

> What is the purpose of this pull request?

This pull request adds the `@stdlib/symbol/split` package.  
The package behaves consistently with existing stdlib symbol packages such as  
`@stdlib/symbol/replace`, `@stdlib/symbol/iterator`, and others.

This pull request:

-   Implements the `SplitSymbol` constant which exports `Symbol.split` when supported, or `null` otherwise.
-   Mirrors the structure and behavior of existing symbol packages exactly, per project standards.
-   Adds complete unit tests validating environmental support and aliasing to `Symbol.split`.
-   Includes examples demonstrating custom split behavior via the `@@split` method.
-   Provides REPL documentation, type definitions, and package metadata consistent with stdlib conventions.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8488

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [x] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance.

This PR was authored with ChatGPT’s assistance for generating boilerplate code, documentation, and test scaffolding, while all logic was reviewed and validated manually.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
