### PR TITLE
docs: improve doctests for complex number instances in `array/base/last`

### DIFF
--- a/lib/node_modules/@stdlib/array/base/last/README.md
+++ b/lib/node_modules/@stdlib/array/base/last/README.md
@@ -73,8 +73,6 @@ var out = last( x );
 
 ```javascript
 var Complex64Array = require( '@stdlib/array/complex64' );
-var realf = require( '@stdlib/complex/float32/real' );
-var imagf = require( '@stdlib/complex/float32/imag' );
 var last = require( '@stdlib/array/base/last' );
 
 // Create a complex number array:
@@ -82,15 +80,9 @@ var arr = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
 
 // Return the last element:
 var out = last( arr );
-// returns <Complex64>
+// returns <Complex64>[ 5.0, 6.0 ]
 
-var re = realf( out );
-// returns 5.0
-
-var im = imagf( out );
-// returns 6.0
-
-console.log( '%d + %di', re, im );
+console.log( out.toString() );
 // => '5 + 6i'
 ```
 

--- a/lib/node_modules/@stdlib/array/base/last/examples/index.js
+++ b/lib/node_modules/@stdlib/array/base/last/examples/index.js
@@ -19,8 +19,6 @@
 'use strict';
 
 var Complex64Array = require( '@stdlib/array/complex64' );
-var realf = require( '@stdlib/complex/float32/real' );
-var imagf = require( '@stdlib/complex/float32/imag' );
 var last = require( './../lib' );
 
 // Create a complex number array:
@@ -28,13 +26,7 @@ var arr = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
 
 // Return the last element:
 var out = last( arr );
-// returns <Complex64>
+// returns <Complex64>[ 5.0, 6.0 ]
 
-var re = realf( out );
-// returns 5.0
-
-var im = imagf( out );
-// returns 6.0
-
-console.log( '%d + %di', re, im );
+console.log( out.toString() );
 // => '5 + 6i'


### PR DESCRIPTION
Resolves a part of #8641 

## Description

> What is the purpose of this pull request?

This pull request:

-   Updates REPL and documentation examples in the `array/base/last` package to use the compact complex instance doctest notation.
-   Replaces example decomposition using `realf`/`imagf` with concise doctest annotations such as ` <Complex64>[ 5.0, 6.0 ]`.
-   Removes example-only imports (`realf`, `imagf`) where they were only used to show decomposed values.
-   Keeps all edits documentation-only (no runtime behavior or type changes).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8641 

(Replace the placeholder above with the relevant issue number if applicable.)

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution.

N/A

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
