### PR TITLE
bench: refactor to use string interpolation in `number/uint32/base/mul`

### DIFF
--- a/lib/node_modules/@stdlib/number/uint32/base/mul/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/number/uint32/base/mul/benchmark/benchmark.js
@@ -22,6 +22,7 @@
 
 var bench = require( '@stdlib/bench' );
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var mul = require( './../lib' );
 
@@ -52,7 +53,7 @@ bench( pkg, function benchmark( b ) {
 	b.end();
 });
 
-bench( pkg+'::inline', function benchmark( b ) {
+bench( format( '%s::inline', pkg ), function benchmark( b ) {
 	var x;
 	var y;
 	var i;

--- a/lib/node_modules/@stdlib/number/uint32/base/mul/benchmark/benchmark.native.js
+++ b/lib/node_modules/@stdlib/number/uint32/base/mul/benchmark/benchmark.native.js
@@ -24,6 +24,7 @@ var resolve = require( 'path' ).resolve;
 var bench = require( '@stdlib/bench' );
 var discreteUniform = require( '@stdlib/random/array/discrete-uniform' );
 var tryRequire = require( '@stdlib/utils/try-require' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 
 
@@ -37,7 +38,7 @@ var opts = {
 
 // MAIN //
 
-bench( pkg+'::native', opts, function benchmark( b ) {
+bench( format( '%s::native', pkg ), opts, function benchmark( b ) {
 	var x;
 	var y;
 	var i;


### PR DESCRIPTION
Progresses a part of #8647.

## Description

> What is the purpose of this pull request?

This pull request:

-   Refactors JavaScript benchmarks in `number/uint32/base/mul` to use string interpolation via `@stdlib/string/format` instead of string concatenation when specifying benchmark names
-   Adds `@stdlib/string/format` import to two benchmark files: `benchmark.js` and `benchmark.native.js`
-   Replaces string concatenation patterns (`pkg+'::inline'`, `pkg+'::native'`) with format function calls using appropriate format specifiers

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8647

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

All benchmarks were tested locally using:
```bash
make benchmark BENCHMARKS_FILTER=".*/number/uint32/base/mul/.*"
```

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md