### PR TITLE
docs: improve doctests for complex number instances in `blas/ext/base/zfill`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/zfill/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/zfill/README.md
@@ -38,8 +38,6 @@ Fills a double-precision complex floating-point strided array `x` with a specifi
 var Float64Array = require( '@stdlib/array/float64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
-var real = require( '@stdlib/complex/float64/real' );
-var imag = require( '@stdlib/complex/float64/imag' );
 
 var arr = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 var x = new Complex128Array( arr );
@@ -49,13 +47,7 @@ var alpha = new Complex128( 10.0, 10.0 );
 zfill( x.length, alpha, x, 1 );
 
 var y = x.get( 0 );
-// returns <Complex128>
-
-var re = real( y );
-// returns 10.0
-
-var im = imag( y );
-// returns 10.0
+// returns <Complex128>[ 10.0, 10.0 ]
 ```
 
 The function has the following parameters:
@@ -71,8 +63,6 @@ The `N` and stride parameters determine which elements in the strided array are 
 var Float64Array = require( '@stdlib/array/float64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
-var real = require( '@stdlib/complex/float64/real' );
-var imag = require( '@stdlib/complex/float64/imag' );
 
 var arr = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 var x = new Complex128Array( arr );
@@ -82,22 +72,10 @@ var alpha = new Complex128( 10.0, 10.0 );
 zfill( 2, alpha, x, 2 );
 
 var y = x.get( 0 );
-// returns <Complex128>
-
-var re = real( y );
-// returns 10.0
-
-var im = imag( y );
-// returns 10.0
+// returns <Complex128>[ 10.0, 10.0 ]
 
 y = x.get( 1 );
-// returns <Complex128>
-
-re = real( y );
-// returns 3.0
-
-im = imag( y );
-// returns 4.0
+// returns <Complex128>[ 3.0, 4.0 ]
 ```
 
 Note that indexing is relative to the first index. To introduce an offset, use [`typed array`][mdn-typed-array] views.
@@ -106,8 +84,6 @@ Note that indexing is relative to the first index. To introduce an offset, use [
 var Float64Array = require( '@stdlib/array/float64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
-var real = require( '@stdlib/complex/float64/real' );
-var imag = require( '@stdlib/complex/float64/imag' );
 
 // Create the underlying floating-point array:
 var arr = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
@@ -125,22 +101,10 @@ var alpha = new Complex128( 10.0, 10.0 );
 zfill( 2, alpha, x1, 2 );
 
 var y = x0.get( 0 );
-// returns <Complex128>
-
-var re = real( y );
-// returns 1.0
-
-var im = imag( y );
-// returns 2.0
+// returns <Complex128>[ 1.0, 2.0 ]
 
 y = x0.get( 1 );
-// returns <Complex128>
-
-re = real( y );
-// returns 10.0
-
-im = imag( y );
-// returns 10.0
+// returns <Complex128>[ 10.0, 10.0 ]
 ```
 
 #### zfill.ndarray( N, alpha, x, strideX, offsetX )
@@ -151,8 +115,6 @@ Fills a double-precision complex floating-point strided array `x` with a specifi
 var Float64Array = require( '@stdlib/array/float64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
-var real = require( '@stdlib/complex/float64/real' );
-var imag = require( '@stdlib/complex/float64/imag' );
 
 var arr = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 var x = new Complex128Array( arr );
@@ -162,13 +124,7 @@ var alpha = new Complex128( 10.0, 10.0 );
 zfill.ndarray( x.length, alpha, x, 1, 0 );
 
 var y = x.get( 0 );
-// returns <Complex128>
-
-var re = real( y );
-// returns 10.0
-
-var im = imag( y );
-// returns 10.0
+// returns <Complex128>[ 10.0, 10.0 ]
 ```
 
 The function has the following additional parameters:
@@ -181,8 +137,6 @@ While [`typed array`][mdn-typed-array] views mandate a view offset based on the 
 var Float64Array = require( '@stdlib/array/float64' );
 var Complex128Array = require( '@stdlib/array/complex128' );
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
-var real = require( '@stdlib/complex/float64/real' );
-var imag = require( '@stdlib/complex/float64/imag' );
 
 var arr = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
 var x = new Complex128Array( arr );
@@ -192,31 +146,13 @@ var alpha = new Complex128( 10.0, 10.0 );
 zfill.ndarray( 2, alpha, x, 1, x.length-2 );
 
 var y = x.get( 0 );
-// returns <Complex128>
-
-var re = real( y );
-// returns 1.0
-
-var im = imag( y );
-// returns 2.0
+// returns <Complex128>[ 1.0, 2.0]
 
 y = x.get( 1 );
-// returns <Complex128>
-
-re = real( y );
-// returns 10.0
-
-im = imag( y );
-// returns 10.0
+// returns <Complex128>[ 10.0, 10.0 ]
 
 y = x.get( 2 );
-// returns <Complex128>
-
-re = real( y );
-// returns 10.0
-
-im = imag( y );
-// returns 10.0
+// returns <Complex128>[ 10.0, 10.0 ]
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/blas/ext/base/zfill/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/zfill/docs/repl.txt
@@ -37,25 +37,16 @@
     > var alpha = new {{alias:@stdlib/complex/float64/ctor}}( 5.0, -5.0 );
     > {{alias}}( x.length, alpha, x, 1 );
     > var z = x.get( 0 );
-    > var re = {{alias:@stdlib/complex/float64/real}}( z )
-    5.0
-    > var im = {{alias:@stdlib/complex/float64/imag}}( z )
-    -5.0
+    // returns <Complex128>[ 5.0, -5.0 ]
 
     // Using `N` and stride parameters:
     > x = new {{alias:@stdlib/array/complex128}}( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
     > alpha = new {{alias:@stdlib/complex/float64/ctor}}( 5.0, -5.0 );
     > {{alias}}( 2, alpha, x, 2 );
     > z = x.get( 0 );
-    > re = {{alias:@stdlib/complex/float64/real}}( z )
-    5.0
-    > im = {{alias:@stdlib/complex/float64/imag}}( z )
-    -5.0
+    // returns <Complex128>[ 5.0, -5.0 ]
     > z = x.get( 1 );
-    > re = {{alias:@stdlib/complex/float64/real}}( z )
-    3.0
-    > im = {{alias:@stdlib/complex/float64/imag}}( z )
-    4.0
+    // returns <Complex128>[ 5.0, -5.0 ]
 
     // Using view offsets:
     > var x0 = new {{alias:@stdlib/array/complex128}}( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
@@ -63,15 +54,9 @@
     > alpha = new {{alias:@stdlib/complex/float64/ctor}}( 5.0, -5.0 );
     > {{alias}}( 2, alpha, x1, 1 );
     > z = x0.get( 0 );
-    > re = {{alias:@stdlib/complex/float64/real}}( z )
-    1.0
-    > im = {{alias:@stdlib/complex/float64/imag}}( z )
-    2.0
+    // returns <Complex128>[ 1.0, 2.0 ]
     > z = x0.get( 1 );
-    > re = {{alias:@stdlib/complex/float64/real}}( z )
-    5.0
-    > im = {{alias:@stdlib/complex/float64/imag}}( z )
-    -5.0
+    // returns <Complex128>[ 5.0, -5.0 ]
 
 
 {{alias}}.ndarray( N, alpha, x, strideX, offsetX )
@@ -111,25 +96,16 @@
     > var alpha = new {{alias:@stdlib/complex/float64/ctor}}( 2.0, 2.0 );
     > {{alias}}.ndarray( x.length, alpha, x, 1, 0 );
     > var z = x.get( 0 );
-    > var re = {{alias:@stdlib/complex/float64/real}}( z )
-    2.0
-    > var im = {{alias:@stdlib/complex/float64/imag}}( z )
-    2.0
+    // returns <Complex128>[ 2.0, 2.0 ]
 
     // Using an index offset:
     > x = new {{alias:@stdlib/array/complex128}}( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
     > alpha = new {{alias:@stdlib/complex/float64/ctor}}( 5.0, -5.0 );
     > {{alias}}.ndarray( 2, alpha, x, 2, 1 );
     > z = x.get( 0 );
-    > re = {{alias:@stdlib/complex/float64/real}}( z )
-    1.0
-    > im = {{alias:@stdlib/complex/float64/imag}}( z )
-    2.0
+    // returns <Complex128>[ 1.0, 2.0 ]
     > z = x.get( 1 );
-    > re = {{alias:@stdlib/complex/float64/real}}( z )
-    5.0
-    > im = {{alias:@stdlib/complex/float64/imag}}( z )
-    -5.0
+    // returns <Complex128>[ 5.0, -5.0 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/blas/ext/base/zfill/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/zfill/docs/repl.txt
@@ -35,7 +35,7 @@
     // Standard Usage:
     > var x = new {{alias:@stdlib/array/complex128}}( [ 1.0, 2.0, 3.0, 4.0 ] );
     > var alpha = new {{alias:@stdlib/complex/float64/ctor}}( 5.0, -5.0 );
-    > {{alias}}( 2, alpha, x, 1 );
+    > {{alias}}( x.length, alpha, x, 1 );
     > var z = x.get( 0 )
     <Complex128>[ 5.0, -5.0 ]
 

--- a/lib/node_modules/@stdlib/blas/ext/base/zfill/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/zfill/docs/repl.txt
@@ -35,28 +35,28 @@
     // Standard Usage:
     > var x = new {{alias:@stdlib/array/complex128}}( [ 1.0, 2.0, 3.0, 4.0 ] );
     > var alpha = new {{alias:@stdlib/complex/float64/ctor}}( 5.0, -5.0 );
-    > {{alias}}( x.length, alpha, x, 1 );
-    > var z = x.get( 0 );
-    // returns <Complex128>[ 5.0, -5.0 ]
+    > {{alias}}( 2, alpha, x, 1 );
+    > var z = x.get( 0 )
+    <Complex128>[ 5.0, -5.0 ]
 
     // Using `N` and stride parameters:
     > x = new {{alias:@stdlib/array/complex128}}( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
     > alpha = new {{alias:@stdlib/complex/float64/ctor}}( 5.0, -5.0 );
     > {{alias}}( 2, alpha, x, 2 );
-    > z = x.get( 0 );
-    // returns <Complex128>[ 5.0, -5.0 ]
-    > z = x.get( 1 );
-    // returns <Complex128>[ 5.0, -5.0 ]
+    > z = x.get( 0 )
+    <Complex128>[ 5.0, -5.0 ]
+    > z = x.get( 2 )
+    <Complex128>[ 5.0, -5.0 ]
 
     // Using view offsets:
     > var x0 = new {{alias:@stdlib/array/complex128}}( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
     > var x1 = new {{alias:@stdlib/array/complex128}}( x0.buffer, x0.BYTES_PER_ELEMENT*1 );
     > alpha = new {{alias:@stdlib/complex/float64/ctor}}( 5.0, -5.0 );
     > {{alias}}( 2, alpha, x1, 1 );
-    > z = x0.get( 0 );
-    // returns <Complex128>[ 1.0, 2.0 ]
-    > z = x0.get( 1 );
-    // returns <Complex128>[ 5.0, -5.0 ]
+    > z = x0.get( 0 )
+    <Complex128>[ 1.0, 2.0 ]
+    > z = x0.get( 1 )
+    <Complex128>[ 5.0, -5.0 ]
 
 
 {{alias}}.ndarray( N, alpha, x, strideX, offsetX )
@@ -95,17 +95,17 @@
     > var x = new {{alias:@stdlib/array/complex128}}( [ 1.0, 2.0, 3.0, 4.0 ] );
     > var alpha = new {{alias:@stdlib/complex/float64/ctor}}( 2.0, 2.0 );
     > {{alias}}.ndarray( x.length, alpha, x, 1, 0 );
-    > var z = x.get( 0 );
-    // returns <Complex128>[ 2.0, 2.0 ]
+    > var z = x.get( 0 )
+    <Complex128>[ 2.0, 2.0 ]
 
     // Using an index offset:
     > x = new {{alias:@stdlib/array/complex128}}( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
     > alpha = new {{alias:@stdlib/complex/float64/ctor}}( 5.0, -5.0 );
     > {{alias}}.ndarray( 2, alpha, x, 2, 1 );
-    > z = x.get( 0 );
-    // returns <Complex128>[ 1.0, 2.0 ]
-    > z = x.get( 1 );
-    // returns <Complex128>[ 5.0, -5.0 ]
+    > z = x.get( 0 )
+    <Complex128>[ 1.0, 2.0 ]
+    > z = x.get( 1 )
+    <Complex128>[ 5.0, -5.0 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/blas/ext/base/zfill/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/zfill/docs/types/index.d.ts
@@ -40,8 +40,6 @@ interface Routine {
 	* var Float64Array = require( '@stdlib/array/float64' );
 	* var Complex128Array = require( '@stdlib/array/complex128' );
 	* var Complex128 = require( '@stdlib/complex/float64/ctor' );
-	* var real = require( '@stdlib/complex/float64/real' );
-	* var imag = require( '@stdlib/complex/float64/imag' );
 	*
 	* var arr = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 	* var x = new Complex128Array( arr );
@@ -51,13 +49,7 @@ interface Routine {
 	* zfill( x.length, alpha, x, 1 );
 	*
 	* var y = x.get( 0 );
-	* // returns <Complex128>
-	*
-	* var re = real( y );
-	* // returns 10.0
-	*
-	* var im = imag( y );
-	* // returns 10.0
+	* // returns <Complex128>[ 10.0, 10.0 ]
 	*/
 	( N: number, alpha: Complex128, x: Complex128Array, strideX: number ): Complex128Array;
 
@@ -75,8 +67,6 @@ interface Routine {
 	* var Float64Array = require( '@stdlib/array/float64' );
 	* var Complex128Array = require( '@stdlib/array/complex128' );
 	* var Complex128 = require( '@stdlib/complex/float64/ctor' );
-	* var real = require( '@stdlib/complex/float64/real' );
-	* var imag = require( '@stdlib/complex/float64/imag' );
 	*
 	* var arr = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 	* var x = new Complex128Array( arr );
@@ -86,13 +76,7 @@ interface Routine {
 	* zfill( x.length, alpha, x, 1, 0 );
 	*
 	* var y = x.get( 0 );
-	* // returns <Complex128>
-	*
-	* var re = real( y );
-	* // returns 10.0
-	*
-	* var im = imag( y );
-	* // returns 10.0
+	* // returns <Complex128>[ 10.0, 10.0 ]
 	*/
 	ndarray( N: number, alpha: Complex128, x: Complex128Array, strideX: number, offsetX: number ): Complex128Array;
 }
@@ -110,8 +94,6 @@ interface Routine {
 * var Float64Array = require( '@stdlib/array/float64' );
 * var Complex128Array = require( '@stdlib/array/complex128' );
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var arr = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var x = new Complex128Array( arr );
@@ -121,13 +103,7 @@ interface Routine {
 * zfill( x.length, alpha, x, 1 );
 *
 * var y = x.get( 0 );
-* // returns <Complex128>
-*
-* var re = real( y );
-* // returns 10.0
-*
-* var im = imag( y );
-* // returns 10.0
+* // returns <Complex128>[ 10.0, 10.0 ]
 */
 declare var zfill: Routine;
 

--- a/lib/node_modules/@stdlib/blas/ext/base/zfill/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zfill/lib/index.js
@@ -27,8 +27,6 @@
 * var Float64Array = require( '@stdlib/array/float64' );
 * var Complex128Array = require( '@stdlib/array/complex128' );
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 * var zfill = require( '@stdlib/blas/ext/base/zfill' );
 *
 * var arr = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
@@ -39,13 +37,7 @@
 * zfill( x.length, alpha, x, 1 );
 *
 * var y = x.get( 0 );
-* // returns <Complex128>
-*
-* var re = real( y );
-* // returns 10.0
-*
-* var im = imag( y );
-* // returns 10.0
+* // returns <Complex128>[ 10.0, 10.0 ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/blas/ext/base/zfill/lib/ndarray.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zfill/lib/ndarray.native.js
@@ -40,8 +40,6 @@ var addon = require( './../src/addon.node' );
 * var Float64Array = require( '@stdlib/array/float64' );
 * var Complex128Array = require( '@stdlib/array/complex128' );
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var arr = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var x = new Complex128Array( arr );
@@ -51,13 +49,7 @@ var addon = require( './../src/addon.node' );
 * zfill( x.length, alpha, x, 1, 0 );
 *
 * var y = x.get( 0 );
-* // returns <Complex128>
-*
-* var re = real( y );
-* // returns 10.0
-*
-* var im = imag( y );
-* // returns 10.0
+* // returns <Complex128>[ 10.0, 10.0 ]
 */
 function zfill( N, alpha, x, strideX, offsetX ) {
 	var view = reinterpret( x, 0 );

--- a/lib/node_modules/@stdlib/blas/ext/base/zfill/lib/zfill.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zfill/lib/zfill.js
@@ -39,8 +39,6 @@ var ndarray = require( './ndarray.js' );
 * var Float64Array = require( '@stdlib/array/float64' );
 * var Complex128Array = require( '@stdlib/array/complex128' );
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var arr = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var x = new Complex128Array( arr );
@@ -50,13 +48,7 @@ var ndarray = require( './ndarray.js' );
 * zfill( x.length, alpha, x, 1 );
 *
 * var y = x.get( 0 );
-* // returns <Complex128>
-*
-* var re = real( y );
-* // returns 10.0
-*
-* var im = imag( y );
-* // returns 10.0
+* // returns <Complex128>[ 10.0, 10.0 ]
 */
 function zfill( N, alpha, x, strideX ) {
 	return ndarray( N, alpha, x, strideX, stride2offset( N, strideX ) );

--- a/lib/node_modules/@stdlib/blas/ext/base/zfill/lib/zfill.native.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/zfill/lib/zfill.native.js
@@ -39,8 +39,6 @@ var addon = require( './../src/addon.node' );
 * var Float64Array = require( '@stdlib/array/float64' );
 * var Complex128Array = require( '@stdlib/array/complex128' );
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var arr = new Float64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var x = new Complex128Array( arr );
@@ -50,13 +48,7 @@ var addon = require( './../src/addon.node' );
 * zfill( x.length, alpha, x, 1 );
 *
 * var y = x.get( 0 );
-* // returns <Complex128>
-*
-* var re = real( y );
-* // returns 10.0
-*
-* var im = imag( y );
-* // returns 10.0
+* // returns <Complex128>[ 10.0, 10.0 ]
 */
 function zfill( N, alpha, x, strideX ) {
 	var view = reinterpret( x, 0 );


### PR DESCRIPTION
# blas/ext/base/zfill

---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes.
report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: passed
  - task: lint_package_json status: na
  - task: lint_repl_help status: passed
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: passed
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: passed
  - task: lint_license_headers status: passed
---

Resolves a part of #8641 

## Description

This pull request updates documentation examples for the `array/base/accessor-getter` package to correctly use complex number instance notation.

## Related Issues

None.

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [ ] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

{{TODO: add disclosure if applicable}}

---

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
