### PR TITLE
bench: refactor to use dynamic memory allocation in `blas/base/caxpy`

### DIFF
--- a/lib/node_modules/@stdlib/blas/base/caxpy/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/base/caxpy/benchmark/c/benchmark.length.c
@@ -97,13 +97,15 @@ static float rand_float( void ) {
 */
 static double benchmark1( int iterations, int len ) {
 	stdlib_complex64_t alpha;
-	float x[ len*2 ];
-	float y[ len*2 ];
+	float *x;
+	float *y;
 	double elapsed;
 	double t;
 	int i;
 
 	alpha = stdlib_complex64( 1.0f, 0.0f );
+	x = (float *) malloc( len * 2 * sizeof( float ) );
+	y = (float *) malloc( len * 2 * sizeof( float ) );
 	for ( i = 0; i < len*2; i += 2 ) {
 		x[ i ] = ( rand_float()*2.0f ) - 1.0f;
 		x[ i+1 ] = ( rand_float()*2.0f ) - 1.0f;
@@ -122,6 +124,8 @@ static double benchmark1( int iterations, int len ) {
 	if ( y[ 0 ] != y[ 0 ] ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( y );
 	return elapsed;
 }
 
@@ -134,13 +138,15 @@ static double benchmark1( int iterations, int len ) {
 */
 static double benchmark2( int iterations, int len ) {
 	stdlib_complex64_t alpha;
-	float x[ len*2 ];
-	float y[ len*2 ];
+	float *x;
+	float *y;
 	double elapsed;
 	double t;
 	int i;
 
 	alpha = stdlib_complex64( 1.0f, 0.0f );
+	x = (float *) malloc( len * 2 * sizeof( float ) );
+	y = (float *) malloc( len * 2 * sizeof( float ) );
 	for ( i = 0; i < len*2; i += 2 ) {
 		x[ i ] = ( rand_float()*2.0f ) - 1.0f;
 		x[ i+1 ] = ( rand_float()*2.0f ) - 1.0f;
@@ -159,6 +165,8 @@ static double benchmark2( int iterations, int len ) {
 	if ( y[ 0 ] != y[ 0 ] ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( y );
 	return elapsed;
 }
 


### PR DESCRIPTION
Resolves a part of  #8643 .

## Description

> What is the purpose of this pull request?

This pull request replaces static memory allocation in C benchmarks with dynamic memory allocation in @stdlib/blas/base/caxpy

## Related Issues

> Does this pull request have any related issues?

[RFC]: replace static memory allocation of large arrays in C benchmarks with dynamic memory allocation (tracking issue) https://github.com/stdlib-js/stdlib/issues/8643

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [X] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [X] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [X] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Used github copilot to understand where to make changes , concepts were already known through the examples given.
* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
