### PR TITLE
bench: refactor to use string interpolation in `array/base/any-has-own-property`

### DIFF
--- a/lib/node_modules/@stdlib/array/base/any-has-own-property/benchmark/benchmark.length.js
+++ b/lib/node_modules/@stdlib/array/base/any-has-own-property/benchmark/benchmark.length.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var filled = require( '@stdlib/array/filled' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var anyHasOwnProp = require( './../lib' );
 
@@ -89,7 +90,7 @@ function main() {
 		len = pow( 10, i );
 
 		f = createBenchmark( len );
-		bench( pkg+':dtype=generic,len='+len, f );
+		bench( format( '%s:dtype=generic,len=%d', pkg, len ), f );
 	}
 }
 


### PR DESCRIPTION
Resolves a part of #8647.

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors the JavaScript benchmark in `@stdlib/array/base/any-has-own-property` to use `@stdlib/string/format` for string interpolation instead of string concatenation when specifying the benchmark name

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8647

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Changes made:**
- Added `@stdlib/string/format` import to the MODULES section
- Replaced string concatenation `pkg+':dtype=generic,len='+len` with `format( '%s:dtype=generic,len=%d', pkg, len )`

**Testing:**
Ran the benchmark locally using `node lib\node_modules\@stdlib\array\base\any-has-own-property\benchmark\benchmark.length.js` and verified that:
- The benchmark executes successfully without errors
- The formatted benchmark names match the original output exactly (`@stdlib/array/base/any-has-own-property:dtype=generic,len=10`, etc.)
- All 18 benchmark tests pass

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md