### PR TITLE
bench: refactor to use dynamic memory allocation in `blas/ext/base/dapxsum`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dapxsum/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/dapxsum/benchmark/c/benchmark.length.c
@@ -96,11 +96,12 @@ static double rand_double( void ) {
 */
 static double benchmark1( int iterations, int len ) {
 	double elapsed;
-	double x[ len ];
+	double *x;
 	double v;
 	double t;
 	int i;
 
+	x = (double *)malloc( len * sizeof( double ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = ( rand_double() * 20000.0 ) - 10000.0;
 	}
@@ -118,6 +119,7 @@ static double benchmark1( int iterations, int len ) {
 	if ( v != v ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
 	return elapsed;
 }
 
@@ -130,11 +132,12 @@ static double benchmark1( int iterations, int len ) {
 */
 static double benchmark2( int iterations, int len ) {
 	double elapsed;
-	double x[ len ];
+	double *x;
 	double v;
 	double t;
 	int i;
 
+	x = (double *)malloc( len * sizeof( double ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = ( rand_double() * 20000.0 ) - 10000.0;
 	}
@@ -152,6 +155,7 @@ static double benchmark2( int iterations, int len ) {
 	if ( v != v ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
 	return elapsed;
 }
 


### PR DESCRIPTION
Progresses #8643

## Description

> What is the purpose of this pull request?

This pull request:

- Refactors the C benchmark for `blas/ext/base/dapxsum` to use dynamic memory allocation instead of static memory allocation for large arrays.

## Related Issues

> Does this pull request have any related issues?

This pull request progresses the following related issues:

- #8643

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

- [ ] Yes
- [x] No

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md