### PR TITLE
bench: refactor to use string interpolation in `array/fixed-endian-factory`

### DIFF
--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.at.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.at.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var isNumber = require( '@stdlib/assert/is-number' ).isPrimitive;
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -33,7 +34,7 @@ var Float64ArrayFE = factory( 'float64' );
 
 // MAIN //
 
-bench( pkg+'::nonnegative_indices:at:endianness=little-endian', function benchmark( b ) {
+bench( format( '%s::nonnegative_indices:at:endianness=little-endian', pkg ), function benchmark( b ) {
 	var arr;
 	var N;
 	var v;
@@ -61,7 +62,7 @@ bench( pkg+'::nonnegative_indices:at:endianness=little-endian', function benchma
 	b.end();
 });
 
-bench( pkg+'::negative_indices:at:endianness=little-endian', function benchmark( b ) {
+bench( format( '%s::negative_indices:at:endianness=little-endian', pkg ), function benchmark( b ) {
 	var arr;
 	var N;
 	var v;
@@ -89,7 +90,7 @@ bench( pkg+'::negative_indices:at:endianness=little-endian', function benchmark(
 	b.end();
 });
 
-bench( pkg+'::nonnegative_indices:at:endianness=big-endian', function benchmark( b ) {
+bench( format( '%s::nonnegative_indices:at:endianness=big-endian', pkg ), function benchmark( b ) {
 	var arr;
 	var N;
 	var v;
@@ -117,7 +118,7 @@ bench( pkg+'::nonnegative_indices:at:endianness=big-endian', function benchmark(
 	b.end();
 });
 
-bench( pkg+'::negative_indices:at:endianness=big-endian', function benchmark( b ) {
+bench( format( '%s::negative_indices:at:endianness=big-endian', pkg ), function benchmark( b ) {
 	var arr;
 	var N;
 	var v;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.at.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.at.js
@@ -22,9 +22,9 @@
 
 var bench = require( '@stdlib/bench' );
 var isNumber = require( '@stdlib/assert/is-number' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.every.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.every.js
@@ -35,7 +35,6 @@ var Float64ArrayFE = factory( 'float64' );
 // MAIN //
 
 bench( format( '%s:every', pkg ), function benchmark( b ) {
-
 	var bool;
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.every.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.every.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -33,7 +34,8 @@ var Float64ArrayFE = factory( 'float64' );
 
 // MAIN //
 
-bench( pkg+':every', function benchmark( b ) {
+bench( format( '%s:every', pkg ), function benchmark( b ) {
+
 	var bool;
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.every.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.every.js
@@ -22,9 +22,9 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.every.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.every.length.js
@@ -24,9 +24,9 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var zeroTo = require( '@stdlib/array/zero-to' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.every.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.every.length.js
@@ -26,6 +26,7 @@ var zeroTo = require( '@stdlib/array/zero-to' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -106,7 +107,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':every:len='+len, f );
+		bench( format( '%s:every:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.filter.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.filter.js
@@ -25,6 +25,7 @@ var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
 var format = require( '@stdlib/string/format' );
 
+
 // VARIABLES //
 
 var Float64ArrayFE = factory( 'float64' );

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.filter.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.filter.js
@@ -23,7 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-
+var format = require( '@stdlib/string/format' );
 
 // VARIABLES //
 
@@ -32,7 +32,8 @@ var Float64ArrayFE = factory( 'float64' );
 
 // MAIN //
 
-bench( pkg+':filter', function benchmark( b ) {
+bench( format( '%s:filter', pkg ), function benchmark( b ) {
+
 	var out;
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.filter.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.filter.js
@@ -21,9 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -34,7 +34,6 @@ var Float64ArrayFE = factory( 'float64' );
 // MAIN //
 
 bench( format( '%s:filter', pkg ), function benchmark( b ) {
-
 	var out;
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.filter.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.filter.length.js
@@ -23,9 +23,9 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var zeroTo = require( '@stdlib/array/zero-to' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -107,7 +107,6 @@ function main() {
 		len = pow( 10, i );
 		f = createBenchmark( len );
 		bench( format( '%s:filter:len=%d', pkg, len ), f );
-
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.filter.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.filter.length.js
@@ -27,6 +27,7 @@ var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
 var format = require( '@stdlib/string/format' );
 
+
 // VARIABLES //
 
 var Float64ArrayFE = factory( 'float64' );

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.filter.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.filter.length.js
@@ -25,7 +25,7 @@ var pow = require( '@stdlib/math/base/special/pow' );
 var zeroTo = require( '@stdlib/array/zero-to' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-
+var format = require( '@stdlib/string/format' );
 
 // VARIABLES //
 
@@ -105,7 +105,8 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':filter:len='+len, f );
+		bench( format( '%s:filter:len=%d', pkg, len ), f );
+
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.for_each.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.for_each.js
@@ -22,9 +22,9 @@
 
 var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -33,8 +33,8 @@ var Float64ArrayFE = factory( 'float64' );
 
 
 // MAIN //
-bench( format( '%s:forEach', pkg ), function benchmark( b ) {
 
+bench( format( '%s:forEach', pkg ), function benchmark( b ) {
 	var arr;
 	var i;
 

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.for_each.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.for_each.js
@@ -24,7 +24,7 @@ var bench = require( '@stdlib/bench' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-
+var format = require( '@stdlib/string/format' );
 
 // VARIABLES //
 
@@ -32,8 +32,8 @@ var Float64ArrayFE = factory( 'float64' );
 
 
 // MAIN //
+bench( format( '%s:forEach', pkg ), function benchmark( b ) {
 
-bench( pkg+':forEach', function benchmark( b ) {
 	var arr;
 	var i;
 

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.for_each.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.for_each.js
@@ -26,6 +26,7 @@ var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
 var format = require( '@stdlib/string/format' );
 
+
 // VARIABLES //
 
 var Float64ArrayFE = factory( 'float64' );

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.for_each.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.for_each.length.js
@@ -24,9 +24,9 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var zeroTo = require( '@stdlib/array/zero-to' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -100,7 +100,6 @@ function main() {
 		len = pow( 10, i );
 		f = createBenchmark( len );
 		bench( format( '%s:forEach:len=%d', pkg, len ), f );
-
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.for_each.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.for_each.length.js
@@ -26,6 +26,7 @@ var zeroTo = require( '@stdlib/array/zero-to' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -98,7 +99,8 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':forEach:len='+len, f );
+		bench( format( '%s:forEach:len=%d', pkg, len ), f );
+
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.from.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.from.js
@@ -25,6 +25,7 @@ var Float64Array = require( '@stdlib/array/float64' );
 var ITERATOR_SYMBOL = require( '@stdlib/symbol/iterator' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -37,7 +38,7 @@ var Float64ArrayFE = factory( 'float64' );
 
 // MAIN //
 
-bench( pkg+'::typed_array:from', function benchmark( b ) {
+bench( format( '%s::typed_array:from', pkg ), function benchmark( b ) {
 	var buf;
 	var arr;
 	var i;
@@ -59,7 +60,7 @@ bench( pkg+'::typed_array:from', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::typed_array:from:len=5', function benchmark( b ) {
+bench( format( '%s::typed_array:from:len=5', pkg ), function benchmark( b ) {
 	var buf;
 	var arr;
 	var i;
@@ -81,7 +82,7 @@ bench( pkg+'::typed_array:from:len=5', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::typed_array,clbk:from:len=5', function benchmark( b ) {
+bench( format( '%s::typed_array,clbk:from:len=5', pkg ), function benchmark( b ) {
 	var buf;
 	var arr;
 	var i;
@@ -107,7 +108,7 @@ bench( pkg+'::typed_array,clbk:from:len=5', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::array:from', function benchmark( b ) {
+bench( format( '%s::array:from', pkg ), function benchmark( b ) {
 	var buf;
 	var arr;
 	var i;
@@ -129,7 +130,7 @@ bench( pkg+'::array:from', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::array:from:len=5', function benchmark( b ) {
+bench( format( '%s::array:from:len=5', pkg ), function benchmark( b ) {
 	var buf;
 	var arr;
 	var i;
@@ -151,7 +152,7 @@ bench( pkg+'::array:from:len=5', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::array,clbk:from:len=5', function benchmark( b ) {
+bench( format( '%s::array,clbk:from:len=5', pkg ), function benchmark( b ) {
 	var buf;
 	var arr;
 	var i;
@@ -177,7 +178,7 @@ bench( pkg+'::array,clbk:from:len=5', function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::iterable:from', opts, function benchmark( b ) {
+bench( format( '%s::iterable:from', pkg ), function benchmark( b ) {
 	var arr;
 	var i;
 
@@ -214,7 +215,7 @@ bench( pkg+'::iterable:from', opts, function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::iterable:from:len=5', opts, function benchmark( b ) {
+bench( format( '%s::iterable:from:len=5', pkg ), function benchmark( b ) {
 	var arr;
 	var i;
 
@@ -260,7 +261,7 @@ bench( pkg+'::iterable:from:len=5', opts, function benchmark( b ) {
 	}
 });
 
-bench( pkg+'::iterable,clbk:from:len=5', opts, function benchmark( b ) {
+bench( format( '%s::iterable,clbk:from:len=5', pkg ), function benchmark( b ) {
 	var arr;
 	var i;
 

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.from.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.from.js
@@ -23,9 +23,9 @@
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var ITERATOR_SYMBOL = require( '@stdlib/symbol/iterator' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -178,7 +178,7 @@ bench( format( '%s::array,clbk:from:len=5', pkg ), function benchmark( b ) {
 	}
 });
 
-bench( format( '%s::iterable:from', pkg ), function benchmark( b ) {
+bench( format( '%s::iterable:from', pkg ), opts, function benchmark( b ) {
 	var arr;
 	var i;
 
@@ -215,7 +215,7 @@ bench( format( '%s::iterable:from', pkg ), function benchmark( b ) {
 	}
 });
 
-bench( format( '%s::iterable:from:len=5', pkg ), function benchmark( b ) {
+bench( format( '%s::iterable:from:len=5', pkg ), opts, function benchmark( b ) {
 	var arr;
 	var i;
 
@@ -261,7 +261,7 @@ bench( format( '%s::iterable:from:len=5', pkg ), function benchmark( b ) {
 	}
 });
 
-bench( format( '%s::iterable,clbk:from:len=5', pkg ), function benchmark( b ) {
+bench( format( '%s::iterable,clbk:from:len=5', pkg ), opts, function benchmark( b ) {
 	var arr;
 	var i;
 

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.get.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.get.js
@@ -22,9 +22,9 @@
 
 var bench = require( '@stdlib/bench' );
 var isNumber = require( '@stdlib/assert/is-number' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -35,7 +35,6 @@ var Float64ArrayFE = factory( 'float64' );
 // MAIN //
 
 bench( format( '%s:get:endianness=little-endian', pkg ), function benchmark( b ) {
-
 	var arr;
 	var N;
 	var v;
@@ -64,7 +63,6 @@ bench( format( '%s:get:endianness=little-endian', pkg ), function benchmark( b )
 });
 
 bench( format( '%s:get:endianness=big-endian', pkg ), function benchmark( b ) {
-
 	var arr;
 	var N;
 	var v;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.get.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.get.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var isNumber = require( '@stdlib/assert/is-number' ).isPrimitive;
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -33,7 +34,8 @@ var Float64ArrayFE = factory( 'float64' );
 
 // MAIN //
 
-bench( pkg+':get:endianness=little-endian', function benchmark( b ) {
+bench( format( '%s:get:endianness=little-endian', pkg ), function benchmark( b ) {
+
 	var arr;
 	var N;
 	var v;
@@ -61,7 +63,8 @@ bench( pkg+':get:endianness=little-endian', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':get:endianness=big-endian', function benchmark( b ) {
+bench( format( '%s:get:endianness=big-endian', pkg ), function benchmark( b ) {
+
 	var arr;
 	var N;
 	var v;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.includes.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.includes.js
@@ -22,9 +22,9 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var factory = require( './../lib' );
 var pkg = require( './../package.json' ).name;
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -35,7 +35,6 @@ var Float64ArrayFE = factory( 'float64' );
 // MAIN //
 
 bench( format( '%s:includes', pkg ), function benchmark( b ) {
-
 	var result;
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.includes.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.includes.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var factory = require( './../lib' );
 var pkg = require( './../package.json' ).name;
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -33,7 +34,8 @@ var Float64ArrayFE = factory( 'float64' );
 
 // MAIN //
 
-bench( pkg+':includes', function benchmark( b ) {
+bench( format( '%s:includes', pkg ), function benchmark( b ) {
+
 	var result;
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.includes.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.includes.length.js
@@ -26,6 +26,7 @@ var zeroTo = require( '@stdlib/array/zero-to' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var factory = require( './../lib' );
 var pkg = require( './../package.json' ).name;
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -96,7 +97,8 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':includes:len='+len, f );
+		bench( format( '%s:includes:len=%d', pkg, len ), f );
+
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.includes.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.includes.length.js
@@ -24,9 +24,9 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var zeroTo = require( '@stdlib/array/zero-to' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var factory = require( './../lib' );
 var pkg = require( './../package.json' ).name;
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -98,7 +98,6 @@ function main() {
 		len = pow( 10, i );
 		f = createBenchmark( len );
 		bench( format( '%s:includes:len=%d', pkg, len ), f );
-
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.index_of.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.index_of.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var factory = require( './../lib' );
 var pkg = require( './../package.json' ).name;
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -33,7 +34,8 @@ var Float64ArrayFE = factory( 'float64' );
 
 // MAIN //
 
-bench( pkg+':indexOf', function benchmark( b ) {
+bench( format( '%s:indexOf', pkg ), function benchmark( b ) {
+
 	var arr;
 	var idx;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.index_of.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.index_of.js
@@ -22,9 +22,9 @@
 
 var bench = require( '@stdlib/bench' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var factory = require( './../lib' );
 var pkg = require( './../package.json' ).name;
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -35,7 +35,6 @@ var Float64ArrayFE = factory( 'float64' );
 // MAIN //
 
 bench( format( '%s:indexOf', pkg ), function benchmark( b ) {
-
 	var arr;
 	var idx;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.index_of.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.index_of.length.js
@@ -26,6 +26,7 @@ var zeroTo = require( '@stdlib/array/zero-to' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var factory = require( './../lib' );
 var pkg = require( './../package.json' ).name;
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -96,7 +97,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':indexOf:len='+len, f );
+		bench( format( '%s:indexOf:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.index_of.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.index_of.length.js
@@ -24,9 +24,9 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var zeroTo = require( '@stdlib/array/zero-to' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var factory = require( './../lib' );
 var pkg = require( './../package.json' ).name;
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.instantiation.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.instantiation.js
@@ -24,9 +24,9 @@ var bench = require( '@stdlib/bench' );
 var ArrayBuffer = require( '@stdlib/array/buffer' );
 var Float64Array = require( '@stdlib/array/float64' );
 var ITERATOR_SYMBOL = require( '@stdlib/symbol/iterator' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -67,7 +67,6 @@ function createIterable() {
 // MAIN //
 
 bench( format( '%s::instantiation,new:endianness=little-endian', pkg ), function benchmark( b ) {
-
 	var arr;
 	var i;
 	b.tic();
@@ -86,7 +85,6 @@ bench( format( '%s::instantiation,new:endianness=little-endian', pkg ), function
 });
 
 bench( format( '%s::instantiation,new:endianness=big-endian', pkg ), function benchmark( b ) {
-
 	var arr;
 	var i;
 	b.tic();
@@ -105,7 +103,6 @@ bench( format( '%s::instantiation,new:endianness=big-endian', pkg ), function be
 });
 
 bench( format( '%s::instantiation,no_new:endianness=little-endian', pkg ), function benchmark( b ) {
-
 	var ctor;
 	var arr;
 	var i;
@@ -128,7 +125,6 @@ bench( format( '%s::instantiation,no_new:endianness=little-endian', pkg ), funct
 });
 
 bench( format( '%s::instantiation,no_new:endianness=big-endian', pkg ), function benchmark( b ) {
-
 	var ctor;
 	var arr;
 	var i;
@@ -151,7 +147,6 @@ bench( format( '%s::instantiation,no_new:endianness=big-endian', pkg ), function
 });
 
 bench( format( '%s::instantiation,length:endianness=little-endian', pkg ), function benchmark( b ) {
-
 	var arr;
 	var i;
 	b.tic();
@@ -170,7 +165,6 @@ bench( format( '%s::instantiation,length:endianness=little-endian', pkg ), funct
 });
 
 bench( format( '%s::instantiation,length:endianness=big-endian', pkg ), function benchmark( b ) {
-
 	var arr;
 	var i;
 	b.tic();
@@ -189,7 +183,6 @@ bench( format( '%s::instantiation,length:endianness=big-endian', pkg ), function
 });
 
 bench( format( '%s::instantiation,typed_array:endianness=little-endian', pkg ), function benchmark( b ) {
-
 	var buf;
 	var arr;
 	var i;
@@ -212,7 +205,6 @@ bench( format( '%s::instantiation,typed_array:endianness=little-endian', pkg ), 
 });
 
 bench( format( '%s::instantiation,typed_array:endianness=big-endian', pkg ), function benchmark( b ) {
-
 	var buf;
 	var arr;
 	var i;
@@ -235,7 +227,6 @@ bench( format( '%s::instantiation,typed_array:endianness=big-endian', pkg ), fun
 });
 
 bench( format( '%s::instantiation,array:endianness=little-endian', pkg ), function benchmark( b ) {
-
 	var buf;
 	var arr;
 	var i;
@@ -258,7 +249,6 @@ bench( format( '%s::instantiation,array:endianness=little-endian', pkg ), functi
 });
 
 bench( format( '%s::instantiation,array:endianness=big-endian', pkg ), function benchmark( b ) {
-
 	var buf;
 	var arr;
 	var i;
@@ -280,8 +270,7 @@ bench( format( '%s::instantiation,array:endianness=big-endian', pkg ), function 
 	b.end();
 });
 
-bench( format( '%s::instantiation,iterable:endianness=little-endian', pkg ), function benchmark( b ) {
-
+bench( format( '%s::instantiation,iterable:endianness=little-endian', pkg ), opts, function benchmark( b ) {
 	var arr;
 	var i;
 
@@ -300,8 +289,7 @@ bench( format( '%s::instantiation,iterable:endianness=little-endian', pkg ), fun
 	b.end();
 });
 
-bench( format( '%s::instantiation,iterable:endianness=big-endian', pkg ), function benchmark( b ) {
-
+bench( format( '%s::instantiation,iterable:endianness=big-endian', pkg ), opts, function benchmark( b ) {
 	var arr;
 	var i;
 
@@ -321,7 +309,6 @@ bench( format( '%s::instantiation,iterable:endianness=big-endian', pkg ), functi
 });
 
 bench( format( '%s::instantiation,arraybuffer:endianness=little-endian', pkg ), function benchmark( b ) {
-
 	var buf;
 	var arr;
 	var i;
@@ -344,7 +331,6 @@ bench( format( '%s::instantiation,arraybuffer:endianness=little-endian', pkg ), 
 });
 
 bench( format( '%s::instantiation,arraybuffer:endianness=big-endian', pkg ), function benchmark( b ) {
-
 	var buf;
 	var arr;
 	var i;
@@ -367,7 +353,6 @@ bench( format( '%s::instantiation,arraybuffer:endianness=big-endian', pkg ), fun
 });
 
 bench( format( '%s::instantiation,arraybuffer,byte_offset:endianness=little-endian', pkg ), function benchmark( b ) {
-
 	var buf;
 	var arr;
 	var i;
@@ -390,7 +375,6 @@ bench( format( '%s::instantiation,arraybuffer,byte_offset:endianness=little-endi
 });
 
 bench( format( '%s::instantiation,arraybuffer,byte_offset:endianness=big-endian', pkg ), function benchmark( b ) {
-
 	var buf;
 	var arr;
 	var i;
@@ -413,7 +397,6 @@ bench( format( '%s::instantiation,arraybuffer,byte_offset:endianness=big-endian'
 });
 
 bench( format( '%s::instantiation,arraybuffer,byte_offset,length:endianness=little-endian', pkg ), function benchmark( b ) {
-
 	var buf;
 	var arr;
 	var i;
@@ -436,7 +419,6 @@ bench( format( '%s::instantiation,arraybuffer,byte_offset,length:endianness=litt
 });
 
 bench( format( '%s::instantiation,arraybuffer,byte_offset,length:endianness=big-endian', pkg ), function benchmark( b ) {
-
 	var buf;
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.instantiation.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.instantiation.js
@@ -26,6 +26,7 @@ var Float64Array = require( '@stdlib/array/float64' );
 var ITERATOR_SYMBOL = require( '@stdlib/symbol/iterator' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -65,7 +66,8 @@ function createIterable() {
 
 // MAIN //
 
-bench( pkg+'::instantiation,new:endianness=little-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,new:endianness=little-endian', pkg ), function benchmark( b ) {
+
 	var arr;
 	var i;
 	b.tic();
@@ -83,7 +85,8 @@ bench( pkg+'::instantiation,new:endianness=little-endian', function benchmark( b
 	b.end();
 });
 
-bench( pkg+'::instantiation,new:endianness=big-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,new:endianness=big-endian', pkg ), function benchmark( b ) {
+
 	var arr;
 	var i;
 	b.tic();
@@ -101,7 +104,8 @@ bench( pkg+'::instantiation,new:endianness=big-endian', function benchmark( b ) 
 	b.end();
 });
 
-bench( pkg+'::instantiation,no_new:endianness=little-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,no_new:endianness=little-endian', pkg ), function benchmark( b ) {
+
 	var ctor;
 	var arr;
 	var i;
@@ -123,7 +127,8 @@ bench( pkg+'::instantiation,no_new:endianness=little-endian', function benchmark
 	b.end();
 });
 
-bench( pkg+'::instantiation,no_new:endianness=big-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,no_new:endianness=big-endian', pkg ), function benchmark( b ) {
+
 	var ctor;
 	var arr;
 	var i;
@@ -145,7 +150,8 @@ bench( pkg+'::instantiation,no_new:endianness=big-endian', function benchmark( b
 	b.end();
 });
 
-bench( pkg+'::instantiation,length:endianness=little-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,length:endianness=little-endian', pkg ), function benchmark( b ) {
+
 	var arr;
 	var i;
 	b.tic();
@@ -163,7 +169,8 @@ bench( pkg+'::instantiation,length:endianness=little-endian', function benchmark
 	b.end();
 });
 
-bench( pkg+'::instantiation,length:endianness=big-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,length:endianness=big-endian', pkg ), function benchmark( b ) {
+
 	var arr;
 	var i;
 	b.tic();
@@ -181,7 +188,8 @@ bench( pkg+'::instantiation,length:endianness=big-endian', function benchmark( b
 	b.end();
 });
 
-bench( pkg+'::instantiation,typed_array:endianness=little-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,typed_array:endianness=little-endian', pkg ), function benchmark( b ) {
+
 	var buf;
 	var arr;
 	var i;
@@ -203,7 +211,8 @@ bench( pkg+'::instantiation,typed_array:endianness=little-endian', function benc
 	b.end();
 });
 
-bench( pkg+'::instantiation,typed_array:endianness=big-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,typed_array:endianness=big-endian', pkg ), function benchmark( b ) {
+
 	var buf;
 	var arr;
 	var i;
@@ -225,7 +234,8 @@ bench( pkg+'::instantiation,typed_array:endianness=big-endian', function benchma
 	b.end();
 });
 
-bench( pkg+'::instantiation,array:endianness=little-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,array:endianness=little-endian', pkg ), function benchmark( b ) {
+
 	var buf;
 	var arr;
 	var i;
@@ -247,7 +257,8 @@ bench( pkg+'::instantiation,array:endianness=little-endian', function benchmark(
 	b.end();
 });
 
-bench( pkg+'::instantiation,array:endianness=big-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,array:endianness=big-endian', pkg ), function benchmark( b ) {
+
 	var buf;
 	var arr;
 	var i;
@@ -269,7 +280,8 @@ bench( pkg+'::instantiation,array:endianness=big-endian', function benchmark( b 
 	b.end();
 });
 
-bench( pkg+'::instantiation,iterable:endianness=little-endian', opts, function benchmark( b ) {
+bench( format( '%s::instantiation,iterable:endianness=little-endian', pkg ), function benchmark( b ) {
+
 	var arr;
 	var i;
 
@@ -288,7 +300,8 @@ bench( pkg+'::instantiation,iterable:endianness=little-endian', opts, function b
 	b.end();
 });
 
-bench( pkg+'::instantiation,iterable:endianness=big-endian', opts, function benchmark( b ) {
+bench( format( '%s::instantiation,iterable:endianness=big-endian', pkg ), function benchmark( b ) {
+
 	var arr;
 	var i;
 
@@ -307,7 +320,8 @@ bench( pkg+'::instantiation,iterable:endianness=big-endian', opts, function benc
 	b.end();
 });
 
-bench( pkg+'::instantiation,arraybuffer:endianness=little-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,arraybuffer:endianness=little-endian', pkg ), function benchmark( b ) {
+
 	var buf;
 	var arr;
 	var i;
@@ -329,7 +343,8 @@ bench( pkg+'::instantiation,arraybuffer:endianness=little-endian', function benc
 	b.end();
 });
 
-bench( pkg+'::instantiation,arraybuffer:endianness=big-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,arraybuffer:endianness=big-endian', pkg ), function benchmark( b ) {
+
 	var buf;
 	var arr;
 	var i;
@@ -351,7 +366,8 @@ bench( pkg+'::instantiation,arraybuffer:endianness=big-endian', function benchma
 	b.end();
 });
 
-bench( pkg+'::instantiation,arraybuffer,byte_offset:endianness=little-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,arraybuffer,byte_offset:endianness=little-endian', pkg ), function benchmark( b ) {
+
 	var buf;
 	var arr;
 	var i;
@@ -373,7 +389,8 @@ bench( pkg+'::instantiation,arraybuffer,byte_offset:endianness=little-endian', f
 	b.end();
 });
 
-bench( pkg+'::instantiation,arraybuffer,byte_offset:endianness=big-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,arraybuffer,byte_offset:endianness=big-endian', pkg ), function benchmark( b ) {
+
 	var buf;
 	var arr;
 	var i;
@@ -395,7 +412,8 @@ bench( pkg+'::instantiation,arraybuffer,byte_offset:endianness=big-endian', func
 	b.end();
 });
 
-bench( pkg+'::instantiation,arraybuffer,byte_offset,length:endianness=little-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,arraybuffer,byte_offset,length:endianness=little-endian', pkg ), function benchmark( b ) {
+
 	var buf;
 	var arr;
 	var i;
@@ -417,7 +435,8 @@ bench( pkg+'::instantiation,arraybuffer,byte_offset,length:endianness=little-end
 	b.end();
 });
 
-bench( pkg+'::instantiation,arraybuffer,byte_offset,length:endianness=big-endian', function benchmark( b ) {
+bench( format( '%s::instantiation,arraybuffer,byte_offset,length:endianness=big-endian', pkg ), function benchmark( b ) {
+
 	var buf;
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.join.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.join.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var factory = require( './../lib' );
 var pkg = require( './../package.json' ).name;
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -32,7 +33,8 @@ var Float64ArrayFE = factory( 'float64' );
 
 // MAIN //
 
-bench( pkg+':join', function benchmark( b ) {
+bench( format( '%s:join', pkg ), function benchmark( b ) {
+
 	var out;
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.join.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.join.js
@@ -21,9 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var factory = require( './../lib' );
 var pkg = require( './../package.json' ).name;
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -34,7 +34,6 @@ var Float64ArrayFE = factory( 'float64' );
 // MAIN //
 
 bench( format( '%s:join', pkg ), function benchmark( b ) {
-
 	var out;
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.join.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.join.length.js
@@ -25,6 +25,7 @@ var pow = require( '@stdlib/math/base/special/pow' );
 var zeroTo = require( '@stdlib/array/zero-to' );
 var factory = require( './../lib' );
 var pkg = require( './../package.json' ).name;
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -92,7 +93,8 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':join:len='+len, f );
+		bench( format( '%s:join:len=%d', pkg, len ), f );
+
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.join.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.join.length.js
@@ -23,9 +23,9 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var zeroTo = require( '@stdlib/array/zero-to' );
+var format = require( '@stdlib/string/format' );
 var factory = require( './../lib' );
 var pkg = require( './../package.json' ).name;
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -94,7 +94,6 @@ function main() {
 		len = pow( 10, i );
 		f = createBenchmark( len );
 		bench( format( '%s:join:len=%d', pkg, len ), f );
-
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.last_index_of.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.last_index_of.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var factory = require( './../lib' );
 var pkg = require( './../package.json' ).name;
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -33,7 +34,8 @@ var Float64ArrayFE = factory( 'float64' );
 
 // MAIN //
 
-bench( pkg+':lastIndexOf', function benchmark( b ) {
+bench( format( '%s:lastIndexOf', pkg ), function benchmark( b ) {
+
 	var arr;
 	var idx;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.last_index_of.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.last_index_of.js
@@ -22,9 +22,9 @@
 
 var bench = require( '@stdlib/bench' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var factory = require( './../lib' );
 var pkg = require( './../package.json' ).name;
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -35,7 +35,6 @@ var Float64ArrayFE = factory( 'float64' );
 // MAIN //
 
 bench( format( '%s:lastIndexOf', pkg ), function benchmark( b ) {
-
 	var arr;
 	var idx;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.last_index_of.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.last_index_of.length.js
@@ -24,9 +24,9 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var zeroTo = require( '@stdlib/array/zero-to' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var factory = require( './../lib' );
 var pkg = require( './../package.json' ).name;
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -98,7 +98,6 @@ function main() {
 		len = pow( 10, i );
 		f = createBenchmark( len );
 		bench( format( '%s:lastIndexOf:len=%d', pkg, len ), f );
-
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.last_index_of.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.last_index_of.length.js
@@ -26,6 +26,7 @@ var zeroTo = require( '@stdlib/array/zero-to' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var factory = require( './../lib' );
 var pkg = require( './../package.json' ).name;
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -96,7 +97,8 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':lastIndexOf:len='+len, f );
+		bench( format( '%s:lastIndexOf:len=%d', pkg, len ), f );
+
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.map.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.map.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -32,7 +33,8 @@ var Float64ArrayFE = factory( 'float64' );
 
 // MAIN //
 
-bench( pkg+':map', function benchmark( b ) {
+bench( format( '%s:map', pkg ), function benchmark( b ) {
+
 	var out;
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.map.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.map.js
@@ -21,9 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -34,7 +34,6 @@ var Float64ArrayFE = factory( 'float64' );
 // MAIN //
 
 bench( format( '%s:map', pkg ), function benchmark( b ) {
-
 	var out;
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.map.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.map.length.js
@@ -23,9 +23,9 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var zeroTo = require( '@stdlib/array/zero-to' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -107,7 +107,6 @@ function main() {
 		len = pow( 10, i );
 		f = createBenchmark( len );
 		bench( format( '%s:map:len=%d', pkg, len ), f );
-
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.map.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.map.length.js
@@ -25,6 +25,7 @@ var pow = require( '@stdlib/math/base/special/pow' );
 var zeroTo = require( '@stdlib/array/zero-to' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -105,7 +106,8 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':map:len='+len, f );
+		bench( format( '%s:map:len=%d', pkg, len ), f );
+
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.of.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.of.js
@@ -21,9 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -34,7 +34,6 @@ var Float64ArrayFE = factory( 'float64' );
 // MAIN //
 
 bench( format( '%s:of', pkg ), function benchmark( b ) {
-
 	var arr;
 	var i;
 
@@ -54,7 +53,6 @@ bench( format( '%s:of', pkg ), function benchmark( b ) {
 });
 
 bench( format( '%s:len=5', pkg ), function benchmark( b ) {
-
 	var buf;
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.of.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.of.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -32,7 +33,8 @@ var Float64ArrayFE = factory( 'float64' );
 
 // MAIN //
 
-bench( pkg+':of', function benchmark( b ) {
+bench( format( '%s:of', pkg ), function benchmark( b ) {
+
 	var arr;
 	var i;
 
@@ -51,7 +53,8 @@ bench( pkg+':of', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+':len=5', function benchmark( b ) {
+bench( format( '%s:len=5', pkg ), function benchmark( b ) {
+
 	var buf;
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.property_access.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.property_access.js
@@ -25,6 +25,7 @@ var isArrayBuffer = require( '@stdlib/assert/is-arraybuffer' );
 var isNonNegativeInteger = require( '@stdlib/assert/is-nonnegative-integer' ).isPrimitive;
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -34,7 +35,8 @@ var Float64ArrayFE = factory( 'float64' );
 
 // MAIN //
 
-bench( pkg+'::get:buffer', function benchmark( b ) {
+bench( format( '%s::get:buffer', pkg ), function benchmark( b ) {
+
 	var arr;
 	var v;
 	var i;
@@ -57,7 +59,8 @@ bench( pkg+'::get:buffer', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::get:byteLength', function benchmark( b ) {
+bench( format( '%s::get:byteLength', pkg ), function benchmark( b ) {
+
 	var arr;
 	var v;
 	var i;
@@ -80,7 +83,8 @@ bench( pkg+'::get:byteLength', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::get:byteOffset', function benchmark( b ) {
+bench( format( '%s::get:byteOffset', pkg ), function benchmark( b ) {
+
 	var arr;
 	var v;
 	var i;
@@ -103,7 +107,8 @@ bench( pkg+'::get:byteOffset', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::get:length', function benchmark( b ) {
+bench( format( '%s::get:length', pkg ), function benchmark( b ) {
+
 	var arr;
 	var v;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.property_access.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.property_access.js
@@ -23,9 +23,9 @@
 var bench = require( '@stdlib/bench' );
 var isArrayBuffer = require( '@stdlib/assert/is-arraybuffer' );
 var isNonNegativeInteger = require( '@stdlib/assert/is-nonnegative-integer' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -36,7 +36,6 @@ var Float64ArrayFE = factory( 'float64' );
 // MAIN //
 
 bench( format( '%s::get:buffer', pkg ), function benchmark( b ) {
-
 	var arr;
 	var v;
 	var i;
@@ -60,7 +59,6 @@ bench( format( '%s::get:buffer', pkg ), function benchmark( b ) {
 });
 
 bench( format( '%s::get:byteLength', pkg ), function benchmark( b ) {
-
 	var arr;
 	var v;
 	var i;
@@ -84,7 +82,6 @@ bench( format( '%s::get:byteLength', pkg ), function benchmark( b ) {
 });
 
 bench( format( '%s::get:byteOffset', pkg ), function benchmark( b ) {
-
 	var arr;
 	var v;
 	var i;
@@ -108,7 +105,6 @@ bench( format( '%s::get:byteOffset', pkg ), function benchmark( b ) {
 });
 
 bench( format( '%s::get:length', pkg ), function benchmark( b ) {
-
 	var arr;
 	var v;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.reduce.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.reduce.js
@@ -22,9 +22,10 @@
 
 var bench = require( '@stdlib/bench' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-var format = require( '@stdlib/string/format' );
+
 
 // VARIABLES //
 
@@ -53,7 +54,6 @@ function reducer( acc, value ) {
 // MAIN //
 
 bench( format( '%s:reduce', pkg ), function benchmark( b ) {
-
 	var out;
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.reduce.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.reduce.js
@@ -24,7 +24,7 @@ var bench = require( '@stdlib/bench' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-
+var format = require( '@stdlib/string/format' );
 
 // VARIABLES //
 
@@ -52,7 +52,8 @@ function reducer( acc, value ) {
 
 // MAIN //
 
-bench( pkg+':reduce', function benchmark( b ) {
+bench( format( '%s:reduce', pkg ), function benchmark( b ) {
+
 	var out;
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.reduce.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.reduce.length.js
@@ -26,6 +26,7 @@ var zeroTo = require( '@stdlib/array/zero-to' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -109,7 +110,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':reduce:len='+len, f );
+		bench( format( '%s:reduce:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.reduce.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.reduce.length.js
@@ -24,9 +24,9 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var zeroTo = require( '@stdlib/array/zero-to' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.reduce_right.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.reduce_right.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -52,7 +53,8 @@ function reducer( acc, value ) {
 
 // MAIN //
 
-bench( pkg+':reduceRight', function benchmark( b ) {
+bench( format( '%s:reduceRight', pkg ), function benchmark( b ) {
+
 	var out;
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.reduce_right.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.reduce_right.js
@@ -22,9 +22,9 @@
 
 var bench = require( '@stdlib/bench' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -54,7 +54,6 @@ function reducer( acc, value ) {
 // MAIN //
 
 bench( format( '%s:reduceRight', pkg ), function benchmark( b ) {
-
 	var out;
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.reduce_right.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.reduce_right.length.js
@@ -24,9 +24,9 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var zeroTo = require( '@stdlib/array/zero-to' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.reduce_right.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.reduce_right.length.js
@@ -26,6 +26,7 @@ var zeroTo = require( '@stdlib/array/zero-to' );
 var isInteger = require( '@stdlib/assert/is-integer' ).isPrimitive;
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -109,7 +110,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':reduceRight:len='+len, f );
+		bench( format( '%s:reduceRight:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.set.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.set.js
@@ -22,9 +22,9 @@
 
 var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -35,7 +35,6 @@ var Float64ArrayFE = factory( 'float64' );
 // MAIN //
 
 bench( format( '%s::number:set:endianness=little-endian', pkg ), function benchmark( b ) {
-
 	var values;
 	var arr;
 	var N;
@@ -65,7 +64,6 @@ bench( format( '%s::number:set:endianness=little-endian', pkg ), function benchm
 });
 
 bench( format( '%s::number:set:endianness=big-endian', pkg ), function benchmark( b ) {
-
 	var values;
 	var arr;
 	var N;
@@ -95,7 +93,6 @@ bench( format( '%s::number:set:endianness=big-endian', pkg ), function benchmark
 });
 
 bench( format( '%s::array:set:endianness=little-endian', pkg ), function benchmark( b ) {
-
 	var values;
 	var arr;
 	var N;
@@ -125,7 +122,6 @@ bench( format( '%s::array:set:endianness=little-endian', pkg ), function benchma
 });
 
 bench( format( '%s::array:set:endianness=big-endian', pkg ), function benchmark( b ) {
-
 	var values;
 	var arr;
 	var N;
@@ -155,7 +151,6 @@ bench( format( '%s::array:set:endianness=big-endian', pkg ), function benchmark(
 });
 
 bench( format( '%s::typed_array:set:endianness=little-endian', pkg ), function benchmark( b ) {
-
 	var values;
 	var arr;
 	var buf;
@@ -188,7 +183,6 @@ bench( format( '%s::typed_array:set:endianness=little-endian', pkg ), function b
 });
 
 bench( format( '%s::typed_array:set:endianness=big-endian', pkg ), function benchmark( b ) {
-
 	var values;
 	var arr;
 	var buf;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.set.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.set.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var Float64Array = require( '@stdlib/array/float64' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -33,7 +34,8 @@ var Float64ArrayFE = factory( 'float64' );
 
 // MAIN //
 
-bench( pkg+'::number:set:endianness=little-endian', function benchmark( b ) {
+bench( format( '%s::number:set:endianness=little-endian', pkg ), function benchmark( b ) {
+
 	var values;
 	var arr;
 	var N;
@@ -62,7 +64,8 @@ bench( pkg+'::number:set:endianness=little-endian', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::number:set:endianness=big-endian', function benchmark( b ) {
+bench( format( '%s::number:set:endianness=big-endian', pkg ), function benchmark( b ) {
+
 	var values;
 	var arr;
 	var N;
@@ -91,7 +94,8 @@ bench( pkg+'::number:set:endianness=big-endian', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::array:set:endianness=little-endian', function benchmark( b ) {
+bench( format( '%s::array:set:endianness=little-endian', pkg ), function benchmark( b ) {
+
 	var values;
 	var arr;
 	var N;
@@ -120,7 +124,8 @@ bench( pkg+'::array:set:endianness=little-endian', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::array:set:endianness=big-endian', function benchmark( b ) {
+bench( format( '%s::array:set:endianness=big-endian', pkg ), function benchmark( b ) {
+
 	var values;
 	var arr;
 	var N;
@@ -149,7 +154,8 @@ bench( pkg+'::array:set:endianness=big-endian', function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::typed_array:set:endianness=little-endian', function benchmark( b ) {
+bench( format( '%s::typed_array:set:endianness=little-endian', pkg ), function benchmark( b ) {
+
 	var values;
 	var arr;
 	var buf;
@@ -181,7 +187,8 @@ bench( pkg+'::typed_array:set:endianness=little-endian', function benchmark( b )
 	b.end();
 });
 
-bench( pkg+'::typed_array:set:endianness=big-endian', function benchmark( b ) {
+bench( format( '%s::typed_array:set:endianness=big-endian', pkg ), function benchmark( b ) {
+
 	var values;
 	var arr;
 	var buf;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.set.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.set.length.js
@@ -25,6 +25,7 @@ var pow = require( '@stdlib/math/base/special/pow' );
 var randu = require( '@stdlib/random/array/randu' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -108,7 +109,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':set:len='+len, f );
+		bench( format( '%s:set:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.set.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.set.length.js
@@ -23,9 +23,9 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var randu = require( '@stdlib/random/array/randu' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.some.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.some.js
@@ -22,9 +22,9 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -35,7 +35,6 @@ var Float64ArrayFE = factory( 'float64' );
 // MAIN //
 
 bench( format( '%s:some', pkg ), function benchmark( b ) {
-
 	var bool;
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.some.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.some.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -33,7 +34,8 @@ var Float64ArrayFE = factory( 'float64' );
 
 // MAIN //
 
-bench( pkg+':some', function benchmark( b ) {
+bench( format( '%s:some', pkg ), function benchmark( b ) {
+
 	var bool;
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.some.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.some.length.js
@@ -24,9 +24,9 @@ var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var zeroTo = require( '@stdlib/array/zero-to' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.some.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.some.length.js
@@ -26,6 +26,7 @@ var zeroTo = require( '@stdlib/array/zero-to' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -106,7 +107,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':some:len='+len, f );
+		bench( format( '%s:some:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.to_string.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.to_string.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -32,7 +33,8 @@ var Float64ArrayFE = factory( 'float64' );
 
 // MAIN //
 
-bench( pkg+':toString', function benchmark( b ) {
+bench( format( '%s:toString', pkg ), function benchmark( b ) {
+
 	var out;
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.to_string.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.to_string.js
@@ -21,9 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -34,7 +34,6 @@ var Float64ArrayFE = factory( 'float64' );
 // MAIN //
 
 bench( format( '%s:toString', pkg ), function benchmark( b ) {
-
 	var out;
 	var arr;
 	var i;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.to_string.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.to_string.length.js
@@ -25,6 +25,7 @@ var pow = require( '@stdlib/math/base/special/pow' );
 var zeroTo = require( '@stdlib/array/zero-to' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -92,7 +93,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':toString:len='+len, f );
+		bench( format( '%s:toString:len=%d', pkg, len ), f );
 	}
 }
 

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.to_string.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.to_string.length.js
@@ -23,9 +23,9 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var zeroTo = require( '@stdlib/array/zero-to' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.with.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.with.js
@@ -23,6 +23,7 @@
 var bench = require( '@stdlib/bench' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -32,7 +33,8 @@ var Float64ArrayFE = factory( 'float64' );
 
 // MAIN //
 
-bench( pkg+':with', function benchmark( b ) {
+bench( format( '%s:with', pkg ), function benchmark( b ) {
+
 	var values;
 	var out;
 	var arr;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.with.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.with.js
@@ -21,9 +21,9 @@
 // MODULES //
 
 var bench = require( '@stdlib/bench' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -34,7 +34,6 @@ var Float64ArrayFE = factory( 'float64' );
 // MAIN //
 
 bench( format( '%s:with', pkg ), function benchmark( b ) {
-
 	var values;
 	var out;
 	var arr;

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.with.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.with.length.js
@@ -23,9 +23,9 @@
 var bench = require( '@stdlib/bench' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var zeroTo = require( '@stdlib/array/zero-to' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
-var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //

--- a/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.with.length.js
+++ b/lib/node_modules/@stdlib/array/fixed-endian-factory/benchmark/benchmark.with.length.js
@@ -25,6 +25,7 @@ var pow = require( '@stdlib/math/base/special/pow' );
 var zeroTo = require( '@stdlib/array/zero-to' );
 var pkg = require( './../package.json' ).name;
 var factory = require( './../lib' );
+var format = require( '@stdlib/string/format' );
 
 
 // VARIABLES //
@@ -99,7 +100,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':with:len='+len, f );
+		bench( format( '%s:with:len=%d', pkg, len ), f );
 	}
 }
 


### PR DESCRIPTION
Resolves a part of https://github.com/stdlib-js/stdlib/issues/8647.

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors the JavaScript benchmark in `array/fixed-endian-factory` to use `@stdlib/string/format` for string interpolation instead of string concatenation when specifying the benchmark name

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   https://github.com/stdlib-js/stdlib/issues/8647

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
