### PR TITLE
bench: refactor to use dynamic memory allocation in `blas/base/sscal`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/sscal/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/base/sscal/benchmark/c/benchmark.length.c
@@ -96,10 +96,11 @@ static float rand_float( void ) {
 */
 static double benchmark1( int iterations, int len ) {
 	double elapsed;
-	float x[ len ];
+	float *x;
 	double t;
 	int i;
 
+	x = (float *)malloc( len * sizeof( float ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = ( rand_float()*200.0f ) - 100.0f;
 	}
@@ -115,15 +116,17 @@ static double benchmark1( int iterations, int len ) {
 	if ( x[ 0 ] != x[ 0 ] ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
 	return elapsed;
 }
 
 static double benchmark2( int iterations, int len ) {
 	double elapsed;
-	float x[ len ];
+	float *x;
 	double t;
 	int i;
 
+	x = (float *)malloc( len * sizeof( float ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = ( rand_float()*200.0f ) - 100.0f;
 	}
@@ -139,6 +142,7 @@ static double benchmark2( int iterations, int len ) {
 	if ( x[ 0 ] != x[ 0 ] ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
 	return elapsed;
 }
 


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

- Refactors the C benchmark for `blas/base/sscal` to use dynamic memory allocation instead of static memory allocation for large arrays.

## Related Issues

> Does this pull request have any related issues?

This pull request progresses the following related issues:

- #8643

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

- [ ] Yes
- [x] No

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md