### PR TITLE
chore: fix JavaScript lint errors

### DIFF
--- a/lib/node_modules/@stdlib/_tools/licenses/insert-header-file-list/lib/index.js
+++ b/lib/node_modules/@stdlib/_tools/licenses/insert-header-file-list/lib/index.js
@@ -24,10 +24,22 @@
 * @module @stdlib/_tools/licenses/insert-header-file-list
 *
 * @example
+* var join = require( 'path' ).join;
+* var readFile = require( '@stdlib/fs/read-file' ).sync;
+* var writeFile = require( '@stdlib/fs/write-file' ).sync;
+* var unlink = require( '@stdlib/fs/unlink' ).sync;
 * var insertHeader = require( '@stdlib/_tools/licenses/insert-header-file-list' );
 *
+* // Create a temporary file:
+* var src = join( __dirname, 'examples', 'fixtures', 'file.js.txt' );
+* var tmp = join( __dirname, 'examples', 'fixtures', 'tmp.js.txt' );
+* var err = writeFile( tmp, readFile( src ) );
+* if ( err ) {
+*     throw err;
+* }
+*
 * var files = [
-*     './foo/bar.js'
+*     tmp
 * ];
 *
 * var header = '// This file is licensed under Apache-2.0.';
@@ -38,21 +50,37 @@
 *     if ( error ) {
 *         throw error;
 *     }
+*     // Remove the temporary file:
+*     unlink( tmp );
 * }
 *
 * @example
+* var join = require( 'path' ).join;
+* var readFile = require( '@stdlib/fs/read-file' ).sync;
+* var writeFile = require( '@stdlib/fs/write-file' ).sync;
+* var unlink = require( '@stdlib/fs/unlink' ).sync;
 * var insertHeader = require( '@stdlib/_tools/licenses/insert-header-file-list' );
 *
+* // Create a temporary file:
+* var src = join( __dirname, 'examples', 'fixtures', 'file.js.txt' );
+* var tmp = join( __dirname, 'examples', 'fixtures', 'tmp.js.txt' );
+* var err = writeFile( tmp, readFile( src ) );
+* if ( err ) {
+*     throw err;
+* }
+*
 * var files = [
-*     './foo/bar.js'
+*     tmp
 * ];
 *
 * var header = '// This file is licensed under Apache-2.0.';
 *
-* var err = insertHeader.sync( files, header );
+* err = insertHeader.sync( files, header );
 * if ( err instanceof Error ) {
 *     throw err;
 * }
+* // Remove the temporary file:
+* unlink( tmp );
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/_tools/licenses/insert-header-file-list/lib/index.js
+++ b/lib/node_modules/@stdlib/_tools/licenses/insert-header-file-list/lib/index.js
@@ -25,62 +25,63 @@
 *
 * @example
 * var join = require( 'path' ).join;
-* var readFile = require( '@stdlib/fs/read-file' ).sync;
 * var writeFile = require( '@stdlib/fs/write-file' ).sync;
 * var unlink = require( '@stdlib/fs/unlink' ).sync;
+* var tmpdir = require( '@stdlib/os/tmpdir' );
 * var insertHeader = require( '@stdlib/_tools/licenses/insert-header-file-list' );
 *
-* // Create a temporary file:
-* var src = join( __dirname, 'examples', 'fixtures', 'file.js.txt' );
-* var tmp = join( __dirname, 'examples', 'fixtures', 'tmp.js.txt' );
-* var err = writeFile( tmp, readFile( src ) );
+* // Create a temporary file in the system temp directory:
+* var tmp = join( tmpdir(), 'example_file.js' );
+* var content = '\'use strict\';\n\nvar x = 3.14;\n';
+* var err = writeFile( tmp, content );
 * if ( err ) {
 *     throw err;
 * }
 *
-* var files = [
-*     tmp
-* ];
-*
+* var files = [ tmp ];
 * var header = '// This file is licensed under Apache-2.0.';
 *
 * insertHeader( files, header, done );
 *
 * function done( error ) {
+*     // Always clean up the temporary file:
+*     var unlinkErr = unlink( tmp );
 *     if ( error ) {
 *         throw error;
 *     }
-*     // Remove the temporary file:
-*     unlink( tmp );
+*     if ( unlinkErr ) {
+*         throw unlinkErr;
+*     }
 * }
 *
 * @example
 * var join = require( 'path' ).join;
-* var readFile = require( '@stdlib/fs/read-file' ).sync;
 * var writeFile = require( '@stdlib/fs/write-file' ).sync;
 * var unlink = require( '@stdlib/fs/unlink' ).sync;
+* var tmpdir = require( '@stdlib/os/tmpdir' );
 * var insertHeader = require( '@stdlib/_tools/licenses/insert-header-file-list' );
 *
-* // Create a temporary file:
-* var src = join( __dirname, 'examples', 'fixtures', 'file.js.txt' );
-* var tmp = join( __dirname, 'examples', 'fixtures', 'tmp.js.txt' );
-* var err = writeFile( tmp, readFile( src ) );
+* // Create a temporary file in the system temp directory:
+* var tmp = join( tmpdir(), 'example_file.js' );
+* var content = '\'use strict\';\n\nvar x = 3.14;\n';
+* var err = writeFile( tmp, content );
 * if ( err ) {
 *     throw err;
 * }
 *
-* var files = [
-*     tmp
-* ];
-*
+* var files = [ tmp ];
 * var header = '// This file is licensed under Apache-2.0.';
 *
 * err = insertHeader.sync( files, header );
+*
+* // Always clean up the temporary file:
+* var unlinkErr = unlink( tmp );
 * if ( err instanceof Error ) {
 *     throw err;
 * }
-* // Remove the temporary file:
-* unlink( tmp );
+* if ( unlinkErr ) {
+*     throw unlinkErr;
+* }
 */
 
 // MODULES //


### PR DESCRIPTION
Resolves #8586

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes JavaScript lint errors in the JSDoc examples of the `insert-header-file-list` module that were causing the "Lint JavaScript files" workflow to fail with an ENOENT error.


## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-     #8586

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

### Problem
The JSDoc `@example` code blocks in `lib/node_modules/@stdlib/_tools/licenses/insert-header-file-list/lib/index.js` referenced a non-existent file path `'./foo/bar.js'`. Since stdlib's custom `jsdoc-doctest` ESLint rule actually executes JSDoc examples in a VM to verify they work correctly, it attempted to run the `insertHeader()` function with this non-existent file, resulting in - Error: ENOENT: no such file or directory, open '/home/runner/work/stdlib/stdlib/foo/bar.js'

### Solution
Updated both JSDoc examples to use realistic, executable code that:
- Created a temporary file from the actual fixture file (`examples/fixtures/file.js.txt`)
- Run the `insertHeader()` function on the temporary file
- Properly cleaned up by removing the temporary file

This pattern now matches the working example already present in `examples/index.js` and ensures the `jsdoc-doctest` rule can execute successfully without errors.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
