### PR TITLE
docs: improve doctests for complex number instances in `lapack/base/clacpy`

### DIFF
--- a/lib/node_modules/@stdlib/lapack/base/clacpy/docs/repl.txt
+++ b/lib/node_modules/@stdlib/lapack/base/clacpy/docs/repl.txt
@@ -47,11 +47,8 @@
     > var A = new {{alias:@stdlib/array/complex64}}( abuf );
     > var B = new {{alias:@stdlib/array/complex64}}( bbuf );
     > {{alias}}( 'row-major', 'all', 2, 2, A, 2, B, 2 );
-    > var z = B.get( 0 );
-    > {{alias:@stdlib/complex/float32/real}}( z )
-    1.0
-    > {{alias:@stdlib/complex/float32/imag}}( z )
-    2.0
+    > var z = B.get( 0 )
+    <Complex64>[ 1.0, 2.0 ]
 
 
 {{alias}}.ndarray( uplo, M, N, A, sa1, sa2, oa, B, sb1, sb2, ob )
@@ -110,11 +107,8 @@
     > var A = new {{alias:@stdlib/array/complex64}}( abuf );
     > var B = new {{alias:@stdlib/array/complex64}}( bbuf );
     > {{alias}}.ndarray( 'all', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
-    > var z = B.get( 2 );
-    > {{alias:@stdlib/complex/float32/real}}( z )
-    3.0
-    > {{alias:@stdlib/complex/float32/imag}}( z )
-    4.0
+    > var z = B.get( 2 )
+    <Complex64>[ 3.0, 4.0 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/lapack/base/clacpy/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/lapack/base/clacpy/docs/types/index.d.ts
@@ -42,8 +42,6 @@ interface Routine {
 	*
 	* @example
 	* var Complex64Array = require( '@stdlib/array/complex64' );
-	* var realf = require( '@stdlib/complex/float32/real' );
-	* var imagf = require( '@stdlib/complex/float32/imag' );
 	*
 	* var A = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 	* var B = new Complex64Array( 4 );
@@ -51,13 +49,7 @@ interface Routine {
 	* clacpy( 'row-major', 'all', 2, 2, A, 2, B, 2 );
 	*
 	* var z = B.get( 0 );
-	* // returns <Complex64>
-	*
-	* var v = realf( z );
-	* // returns 1.0
-	*
-	* v = imagf( z );
-	* // returns 2.0
+	* // returns <Complex64>[ 1.0, 2.0 ]
 	*/
 	( order: Layout, uplo: string, M: number, N: number, A: Complex64Array, LDA: number, B: Complex64Array, LDB: number ): Complex64Array;
 
@@ -79,8 +71,6 @@ interface Routine {
 	*
 	* @example
 	* var Complex64Array = require( '@stdlib/array/complex64' );
-	* var realf = require( '@stdlib/complex/float32/real' );
-	* var imagf = require( '@stdlib/complex/float32/imag' );
 	*
 	* var A = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ] );
 	* var B = new Complex64Array( 12 );
@@ -88,13 +78,7 @@ interface Routine {
 	* clacpy.ndarray( 'all', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
 	*
 	* var z = B.get( 2 );
-	* // returns <Complex64>
-	*
-	* var v = realf( z );
-	* // returns 3.0
-	*
-	* v = imagf( z );
-	* // returns 4.0
+	* // returns <Complex64>[ 3.0, 4.0 ]
 	*/
 	ndarray( uplo: string, M: number, N: number, A: Complex64Array, strideA1: number, strideA2: number, offsetA: number, B: Complex64Array, strideB1: number, strideB2: number, offsetB: number ): Complex64Array;
 }
@@ -114,8 +98,6 @@ interface Routine {
 *
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * var A = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
 * var B = new Complex64Array( 4 );
@@ -123,18 +105,10 @@ interface Routine {
 * clacpy( 'row-major', 'all', 2, 2, A, 2, B, 2 );
 *
 * var z = B.get( 0 );
-* // returns <Complex64>
-*
-* var v = realf( z );
-* // returns 1.0
-*
-* v = imagf( z );
-* // returns 2.0
+* // returns <Complex64>[ 1.0, 2.0 ]
 *
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * var A = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ] );
 * var B = new Complex64Array( 12 );
@@ -142,13 +116,7 @@ interface Routine {
 * clacpy.ndarray( 'all', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
 *
 * var z = B.get( 2 );
-* // returns <Complex64>
-*
-* var v = realf( z );
-* // returns 3.0
-*
-* v = imagf( z );
-* // returns 4.0
+* // returns <Complex64>[ 3.0, 4.0 ]
 */
 declare var clacpy: Routine;
 

--- a/lib/node_modules/@stdlib/lapack/base/clacpy/lib/base.js
+++ b/lib/node_modules/@stdlib/lapack/base/clacpy/lib/base.js
@@ -444,8 +444,6 @@ function copyLower( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2,
 *
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * var A = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex64Array( 4 );
@@ -453,45 +451,19 @@ function copyLower( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2,
 * clacpy( 'all', 2, 2, A, 2, 1, 0, B, 2, 1, 0 );
 *
 * var z = B.get( 0 );
-* // returns <Complex64>
-*
-* var v = realf( z );
-* // returns 1.0
-*
-* v = imagf( z );
-* // returns 2.0
+* // returns <Complex64>[ 1.0, 2.0 ]
 *
 * z = B.get( 1 );
-* // returns <Complex64>
-*
-* v = realf( z );
-* // returns 3.0
-*
-* v = imagf( z );
-* // returns 4.0
+* // returns <Complex64>[ 3.0, 4.0 ]
 *
 * z = B.get( 2 );
-* // returns <Complex64>
-*
-* v = realf( z );
-* // returns 5.0
-*
-* v = imagf( z );
-* // returns 6.0
+* // returns <Complex64>[ 5.0, 6.0 ]
 *
 * z = B.get( 3 );
-* // returns <Complex64>
-*
-* v = realf( z );
-* // returns 7.0
-*
-* v = imagf( z );
-* // returns 8.0
+* // returns <Complex64>[ 7.0, 8.0 ]
 *
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * var A = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex64Array( 4 );
@@ -500,45 +472,19 @@ function copyLower( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2,
 * // B => <Complex64Array>
 *
 * var z = B.get( 0 );
-* // returns <Complex64>
-*
-* var v = realf( z );
-* // returns 1.0
-*
-* v = imagf( z );
-* // returns 2.0
+* // returns <Complex64>[ 1.0, 2.0 ]
 *
 * z = B.get( 1 );
-* // returns <Complex64>
-*
-* v = realf( z );
-* // returns 3.0
-*
-* v = imagf( z );
-* // returns 4.0
+* // returns <Complex64>[ 3.0, 4.0 ]
 *
 * z = B.get( 2 );
-* // returns <Complex64>
-*
-* v = realf( z );
-* // returns 0.0
-*
-* v = imagf( z );
-* // returns 0.0
+* // returns <Complex64>[ 0.0, 0.0 ]
 *
 * z = B.get( 3 );
-* // returns <Complex64>
-*
-* v = realf( z );
-* // returns 7.0
-*
-* v = imagf( z );
-* // returns 8.0
+* // returns <Complex64>[ 7.0, 8.0 ]
 *
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * var A = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex64Array( 4 );
@@ -546,40 +492,16 @@ function copyLower( M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2,
 * clacpy( 'lower', 2, 2, A, 2, 1, 0, B, 2, 1, 0 );
 *
 * var z = B.get( 0 );
-* // returns <Complex64>
-*
-* var v = realf( z );
-* // returns 1.0
-*
-* v = imagf( z );
-* // returns 2.0
+* // returns <Complex64>[ 1.0, 2.0 ]
 *
 * z = B.get( 1 );
-* // returns <Complex64>
-*
-* v = realf( z );
-* // returns 0.0
-*
-* v = imagf( z );
-* // returns 0.0
+* // returns <Complex64>[ 0.0, 0.0 ]
 *
 * z = B.get( 2 );
-* // returns <Complex64>
-*
-* v = realf( z );
-* // returns 5.0
-*
-* v = imagf( z );
-* // returns 6.0
+* // returns <Complex64>[ 5.0, 6.0 ]
 *
 * z = B.get( 3 );
-* // returns <Complex64>
-*
-* v = realf( z );
-* // returns 7.0
-*
-* v = imagf( z );
-* // returns 8.0
+* // returns <Complex64>[ 7.0, 8.0 ]
 */
 function clacpy( uplo, M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB ) {
 	var viewA;

--- a/lib/node_modules/@stdlib/lapack/base/clacpy/lib/clacpy.js
+++ b/lib/node_modules/@stdlib/lapack/base/clacpy/lib/clacpy.js
@@ -46,8 +46,6 @@ var base = require( './base.js' );
 *
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * var A = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex64Array( 4 );
@@ -55,18 +53,10 @@ var base = require( './base.js' );
 * clacpy( 'row-major', 'all', 2, 2, A, 2, B, 2 );
 *
 * var z = B.get( 0 );
-* // returns <Complex64>
-*
-* var v = realf( z );
-* // returns 1.0
-*
-* v = imagf( z );
-* // returns 2.0
+* // returns <Complex64>[ 1.0, 2.0 ]
 *
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * var A = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex64Array( 4 );
@@ -74,27 +64,13 @@ var base = require( './base.js' );
 * clacpy( 'row-major', 'upper', 2, 2, A, 2, B, 2 );
 *
 * var z = B.get( 0 );
-* // returns <Complex64>
-*
-* var v = realf( z );
-* // returns 1.0
-*
-* v = imagf( z );
-* // returns 2.0
+* // returns <Complex64>[ 1.0, 2.0 ]
 *
 * z = B.get( 2 );
-* // returns <Complex64>
-*
-* v = realf( z );
-* // returns 0.0
-*
-* v = imagf( z );
-* // returns 0.0
+* // returns <Complex64>[ 0.0, 0.0 ]
 *
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * var A = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var B = new Complex64Array( 4 );
@@ -102,22 +78,10 @@ var base = require( './base.js' );
 * clacpy( 'row-major', 'lower', 2, 2, A, 2, B, 2 );
 *
 * var z = B.get( 0 );
-* // returns <Complex64>
-*
-* var v = realf( z );
-* // returns 1.0
-*
-* v = imagf( z );
-* // returns 2.0
+* // returns <Complex64>[ 1.0, 2.0 ]
 *
 * z = B.get( 1 );
-* // returns <Complex64>
-*
-* v = realf( z );
-* // returns 0.0
-*
-* v = imagf( z );
-* // returns 0.0
+* // returns <Complex64>[ 0.0, 0.0 ]
 */
 function clacpy( order, uplo, M, N, A, LDA, B, LDB ) {
 	var sa1;

--- a/lib/node_modules/@stdlib/lapack/base/clacpy/lib/index.js
+++ b/lib/node_modules/@stdlib/lapack/base/clacpy/lib/index.js
@@ -25,8 +25,6 @@
 *
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 * var clacpy = require( '@stdlib/lapack/base/clacpy' );
 *
 * var A = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
@@ -35,18 +33,10 @@
 * clacpy( 'row-major', 'all', 2, 2, A, 2, B, 2 );
 *
 * var z = B.get( 0 );
-* // returns <Complex64>
-*
-* var v = realf( z );
-* // returns 1.0
-*
-* v = imagf( z );
-* // returns 2.0
+* // returns <Complex64>[ 1.0, 2.0 ]
 *
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 * var clacpy = require( '@stdlib/lapack/base/clacpy' );
 *
 * var A = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ] );
@@ -55,13 +45,7 @@
 * clacpy.ndarray( 'all', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
 *
 * var z = B.get( 2 );
-* // returns <Complex64>
-*
-* var v = realf( z );
-* // returns 3.0
-*
-* v = imagf( z );
-* // returns 4.0
+* // returns <Complex64>[ 3.0, 4.0 ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/lapack/base/clacpy/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/lapack/base/clacpy/lib/ndarray.js
@@ -43,8 +43,6 @@ var base = require( './base.js' );
 *
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * var A = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ] );
 * var B = new Complex64Array( 12 );
@@ -52,18 +50,10 @@ var base = require( './base.js' );
 * clacpy( 'all', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
 *
 * var z = B.get( 2 );
-* // returns <Complex64>
-*
-* var v = realf( z );
-* // returns 3.0
-*
-* v = imagf( z );
-* // returns 4.0
+* // returns <Complex64>[ 3.0, 4.0 ]
 *
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * var A = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ] );
 * var B = new Complex64Array( 12 );
@@ -71,27 +61,13 @@ var base = require( './base.js' );
 * clacpy( 'upper', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
 *
 * var z = B.get( 2 );
-* // returns <Complex64>
-*
-* var v = realf( z );
-* // returns 3.0
-*
-* v = imagf( z );
-* // returns 4.0
+* // returns <Complex64>[ 3.0, 4.0 ]
 *
 * z = B.get( 4 );
-* // returns <Complex64>
-*
-* v = realf( z );
-* // returns 0.0
-*
-* v = imagf( z );
-* // returns 0.0
+* // returns <Complex64>[ 0.0, 0.0 ]
 *
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * var A = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 ] );
 * var B = new Complex64Array( 12 );
@@ -99,22 +75,10 @@ var base = require( './base.js' );
 * clacpy( 'lower', 2, 2, A, 2, 1, 1, B, 2, 1, 2 );
 *
 * var z = B.get( 2 );
-* // returns <Complex64>
-*
-* var v = realf( z );
-* // returns 3.0
-*
-* v = imagf( z );
-* // returns 4.0
+* // returns <Complex64>[ 3.0, 4.0 ]
 *
 * z = B.get( 1 );
-* // returns <Complex64>
-*
-* v = realf( z );
-* // returns 0.0
-*
-* v = imagf( z );
-* // returns 0.0
+* // returns <Complex64>[ 0.0, 0.0 ]
 */
 function clacpy( uplo, M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB ) { // eslint-disable-line max-len, max-params
 	return base( uplo, M, N, A, strideA1, strideA2, offsetA, B, strideB1, strideB2, offsetB ); // eslint-disable-line max-len


### PR DESCRIPTION
# lapack/base/clacpy

---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes.
report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: passed
  - task: lint_package_json status: na
  - task: lint_repl_help status: passed
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: passed
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: passed
  - task: lint_license_headers status: passed
---

Resolves a part of #8641 

## Description

This pull request updates documentation examples for the `array/base/accessor-getter` package to correctly use complex number instance notation.

## Related Issues

None.

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [ ] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

{{TODO: add disclosure if applicable}}

---

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
