### PR TITLE
bench: refactor to use dynamic memory allocation in `blas/ext/base/dsumkbn`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/dsumkbn/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/dsumkbn/benchmark/c/benchmark.length.c
@@ -96,11 +96,12 @@ static double rand_double( void ) {
 */
 static double benchmark1( int iterations, int len ) {
 	double elapsed;
-	double x[ len ];
+	double *x;
 	double v;
 	double t;
 	int i;
 
+	x = (double *)malloc( len * sizeof( double ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = ( rand_double() * 20000.0 ) - 10000.0;
 	}
@@ -118,6 +119,7 @@ static double benchmark1( int iterations, int len ) {
 	if ( v != v ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
 	return elapsed;
 }
 
@@ -130,11 +132,12 @@ static double benchmark1( int iterations, int len ) {
 */
 static double benchmark2( int iterations, int len ) {
 	double elapsed;
-	double x[ len ];
+	double *x;
 	double v;
 	double t;
 	int i;
 
+	x = (double *)malloc( len * sizeof( double ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = ( rand_double() * 20000.0 ) - 10000.0;
 	}
@@ -152,6 +155,7 @@ static double benchmark2( int iterations, int len ) {
 	if ( v != v ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
 	return elapsed;
 }
 


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes.
report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: missing_dependencies
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed
---

Progresses #8643.

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors the C benchmarks for `@stdlib/blas/ext/base/dsum` to use dynamic memory allocation instead of static memory allocation for large arrays.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8643
-   #369

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md