### PR TITLE
docs: improve doctests for complex number instances in `lapack/base/clacgv`

### DIFF
--- a/lib/node_modules/@stdlib/lapack/base/clacgv/README.md
+++ b/lib/node_modules/@stdlib/lapack/base/clacgv/README.md
@@ -36,21 +36,13 @@ Conjugates each element in a single-precision complex floating-point vector.
 
 ```javascript
 var Complex64Array = require( '@stdlib/array/complex64' );
-var realf = require( '@stdlib/complex/float32/real' );
-var imagf = require( '@stdlib/complex/float32/imag' );
 
 var cx = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
 
 clacgv( 2, cx, 1 );
 
 var z = cx.get( 0 );
-// returns <Complex64>
-
-var re = realf( z );
-// returns 1.0
-
-var im = imagf( z );
-// returns -2.0
+// returns <Complex64>[ 1.0, -2.0 ]
 ```
 
 The function has the following parameters:
@@ -63,21 +55,13 @@ The `N` and stride parameters determine which elements in `cx` are conjugated. F
 
 ```javascript
 var Complex64Array = require( '@stdlib/array/complex64' );
-var realf = require( '@stdlib/complex/float32/real' );
-var imagf = require( '@stdlib/complex/float32/imag' );
 
 var cx = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 
 clacgv( 2, cx, 2 );
 
 var z = cx.get( 0 );
-// returns <Complex64>
-
-var re = realf( z );
-// returns 1.0
-
-var im = imagf( z );
-// returns -2.0
+// returns <Complex64>[ 1.0, -2.0 ]
 ```
 
 Note that indexing is relative to the first index. To introduce an offset, use [`typed array`][mdn-typed-array] views.
@@ -87,8 +71,6 @@ Note that indexing is relative to the first index. To introduce an offset, use [
 ```javascript
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
-var realf = require( '@stdlib/complex/float32/real' );
-var imagf = require( '@stdlib/complex/float32/imag' );
 
 // Initial array:
 var cx0 = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
@@ -100,13 +82,7 @@ var cx1 = new Complex64Array( cx0.buffer, cx0.BYTES_PER_ELEMENT*1 ); // start at
 clacgv( 3, cx1, 1 );
 
 var z = cx0.get( 1 );
-// returns <Complex64>
-
-var re = realf( z );
-// returns 3.0
-
-var im = imagf( z );
-// returns -4.0
+// returns <Complex64>[ 3.0, -4.0 ]
 ```
 
 #### clacgv.ndarray( N, cx, strideCX, offsetCX )
@@ -115,21 +91,13 @@ Conjugates each element in a single-precision floating-point vector using altern
 
 ```javascript
 var Complex64Array = require( '@stdlib/array/complex64' );
-var realf = require( '@stdlib/complex/float32/real' );
-var imagf = require( '@stdlib/complex/float32/imag' );
 
 var cx = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
 
 clacgv.ndarray( 3, cx, 1, 0 );
 
 var z = cx.get( 0 );
-// returns <Complex64>
-
-var re = realf( z );
-// returns 1.0
-
-var im = imagf( z );
-// returns -2.0
+// returns <Complex64>[ 1.0, -2.0 ]
 ```
 
 The function has the following additional parameters:
@@ -140,21 +108,13 @@ While [`typed array`][mdn-typed-array] views mandate a view offset based on the 
 
 ```javascript
 var Complex64Array = require( '@stdlib/array/complex64' );
-var realf = require( '@stdlib/complex/float32/real' );
-var imagf = require( '@stdlib/complex/float32/imag' );
 
 var cx = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 
 clacgv.ndarray( 2, cx, 2, 1 );
 
 var z = cx.get( 3 );
-// returns <Complex64>
-
-var re = realf( z );
-// returns 7.0
-
-var im = imagf( z );
-// returns -8.0
+// returns <Complex64>[ 7.0, -8.0 ]
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/lapack/base/clacgv/docs/repl.txt
+++ b/lib/node_modules/@stdlib/lapack/base/clacgv/docs/repl.txt
@@ -31,30 +31,21 @@
     // Standard usage:
     > var cx = new {{alias:@stdlib/array/complex64}}( [ 1.0, 2.0, 3.0, 4.0 ] );
     > {{alias}}( 2, cx, 1 );
-    > var z = cx.get( 0 );
-    > var re = {{alias:@stdlib/complex/float32/real}}( z )
-    1.0
-    > var im = {{alias:@stdlib/complex/float32/imag}}( z )
-    -2.0
+    > var z = cx.get( 0 )
+    <Complex64>[ 1.0, -2.0 ]
 
     // Advanced indexing:
     > cx = new {{alias:@stdlib/array/complex64}}( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
     > {{alias}}( 2, cx, 2 );
-    > z = cx.get( 0 );
-    > re = {{alias:@stdlib/complex/float32/real}}( z )
-    1.0
-    > im = {{alias:@stdlib/complex/float32/imag}}( z )
-    -2.0
+    > z = cx.get( 0 )
+    <Complex64>[ 1.0, -2.0 ]
 
     // Using typed array views:
     > var cx0 = new {{alias:@stdlib/array/complex64}}( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
     > var cx1 = new {{alias:@stdlib/array/complex64}}( cx0.buffer, cx0.BYTES_PER_ELEMENT*1 );
     > {{alias}}( 2, cx1, 1 );
-    > z = cx0.get( 1 );
-    > re = {{alias:@stdlib/complex/float32/real}}( z )
-    3.0
-    > im = {{alias:@stdlib/complex/float32/imag}}( z )
-    -4.0
+    > z = cx0.get( 1 )
+    <Complex64>[ 3.0, -4.0 ]
 
 
 {{alias}}.ndarray( N, cx, strideCX, offsetCX )
@@ -89,20 +80,14 @@
     // Standard usage:
     > var cx = new {{alias:@stdlib/array/complex64}}( [ 1.0, 2.0, 3.0, 4.0 ] );
     > {{alias}}.ndarray( 2, cx, 1, 0 );
-    > var z = cx.get( 0 );
-    > var re = {{alias:@stdlib/complex/float32/real}}( z )
-    1.0
-    > var im = {{alias:@stdlib/complex/float32/imag}}( z )
-    -2.0
+    > var z = cx.get( 0 )
+    <Complex64>[ 1.0, -2.0 ]
 
     // Advanced indexing:
     > cx = new {{alias:@stdlib/array/complex64}}( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
     > {{alias}}.ndarray( 2, cx, 1, 2 );
-    > z = cx.get( 2 );
-    > re = {{alias:@stdlib/complex/float32/real}}( z )
-    5.0
-    > im = {{alias:@stdlib/complex/float32/imag}}( z )
-    -6.0
+    > z = cx.get( 2 )
+    <Complex64>[ 5.0, -6.0 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/lapack/base/clacgv/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/lapack/base/clacgv/docs/types/index.d.ts
@@ -36,21 +36,13 @@ interface Routine {
 	*
 	* @example
 	* var Complex64Array = require( '@stdlib/array/complex64' );
-	* var realf = require( '@stdlib/complex/float32/real' );
-	* var imagf = require( '@stdlib/complex/float32/imag' );
 	*
 	* var cx = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
 	*
 	* clacgv( 3, cx, 1 );
 	*
 	* var z = cx.get( 0 );
-	* // returns <Complex64>
-	*
-	* var re = realf( z );
-	* // returns 1.0
-	*
-	* var im = imagf( z );
-	* // returns -2.0
+	* // returns <Complex64>[ 1.0, -2.0 ]
 	*/
 	( N: number, cx: Complex64Array, strideCX: number ): Complex64Array;
 
@@ -65,21 +57,13 @@ interface Routine {
 	*
 	* @example
 	* var Complex64Array = require( '@stdlib/array/complex64' );
-	* var realf = require( '@stdlib/complex/float32/real' );
-	* var imagf = require( '@stdlib/complex/float32/imag' );
 	*
 	* var cx = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
 	*
 	* clacgv.ndarray( 3, cx, 1, 0 );
 	*
 	* var z = cx.get( 0 );
-	* // returns <Complex64>
-	*
-	* var re = realf( z );
-	* // returns 1.0
-	*
-	* var im = imagf( z );
-	* // returns -2.0
+	* // returns <Complex64>[ 1.0, -2.0 ]
 	*/
 	ndarray( N: number, cx: Complex64Array, strideCX: number, offsetCX: number ): Complex64Array;
 }
@@ -94,39 +78,23 @@ interface Routine {
 *
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * var cx = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
 *
 * clacgv( 3, cx, 1 );
 *
 * var z = cx.get( 1 );
-* // returns <Complex64>
-*
-* var re = realf( z );
-* // returns 3.0
-*
-* var im = imagf( z );
-* // returns -4.0
+* // returns <Complex64>[ 3.0, -4.0 ]
 *
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * var cx = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
 *
 * clacgv.ndarray( 2, cx, 1, 1 );
 *
 * var z = cx.get( 1 );
-* // returns <Complex64>
-*
-* var re = realf( z );
-* // returns 3.0
-*
-* var im = imagf( z );
-* // returns -4.0
+* // returns <Complex64>[ 3.0, -4.0 ]
 */
 declare var clacgv: Routine;
 

--- a/lib/node_modules/@stdlib/lapack/base/clacgv/lib/clacgv.js
+++ b/lib/node_modules/@stdlib/lapack/base/clacgv/lib/clacgv.js
@@ -36,21 +36,13 @@ var ndarray = require( './ndarray.js' );
 *
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * var cx = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
 *
 * clacgv( 3, cx, 1 );
 *
 * var z = cx.get( 0 );
-* // returns <Complex64>
-*
-* var re = realf( z );
-* // returns 1.0
-*
-* var im = imagf( z );
-* // returns -2.0
+* // returns <Complex64>[ 1.0, -2.0 ]
 */
 function clacgv( N, cx, strideCX ) {
 	return ndarray( N, cx, strideCX, stride2offset( N, strideCX ) );

--- a/lib/node_modules/@stdlib/lapack/base/clacgv/lib/index.js
+++ b/lib/node_modules/@stdlib/lapack/base/clacgv/lib/index.js
@@ -25,8 +25,6 @@
 *
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 * var clacgv = require( '@stdlib/lapack/base/clacgv' );
 *
 * var cx = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
@@ -34,18 +32,10 @@
 * clacgv( 3, cx, 1 );
 *
 * var z = cx.get( 0 );
-* // returns <Complex64>
-*
-* var re = realf( z );
-* // returns 1.0
-*
-* var im = imagf( z );
-* // returns -2.0
+* // returns <Complex64>[ 1.0, -2.0 ]
 *
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 * var clacgv = require( '@stdlib/lapack/base/clacgv' );
 *
 * var cx = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
@@ -53,13 +43,7 @@
 * clacgv.ndarray( 3, cx, 1, 0 );
 *
 * var z = cx.get( 0 );
-* // returns <Complex64>
-*
-* var re = realf( z );
-* // returns 1.0
-*
-* var im = imagf( z );
-* // returns -2.0
+* // returns <Complex64>[ 1.0, -2.0 ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/lapack/base/clacgv/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/lapack/base/clacgv/lib/ndarray.js
@@ -36,21 +36,13 @@ var reinterpret = require( '@stdlib/strided/base/reinterpret-complex64' );
 *
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * var cx = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
 *
 * clacgv( 3, cx, 1, 0 );
 *
 * var z = cx.get( 0 );
-* // returns <Complex64>
-*
-* var re = realf( z );
-* // returns 1.0
-*
-* var im = imagf( z );
-* // returns -2.0
+* // returns <Complex64>[ 1.0, -2.0 ]
 */
 function clacgv( N, cx, strideCX, offsetCX ) {
 	var cx32;


### PR DESCRIPTION
# lapack/base/clacgv

---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes.
report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: passed
  - task: lint_package_json status: na
  - task: lint_repl_help status: passed
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: passed
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: passed
  - task: lint_license_headers status: passed
---

Resolves a part of #8641 

## Description

This pull request updates documentation examples for the `array/base/accessor-getter` package to correctly use complex number instance notation.

## Related Issues

None.

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [ ] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

{{TODO: add disclosure if applicable}}

---

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
