### PR TITLE
chore: fix devcontainer build failures in github codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,11 @@
 {
   "name": "stdlib - OSS Development",
-  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm",
   "features": {
+    "ghcr.io/devcontainers/features/python:1": {},
     "ghcr.io/rocker-org/devcontainer-features/r-apt:0": {},
     "ghcr.io/julialang/devcontainer-features/julia:1": {},
-    "ghcr.io/marcozac/devcontainer-features/shellcheck:1": {},
+    "ghcr.io/devcontainers-extra/features/shellcheck:1": {},
     "ghcr.io/rocker-org/devcontainer-features/pandoc:1": {}
   },
   "postCreateCommand": "./.devcontainer/post-create",


### PR DESCRIPTION
# Fix Devcontainer Build Failures in GitHub Codespaces

## Summary

Resolved persistent devcontainer build failures caused by disk space exhaustion and broken feature dependencies. The environment is now leaner, faster, and reliable on standard GitHub Codespaces.

## The Issue

Developers were unable to start the devcontainer in GitHub Codespaces, encountering two critical errors:

### 1. Disk Exhaustion
The build failed with `write error: no space left on device` (specifically when unpacking `libtorch`). This was caused by the massive `mcr.microsoft.com/devcontainers/universal` base image (~10GB+) consuming nearly all available storage on standard 32GB Codespaces instances.

### 2. Broken Dependency
The `ghcr.io/marcozac/devcontainer-features/shellcheck` feature was unmaintained and referenced a deprecated dependency, causing build interruptions.

## The Fix

### 1. Optimized Base Image
Switched from the heavy `universal` image to `mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm`. This significantly reduces the container's footprint while providing the latest Node.js environment required for the project.

### 2. Restored Python Support
Explicitly added the `ghcr.io/devcontainers/features/python:1` feature to ensure Python tooling remains available (as it was previously inherited from the universal image).

### 3. Updated ShellCheck
Replaced the broken `marcozac` feature with the maintained `ghcr.io/devcontainers-extra/features/shellcheck:1`.

## Impact

- **Reliability**: The container now builds successfully on standard Codespaces without running out of disk space.
- **Performance**: Faster container startup and rebuild times due to the smaller image size.
- **Maintenance**: Dependencies are now pointed to maintained sources.

## Verification

Verified by rebuilding the container in a fresh Codespace environment. The build completes successfully, and all required languages (Node.js, Python, R, Julia) are installed and accessible.
<img width="1352" height="878" alt="Screenshot 2025-11-26 at 2 01 29 AM" src="https://github.com/user-attachments/assets/4f67b54f-2a96-48f8-9f18-92146968c7f8" />
issue number  #7558
---