### PR TITLE
chore: add structured package data for `math/base/special/croundf`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/croundf/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/croundf/package.json
@@ -67,5 +67,142 @@
     "complex",
     "cmplx",
     "number"
-  ]
+  ],
+  "__stdlib__": {
+    "scaffold": {
+      "$schema": "math/base@v1.0",
+      "base_alias": "cround",
+      "alias": "croundf",
+      "pkg_desc": "round each component of a single-precision complex floating-point number to the nearest integer",
+      "desc": "rounds each component of a single-precision complex floating-point number to the nearest integer",
+      "short_desc": "round each component of a complex number to the nearest integer",
+      "parameters": [
+        {
+          "name": "z",
+          "desc": "input value",
+          "type": {
+            "javascript": "Complex64",
+            "jsdoc": "Complex64",
+            "c": "stdlib_complex64_t",
+            "dtype": "complex64"
+          },
+          "domain": null,
+          "rand": {
+            "prng": "random/base/uniform",
+            "parameters": [
+              [
+                -10,
+                10
+              ],
+              [
+                -10,
+                10
+              ]
+            ]
+          },
+          "example_values": [
+            {
+              "re": 5.5,
+              "im": 3.3
+            },
+            {
+              "re": -4.2,
+              "im": 1.7
+            },
+            {
+              "re": 0.8,
+              "im": -0.4
+            },
+            {
+              "re": -1.5,
+              "im": 2.9
+            },
+            {
+              "re": 3.1,
+              "im": -3.7
+            },
+            {
+              "re": -2.6,
+              "im": 0.5
+            },
+            {
+              "re": 1.9,
+              "im": -1.1
+            },
+            {
+              "re": -0.3,
+              "im": 4.8
+            },
+            {
+              "re": 2.4,
+              "im": 2.6
+            },
+            {
+              "re": -3.9,
+              "im": -2.2
+            },
+            {
+              "re": 0.1,
+              "im": 1.5
+            },
+            {
+              "re": -1.7,
+              "im": -0.9
+            },
+            {
+              "re": 4.6,
+              "im": 3.5
+            },
+            {
+              "re": -5.1,
+              "im": 0.2
+            },
+            {
+              "re": 1.3,
+              "im": -4.4
+            },
+            {
+              "re": -0.6,
+              "im": 2.1
+            },
+            {
+              "re": 3.7,
+              "im": -1.8
+            },
+            {
+              "re": -2.3,
+              "im": 3.9
+            },
+            {
+              "re": 0.5,
+              "im": -0.7
+            },
+            {
+              "re": -4.8,
+              "im": 1.2
+            }
+          ]
+        }
+      ],
+      "returns": {
+        "desc": "result",
+        "type": {
+          "javascript": "Complex64",
+          "jsdoc": "Complex64",
+          "c": "stdlib_complex64_t",
+          "dtype": "complex64"
+        }
+      },
+      "keywords": [
+        "cround",
+        "round",
+        "floor",
+        "ceil",
+        "integer",
+        "complex",
+        "cmplx"
+      ],
+      "extra_keywords": []
+    }
+  }
 }


### PR DESCRIPTION
Resolves a part of #7924

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR adds structured package data to the `package.json` file for `@stdlib/math/base/special/croundf`. This is part of the ongoing effort tracked in RFC https://github.com/stdlib-js/stdlib/issues/7924 to add structured scaffold data for math/base/special unary functions.
## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

- Resolves a part of #7924 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
