### PR TITLE
chore: fix JavaScript lint errors (issue #8567)

### DIFF
--- a/lib/node_modules/@stdlib/repl/presentation/lib/commands/last.js
+++ b/lib/node_modules/@stdlib/repl/presentation/lib/commands/last.js
@@ -37,15 +37,15 @@ function command( pres ) {
 	*/
 	function onCommand() {
 		pres._repl.once( 'drain', onDrain ); // eslint-disable-line no-underscore-dangle
+	}
 
-		/**
-		* Callback invoked upon a `drain` event.
-		*
-		* @private
-		*/
-		function onDrain() {
-			pres.last().show();
-		}
+	/**
+	* Callback invoked upon a `drain` event.
+	*
+	* @private
+	*/
+	function onDrain() {
+		pres.last().show();
 	}
 }
 


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. 
report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed
---

Resolves #8567.

## Description

This pull request fixes a JavaScript lint error in the
`lib/node_modules/@stdlib/repl/presentation/lib/commands/last.js` module.

Specifically, the `stdlib/no-unnecessary-nested-functions` rule required that
the `onDrain` callback function be moved from inside `onCommand` to the outer
scope of the `command` function. This change removes the unnecessary nested
function while preserving the original behavior.

### Fixed

- Moved `onDrain` to the outer scope of `command` while keeping access to `pres`
  through closure.
- Ensured the file passes all JavaScript lint rules.
- No runtime behavior or API changes were introduced.

- Resolves #8567

## Questions

No questions for reviewers.

## Other

No additional notes.

## Checklist

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

- [ ] Yes  
- [x] No

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
