### PR TITLE
docs: fix incorrect example output in csrot dtype declarations

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/wasm/csrot/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/base/wasm/csrot/docs/types/index.d.ts
@@ -434,10 +434,10 @@ interface Routine extends ModuleWrapper {
 	* mod.read( cyptr, viewY );
 	*
 	* console.log( reinterpretComplex64( viewY, 0 ) );
-	* // => <Float32Array>[ ~-0.6, ~-1.2, ~-1.8, ~-2.4, -3.0, ~-3.6, ~-4.2, ~-4.8, ~-5.4, -6 ]
+	* // => <Float32Array>[ ~-0.6, ~-1.2, ~-1.8, ~-2.4, -3.0, ~-3.6, ~-4.2, ~-4.8, ~-5.4, -6.0 ]
 	*
 	* console.log( reinterpretComplex64( viewX, 0 ) );
-	* // => <Float32Array>[ ~0.8, ~1.6, ~2.4, ~3.2, 4.0, ~4.8, ~5.6, ~6.4, ~7.2, 8 ]
+	* // => <Float32Array>[ ~0.8, ~1.6, ~2.4, ~3.2, 4.0, ~4.8, ~5.6, ~6.4, ~7.2, 8.0 ]
 	*/
 	Module: ModuleConstructor;
 }


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes.
report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: passed
  - task: lint_license_headers status: passed
---

Resolves #8700.

## Description

This pull request fixes incorrect example output values in the `csrot` TypeScript declaration documentation.

Specifically:

- Corrects the last element of the `viewX` example output to `8.0`
-  Corrects the last element of the `viewY` example output to `6.0`
- Updates the example arrays to match the expected results of the BLAS `csrot` operation
- Ensures formatting consistency with other examples in the package (`~` for approximate values)

No implementation changes were made. This is a documentation-only update.

## Related Issues

None.

## Questions

No questions.

## Other

No additional information.

## Checklist

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

- [x] Yes
- [ ] No

If you answered "yes" above, how did you use AI assistance?

- [ ] Code generation
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding

#### Disclosure

I used ChatGPT to help verify the expected numerical output of the `csrot` example and to ensure the commit message and PR description follow stdlib contribution guidelines. All changes were manually applied by me.

---

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
