### PR TITLE
feat: add `stats/base/ndarray/mode`

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/ndarray/mode/README.md
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/mode/README.md
@@ -1,0 +1,112 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2025 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# mode
+
+> Compute the mode of a one-dimensional double-precision floating-point ndarray.
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var mode = require( '@stdlib/stats/base/ndarray/mode' );
+```
+
+#### mode( arrays )
+
+Computes the mode of a one-dimensional double-precision floating-point ndarray.
+
+```javascript
+var Float64Array = require( '@stdlib/array/float64' );
+var ndarray = require( '@stdlib/ndarray/base/ctor' );
+
+var xbuf = new Float64Array( [ 1.0, 2.0, 4.0, 2.0 ] );
+var x = new ndarray( 'float64', xbuf, [ 4 ], [ 1 ], 0, 'row-major' );
+
+var v = mode( [ x ] );
+// returns 2.0
+```
+
+The function has the following parameters:
+
+-   **arrays**: array-like object containing a one-dimensional input ndarray.
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   If provided an empty one-dimensional ndarray, the function returns `NaN`.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var ndarray = require( '@stdlib/ndarray/base/ctor' );
+var ndarray2array = require( '@stdlib/ndarray/to-array' );
+var mode = require( '@stdlib/stats/base/ndarray/mode' );
+
+var xbuf = discreteUniform( 10, -50, 50, {
+    'dtype': 'float64'
+});
+var x = new ndarray( 'float64', xbuf, [ xbuf.length ], [ 1 ], 0, 'row-major' );
+console.log( ndarray2array( x ) );
+
+var v = mode( [ x ] );
+console.log( v );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/stats/base/ndarray/mode/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/mode/benchmark/benchmark.js
@@ -1,0 +1,111 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the LICENSE is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var uniform = require( '@stdlib/random/array/uniform' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var ndarray = require( '@stdlib/ndarray/base/ctor' );
+var pkg = require( './../package.json' ).name;
+var mode = require( './../lib' );   // renamed
+
+
+// VARIABLES //
+
+var options = {
+	'dtype': 'float64'
+};
+
+
+// FUNCTIONS //
+
+/**
+* Creates a benchmark function.
+*
+* @private
+* @param {PositiveInteger} len - array length
+* @returns {Function} benchmark function
+*/
+function createBenchmark( len ) {
+	var xbuf;
+	var x;
+
+	xbuf = uniform( len, -10.0, 10.0, options );
+	x = new ndarray( options.dtype, xbuf, [ len ], [ 1 ], 0, 'row-major' );
+
+	return benchmark;
+	/**
+* Benchmark function for measuring performance of the `mode` implementation.
+*
+* @private
+* @param {Object} b - Benchmark instance
+* @returns {void}
+*/
+	function benchmark( b ) {
+		var v;
+		var i;
+
+		b.tic();
+		for ( i = 0; i < b.iterations; i++ ) {
+			v = mode( [ x ] );   // renamed usage
+			if ( isnan( v ) ) {
+				b.fail( 'should not return NaN' );
+			}
+		}
+		b.toc();
+		if ( isnan( v ) ) {
+			b.fail( 'should not return NaN' );
+		}
+		b.pass( 'benchmark finished' );
+		b.end();
+	}
+}
+
+
+// MAIN //
+
+/**
+* Main execution sequence.
+*
+* @private
+*/
+function main() {
+	var len;
+	var min;
+	var max;
+	var f;
+	var i;
+
+	min = 1; // 10^min
+	max = 6; // 10^max
+
+	for ( i = min; i <= max; i++ ) {
+		len = pow( 10, i );
+		f = createBenchmark( len );
+		bench( pkg+':len='+len, f );
+	}
+}
+
+// If the script is run directly, execute main:
+if ( require.main === module ) {
+	main();
+}

--- a/lib/node_modules/@stdlib/stats/base/ndarray/mode/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/mode/docs/repl.txt
@@ -1,0 +1,30 @@
+{{alias}}( arrays )
+    Computes the mode of a one-dimensional ndarray.
+
+    If provided an empty input ndarray, the function returns NaN.
+
+    Parameters
+    ----------
+    arrays: ArrayLikeObject<ndarray>
+        Array-like object containing a one-dimensional input ndarray.
+
+    Returns
+    -------
+    out: number
+        Mode value.
+
+
+    Examples
+    --------
+    > var xbuf = [ 1.0, 2.0, 2.0, 3.0 ];
+    > var sh = [ xbuf.length ];
+    > var st = [ 1 ];
+    > var oo = 0;
+    > var ord = 'row-major';
+    > var x = new {{alias:@stdlib/ndarray/ctor}}( 'float64', xbuf, sh, st, oo, ord );
+    > {{alias}}( [ x ] )
+    2
+
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/stats/base/ndarray/mode/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/mode/docs/types/index.d.ts
@@ -1,0 +1,49 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { float64ndarray } from '@stdlib/types/ndarray';
+
+/**
+* Computes the mode of a one-dimensional double-precision floating-point ndarray.
+*
+* The mode is the value which appears most frequently in the input. If multiple
+* values share the highest frequency, the smallest such value is returned.
+*
+* @param arrays - array-like object containing an input ndarray
+* @returns mode
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+* var ndarray = require( '@stdlib/ndarray/base/ctor' );
+*
+* var xbuf = new Float64Array( [ 1.0, 2.0, 2.0, 3.0 ] );
+* var x = new ndarray( 'float64', xbuf, [ 4 ], [ 1 ], 0, 'row-major' );
+*
+* var v = mode( [ x ] );
+* // returns 2.0
+*/
+declare function mode( arrays: [ float64ndarray ] ): number;
+
+
+// EXPORTS //
+
+export = mode;

--- a/lib/node_modules/@stdlib/stats/base/ndarray/mode/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/mode/docs/types/test.ts
@@ -1,0 +1,57 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* eslint-disable space-in-parens */
+
+import zeros = require( '@stdlib/ndarray/zeros' );
+import mode = require( './index' );
+
+
+// TESTS //
+
+// The function returns a number...
+{
+	const x = zeros( [ 10 ], {
+		'dtype': 'float64'
+	});
+
+	mode( [ x ] ); // $ExpectType number
+}
+
+// The compiler throws an error if the function is provided a first argument which is not an array of ndarrays...
+{
+	mode( '10' ); // $ExpectError
+	mode( 10 ); // $ExpectError
+	mode( true ); // $ExpectError
+	mode( false ); // $ExpectError
+	mode( null ); // $ExpectError
+	mode( undefined ); // $ExpectError
+	mode( [] ); // $ExpectError
+	mode( {} ); // $ExpectError
+	mode( ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	const x = zeros( [ 10 ], {
+		'dtype': 'float64'
+	});
+
+	mode(); // $ExpectError
+	mode( [ x ], {} ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/stats/base/ndarray/mode/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/mode/examples/index.js
@@ -1,0 +1,40 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var ndarray = require( '@stdlib/ndarray/base/ctor' );
+var ndarray2array = require( '@stdlib/ndarray/to-array' );
+var mode = require( './../lib' ); // <-- updated
+
+
+// MAIN //
+
+var xbuf = discreteUniform( 10, -5, 5, {
+	'dtype': 'float64'
+});
+
+var x = new ndarray( 'float64', xbuf, [ xbuf.length ], [ 1 ], 0, 'row-major' );
+var v = mode( [ x ] );
+
+console.log( ndarray2array( x ) );
+
+console.log( v );

--- a/lib/node_modules/@stdlib/stats/base/ndarray/mode/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/mode/lib/index.js
@@ -1,0 +1,45 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Compute the mode of a one-dimensional double-precision floating-point ndarray.
+*
+* @module @stdlib/stats/base/ndarray/mode
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+* var ndarray = require( '@stdlib/ndarray/base/ctor' );
+* var mode = require( '@stdlib/stats/base/ndarray/mode' );
+*
+* var xbuf = new Float64Array( [ 1.0, 2.0, 2.0, 3.0 ] );
+* var x = new ndarray( 'float64', xbuf, [ 4 ], [ 1 ], 0, 'row-major' );
+*
+* var v = mode( [ x ] );
+* // returns 2.0
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/ndarray/mode/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/mode/lib/main.js
@@ -1,0 +1,99 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var numelDimension = require( '@stdlib/ndarray/base/numel-dimension' );
+var getStride = require( '@stdlib/ndarray/base/stride' );
+var getOffset = require( '@stdlib/ndarray/base/offset' );
+var getData = require( '@stdlib/ndarray/base/data-buffer' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+
+
+// MAIN //
+
+/**
+* Computes the mode of a one-dimensional double-precision floating-point ndarray.
+*
+* @param {ArrayLikeObject<Object>} arrays - array-like object containing an input ndarray
+* @returns {number} mode value
+*
+* @example
+* var Float64Array = require( '@stdlib/array/float64' );
+* var ndarray = require( '@stdlib/ndarray/base/ctor' );
+*
+* var xbuf = new Float64Array( [ 1.0, 2.0, 2.0, 3.0 ] );
+* var x = new ndarray( 'float64', xbuf, [ 4 ], [ 1 ], 0, 'row-major' );
+*
+* var v = mode( [ x ] );
+* // returns 2.0
+*/
+function mode( arrays ) {
+	var modeVal; // 7
+	var maxFreq; // 7
+	var offset;  // 6
+	var stride;  // 6
+	var data;    // 4
+	var freq;    // 4
+	var x;       // 1
+	var N;       // 1
+	var v;       // 1
+	var i;       // 1
+
+	x = arrays[ 0 ];
+	N = numelDimension( x, 0 );
+
+	// Edge case: empty ndarray
+	if ( N === 0 ) {
+		return NaN;
+	}
+
+	data = getData( x );
+	stride = getStride( x, 0 );
+	offset = getOffset( x );
+
+	freq = {};
+	maxFreq = 0;
+	modeVal = void 0;
+
+	for ( i = 0; i < N; i++ ) {
+		// eslint-disable-next-line no-mixed-operators
+		v = data[ offset + i*stride ];
+
+		if ( isnan( v ) ) {
+			return NaN;
+		}
+
+		freq[ v ] = ( freq[ v ] || 0 ) + 1;
+
+		// Highest frequency wins; if tied, choose the smaller value consistently
+		if ( freq[ v ] > maxFreq || ( freq[ v ] === maxFreq && ( modeVal === void 0 || v < modeVal ) ) ) {
+			maxFreq = freq[ v ];
+			modeVal = v;
+		}
+	}
+
+	return modeVal;
+}
+
+
+// EXPORTS //
+
+module.exports = mode;

--- a/lib/node_modules/@stdlib/stats/base/ndarray/mode/package.json
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/mode/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@stdlib/stats/base/ndarray/mode",
+  "version": "0.0.0",
+  "description": "Compute the mode of a one-dimensional double-precision floating-point ndarray.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "statistics",
+    "stats",
+    "mathematics",
+    "math",
+    "mode",
+    "frequency",
+    "statistics-mode",
+    "central-tendency",
+    "ndarray"
+  ],
+  "__stdlib__": {}
+}

--- a/lib/node_modules/@stdlib/stats/base/ndarray/mode/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/ndarray/mode/test/test.js
@@ -1,0 +1,76 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var Float64Array = require( '@stdlib/array/float64' );
+var ndarray = require( '@stdlib/ndarray/base/ctor' );
+var mode = require( './../lib' );
+
+
+// FUNCTIONS //
+
+/**
+* Create 1D ndarray.
+*
+* @private
+* @param {Float64Array} buffer - data buffer
+* @param {NonNegativeInteger} length - length
+* @param {integer} stride - stride
+* @param {NonNegativeInteger} offset - index offset
+* @returns {ndarray} ndarray
+*/
+function vector( buffer, length, stride, offset ) {
+	return new ndarray( 'float64', buffer, [ length ], [ stride ], offset, 'row-major' );
+}
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof mode, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function computes the mode', function test( t ) {
+	var x = new Float64Array( [ 1.0, 2.0, 2.0, 3.0 ] );
+	var v = mode( [ vector( x, 4, 1, 0 ) ] );
+	t.strictEqual( v, 2.0, 'returns expected value' );
+
+	x = new Float64Array( [ 5.0, 5.0, 2.0, 2.0 ] );
+	v = mode( [ vector( x, 4, 1, 0 ) ] );
+	t.strictEqual( v, 2.0, 'ties return smallest' );
+
+	x = new Float64Array( [ NaN, 2.0 ] );
+	v = mode( [ vector( x, 2, 1, 0 ) ] );
+	t.strictEqual( isnan( v ), true, 'returns NaN' );
+
+	t.end();
+});
+
+tape( 'if provided an empty vector, returns NaN', function test( t ) {
+	var x = new Float64Array( [] );
+	var v = mode( [ vector( x, 0, 1, 0 ) ] );
+	t.strictEqual( isnan( v ), true, 'returns NaN' );
+	t.end();
+});


### PR DESCRIPTION
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes.
report:

task: lint_filenames status: passed
task: lint_editorconfig status: passed
task: lint_markdown status: passed
task: lint_package_json status: passed
task: lint_repl_help status: passed
task: lint_javascript_src status: passed
task: lint_javascript_cli status: na
task: lint_javascript_examples status: passed
task: lint_javascript_tests status: passed
task: lint_javascript_benchmarks status: passed
task: lint_python status: na
task: lint_r status: na
task: lint_c_src status: na
task: lint_c_examples status: na
task: lint_c_benchmarks status: na
task: lint_c_tests_fixtures status: na
task: lint_shell status: na
task: lint_typescript_declarations status: passed
task: lint_typescript_tests status: passed
task: lint_license_headers status: passed

Resolves None.

---

## Description

This pull request adds a new package:

`feat: add stats/base/ndarray/mode`

The package provides an implementation for computing the mode of a one-dimensional `ndarray` supporting arbitrary strides, offsets, and negative strides. Includes documentation, benchmarks, examples, test coverage, and REPL help.

---
## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

---
## Related Issues

None.

---

## Questions

No questions for reviewers.

---

## Other

No additional notes.

---

## Checklist

- [x] Read, understood, and followed the contributing guidelines.
- [x] All lint checks passed.
- [x] Includes full examples, benchmarks, tests, and documentation.

---

## AI Assistance

**Did you use AI assistance?**
No
---
@stdlib-js/reviewers
