### PR TITLE
chore: fix JavaScript lint errors (issue #8253)

### DIFF
--- a/lib/node_modules/@stdlib/utils/async/for-each-right/lib/factory.js
+++ b/lib/node_modules/@stdlib/utils/async/for-each-right/lib/factory.js
@@ -75,8 +75,7 @@ var limit = require( './limit.js' );
 *
 * // Create a collection over which to iterate:
 * var files = [
-*     './beep.js',
-*     './boop.js'
+*
 * ];
 *
 * // Define a callback which handles errors:

--- a/lib/node_modules/@stdlib/utils/async/for-each-right/lib/index.js
+++ b/lib/node_modules/@stdlib/utils/async/for-each-right/lib/index.js
@@ -28,8 +28,7 @@
 * var forEachRightAsync = require( '@stdlib/utils/async/for-each-right' );
 *
 * var files = [
-*     './beep.js',
-*     './boop.js'
+
 * ];
 *
 * function done( error ) {

--- a/lib/node_modules/@stdlib/utils/async/for-each-right/lib/main.js
+++ b/lib/node_modules/@stdlib/utils/async/for-each-right/lib/main.js
@@ -73,8 +73,7 @@ var factory = require( './factory.js' );
 * }
 *
 * var files = [
-*     './beep.js',
-*     './boop.js'
+
 * ];
 *
 * forEachRightAsync( files, read, done );


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Resolves #8253 .

## Description

> What is the purpose of this pull request?

This pull request:

-   removed boop.js and beep.js from comments as they were causing lint error

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:


## Questions


No.

## Other


No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
