### PR TITLE
bench: refactor to use string interpolation in `number/uint8/base/mul`

### DIFF
--- a/lib/node_modules/@stdlib/number/uint8/base/mul/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/number/uint8/base/mul/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var mul = require( './../lib' );
 
@@ -52,7 +53,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::inline', function benchmark( b ) {
+bench( format( '%s::inline', pkg ), function benchmark( b ) {
 	var x;
 	var y;
 	var i;

--- a/lib/node_modules/@stdlib/number/uint8/base/mul/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/number/uint8/base/mul/benchmark/benchmark.native.js
@@ -23,6 +23,7 @@
 var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var format = require( '@stdlib/string/format' );
 var tryRequire = require( '@stdlib/utils/try-require' );
 var pkg = require( './../package.json' ).name;
 
@@ -37,7 +38,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var x;
 	var y;
 	var i;


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes.
report:
  - task: lint_filenames
    status: passed
  - task: lint_editorconfig
    status: passed
  - task: lint_markdown
    status: na
  - task: lint_package_json
    status: na
  - task: lint_repl_help
    status: na
  - task: lint_javascript_src
    status: na
  - task: lint_javascript_cli
    status: na
  - task: lint_javascript_examples
    status: na
  - task: lint_javascript_tests
    status: na
  - task: lint_javascript_benchmarks
    status: passed
  - task: lint_python
    status: na
  - task: lint_r
    status: na
  - task: lint_c_src
    status: na
  - task: lint_c_examples
    status: na
  - task: lint_c_benchmarks
    status: na
  - task: lint_c_tests_fixtures
    status: na
  - task: lint_shell
    status: na
  - task: lint_typescript_declarations
    status: passed
  - task: lint_typescript_tests
    status: na
  - task: lint_license_headers
    status: passed
---

Resolves a part of #8647.

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors JavaScript benchmarks in `@stdlib/number/uint8/base/mul` to use `@stdlib/string/format` for string interpolation instead of string concatenation when specifying benchmark names.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8647

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

- Updated `benchmark.js` to replace `pkg+'::inline'` with `format( '%s::inline', pkg )`
- Updated `benchmark.native.js` to replace `pkg+'::native'` with `format( '%s::native', pkg )`
- All benchmarks run successfully and produce the same output as before
- No other changes were made to the benchmark logic

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

---

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md