### PR TITLE
chore: add structured package data for `math/base/special/cphase`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cphase/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/package.json
@@ -65,5 +65,124 @@
     "complex",
     "cmplx",
     "number"
-  ]
+  ],
+  "__stdlib__": {
+    "scaffold": {
+      "$schema": "math/base@v1.0",
+      "base_alias": "cphase",
+      "alias": "cphase",
+      "pkg_desc": "compute the argument of a double-precision complex floating-point number in radians",
+      "desc": "computes the argument of a double-precision complex floating-point number in radians",
+      "short_desc": "argument of a complex number",
+      "parameters": [
+        {
+          "name": "z",
+          "type": {
+            "javascript": "Complex128",
+            "c": "stdlib_complex128_t",
+            "dtype": "complex128"
+          },
+          "description": "complex number",
+          "example_values": [
+            {
+              "re": 5.0,
+              "im": 3.0
+            },
+            {
+              "re": -5.0,
+              "im": 3.0
+            },
+            {
+              "re": 5.0,
+              "im": -3.0
+            },
+            {
+              "re": -5.0,
+              "im": -3.0
+            },
+            {
+              "re": 1.0,
+              "im": 1.0
+            },
+            {
+              "re": -1.0,
+              "im": 1.0
+            },
+            {
+              "re": 1.0,
+              "im": -1.0
+            },
+            {
+              "re": -1.0,
+              "im": -1.0
+            },
+            {
+              "re": 3.0,
+              "im": 4.0
+            },
+            {
+              "re": -3.0,
+              "im": 4.0
+            },
+            {
+              "re": 0.0,
+              "im": 1.0
+            },
+            {
+              "re": 0.0,
+              "im": -1.0
+            },
+            {
+              "re": 1.0,
+              "im": 0.0
+            },
+            {
+              "re": -1.0,
+              "im": 0.0
+            },
+            {
+              "re": 2.0,
+              "im": 2.0
+            },
+            {
+              "re": -2.0,
+              "im": 2.0
+            },
+            {
+              "re": 4.0,
+              "im": 3.0
+            },
+            {
+              "re": 6.0,
+              "im": 8.0
+            },
+            {
+              "re": 7.0,
+              "im": 24.0
+            },
+            {
+              "re": 0.5,
+              "im": 0.5
+            }
+          ]
+        }
+      ],
+      "returns": {
+        "type": {
+          "javascript": "number",
+          "dtype": "float64"
+        },
+        "description": "argument in radians"
+      },
+      "keywords": [
+        "cphase",
+        "phase",
+        "argument",
+        "arg",
+        "angle",
+        "complex",
+        "cmplx"
+      ]
+    }
+  }
 }

--- a/lib/node_modules/@stdlib/math/base/special/cphase/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/package.json
@@ -77,88 +77,103 @@
       "parameters": [
         {
           "name": "z",
+          "desc": "input value",
           "type": {
             "javascript": "Complex128",
+            "jsdoc": "Complex128",
             "c": "stdlib_complex128_t",
             "dtype": "complex128"
           },
-          "description": "complex number",
+          "domain": null,
+          "rand": {
+            "prng": "random/base/uniform",
+            "parameters": [
+              [
+                -10,
+                10
+              ],
+              [
+                -10,
+                10
+              ]
+            ]
+          },
           "example_values": [
             {
-              "re": 5.0,
-              "im": 3.0
+              "re": 5,
+              "im": 3
             },
             {
-              "re": -5.0,
-              "im": 3.0
+              "re": -5,
+              "im": 3
             },
             {
-              "re": 5.0,
-              "im": -3.0
+              "re": 5,
+              "im": -3
             },
             {
-              "re": -5.0,
-              "im": -3.0
+              "re": -5,
+              "im": -3
             },
             {
-              "re": 1.0,
-              "im": 1.0
+              "re": 1,
+              "im": 1
             },
             {
-              "re": -1.0,
-              "im": 1.0
+              "re": -1,
+              "im": 1
             },
             {
-              "re": 1.0,
-              "im": -1.0
+              "re": 1,
+              "im": -1
             },
             {
-              "re": -1.0,
-              "im": -1.0
+              "re": -1,
+              "im": -1
             },
             {
-              "re": 3.0,
-              "im": 4.0
+              "re": 3,
+              "im": 4
             },
             {
-              "re": -3.0,
-              "im": 4.0
+              "re": -3,
+              "im": 4
             },
             {
-              "re": 0.0,
-              "im": 1.0
+              "re": 0,
+              "im": 1
             },
             {
-              "re": 0.0,
-              "im": -1.0
+              "re": 0,
+              "im": -1
             },
             {
-              "re": 1.0,
-              "im": 0.0
+              "re": 1,
+              "im": 0
             },
             {
-              "re": -1.0,
-              "im": 0.0
+              "re": -1,
+              "im": 0
             },
             {
-              "re": 2.0,
-              "im": 2.0
+              "re": 2,
+              "im": 2
             },
             {
-              "re": -2.0,
-              "im": 2.0
+              "re": -2,
+              "im": 2
             },
             {
-              "re": 4.0,
-              "im": 3.0
+              "re": 4,
+              "im": 3
             },
             {
-              "re": 6.0,
-              "im": 8.0
+              "re": 6,
+              "im": 8
             },
             {
-              "re": 7.0,
-              "im": 24.0
+              "re": 7,
+              "im": 24
             },
             {
               "re": 0.5,
@@ -168,11 +183,15 @@
         }
       ],
       "returns": {
+        "desc": "argument in radians",
         "type": {
           "javascript": "number",
+          "jsdoc": "number",
+          "c": "double",
+          "mex": "double",
+          "fortran": "double precision",
           "dtype": "float64"
-        },
-        "description": "argument in radians"
+        }
       },
       "keywords": [
         "cphase",
@@ -182,7 +201,8 @@
         "angle",
         "complex",
         "cmplx"
-      ]
+      ],
+      "extra_keywords": []
     }
   }
 }

--- a/lib/node_modules/@stdlib/math/base/special/cphase/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/cphase/package.json
@@ -188,8 +188,6 @@
           "javascript": "number",
           "jsdoc": "number",
           "c": "double",
-          "mex": "double",
-          "fortran": "double precision",
           "dtype": "float64"
         }
       },


### PR DESCRIPTION
Resolves a part of #7924

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR adds structured package data to the `package.json` file for `@stdlib/math/base/special/cphase`. This is part of the ongoing effort tracked in RFC #7924 to add structured scaffold data for math/base/special unary functions.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   Resolves a part of #7924 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
