### PR TITLE
feat: add `math/base/special/asechf`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/asechf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/asechf/README.md
@@ -1,0 +1,203 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2025 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# asechf
+
+> Compute the [hyperbolic arcsecant][hyperbolic-arcsecant] of a single-precision floating-point number.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var asechf = require( '@stdlib/math/base/special/asechf' );
+```
+
+#### asechf( x )
+
+Computes the [hyperbolic arcsecant][hyperbolic-arcsecant] of a single-precision floating-point number.
+
+```javascript
+var v = asechf( 1.0 );
+// returns 0.0
+
+v = asechf( 0.5 );
+// returns ~1.317
+
+v = asechf( 0.0 );
+// returns Infinity
+```
+
+The domain of `x` is restricted to the interval `[0, 1]`. For `x` outside of this interval, the function returns `NaN`.
+
+```javascript
+var v = asechf( -1.0 );
+// returns NaN
+
+v = asechf( 2.0 );
+// returns NaN
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
+var asechf = require( '@stdlib/math/base/special/asechf' );
+
+var x = uniform( 100, 0.1, 1.0, {
+    'dtype': 'float32'
+});
+
+logEachMap( 'asechf(%0.4f) = %0.4f', x, asechf );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/math/base/special/asechf.h"
+```
+
+#### stdlib_base_asechf( x )
+
+Computes the [hyperbolic arcsecant][hyperbolic-arcsecant] of a single-precision floating-point number.
+
+```c
+float out = stdlib_base_asechf( 0.5f );
+// returns ~1.317f
+```
+
+The function accepts the following arguments:
+
+-   **x**: `[in] float` input value.
+
+```c
+float stdlib_base_asechf( const float x );
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+### Examples
+
+```c
+#include "stdlib/math/base/special/asechf.h"
+#include <stdio.h>
+
+int main( void ) {
+    const float x[] = { 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f };
+
+    float v;
+    int i;
+    for ( i = 0; i < 10; i++ ) {
+        v = stdlib_base_asechf( x[ i ] );
+        printf( "asechf(%f) = %f\n", x[ i ], v );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/math/base/special/asech`][@stdlib/math/base/special/asech]</span><span class="delimiter">: </span><span class="description">compute the hyperbolic arcsecant of a number.</span>
+-   <span class="package-name">[`@stdlib/math/base/special/asecf`][@stdlib/math/base/special/asecf]</span><span class="delimiter">: </span><span class="description">compute the inverse (arc) secant of a single-precision floating-point number.</span>
+-   <span class="package-name">[`@stdlib/math/base/special/acosh`][@stdlib/math/base/special/acosh]</span><span class="delimiter">: </span><span class="description">compute the hyperbolic arccosine of a double-precision floating-point number.</span>
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[hyperbolic-arcsecant]: https://en.wikipedia.org/wiki/Inverse_hyperbolic_functions
+
+<!-- <related-links> -->
+
+[@stdlib/math/base/special/asech]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/asech
+
+[@stdlib/math/base/special/asecf]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/asecf
+
+[@stdlib/math/base/special/acosh]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/math/base/special/acosh
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/math/base/special/asechf/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/math/base/special/asechf/benchmark/benchmark.js
@@ -1,0 +1,51 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var pkg = require( './../package.json' ).name;
+var asechf = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		x = randu();
+		y = asechf( x );
+		if ( isnanf( y ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnanf( y ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/asechf/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/asechf/benchmark/benchmark.native.js
@@ -1,0 +1,60 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+var pkg = require( './../package.json' ).name;
+
+
+// VARIABLES //
+
+var asechf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( asechf instanceof Error )
+};
+
+
+// MAIN //
+
+bench( pkg+'::native', opts, function benchmark( b ) {
+	var x;
+	var y;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		x = randu();
+		y = asechf( x );
+		if ( isnanf( y ) ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( isnanf( y ) ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/asechf/benchmark/c/native/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/asechf/benchmark/c/native/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2025 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := benchmark.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) $(LIBRARIES) -lm
+
+#/
+# Runs compiled benchmarks.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/asechf/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/math/base/special/asechf/benchmark/c/native/benchmark.c
@@ -1,0 +1,133 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/asechf.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define NAME "asechf"
+#define ITERATIONS 1000000
+#define REPEATS 3
+
+/**
+* Prints the TAP version.
+*/
+static void print_version( void ) {
+	printf( "TAP version 13\n" );
+}
+
+/**
+* Prints the TAP summary.
+*
+* @param total     total number of tests
+* @param passing   total number of passing tests
+*/
+static void print_summary( int total, int passing ) {
+	printf( "#\n" );
+	printf( "1..%d\n", total ); // TAP plan
+	printf( "# total %d\n", total );
+	printf( "# pass  %d\n", passing );
+	printf( "#\n" );
+	printf( "# ok\n" );
+}
+
+/**
+* Prints benchmarks results.
+*
+* @param elapsed   elapsed time in seconds
+*/
+static void print_results( double elapsed ) {
+	double rate = (double)ITERATIONS / elapsed;
+	printf( "  ---\n" );
+	printf( "  iterations: %d\n", ITERATIONS );
+	printf( "  elapsed: %0.9f\n", elapsed );
+	printf( "  rate: %0.9f\n", rate );
+	printf( "  ...\n" );
+}
+
+/**
+* Returns a clock time.
+*
+* @return clock time
+*/
+static double tic( void ) {
+	struct timeval now;
+	gettimeofday( &now, NULL );
+	return (double)now.tv_sec + (double)now.tv_usec/1.0e6;
+}
+
+/**
+* Generates a random number on the interval [0,1).
+*
+* @return random number
+*/
+static float rand_float( void ) {
+	int r = rand();
+	return (float)r / ( (float)RAND_MAX + 1.0f );
+}
+
+/**
+* Runs a benchmark.
+*
+* @return elapsed time in seconds
+*/
+static double benchmark( void ) {
+	double elapsed;
+	double t;
+	float x;
+	float y;
+	int i;
+
+	t = tic();
+	for ( i = 0; i < ITERATIONS; i++ ) {
+		x = rand_float();
+		y = stdlib_base_asechf( x );
+		if ( y != y ) {
+			printf( "should not return NaN\n" );
+			break;
+		}
+	}
+	elapsed = tic() - t;
+	if ( y != y ) {
+		printf( "should not return NaN\n" );
+	}
+	return elapsed;
+}
+
+/**
+* Main execution sequence.
+*/
+int main( void ) {
+	double elapsed;
+	int i;
+
+	// Use the current time to seed the random number generator:
+	srand( time( NULL ) );
+
+	print_version();
+	for ( i = 0; i < REPEATS; i++ ) {
+		printf( "# c::native::%s\n", NAME );
+		elapsed = benchmark();
+		print_results( elapsed );
+		printf( "ok %d benchmark finished\n", i+1 );
+	}
+	print_summary( REPEATS, REPEATS );
+}

--- a/lib/node_modules/@stdlib/math/base/special/asechf/binding.gyp
+++ b/lib/node_modules/@stdlib/math/base/special/asechf/binding.gyp
@@ -1,0 +1,170 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2025 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A `.gyp` file for building a Node.js native add-on.
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # List of files to include in this file:
+  'includes': [
+    './include.gypi',
+  ],
+
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Target name should match the add-on export name:
+    'addon_target_name%': 'addon',
+
+    # Set variables based on the host OS:
+    'conditions': [
+      [
+        'OS=="win"',
+        {
+          # Define the object file suffix:
+          'obj': 'obj',
+        },
+        {
+          # Define the object file suffix:
+          'obj': 'o',
+        }
+      ], # end condition (OS=="win")
+    ], # end conditions
+  }, # end variables
+
+  # Define compile targets:
+  'targets': [
+
+    # Target to generate an add-on:
+    {
+      # The target name should match the add-on export name:
+      'target_name': '<(addon_target_name)',
+
+      # Define dependencies:
+      'dependencies': [],
+
+      # Define directories which contain relevant include headers:
+      'include_dirs': [
+        # Local include directory:
+        '<@(include_dirs)',
+      ],
+
+      # List of source files:
+      'sources': [
+        '<@(src_files)',
+      ],
+
+      # Settings which should be applied when a target's object files are used as linker input:
+      'link_settings': {
+        # Define libraries:
+        'libraries': [
+          '<@(libraries)',
+        ],
+
+        # Define library directories:
+        'library_dirs': [
+          '<@(library_dirs)',
+        ],
+      },
+
+      # C/C++ compiler flags:
+      'cflags': [
+        # Enable commonly used warning options:
+        '-Wall',
+
+        # Aggressive optimization:
+        '-O3',
+      ],
+
+      # C specific compiler flags:
+      'cflags_c': [
+        # Specify the C standard to which a program is expected to conform:
+        '-std=c99',
+      ],
+
+      # C++ specific compiler flags:
+      'cflags_cpp': [
+        # Specify the C++ standard to which a program is expected to conform:
+        '-std=c++11',
+      ],
+
+      # Linker flags:
+      'ldflags': [],
+
+      # Apply conditions based on the host OS:
+      'conditions': [
+        [
+          'OS=="mac"',
+          {
+            # Linker flags:
+            'ldflags': [
+              '-undefined dynamic_lookup',
+              '-Wl,-no-pie',
+              '-Wl,-search_paths_first',
+            ],
+          },
+        ], # end condition (OS=="mac")
+        [
+          'OS!="win"',
+          {
+            # C/C++ flags:
+            'cflags': [
+              # Generate platform-independent code:
+              '-fPIC',
+            ],
+          },
+        ], # end condition (OS!="win")
+      ], # end conditions
+    }, # end target <(addon_target_name)
+
+    # Target to copy a generated add-on to a standard location:
+    {
+      'target_name': 'copy_addon',
+
+      # Declare that the output of this target is not linked:
+      'type': 'none',
+
+      # Define dependencies:
+      'dependencies': [
+        # Require that the add-on be generated before building this target:
+        '<(addon_target_name)',
+      ],
+
+      # Define a list of actions:
+      'actions': [
+        {
+          'action_name': 'copy_addon',
+          'message': 'Copying addon...',
+
+          # Explicitly list the inputs in the command-line invocation below:
+          'inputs': [],
+
+          # Declare the expected outputs:
+          'outputs': [
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+
+          # Define the command-line invocation:
+          'action': [
+            'cp',
+            '<(PRODUCT_DIR)/<(addon_target_name).node',
+            '<(addon_output_dir)/<(addon_target_name).node',
+          ],
+        },
+      ], # end actions
+    }, # end target copy_addon
+  ], # end targets
+}

--- a/lib/node_modules/@stdlib/math/base/special/asechf/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/asechf/docs/repl.txt
@@ -1,0 +1,30 @@
+
+{{alias}}( x )
+    Computes the hyperbolic arcsecant of a single-precision floating-point
+    number.
+
+    The domain of `x` is restricted to `[0, 1]`. For `x` outside of this
+    interval, the function returns `NaN`.
+
+    Parameters
+    ----------
+    x: number
+        Input value.
+
+    Returns
+    -------
+    y: number
+        Hyperbolic arcsecant.
+
+    Examples
+    --------
+    > var y = {{alias}}( 1.0 )
+    0.0
+    > y = {{alias}}( 0.5 )
+    ~1.317
+    > y = {{alias}}( NaN )
+    NaN
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/math/base/special/asechf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/asechf/docs/types/index.d.ts
@@ -1,0 +1,44 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Computes the hyperbolic arcsecant of a single-precision floating-point number.
+*
+* @param x - input value
+* @returns hyperbolic arcsecant
+*
+* @example
+* var v = asechf( 1.0 );
+* // returns 0.0
+*
+* @example
+* var v = asechf( 0.5 );
+* // returns ~1.317
+*
+* @example
+* var v = asechf( NaN );
+* // returns NaN
+*/
+declare function asechf( x: number ): number;
+
+
+// EXPORTS //
+
+export = asechf;

--- a/lib/node_modules/@stdlib/math/base/special/asechf/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/math/base/special/asechf/docs/types/test.ts
@@ -1,0 +1,44 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import asechf = require( './index' );
+
+
+// TESTS //
+
+// The function returns a number...
+{
+	asechf( 0.5 ); // $ExpectType number
+}
+
+// The compiler throws an error if the function is provided a value other than a number...
+{
+	asechf( true ); // $ExpectError
+	asechf( false ); // $ExpectError
+	asechf( null ); // $ExpectError
+	asechf( undefined ); // $ExpectError
+	asechf( '5' ); // $ExpectError
+	asechf( [] ); // $ExpectError
+	asechf( {} ); // $ExpectError
+	asechf( ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided insufficient arguments...
+{
+	asechf(); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/math/base/special/asechf/examples/c/Makefile
+++ b/lib/node_modules/@stdlib/math/base/special/asechf/examples/c/Makefile
@@ -1,0 +1,146 @@
+#/
+# @license Apache-2.0
+#
+# Copyright (c) 2025 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/
+
+# VARIABLES #
+
+ifndef VERBOSE
+	QUIET := @
+else
+	QUIET :=
+endif
+
+# Determine the OS ([1][1], [2][2]).
+#
+# [1]: https://en.wikipedia.org/wiki/Uname#Examples
+# [2]: http://stackoverflow.com/a/27776822/2225624
+OS ?= $(shell uname)
+ifneq (, $(findstring MINGW,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring MSYS,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring CYGWIN,$(OS)))
+	OS := WINNT
+else
+ifneq (, $(findstring Windows_NT,$(OS)))
+	OS := WINNT
+endif
+endif
+endif
+endif
+
+# Define the program used for compiling C source files:
+ifdef C_COMPILER
+	CC := $(C_COMPILER)
+else
+	CC := gcc
+endif
+
+# Define the command-line options when compiling C files:
+CFLAGS ?= \
+	-std=c99 \
+	-O3 \
+	-Wall \
+	-pedantic
+
+# Determine whether to generate position independent code ([1][1], [2][2]).
+#
+# [1]: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#Code-Gen-Options
+# [2]: http://stackoverflow.com/questions/5311515/gcc-fpic-option
+ifeq ($(OS), WINNT)
+	fPIC ?=
+else
+	fPIC ?= -fPIC
+endif
+
+# List of includes (e.g., `-I /foo/bar -I /beep/boop/include`):
+INCLUDE ?=
+
+# List of source files:
+SOURCE_FILES ?=
+
+# List of libraries (e.g., `-lopenblas -lpthread`):
+LIBRARIES ?=
+
+# List of library paths (e.g., `-L /foo/bar -L /beep/boop`):
+LIBPATH ?=
+
+# List of C targets:
+c_targets := example.out
+
+
+# RULES #
+
+#/
+# Compiles source files.
+#
+# @param {string} [C_COMPILER] - C compiler (e.g., `gcc`)
+# @param {string} [CFLAGS] - C compiler options
+# @param {(string|void)} [fPIC] - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} [INCLUDE] - list of includes (e.g., `-I /foo/bar -I /beep/boop/include`)
+# @param {string} [SOURCE_FILES] - list of source files
+# @param {string} [LIBPATH] - list of library paths (e.g., `-L /foo/bar -L /beep/boop`)
+# @param {string} [LIBRARIES] - list of libraries (e.g., `-lopenblas -lpthread`)
+#
+# @example
+# make
+#
+# @example
+# make all
+#/
+all: $(c_targets)
+
+.PHONY: all
+
+#/
+# Compiles C source files.
+#
+# @private
+# @param {string} CC - C compiler (e.g., `gcc`)
+# @param {string} CFLAGS - C compiler options
+# @param {(string|void)} fPIC - compiler flag determining whether to generate position independent code (e.g., `-fPIC`)
+# @param {string} INCLUDE - list of includes (e.g., `-I /foo/bar`)
+# @param {string} SOURCE_FILES - list of source files
+# @param {string} LIBPATH - list of library paths (e.g., `-L /foo/bar`)
+# @param {string} LIBRARIES - list of libraries (e.g., `-lopenblas`)
+#/
+$(c_targets): %.out: %.c
+	$(QUIET) $(CC) $(CFLAGS) $(fPIC) $(INCLUDE) -o $@ $(SOURCE_FILES) $< $(LIBPATH) -lm $(LIBRARIES)
+
+#/
+# Runs compiled examples.
+#
+# @example
+# make run
+#/
+run: $(c_targets)
+	$(QUIET) ./$<
+
+.PHONY: run
+
+#/
+# Removes generated files.
+#
+# @example
+# make clean
+#/
+clean:
+	$(QUIET) -rm -f *.o *.out
+
+.PHONY: clean

--- a/lib/node_modules/@stdlib/math/base/special/asechf/examples/c/example.c
+++ b/lib/node_modules/@stdlib/math/base/special/asechf/examples/c/example.c
@@ -1,0 +1,31 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/asechf.h"
+#include <stdio.h>
+
+int main( void ) {
+	const float x[] = { 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f };
+
+	float v;
+	int i;
+	for ( i = 0; i < 10; i++ ) {
+		v = stdlib_base_asechf( x[ i ] );
+		printf( "asechf(%f) = %f\n", x[ i ], v );
+	}
+}

--- a/lib/node_modules/@stdlib/math/base/special/asechf/examples/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/asechf/examples/index.js
@@ -1,0 +1,29 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var uniform = require( '@stdlib/random/array/uniform' );
+var logEachMap = require( '@stdlib/console/log-each-map' );
+var asechf = require( './../lib' );
+
+var x = uniform( 100, 0.1, 1.0, {
+	'dtype': 'float32'
+});
+
+logEachMap( 'asechf(%0.4f) = %0.4f', x, asechf );

--- a/lib/node_modules/@stdlib/math/base/special/asechf/include.gypi
+++ b/lib/node_modules/@stdlib/math/base/special/asechf/include.gypi
@@ -1,0 +1,53 @@
+# @license Apache-2.0
+#
+# Copyright (c) 2025 The Stdlib Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A GYP include file for building a Node.js native add-on.
+#
+# Main documentation:
+#
+# [1]: https://gyp.gsrc.io/docs/InputFormatReference.md
+# [2]: https://gyp.gsrc.io/docs/UserDocumentation.md
+{
+  # Define variables to be used throughout the configuration for all targets:
+  'variables': {
+    # Source directory:
+    'src_dir': './src',
+
+    # Include directories:
+    'include_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).include; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Add-on destination directory:
+    'addon_output_dir': './src',
+
+    # Source files:
+    'src_files': [
+      '<(src_dir)/addon.c',
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).src; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library dependencies:
+    'libraries': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libraries; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+
+    # Library directories:
+    'library_dirs': [
+      '<!@(node -e "var arr = require(\'@stdlib/utils/library-manifest\')(\'./manifest.json\',{},{\'basedir\':process.cwd(),\'paths\':\'posix\'}).libpath; for ( var i = 0; i < arr.length; i++ ) { console.log( arr[ i ] ); }")',
+    ],
+  }, # end variables
+}

--- a/lib/node_modules/@stdlib/math/base/special/asechf/include/stdlib/math/base/special/asechf.h
+++ b/lib/node_modules/@stdlib/math/base/special/asechf/include/stdlib/math/base/special/asechf.h
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_MATH_BASE_SPECIAL_ASECHF_H
+#define STDLIB_MATH_BASE_SPECIAL_ASECHF_H
+
+/*
+* If C++, prevent name mangling so that the compiler emits a binary file having undecorated names, thus mirroring the behavior of a C compiler.
+*/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* Computes the hyperbolic arcsecant of a single-precision floating-point number.
+*/
+float stdlib_base_asechf( const float x );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // !STDLIB_MATH_BASE_SPECIAL_ASECHF_H

--- a/lib/node_modules/@stdlib/math/base/special/asechf/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/asechf/lib/index.js
@@ -1,0 +1,46 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Compute the hyperbolic arcsecant of a single-precision floating-point number.
+*
+* @module @stdlib/math/base/special/asechf
+*
+* @example
+* var asechf = require( '@stdlib/math/base/special/asechf' );
+*
+* var v = asechf( 1.0 );
+* // returns 0.0
+*
+* v = asechf( 0.5 );
+* // returns ~1.317
+*
+* v = asechf( NaN );
+* // returns NaN
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/math/base/special/asechf/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/asechf/lib/main.js
@@ -1,0 +1,60 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var acosh = require( '@stdlib/math/base/special/acosh' );
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+
+
+// MAIN //
+
+/**
+* Computes the hyperbolic arcsecant of a single-precision floating-point number.
+*
+* ## Method
+*
+* ```tex
+* \operatorname{asechf}(x) = \operatorname{acosh}(\frac{1}{x})
+* ```
+*
+* @param {number} x - input value
+* @returns {number} hyperbolic arcsecant
+*
+* @example
+* var v = asechf( 1.0 );
+* // returns 0.0
+*
+* @example
+* var v = asechf( 0.5 );
+* // returns ~1.317
+*
+* @example
+* var v = asechf( NaN );
+* // returns NaN
+*/
+function asechf( x ) {
+	return float64ToFloat32( acosh( 1.0 / float64ToFloat32( x ) ) );
+}
+
+
+// EXPORTS //
+
+module.exports = asechf;

--- a/lib/node_modules/@stdlib/math/base/special/asechf/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/asechf/lib/native.js
@@ -1,0 +1,54 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var addon = require( './../src/addon.node' );
+
+
+// MAIN //
+
+/**
+* Computes the hyperbolic arcsecant of a single-precision floating-point number.
+*
+* @private
+* @param {number} x - input value
+* @returns {number} hyperbolic arcsecant
+*
+* @example
+* var v = asechf( 1.0 );
+* // returns 0.0
+*
+* @example
+* var v = asechf( 0.5 );
+* // returns ~1.317
+*
+* @example
+* var v = asechf( NaN );
+* // returns NaN
+*/
+function asechf( x ) {
+	return addon( x );
+}
+
+
+// EXPORTS //
+
+module.exports = asechf;

--- a/lib/node_modules/@stdlib/math/base/special/asechf/manifest.json
+++ b/lib/node_modules/@stdlib/math/base/special/asechf/manifest.json
@@ -1,0 +1,72 @@
+{
+  "options": {
+    "task": "build"
+  },
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "task": "build",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/napi/unary",
+        "@stdlib/math/base/special/acosh"
+      ]
+    },
+    {
+      "task": "benchmark",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/acosh"
+      ]
+    },
+    {
+      "task": "examples",
+      "src": [
+        "./src/main.c"
+      ],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": [
+        "@stdlib/math/base/special/acosh"
+      ]
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/math/base/special/asechf/package.json
+++ b/lib/node_modules/@stdlib/math/base/special/asechf/package.json
@@ -1,0 +1,149 @@
+{
+  "name": "@stdlib/math/base/special/asechf",
+  "version": "0.0.0",
+  "description": "Compute the hyperbolic arcsecant of a single-precision floating-point number.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "gypfile": true,
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "src": "./src",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "mathematics",
+    "math",
+    "asechf",
+    "inverse",
+    "hyperbolic",
+    "arc",
+    "arcsecant",
+    "secant",
+    "acosh",
+    "cosh",
+    "hyperbolic secant",
+    "area",
+    "area hyperbolic secant"
+  ],
+  "__stdlib__": {
+    "scaffold": {
+      "$schema": "math/base@v1.0",
+      "base_alias": "asech",
+      "alias": "asechf",
+      "pkg_desc": "compute the hyperbolic arcsecant of a single-precision floating-point number",
+      "desc": "computes the hyperbolic arcsecant of a single-precision floating-point number",
+      "short_desc": "hyperbolic arcsecant",
+      "parameters": [
+        {
+          "name": "x",
+          "desc": "input value",
+          "type": {
+            "javascript": "number",
+            "jsdoc": "number",
+            "c": "float",
+            "dtype": "float32"
+          },
+          "domain": [
+            {
+              "min": 0,
+              "max": 1
+            }
+          ],
+          "rand": {
+            "prng": "random/base/uniform",
+            "parameters": [
+              0.1,
+              1
+            ]
+          },
+          "example_values": [
+            0.5,
+            0.75,
+            0.1,
+            0.9,
+            0.25,
+            0.33,
+            0.66,
+            0.8,
+            0.42,
+            0.12,
+            0.99,
+            0.05,
+            0.55,
+            0.7,
+            0.22,
+            0.88,
+            0.15,
+            0.6,
+            0.35,
+            0.95
+          ]
+        }
+      ],
+      "output_policy": "real_floating_point_and_generic",
+      "returns": {
+        "desc": "hyperbolic arcsecant",
+        "type": {
+          "javascript": "number",
+          "jsdoc": "number",
+          "c": "float",
+          "dtype": "float32"
+        }
+      },
+      "keywords": [
+        "asechf",
+        "inverse",
+        "hyperbolic",
+        "secant",
+        "arcsecant",
+        "acosh"
+      ],
+      "extra_keywords": [
+        "math.acosh"
+      ]
+    }
+  }
+}

--- a/lib/node_modules/@stdlib/math/base/special/asechf/src/addon.c
+++ b/lib/node_modules/@stdlib/math/base/special/asechf/src/addon.c
@@ -1,0 +1,22 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/asechf.h"
+#include "stdlib/math/base/napi/unary.h"
+
+STDLIB_MATH_BASE_NAPI_MODULE_F_F( stdlib_base_asechf )

--- a/lib/node_modules/@stdlib/math/base/special/asechf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/asechf/src/main.c
@@ -1,0 +1,34 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "stdlib/math/base/special/asechf.h"
+#include "stdlib/math/base/special/acosh.h"
+
+/**
+* Computes the hyperbolic arcsecant of a single-precision floating-point number.
+*
+* @param x    input value
+* @return     output value
+*
+* @example
+* float out = stdlib_base_asechf( 1.0f );
+* // returns 0.0f
+*/
+float stdlib_base_asechf( const float x ) {
+	return (float)stdlib_base_acosh( (double)( 1.0f / x ) );
+}

--- a/lib/node_modules/@stdlib/math/base/special/asechf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/asechf/test/test.js
@@ -1,0 +1,76 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var absf = require( '@stdlib/math/base/special/absf' );
+var EPS = require( '@stdlib/constants/float32/eps' );
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var asechf = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof asechf, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function computes the hyperbolic arcsecant of 1', function test( t ) {
+	var v = asechf( 1.0 );
+	t.strictEqual( v, 0.0, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function computes the hyperbolic arcsecant of 0.5', function test( t ) {
+	var v = asechf( 0.5 );
+	var expected = float64ToFloat32( 1.3169578969248166 );
+	var delta = absf( v - expected );
+	var tol = 10.0 * EPS;
+	t.ok( delta <= tol, 'within tolerance. v: ' + v + '. expected: ' + expected + '. Δ: ' + delta + '. tol: ' + tol + '.' );
+	t.end();
+});
+
+tape( 'the function returns `Infinity` for `x = 0`', function test( t ) {
+	var v = asechf( 0.0 );
+	t.strictEqual( v, Infinity, 'returns Infinity' );
+	t.end();
+});
+
+tape( 'the function returns `NaN` for negative values', function test( t ) {
+	var v = asechf( -1.0 );
+	t.strictEqual( isnanf( v ), true, 'returns NaN' );
+	t.end();
+});
+
+tape( 'the function returns `NaN` for values greater than 1', function test( t ) {
+	var v = asechf( 2.0 );
+	t.strictEqual( isnanf( v ), true, 'returns NaN' );
+	t.end();
+});
+
+tape( 'the function returns `NaN` if provided `NaN`', function test( t ) {
+	var v = asechf( NaN );
+	t.strictEqual( isnanf( v ), true, 'returns NaN' );
+	t.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/asechf/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/asechf/test/test.js
@@ -43,10 +43,14 @@ tape( 'the function computes the hyperbolic arcsecant of 1', function test( t ) 
 });
 
 tape( 'the function computes the hyperbolic arcsecant of 0.5', function test( t ) {
-	var v = asechf( 0.5 );
 	var expected = float64ToFloat32( 1.3169578969248166 );
-	var delta = absf( v - expected );
-	var tol = 10.0 * EPS;
+	var delta;
+	var tol;
+	var v;
+
+	v = asechf( 0.5 );
+	delta = absf( v - expected );
+	tol = 10.0 * EPS;
 	t.ok( delta <= tol, 'within tolerance. v: ' + v + '. expected: ' + expected + '. Δ: ' + delta + '. tol: ' + tol + '.' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/asechf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/asechf/test/test.native.js
@@ -52,10 +52,14 @@ tape( 'the function computes the hyperbolic arcsecant of 1', opts, function test
 });
 
 tape( 'the function computes the hyperbolic arcsecant of 0.5', opts, function test( t ) {
-	var v = asechf( 0.5 );
 	var expected = float64ToFloat32( 1.3169578969248166 );
-	var delta = absf( v - expected );
-	var tol = 10.0 * EPS;
+	var delta;
+	var tol;
+	var v;
+
+	v = asechf( 0.5 );
+	delta = absf( v - expected );
+	tol = 10.0 * EPS;
 	t.ok( delta <= tol, 'within tolerance. v: ' + v + '. expected: ' + expected + '. Δ: ' + delta + '. tol: ' + tol + '.' );
 	t.end();
 });

--- a/lib/node_modules/@stdlib/math/base/special/asechf/test/test.native.js
+++ b/lib/node_modules/@stdlib/math/base/special/asechf/test/test.native.js
@@ -1,0 +1,85 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var resolve = require( 'path' ).resolve;
+var tape = require( 'tape' );
+var isnanf = require( '@stdlib/math/base/assert/is-nanf' );
+var absf = require( '@stdlib/math/base/special/absf' );
+var EPS = require( '@stdlib/constants/float32/eps' );
+var float64ToFloat32 = require( '@stdlib/number/float64/base/to-float32' );
+var tryRequire = require( '@stdlib/utils/try-require' );
+
+
+// VARIABLES //
+
+var asechf = tryRequire( resolve( __dirname, './../lib/native.js' ) );
+var opts = {
+	'skip': ( asechf instanceof Error )
+};
+
+
+// TESTS //
+
+tape( 'main export is a function', opts, function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof asechf, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function computes the hyperbolic arcsecant of 1', opts, function test( t ) {
+	var v = asechf( 1.0 );
+	t.strictEqual( v, 0.0, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function computes the hyperbolic arcsecant of 0.5', opts, function test( t ) {
+	var v = asechf( 0.5 );
+	var expected = float64ToFloat32( 1.3169578969248166 );
+	var delta = absf( v - expected );
+	var tol = 10.0 * EPS;
+	t.ok( delta <= tol, 'within tolerance. v: ' + v + '. expected: ' + expected + '. Δ: ' + delta + '. tol: ' + tol + '.' );
+	t.end();
+});
+
+tape( 'the function returns `Infinity` for `x = 0`', opts, function test( t ) {
+	var v = asechf( 0.0 );
+	t.strictEqual( v, Infinity, 'returns Infinity' );
+	t.end();
+});
+
+tape( 'the function returns `NaN` for negative values', opts, function test( t ) {
+	var v = asechf( -1.0 );
+	t.strictEqual( isnanf( v ), true, 'returns NaN' );
+	t.end();
+});
+
+tape( 'the function returns `NaN` for values greater than 1', opts, function test( t ) {
+	var v = asechf( 2.0 );
+	t.strictEqual( isnanf( v ), true, 'returns NaN' );
+	t.end();
+});
+
+tape( 'the function returns `NaN` if provided `NaN`', opts, function test( t ) {
+	var v = asechf( NaN );
+	t.strictEqual( isnanf( v ), true, 'returns NaN' );
+	t.end();
+});


### PR DESCRIPTION
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:

- task: lint_filenames status: passed
- task: lint_editorconfig status: passed
- task: lint_markdown status: passed
- task: lint_package_json status: passed
- task: lint_repl_help status: passed
- task: lint_javascript_src status: passed
- task: lint_javascript_cli status: na
- task: lint_javascript_examples status: passed
- task: lint_javascript_tests status: passed
- task: lint_javascript_benchmarks status: passed
- task: lint_python status: na
- task: lint_r status: na
- task: lint_c_src status: passed
- task: lint_c_examples status: passed
- task: lint_c_benchmarks status: passed
- task: lint_c_tests_fixtures status: na
- task: lint_shell status: na
- task: lint_typescript_declarations status: passed
- task: lint_typescript_tests status: passed
- task: lint_license_headers status: passed ---

Resolves a part of #649

## Description

> What is the purpose of this pull request?

This pull request:

- adds a C implementation for `@stdlib/math/base/special/asechf`.

The package computes the hyperbolic arcsecant of a single-precision floating-point number using the relationship:
```math
asechf(x) = acosh(1/x)
````
Since `acoshf` does not yet have a C implementation, this implementation uses the double-precision `acosh` function with appropriate float conversions.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   ref #649 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [x] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

I used AI to generate the boilerplate code for the benchmark files and to generate the numerical test fixtures (input/output pairs) for `test.c`. The core implementation logic and mathematical correctness were manually verified against standard definitions.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
