### PR TITLE
chore: fix JavaScript lint errors (issue #8876)

### DIFF
--- a/lib/node_modules/@stdlib/assert/is-configurable-property-in/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-configurable-property-in/benchmark/benchmark.js
@@ -33,7 +33,7 @@ bench( pkg, function benchmark( b ) {
 	var arr;
 	var i;
 
-	arr = new Array( 100 );
+	arr = Array( 100 ).fill( 0 );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {

--- a/lib/node_modules/@stdlib/assert/is-configurable-property-in/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/assert/is-configurable-property-in/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var isBoolean = require( '@stdlib/assert/is-boolean' ).isPrimitive;
+var zeros = require( '@stdlib/array/base/zeros' );
 var pkg = require( './../package.json' ).name;
 var isConfigurablePropertyIn = require( './../lib' );
 
@@ -33,7 +34,7 @@ bench( pkg, function benchmark( b ) {
 	var arr;
 	var i;
 
-	arr = Array( 100 ).fill( 0 );
+	arr = zeros( 100 );
 
 	b.tic();
 	for ( i = 0; i < b.iterations; i++ ) {


### PR DESCRIPTION
Resolves #8876 .

## Description

> Fix linting error: Replace new Array() with safe Array creation to follow stdlib/no-new-array rule.

This pull request:

-   Using the `new Array()` constructor is not allowed; use an array literal with push instead.

## Related Issues

> No

This pull request has the following related issues:

-   No

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
