### PR TITLE
docs: improve doctests for complex number instances in `array/base/accessor-setter`

### DIFF
--- a/lib/node_modules/@stdlib/array/base/accessor-setter/README.md
+++ b/lib/node_modules/@stdlib/array/base/accessor-setter/README.md
@@ -47,8 +47,6 @@ Returns an accessor function for setting an element in an array-like object supp
 ```javascript
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
-var realf = require( '@stdlib/complex/float32/real' );
-var imagf = require( '@stdlib/complex/float32/imag' );
 
 var arr = new Complex64Array( [ 1, 2, 3, 4 ] );
 
@@ -56,13 +54,7 @@ var set = accessorSetter( 'complex64' );
 set( arr, 1, new Complex64( 10.0, 11.0 ) );
 
 var v = arr.get( 1 );
-// returns <Complex64>
-
-var re = realf( v );
-// returns 10.0
-
-var im = imagf( v );
-// returns 11.0
+// returns <Complex64>[ 10.0, 11.0 ]
 ```
 
 The returned accessor function accepts the following arguments:
@@ -113,7 +105,7 @@ var arr = new Complex128Array( zeroTo( 10 ) );
 accessorSetter( dtype( arr ) )( arr, 2, new Complex128( 100.0, 101.0 ) );
 
 var v = arr.get( 2 );
-// returns <Complex128>
+// returns <Complex128>[ 100.0, 101.0 ]
 
 console.log( '%s', v.toString() );
 // => '100 + 101i'
@@ -122,7 +114,7 @@ arr = new Complex64Array( zeroTo( 10 ) );
 accessorSetter( dtype( arr ) )( arr, 4, new Complex64( 102.0, 103.0 ) );
 
 v = arr.get( 4 );
-// returns <Complex64>
+// returns <Complex64>[ 102.0, 103.0 ]
 
 console.log( '%s', v.toString() );
 // => '102 + 103i'

--- a/lib/node_modules/@stdlib/array/base/accessor-setter/docs/repl.txt
+++ b/lib/node_modules/@stdlib/array/base/accessor-setter/docs/repl.txt
@@ -49,11 +49,7 @@
     > var x = {{alias:@stdlib/array/complex64}}( [ 1, 2, 3, 4 ] );
     > f( x, 1, new {{alias:@stdlib/complex/float32/ctor}}( 10.0, 11.0 ) );
     > var v = x.get( 1 )
-    <Complex64>
-    > var r = {{alias:@stdlib/complex/float32/real}}( v )
-    10.0
-    > var i = {{alias:@stdlib/complex/float32/imag}}( v )
-    11.0
+    <Complex64>[ 10.0, 11.0]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/array/base/accessor-setter/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/accessor-setter/docs/types/index.d.ts
@@ -59,8 +59,6 @@ type SetArrayLike<T> = ( arr: AccessorArrayLike<T>, idx: number, value: T ) => v
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/array/real' );
-* var imag = require( '@stdlib/array/imag' );
 *
 * var arr = new Complex128Array( [ 1, 2, 3, 4 ] );
 *
@@ -68,13 +66,7 @@ type SetArrayLike<T> = ( arr: AccessorArrayLike<T>, idx: number, value: T ) => v
 * set( arr, 1, new Complex128( 10.0, 11.0 ) );
 *
 * var v = arr.get( 1 );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns 10.0
-*
-* var im = imag( v );
-* // returns 11.0
+* // returns <Complex128>[ 10.0, 11.0 ]
 */
 declare function setter( dtype: 'complex128' ): SetComplex128;
 
@@ -87,8 +79,6 @@ declare function setter( dtype: 'complex128' ): SetComplex128;
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/array/realf' );
-* var imagf = require( '@stdlib/array/imagf' );
 *
 * var arr = new Complex64Array( [ 1, 2, 3, 4 ] );
 *
@@ -96,13 +86,7 @@ declare function setter( dtype: 'complex128' ): SetComplex128;
 * set( arr, 1, new Complex64( 10.0, 11.0 ) );
 *
 * var v = arr.get( 1 );
-* // returns <Complex64>
-*
-* var re = realf( v );
-* // returns 3.0
-*
-* var im = imagf( v );
-* // returns 4.0
+* // returns <Complex64>[ 10.0, 11.0 ]
 */
 declare function setter( dtype: 'complex64' ): SetComplex64;
 
@@ -130,7 +114,7 @@ declare function setter( dtype: 'complex64' ): SetComplex64;
 * set( arr, 2, 10 );
 *
 * var v = arr.get( 2 );
-* // returns 3
+* // returns 10
 */
 declare function setter<T = unknown>( dtype: string ): SetArrayLike<T>;
 

--- a/lib/node_modules/@stdlib/array/base/accessor-setter/examples/index.js
+++ b/lib/node_modules/@stdlib/array/base/accessor-setter/examples/index.js
@@ -30,7 +30,7 @@ var arr = new Complex128Array( zeroTo( 10 ) );
 accessorSetter( dtype( arr ) )( arr, 2, new Complex128( 100.0, 101.0 ) );
 
 var v = arr.get( 2 );
-// returns <Complex128>
+// returns <Complex128>[ 100.0, 101.0 ]
 
 console.log( '%s', v.toString() );
 // => '100 + 101i'
@@ -39,7 +39,7 @@ arr = new Complex64Array( zeroTo( 10 ) );
 accessorSetter( dtype( arr ) )( arr, 4, new Complex64( 102.0, 103.0 ) );
 
 v = arr.get( 4 );
-// returns <Complex64>
+// returns <Complex64>[ 102.0, 103.0 ]
 
 console.log( '%s', v.toString() );
 // => '102 + 103i'

--- a/lib/node_modules/@stdlib/array/base/accessor-setter/lib/index.js
+++ b/lib/node_modules/@stdlib/array/base/accessor-setter/lib/index.js
@@ -26,8 +26,6 @@
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 * var dtype = require( '@stdlib/array/dtype' );
 * var setter = require( '@stdlib/array/base/accessor-setter' );
 *
@@ -37,13 +35,7 @@
 * set( arr, 1, new Complex64( 10.0, 11.0 ) );
 *
 * var v = arr.get( 1 );
-* // returns <Complex64>
-*
-* var re = realf( v );
-* // returns 10.0
-*
-* var im = imagf( v );
-* // returns 11.0
+* // returns <Complex64>[ 10.0, 11.0 ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/array/base/accessor-setter/lib/main.js
+++ b/lib/node_modules/@stdlib/array/base/accessor-setter/lib/main.js
@@ -40,20 +40,12 @@ var SETTERS = {
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var arr = new Complex128Array( [ 1, 2, 3, 4 ] );
 *
 * setComplex128( arr, 1, new Complex128( 10.0, 11.0 ) );
 * var v = arr.get( 1 );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns 10.0
-*
-* var im = imag( v );
-* // returns 11.0
+* // returns <Complex128>[ 10.0, 11.0 ]
 */
 function setComplex128( arr, idx, value ) {
 	arr.set( value, idx );
@@ -70,20 +62,12 @@ function setComplex128( arr, idx, value ) {
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * var arr = new Complex64Array( [ 1, 2, 3, 4 ] );
 *
 * setComplex64( arr, 1, new Complex64( 10.0, 11.0 ) );
 * var v = arr.get( 1 );
-* // returns <Complex64>
-*
-* var re = realf( v );
-* // returns 10.0
-*
-* var im = imagf( v );
-* // returns 11.0
+* // returns <Complex64>[ 10.0, 11.0 ]
 */
 function setComplex64( arr, idx, value ) {
 	arr.set( value, idx );
@@ -132,8 +116,6 @@ function setArrayLike( arr, idx, value ) {
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 * var dtype = require( '@stdlib/array/dtype' );
 *
 * var arr = new Complex64Array( [ 1, 2, 3, 4 ] );
@@ -142,13 +124,7 @@ function setArrayLike( arr, idx, value ) {
 * set( arr, 1, new Complex64( 10.0, 11.0 ) );
 *
 * var v = arr.get( 1 );
-* // returns <Complex64>
-*
-* var re = realf( v );
-* // returns 10.0
-*
-* var im = imagf( v );
-* // returns 11.0
+* // returns <Complex64>[ 10.0, 11.0 ]
 */
 function setter( dtype ) {
 	var f = SETTERS[ dtype ];


### PR DESCRIPTION
# array/base/accessor-setter

---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes.
report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: passed
  - task: lint_package_json status: na
  - task: lint_repl_help status: passed
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: passed
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: passed
  - task: lint_license_headers status: passed
---

Resolves a part of #8641 

## Description

This pull request updates documentation examples for the `array/base/accessor-getter` package to correctly use complex number instance notation.

## Related Issues

None.

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [ ] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

{{TODO: add disclosure if applicable}}

---

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
