### PR TITLE
chore: fix JavaScript lint errors (issue #8577)

### DIFF
--- a/lib/node_modules/@stdlib/utils/async/for-each/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/async/for-each/lib/main.js
@@ -48,36 +48,29 @@ var factory = require( './factory.js' );
 * @returns {void}
 *
 * @example
-* var readFile = require( '@stdlib/fs/read-file' );
-*
 * function done( error ) {
 *     if ( error ) {
 *         throw error;
 *     }
-*     console.log( 'Successfully read all files.' );
+*     console.log( 'Successfully processed all files.' );
 * }
 *
-* function read( file, next ) {
-*     var opts = {
-*         'encoding': 'utf8'
-*     };
-*     readFile( file, opts, onFile );
+* function process( file, next ) {
+*     console.log( 'Processing file: %s', file );
+*     setTimeout( onTimeout, 1000 );
 *
-*     function onFile( error ) {
-*         if ( error ) {
-*             return next( error );
-*         }
-*         console.log( 'Successfully read file: %s', file );
+*     function onTimeout() {
+*         console.log( 'Finished processing file: %s', file );
 *         next();
 *     }
 * }
 *
 * var files = [
-*     './beep.js',
-*     './boop.js'
+*     'beep.js',
+*     'boop.js'
 * ];
 *
-* forEachAsync( files, read, done );
+* forEachAsync( files, process, done );
 */
 function forEachAsync( collection, options, fcn, done ) {
 	if ( arguments.length < 4 ) {


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed
---

Resolves #8577.

## Description

This pull request fixes a JavaScript linting failure caused by ESLint attempting  
to read a non-existent file (`beep.js`). The issue resulted in an ENOENT error  
during automated linting. The changes ensure that the lint workflow no longer  
references the missing file and that the linting process completes successfully.

## Related Issues

-   #8577

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [ ] Yes  
-   [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md