### PR TITLE
chore: fix JavaScript lint errors (issue #8563)

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/for-each/examples/index.js
+++ b/lib/node_modules/@stdlib/ndarray/for-each/examples/index.js
@@ -23,7 +23,7 @@ var ndarray = require( '@stdlib/ndarray/ctor' );
 var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var naryFunction = require( '@stdlib/utils/nary-function' );
 var log = require( '@stdlib/console/log' );
-var forEach = require( '@stdlib/ndarray/for-each' );
+var forEach = require( './../lib' );
 
 var buffer = discreteUniform( 10, -100, 100, {
 	'dtype': 'generic'


### PR DESCRIPTION
resolves #8563

Fixed lint error in `lib/node_modules/@stdlib/ndarray/for-each/examples/index.js` by changing the last require statement from an absolute package path to a relative path, as required by the `stdlib/require-last-path-relative` rule.