### PR TITLE
chore: update array allocation and example path (#8265)

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/zscal/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/base/zscal/examples/index.js
@@ -21,7 +21,7 @@
 var discreteUniform = require( '@stdlib/random/base/discrete-uniform' );
 var filledarrayBy = require( '@stdlib/array/filled-by' );
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
-var zscal = require( '@stdlib/blas/base/zscal' );
+var zscal = require( './../lib' );
 
 function rand() {
 	return new Complex128( discreteUniform( 0, 10 ), discreteUniform( -5, 5 ) );

--- a/lib/node_modules/@stdlib/plot/components/svg/axis/lib/components/ticks.js
+++ b/lib/node_modules/@stdlib/plot/components/svg/axis/lib/components/ticks.js
@@ -53,10 +53,10 @@ function render( ctx ) {
 	transform = tickTransform( ctx._orientation, ctx._scale );
 
 	debug( 'Rendering ticks...' );
-	out = new Array( values.length );
+	out = [];
 	for ( i = 0; i < values.length; i++ ) {
 		debug( 'Rendering tick %d with value %s...', i, values[i] );
-		out[ i ] = tick( ctx, values[i], transform );
+		out.push( tick( ctx, values[i], transform ) );
 	}
 	debug( 'Finished rendering ticks.' );
 	return out;


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: passed
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Resolves #8265 .

## Description

> What is the purpose of this pull request?

This pull request:

-   **Replace array Constructor ** replaced constructor by initializing empty array and pushing elements inside the loop.
- **Fixes the import path for `zscal`**, switching from an incorrect relative path to the correct example usage (`./../lib`), ensuring the example runs when executed locally.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8265 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
