### PR TITLE
chore: add structured package data for `math/base/special/cinvf`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cinvf/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/cinvf/package.json
@@ -77,52 +77,67 @@
       "parameters": [
         {
           "name": "z",
+          "desc": "input value",
           "type": {
             "javascript": "Complex64",
+            "jsdoc": "Complex64",
             "c": "stdlib_complex64_t",
             "dtype": "complex64"
           },
-          "description": "complex number",
+          "domain": null,
+          "rand": {
+            "prng": "random/base/uniform",
+            "parameters": [
+              [
+                -10,
+                10
+              ],
+              [
+                -10,
+                10
+              ]
+            ]
+          },
           "example_values": [
             {
-              "re": 2.0,
-              "im": 4.0
+              "re": 2,
+              "im": 4
             },
             {
-              "re": 1.0,
-              "im": 1.0
+              "re": 1,
+              "im": 1
             },
             {
-              "re": -1.0,
-              "im": -1.0
+              "re": -1,
+              "im": -1
             },
             {
               "re": 0.5,
               "im": 0.5
             },
             {
-              "re": 3.0,
-              "im": -4.0
+              "re": 3,
+              "im": -4
             },
             {
-              "re": -2.0,
-              "im": 3.0
+              "re": -2,
+              "im": 3
             },
             {
-              "re": 1.0,
-              "im": -2.0
+              "re": 1,
+              "im": -2
             },
             {
-              "re": -3.0,
-              "im": 2.0
+              "re": -3,
+              "im": 2
             },
             {
-              "re": 4.0,
-              "im": 3.0
+              "re": 4,
+              "im": 3
             },
             {
-              "re": -5.0,
-              "im": -2.0
+              "re": -5,
+              "im": -2
             },
             {
               "re": 2.5,
@@ -142,7 +157,7 @@
             },
             {
               "re": -0.5,
-              "im": 1.0
+              "im": 1
             },
             {
               "re": 3.5,
@@ -157,8 +172,8 @@
               "im": 0.75
             },
             {
-              "re": -4.0,
-              "im": 1.0
+              "re": -4,
+              "im": 1
             },
             {
               "re": 0.1,
@@ -168,11 +183,13 @@
         }
       ],
       "returns": {
+        "desc": "result",
         "type": {
           "javascript": "Complex64",
+          "jsdoc": "Complex64",
+          "c": "stdlib_complex64_t",
           "dtype": "complex64"
-        },
-        "description": "result"
+        }
       },
       "keywords": [
         "cinvf",
@@ -181,7 +198,8 @@
         "reciprocal",
         "complex",
         "cmplx"
-      ]
+      ],
+      "extra_keywords": []
     }
   }
 }

--- a/lib/node_modules/@stdlib/math/base/special/cinvf/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/cinvf/package.json
@@ -192,7 +192,7 @@
         }
       },
       "keywords": [
-        "cinvf",
+        "cinv",
         "inv",
         "inverse",
         "reciprocal",

--- a/lib/node_modules/@stdlib/math/base/special/cinvf/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/cinvf/package.json
@@ -65,5 +65,123 @@
     "complex",
     "cmplx",
     "number"
-  ]
+  ],
+  "__stdlib__": {
+    "scaffold": {
+      "$schema": "math/base@v1.0",
+      "base_alias": "cinvf",
+      "alias": "cinvf",
+      "pkg_desc": "compute the inverse of a single-precision complex floating-point number",
+      "desc": "computes the inverse of a single-precision complex floating-point number",
+      "short_desc": "inverse of a single-precision complex number",
+      "parameters": [
+        {
+          "name": "z",
+          "type": {
+            "javascript": "Complex64",
+            "c": "stdlib_complex64_t",
+            "dtype": "complex64"
+          },
+          "description": "complex number",
+          "example_values": [
+            {
+              "re": 2.0,
+              "im": 4.0
+            },
+            {
+              "re": 1.0,
+              "im": 1.0
+            },
+            {
+              "re": -1.0,
+              "im": -1.0
+            },
+            {
+              "re": 0.5,
+              "im": 0.5
+            },
+            {
+              "re": 3.0,
+              "im": -4.0
+            },
+            {
+              "re": -2.0,
+              "im": 3.0
+            },
+            {
+              "re": 1.0,
+              "im": -2.0
+            },
+            {
+              "re": -3.0,
+              "im": 2.0
+            },
+            {
+              "re": 4.0,
+              "im": 3.0
+            },
+            {
+              "re": -5.0,
+              "im": -2.0
+            },
+            {
+              "re": 2.5,
+              "im": 1.5
+            },
+            {
+              "re": -1.5,
+              "im": 2.5
+            },
+            {
+              "re": 0.25,
+              "im": 0.75
+            },
+            {
+              "re": 1.75,
+              "im": -1.25
+            },
+            {
+              "re": -0.5,
+              "im": 1.0
+            },
+            {
+              "re": 3.5,
+              "im": 2.5
+            },
+            {
+              "re": -2.5,
+              "im": -3.5
+            },
+            {
+              "re": 1.25,
+              "im": 0.75
+            },
+            {
+              "re": -4.0,
+              "im": 1.0
+            },
+            {
+              "re": 0.1,
+              "im": 0.2
+            }
+          ]
+        }
+      ],
+      "returns": {
+        "type": {
+          "javascript": "Complex64",
+          "dtype": "complex64"
+        },
+        "description": "result"
+      },
+      "keywords": [
+        "cinvf",
+        "inv",
+        "inverse",
+        "reciprocal",
+        "complex",
+        "cmplx"
+      ]
+    }
+  }
 }

--- a/lib/node_modules/@stdlib/math/base/special/cinvf/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/cinvf/package.json
@@ -69,7 +69,7 @@
   "__stdlib__": {
     "scaffold": {
       "$schema": "math/base@v1.0",
-      "base_alias": "cinvf",
+      "base_alias": "cinv",
       "alias": "cinvf",
       "pkg_desc": "compute the inverse of a single-precision complex floating-point number",
       "desc": "computes the inverse of a single-precision complex floating-point number",


### PR DESCRIPTION
Resolves a part of #7924

## Description

> What is the purpose of this pull request?

This pull request:

- This PR adds structured package data to the `package.json` file for `@stdlib/math/base/special/cinvf`. This is part of the ongoing effort tracked in RFC #7924 to add structured scaffold data for math/base/special unary functions.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   Resolves a part of #7924 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
