### PR TITLE
feat(lib): add stats/incr/nanmmax

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/nanmmax/README.md
+++ b/lib/node_modules/@stdlib/stats/incr/nanmmax/README.md
@@ -1,0 +1,123 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2018 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# nanmmax
+
+> Compute a cumulative maximum value incrementally, ignoring NaN values.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var nanmmax = require( '@stdlib/stats/incr/nanmmax' );
+```
+
+#### nanmmax()
+
+Returns an accumulator function which incrementally computes a moving maximum value. The window parameter defines the number of values over which to compute the moving maximum.
+
+
+#### accumulator( \[x] )
+
+If provided an input value x, the accumulator function returns an updated maximum value. If not provided an input value x, the accumulator function returns the current maximum value.
+
+```javascript
+var accumulator = nanmmax();
+
+var m = accumulator();
+// returns null
+
+m = accumulator( 2.0 );
+// returns 2.0
+
+m = accumulator( NaN );
+// returns 2.0
+
+m = accumulator( 5.0 );
+// returns 5.0
+
+m = accumulator();
+// returns 5.0
+```
+
+</section>
+
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+
+-   Input values are not type checked.
+-   `Nan` values are ignored and do not affect the accumulated maximum.
+-   If no non-NaN values have been provided, the accumulator returns null.  `null`.
+
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var randu = require( '@stdlib/random/base/randu' );
+var nanmmax = require( '@stdlib/stats/incr/nanmmax' );
+
+var accumulator = nanmmax();
+var v;
+var i;
+
+for ( i = 0; i < 100; i++ ) {
+    v = randu() * 100.0;
+    accumulator( v );
+}
+console.log( accumulator() );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/stats/incr/nanmmax/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmmax/benchmark/benchmark.js
@@ -1,0 +1,72 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var pkg = require( './../package.json' ).name;
+var nanmmax = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var f;
+	var i;
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		f = nanmmax();
+		if ( typeof f !== 'function' ) {
+			b.fail( 'should return a function' );
+		}
+	}
+	b.toc();
+
+	if ( typeof f !== 'function' ) {
+		b.fail( 'should return a function' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::accumulator', function benchmark( b ) {
+	var acc;
+	var v;
+	var i;
+
+	acc = nanmmax();
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		v = acc( randu() );
+		if ( v !== v ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+
+	if ( v !== v ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/stats/incr/nanmmax/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/incr/nanmmax/docs/repl.txt
@@ -1,0 +1,39 @@
+{{alias}}()
+    Returns an accumulator function which incrementally computes a cumulative
+    maximum value while **ignoring NaN values**.
+
+    If provided a numeric value, the accumulator function updates the cumulative
+    maximum. If provided `NaN`, the value is ignored. If not provided any value,
+    the accumulator function returns the current maximum.
+
+    Until a non-NaN value is provided, the accumulator returns `null`.
+
+    Parameters
+    ----------
+    (none)
+
+    Returns
+    -------
+    acc: Function
+        Accumulator function.
+
+    Examples
+    --------
+    > var accumulator = {{alias}}();
+    > var m = accumulator()
+    null
+    > m = accumulator( 2.0 )
+    2.0
+    > m = accumulator( NaN )
+    2.0
+    > m = accumulator( -5.0 )
+    2.0
+    > m = accumulator( 3.0 )
+    3.0
+    > m = accumulator( 5.0 )
+    5.0
+    > m = accumulator()
+    5.0
+
+    See Also
+    --------

--- a/lib/node_modules/@stdlib/stats/incr/nanmmax/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/incr/nanmmax/docs/types/index.d.ts
@@ -1,0 +1,65 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+/**
+* If provided a value, returns an updated maximum value; otherwise, returns the current maximum value.
+*
+* ## Notes
+*
+* -   `NaN` values are ignored.
+* -   The accumulator returns `null` until at least one non-NaN value has been provided.
+*
+* @param x - input value
+* @returns maximum value or null
+*/
+type accumulator = ( x?: number ) => number | null;
+
+/**
+* Returns an accumulator function which incrementally computes a maximum value,
+* **ignoring `NaN` values**.
+*
+* @returns accumulator function
+*
+* @example
+* var acc = nanmmax();
+*
+* var m = acc();
+* // returns null
+*
+* m = acc( 2.0 );
+* // returns 2.0
+*
+* m = acc( NaN );
+* // returns 2.0
+*
+* m = acc( 5.0 );
+* // returns 5.0
+*
+* m = acc();
+* // returns 5.0
+*/
+declare function nanmmax(): accumulator;
+
+
+// EXPORTS //
+
+export = nanmmax;

--- a/lib/node_modules/@stdlib/stats/incr/nanmmax/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/incr/nanmmax/docs/types/test.ts
@@ -1,0 +1,48 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2019 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import nanmmax = require( './index' );
+
+
+// TESTS //
+
+// The function returns an accumulator function...
+{
+	nanmmax(); // $ExpectType accumulator
+}
+
+// The compiler throws an error if the returned accumulator function is provided invalid arguments...
+{
+	const acc = nanmmax();
+
+	acc( '5' ); // $ExpectError
+	acc( true ); // $ExpectError
+	acc( false ); // $ExpectError
+	acc( null ); // $ExpectError
+	acc( [] ); // $ExpectError
+	acc( {} ); // $ExpectError
+	acc( ( x: number ): number => x ); // $ExpectError
+}
+
+// The function returns an accumulator function which returns an accumulated result...
+{
+	const acc = nanmmax();
+
+	acc(); // $ExpectType number | null
+	acc( 3.14 ); // $ExpectType number | null
+}

--- a/lib/node_modules/@stdlib/stats/incr/nanmmax/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmmax/examples/index.js
@@ -1,0 +1,50 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var randu = require( '@stdlib/random/base/randu' );
+var nanmmax = require( './../lib' );
+
+
+// MAIN //
+
+// Initialize an accumulator (no window size for nanmmax):
+var accumulator = nanmmax();
+
+var v;
+var m;
+var i;
+
+console.log( '\nValue\tMax (ignoring NaN)\n' );
+
+// Generate random values including some NaNs:
+for ( i = 0; i < 100; i++ ) {
+	// Insert a NaN with ~10% probability:
+	if ( randu() < 0.1 ) {
+		v = NaN;
+	} else {
+		v = randu() * 100.0;
+	}
+
+	m = accumulator( v );
+
+	console.log( '%s\t%s', String(v), (m === null) ? 'null' : m.toFixed( 4 ) );
+}

--- a/lib/node_modules/@stdlib/stats/incr/nanmmax/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmmax/lib/index.js
@@ -1,0 +1,54 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Compute a cumulative maximum while ignoring NaN values.
+*
+* @module @stdlib/stats/incr/nanmmax
+*
+* @example
+* var nanmmax = require( '@stdlib/stats/incr/nanmmax' );
+*
+* var accumulator = nanmmax();
+*
+* var m = accumulator();
+* // returns null
+*
+* m = accumulator( 2.0 );
+* // returns 2.0
+*
+* m = accumulator( NaN );
+* // returns 2.0  (ignores NaN)
+*
+* m = accumulator( 5.0 );
+* // returns 5.0
+*
+* m = accumulator();
+* // returns 5.0
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/incr/nanmmax/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmmax/lib/main.js
@@ -1,0 +1,78 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2018 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
+
+
+// MAIN //
+
+/**
+* Returns an accumulator function that computes a cumulative maximum while ignoring NaN values.
+*
+* @returns {Function} accumulator function
+*
+* @example
+* var accumulator = nanmmax();
+*/
+function nanmmax() {
+	var max = null;
+
+	return accumulator;
+
+	/**
+	* If called without arguments, returns the current cumulative maximum.
+	* Otherwise, updates the cumulative maximum.
+	*
+	* @private
+	* @param {number} [x] - input value
+	* @returns {(number|null)} current cumulative maximum (or null if no non-NaN value seen yet)
+	*/
+	function accumulator( x ) {
+		if ( arguments.length === 0 ) {
+			return max;
+		}
+
+		if ( isnan( x ) ) {
+			return max;
+		}
+
+		if ( max === null ) {
+			max = x;
+			return max;
+		}
+
+		if (
+			x > max ||
+			( x === max && isPositiveZero( x ) )
+		) {
+			max = x;
+		}
+
+		return max;
+	}
+}
+
+
+// EXPORTS //
+
+module.exports = nanmmax;

--- a/lib/node_modules/@stdlib/stats/incr/nanmmax/package.json
+++ b/lib/node_modules/@stdlib/stats/incr/nanmmax/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@stdlib/stats/incr/nanmmax",
+  "version": "0.0.0",
+  "description": "Compute a cumulative maximum incrementally, ignoring NaN values.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "statistics",
+    "stats",
+    "mathematics",
+    "math",
+    "maximum",
+    "max",
+    "extreme",
+    "extent",
+    "range",
+    "incremental",
+    "accumulator",
+    "moving max",
+    "sliding window",
+    "sliding",
+    "window",
+    "moving"
+  ]
+}

--- a/lib/node_modules/@stdlib/stats/incr/nanmmax/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmmax/test/test.js
@@ -1,0 +1,153 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isPositiveZero = require( '@stdlib/math/base/assert/is-positive-zero' );
+var isNegativeZero = require( '@stdlib/math/base/assert/is-negative-zero' );
+var nanmmax = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof nanmmax, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns an accumulator function', function test( t ) {
+	t.strictEqual( typeof nanmmax(), 'function', 'returns expected value' );
+	t.end();
+});
+
+tape( 'the accumulator returns `null` until a non-NaN value is provided', function test( t ) {
+	var acc = nanmmax();
+	var i;
+	var v;
+
+	for ( i = 0; i < 10; i++ ) {
+		v = acc( NaN );
+		t.strictEqual( v, null, 'returns null' );
+	}
+	t.end();
+});
+
+tape( 'the accumulator computes a cumulative maximum, ignoring NaN values', function test( t ) {
+	var expected;
+	var actual;
+	var data;
+	var acc;
+	var i;
+
+	acc = nanmmax();
+
+	data = [ 2.0, NaN, -5.0, 3.0, NaN, 4.0, 5.0, -2.0, 3.0, 1.0 ];
+	expected = [
+		2.0, // 2
+		2.0, // ignore NaN
+		2.0, // max(2, -5)
+		3.0, // max(2, -5, 3)
+		3.0, // ignore NaN
+		4.0, // max(3, 4)
+		5.0, // max(4, 5)
+		5.0, // max(5, -2)
+		5.0, // max(5, 3)
+		5.0  // max(5, 1)
+	];
+
+	for ( i = 0; i < data.length; i++ ) {
+		actual = acc( data[ i ] );
+		t.strictEqual( actual, expected[ i ], 'returns expected value for index '+i );
+	}
+	t.end();
+});
+
+tape( 'if not provided a value, the accumulator returns the current maximum', function test( t ) {
+	var acc;
+	var v;
+
+	acc = nanmmax();
+
+	v = acc();
+	t.strictEqual( v, null, 'returns null before data' );
+
+	acc( 3.0 );
+	acc( NaN );
+	acc( 5.0 );
+
+	v = acc();
+	t.strictEqual( v, 5.0, 'returns current maximum' );
+
+	t.end();
+});
+
+tape( 'the accumulator correctly handles signed zeros', function test( t ) {
+	var expected;
+	var actual;
+	var data;
+	var acc;
+	var i;
+
+	acc = nanmmax();
+
+	data = [
+		-0.0,  // max = -0
+		0.0,   // max = +0
+		-0.0,  // max = +0 (positive zero wins)
+		-0.0,  // max = +0
+		0.0    // max = +0
+	];
+
+	expected = [
+		-0.0,
+		0.0,
+		0.0,
+		0.0,
+		0.0
+	];
+
+	for ( i = 0; i < data.length; i++ ) {
+		actual = acc( data[ i ] );
+		if ( isPositiveZero( expected[ i ] ) ) {
+			t.strictEqual( isPositiveZero( actual ), true, 'returns +0 at index '+i );
+		} else {
+			t.strictEqual( isNegativeZero( actual ), true, 'returns -0 at index '+i );
+		}
+	}
+	t.end();
+});
+
+tape( 'ignores NaN values when determining the maximum', function test( t ) {
+	var acc = nanmmax();
+	var v;
+
+	acc( 4.0 );
+	acc( NaN );
+	acc( 2.0 );
+	acc( NaN );
+	acc( 10.0 );
+	acc( NaN );
+
+	v = acc();
+	t.strictEqual( v, 10.0, 'correctly ignores NaN values' );
+	t.end();
+});


### PR DESCRIPTION
Resolves #5584.

## Description
This pull request adds a new incremental statistics package `@stdlib/stats/incr/nanmmax`, which provides an accumulator function that computes a cumulative maximum while correctly ignoring `NaN` values (similar to `nanmin`, `nansum`, etc.).

The implementation properly handles signed-zero edge cases and returns `null` until the first non-NaN value is observed.

## Related Issues
This pull request resolves #5584.

## Questions
No.

## Other
No.

## Checklist
- [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *
@stdlib-js/reviewers
[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md