### PR TITLE
docs: improve doctests for complex number instances in `array/base/accessor-getter`

### DIFF
--- a/lib/node_modules/@stdlib/array/base/accessor-getter/README.md
+++ b/lib/node_modules/@stdlib/array/base/accessor-getter/README.md
@@ -46,20 +46,12 @@ Returns an accessor function for retrieving an element from an array-like object
 
 ```javascript
 var Complex64Array = require( '@stdlib/array/complex64' );
-var realf = require( '@stdlib/complex/float32/real' );
-var imagf = require( '@stdlib/complex/float32/imag' );
 
 var arr = new Complex64Array( [ 1, 2, 3, 4 ] );
 
 var get = accessorGetter( 'complex64' );
 var v = get( arr, 1 );
-// returns <Complex64>
-
-var re = realf( v );
-// returns 3.0
-
-var im = imagf( v );
-// returns 4.0
+// returns <Complex64>[ 3.0, 4.0 ]
 ```
 
 The returned accessor function accepts the following arguments:
@@ -104,14 +96,14 @@ var accessorGetter = require( '@stdlib/array/base/accessor-getter' );
 
 var arr = new Complex128Array( zeroTo( 10 ) );
 var v = accessorGetter( dtype( arr ) )( arr, 2 );
-// returns <Complex128>
+// returns <Complex128>[ 4.0, 5.0 ]
 
 console.log( v.toString() );
 // => '4 + 5i'
 
 arr = new Complex64Array( zeroTo( 10 ) );
 v = accessorGetter( dtype( arr ) )( arr, 4 );
-// returns <Complex64>
+// returns <Complex64>[ 8.0, 9.0 ]
 
 console.log( v.toString() );
 // => '8 + 9i'

--- a/lib/node_modules/@stdlib/array/base/accessor-getter/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/base/accessor-getter/docs/repl.txt
@@ -44,11 +44,7 @@
     --------
     > var f = {{alias}}( 'complex64' );
     > var v = f( {{alias:@stdlib/array/complex64}}( [ 1, 2, 3, 4 ] ), 1 )
-    <Complex64>
-    > var r = {{alias:@stdlib/complex/float32/real}}( v )
-    3.0
-    > var i = {{alias:@stdlib/complex/float32/imag}}( v )
-    4.0
+    <Complex64>[ 3.0, 4.0 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/array/base/accessor-getter/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/accessor-getter/docs/types/index.d.ts
@@ -58,20 +58,12 @@ type GetArrayLike<T> = ( arr: AccessorArrayLike<T>, idx: number ) => T;
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
-* var real = require( '@stdlib/array/real' );
-* var imag = require( '@stdlib/array/imag' );
 *
 * var arr = new Complex128Array( [ 1, 2, 3, 4 ] );
 *
 * var get = getter( 'complex128' );
 * var v = get( arr, 1 );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns 3.0
-*
-* var im = imag( v );
-* // returns 4.0
+* // returns <Complex128>[ 3.0, 4.0 ]
 */
 declare function getter( dtype: 'complex128' ): GetComplex128;
 
@@ -83,20 +75,12 @@ declare function getter( dtype: 'complex128' ): GetComplex128;
 *
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
-* var realf = require( '@stdlib/array/realf' );
-* var imagf = require( '@stdlib/array/imagf' );
 *
 * var arr = new Complex64Array( [ 1, 2, 3, 4 ] );
 *
 * var get = getter( 'complex64' );
 * var v = get( arr, 1 );
-* // returns <Complex64>
-*
-* var re = realf( v );
-* // returns 3.0
-*
-* var im = imagf( v );
-* // returns 4.0
+* // returns <Complex64>[ 3.0, 4.0 ]
 */
 declare function getter( dtype: 'complex64' ): GetComplex64;
 

--- a/lib/node_modules/@stdlib/array/base/accessor-getter/examples/index.js
+++ b/lib/node_modules/@stdlib/array/base/accessor-getter/examples/index.js
@@ -26,12 +26,12 @@ var accessorGetter = require( './../lib' );
 
 var arr = new Complex128Array( zeroTo( 10 ) );
 var v = accessorGetter( dtype( arr ) )( arr, 2 );
-// returns <Complex128>
+// returns <Complex128>[ 4.0, 5.0 ]
 
 console.log( '%s', v.toString() );
 
 arr = new Complex64Array( zeroTo( 10 ) );
 v = accessorGetter( dtype( arr ) )( arr, 4 );
-// returns <Complex64>
+// returns <Complex64>[ 8.0, 9.0 ]
 
 console.log( '%s', v.toString() );

--- a/lib/node_modules/@stdlib/array/base/accessor-getter/lib/index.js
+++ b/lib/node_modules/@stdlib/array/base/accessor-getter/lib/index.js
@@ -25,8 +25,6 @@
 *
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 * var dtype = require( '@stdlib/array/dtype' );
 * var getter = require( '@stdlib/array/base/accessor-getter' );
 *
@@ -34,13 +32,7 @@
 *
 * var get = getter( dtype( arr ) );
 * var v = get( arr, 1 );
-* // returns <Complex64>
-*
-* var re = realf( v );
-* // returns 3.0
-*
-* var im = imagf( v );
-* // returns 4.0
+* // returns <Complex64>[ 3.0, 4.0 ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/array/base/accessor-getter/lib/main.js
+++ b/lib/node_modules/@stdlib/array/base/accessor-getter/lib/main.js
@@ -39,19 +39,11 @@ var GETTERS = {
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var arr = new Complex128Array( [ 1, 2, 3, 4 ] );
 *
 * var v = getComplex128( arr, 1 );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns 3.0
-*
-* var im = imag( v );
-* // returns 4.0
+* // returns <Complex128>[ 3.0, 4.0 ]
 */
 function getComplex128( arr, idx ) {
 	return arr.get( idx );
@@ -67,19 +59,11 @@ function getComplex128( arr, idx ) {
 *
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * var arr = new Complex64Array( [ 1, 2, 3, 4 ] );
 *
 * var v = getComplex64( arr, 1 );
-* // returns <Complex64>
-*
-* var re = realf( v );
-* // returns 3.0
-*
-* var im = imagf( v );
-* // returns 4.0
+* // returns <Complex64>[ 3.0, 4.0 ]
 */
 function getComplex64( arr, idx ) {
 	return arr.get( idx );
@@ -125,21 +109,13 @@ function getArrayLike( arr, idx ) {
 *
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 * var dtype = require( '@stdlib/array/dtype' );
 *
 * var arr = new Complex64Array( [ 1, 2, 3, 4 ] );
 *
 * var get = getter( dtype( arr ) );
 * var v = get( arr, 1 );
-* // returns <Complex64>
-*
-* var re = realf( v );
-* // returns 3.0
-*
-* var im = imagf( v );
-* // returns 4.0
+* // returns <Complex64>[ 3.0, 4.0 ]
 */
 function getter( dtype ) {
 	var f = GETTERS[ dtype ];


### PR DESCRIPTION
# array/base/accessor-getter

---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes.
report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: passed
  - task: lint_package_json status: na
  - task: lint_repl_help status: passed
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: passed
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: passed
  - task: lint_license_headers status: passed
---

Resolves a part of #8641 

## Description

This pull request updates documentation examples for the `array/base/accessor-getter` package to correctly use complex number instance notation.

## Related Issues

None.

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [ ] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

{{TODO: add disclosure if applicable}}

---

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
