### PR TITLE
bench: refactor to use string interpolation in `number/uint8/base/identity`

### DIFF
--- a/lib/node_modules/@stdlib/number/uint8/base/identity/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/number/uint8/base/identity/benchmark/benchmark.native.js
@@ -25,6 +25,7 @@ var bench = require( '@stdlib/bench' );
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -38,7 +39,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var x;
 	var y;
 	var i;


### PR DESCRIPTION
Progresses #8647.

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors JavaScript benchmarks in `number/uint8/base/identity` to use string interpolation via `@stdlib/string/format` instead of string concatenation when specifying benchmark names
-   Adds `@stdlib/string/format` import to `benchmark.native.js`
-   Replaces string concatenation pattern (`pkg+'::native'`) with format function call using appropriate format specifier

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8647

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

All benchmarks were tested locally using:
```bash
make benchmark BENCHMARKS_FILTER=".*/number/uint8/base/identity/.*"
```

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md