### PR TITLE
chore: fix JavaScript lint errors (issue #8670)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-list-item-bullet-indent/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-list-item-bullet-indent/lib/main.js
@@ -40,6 +40,26 @@ var rule;
 // FUNCTIONS //
 
 /**
+* Copies AST node location info.
+*
+* @private
+* @param {Object} loc - AST node location
+* @returns {Object} copied location info
+*/
+function copyLocationInfo( loc ) {
+	return {
+		'start': {
+			'line': loc.start.line,
+			'column': loc.start.column
+		},
+		'end': {
+			'line': loc.end.line,
+			'column': loc.end.column
+		}
+	};
+}
+
+/**
 * Rule to prevent unnecessary indentation of Markdown list item bullets in JSDoc descriptions.
 *
 * @param {Object} context - ESLint context
@@ -110,26 +130,6 @@ function main( context ) {
 			loc.start.column = err.location.start.column + 1; // Note: we assume that 1 space separates `*` from JSDoc description content (e.g., `* ## Beep`)
 			report( msg, loc );
 		}
-	}
-
-	/**
-	* Copies AST node location info.
-	*
-	* @private
-	* @param {Object} loc - AST node location
-	* @returns {Object} copied location info
-	*/
-	function copyLocationInfo( loc ) {
-		return {
-			'start': {
-				'line': loc.start.line,
-				'column': loc.start.column
-			},
-			'end': {
-				'line': loc.end.line,
-				'column': loc.end.column
-			}
-		};
 	}
 
 	/**

--- a/lib/node_modules/@stdlib/repl/presentation/lib/commands/last_fragment.js
+++ b/lib/node_modules/@stdlib/repl/presentation/lib/commands/last_fragment.js
@@ -31,21 +31,21 @@ function command( pres ) {
 	return onCommand;
 
 	/**
+	* Callback invoked upon a `drain` event.
+	*
+	* @private
+	*/
+	function onDrain() {
+		pres.lastFragment().show();
+	}
+
+	/**
 	* Jumps to the last fragment of the current slide.
 	*
 	* @private
 	*/
 	function onCommand() {
 		pres._repl.once( 'drain', onDrain ); // eslint-disable-line no-underscore-dangle
-
-		/**
-		* Callback invoked upon a `drain` event.
-		*
-		* @private
-		*/
-		function onDrain() {
-			pres.lastFragment().show();
-		}
 	}
 }
 

--- a/lib/node_modules/@stdlib/utils/timeit/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/timeit/lib/main.js
@@ -35,7 +35,8 @@ var transform = require( './transform.js' );
 
 // VARIABLES //
 
-var FILENAME = 'timeit.js';
+// cspell:ignore timeit
+var FILENAME = 'timeit.js'; // filename
 var MIN_TIME = 0.1; // seconds
 var ITERATIONS = 10; // 10^1
 var MAX_ITERATIONS = 10000000000; // 10^10
@@ -83,6 +84,7 @@ function timeit( code, options, clbk ) {
 	var err;
 	var idx;
 	var cb;
+	var i;
 
 	if ( !isString( code ) ) {
 		throw new TypeError( format( 'invalid argument. First argument must be a string. Value: `%s`.', code ) );
@@ -100,7 +102,10 @@ function timeit( code, options, clbk ) {
 	if ( !isFunction( cb ) ) {
 		throw new TypeError( format( 'invalid argument. Callback argument must be a function. Value: `%s`.', cb ) );
 	}
-	results = new Array( opts.repeats );
+	results = [ ];
+	for ( i = 0; i < opts.repeats; i++ ) {
+		results[ i ] = 0;
+	}
 	dir = cwd();
 	idx = 0;
 
@@ -213,6 +218,7 @@ function timeit( code, options, clbk ) {
 		if ( !error ) {
 			out = transform( results, opts.iterations );
 		}
+		// cspell:ignore zalgo
 		// Avoid releasing the zalgo:
 		nextTick( onTick );
 


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Resolves #8670 .

## Description

> What is the purpose of this pull request?

This pull request:

-   Resolves the linting error in lib/node_modules/@stdlib/utils/timeit/lib/main.js by replay new Array( ) by [ ] and push to initialize, lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-list-item-bullet-indent/lib/main.js to bring copyLocationInfo( ) into a module scope and lib/node_modules/@stdlib/repl/presentation/lib/commands/last_fragment.js to bring onDrain() to function scope ( ).

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #resolves #8670 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
