### PR TITLE
bench: refactor to use string interpolation in array/base/accessor-getter

### DIFF
--- a/lib/node_modules/@stdlib/array/base/accessor-getter/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/array/base/accessor-getter/benchmark/benchmark.js
@@ -33,6 +33,7 @@ var imag = require( '@stdlib/complex/float64/imag' );
 var realf = require( '@stdlib/complex/float32/real' );
 var imagf = require( '@stdlib/complex/float32/imag' );
 var dtype = require( '@stdlib/array/dtype' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var getter = require( './../lib' );
 
@@ -70,7 +71,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':dtype=complex128', function benchmark( b ) {
+bench( format( '%s:dtype=complex128', pkg ), function benchmark( b ) {
 	var arr;
 	var buf;
 	var get;
@@ -96,7 +97,7 @@ bench( pkg+':dtype=complex128', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':dtype=complex64', function benchmark( b ) {
+bench( format( '%s:dtype=complex64', pkg ), function benchmark( b ) {
 	var arr;
 	var buf;
 	var get;


### PR DESCRIPTION
Resolves a part of #8647 .

## Description

> What is the purpose of this pull request?

This pull request:

-  Refactors the javaScript benchmark in @stdlib/array/base/accessor-getter to use @stdlib/string/format for string interpolation instead of string concatenation.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8647 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
