### PR TITLE
bench: refactor to use string interpolation in `complex/float64/base/add`

### DIFF
--- a/lib/node_modules/@stdlib/complex/float64/base/add/benchmark/benchmark.assign.js
+++ b/lib/node_modules/@stdlib/complex/float64/base/add/benchmark/benchmark.assign.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var add = require( './../lib' );
 
@@ -37,7 +38,7 @@ var options = {
 
 // MAIN //
 
-bench( pkg+':assign', function benchmark( b ) {
+bench( format( '%s:assign', pkg ), function benchmark( b ) {
 	var out;
 	var re;
 	var im;

--- a/lib/node_modules/@stdlib/complex/float64/base/add/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/complex/float64/base/add/benchmark/benchmark.native.js
@@ -28,6 +28,7 @@ var Complex128 = require( '@stdlib/complex/float64/ctor' );
 var real = require( '@stdlib/complex/float64/real' );
 var imag = require( '@stdlib/complex/float64/imag' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -41,7 +42,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var values;
 	var out;
 	var z;

--- a/lib/node_modules/@stdlib/complex/float64/base/add/benchmark/benchmark.strided.js
+++ b/lib/node_modules/@stdlib/complex/float64/base/add/benchmark/benchmark.strided.js
@@ -24,6 +24,7 @@ var bench = require( '@stdlib/bench' );
 var uniform = require( '@stdlib/random/array/uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var Float64Array = require( '@stdlib/array/float64' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var add = require( './../lib' );
 
@@ -37,7 +38,7 @@ var options = {
 
 // MAIN //
 
-bench( pkg+':strided', function benchmark( b ) {
+bench( format( '%s:strided', pkg ), function benchmark( b ) {
 	var out;
 	var z1;
 	var z2;


### PR DESCRIPTION
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Progresses https://github.com/stdlib-js/stdlib/issues/8647

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors JavaScript benchmark files in \`@stdlib/complex/float64/base/add\` to use string interpolation via \`@stdlib/string/format\` instead of string concatenation when specifying benchmark names.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   https://github.com/stdlib-js/stdlib/issues/8647

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md"