### PR TITLE
docs: improve doctests for complex number instances in `lapack/base/crot`

### DIFF
--- a/lib/node_modules/@stdlib/lapack/base/crot/README.md
+++ b/lib/node_modules/@stdlib/lapack/base/crot/README.md
@@ -47,22 +47,10 @@ var s = new Complex64( 0.0, 0.75 );
 crot( cx.length, cx, 1, cy, 1, 1.25, s );
 
 var z = cy.get( 0 );
-// returns <Complex64>
-
-var re = realf( z );
-// returns ~-1.5
-
-var im = imagf( z );
-// returns ~0.75
+// returns <Complex64>[ ~-1.5, ~0.75 ]
 
 z = cx.get( 0 );
-// returns <Complex64>
-
-re = realf( z );
-// returns ~1.25
-
-im = imagf( z );
-// returns ~2.5
+// returns <Complex64>[ ~1.25, ~2.5 ]
 ```
 
 The function has the following parameters:
@@ -88,22 +76,10 @@ var s = new Complex64( 0.0, 0.75 );
 crot( 2, cx, 2, cy, 2, 1.25, s );
 
 var z = cy.get( 0 );
-// returns <Complex64>
-
-var re = realf( z );
-// returns ~-1.5
-
-var im = imagf( z );
-// returns ~0.75
+// returns <Complex64>[ ~-1.5, ~0.75 ]
 
 z = cx.get( 0 );
-// returns <Complex64>
-
-re = realf( z );
-// returns ~1.25
-
-im = imagf( z );
-// returns ~2.5
+// returns <Complex64>[ ~1.25, ~2.5 ]
 ```
 
 Note that indexing is relative to the first index. To introduce an offset, use [`typed array`][mdn-typed-array] views.
@@ -129,22 +105,10 @@ var s = new Complex64( 0.0, 0.75 );
 crot( 2, cx1, -2, cy1, 1, 1.25, s );
 
 var z = cy0.get( 2 );
-// returns <Complex64>
-
-var re = realf( z );
-// returns ~-6
-
-var im = imagf( z );
-// returns ~5.25
+// returns <Complex64>[ ~-6, ~5.25 ]
 
 z = cx0.get( 3 );
-// returns <Complex64>
-
-re = realf( z );
-// returns ~8.75
-
-im = imagf( z );
-// returns ~10
+// returns <Complex64>[ ~8.75, ~10 ]
 ```
 
 #### crot.ndarray( N, cx, strideCX, offsetCX, cy, strideCY, offsetCY, c, s )
@@ -164,22 +128,10 @@ var s = new Complex64( 0.0, 0.75 );
 crot.ndarray( cx.length, cx, 1, 0, cy, 1, 0, 1.25, s );
 
 var z = cy.get( 0 );
-// returns <Complex64>
-
-var re = realf( z );
-// returns ~-1.5
-
-var im = imagf( z );
-// returns ~0.75
+// returns <Complex64>[ ~-1.5, ~0.75 ]
 
 z = cx.get( 0 );
-// returns <Complex64>
-
-re = realf( z );
-// returns ~1.25
-
-im = imagf( z );
-// returns ~2.5
+// returns <Complex64>[ ~1.25, ~2.5 ]
 ```
 
 The function has the following additional parameters:
@@ -202,22 +154,10 @@ var s = new Complex64( 0.0, 0.75 );
 crot.ndarray( 2, cx, 2, 1, cy, 2, 1, 1.25, s );
 
 var z = cy.get( 3 );
-// returns <Complex64>
-
-var re = realf( z );
-// returns ~-6.0
-
-var im = imagf( z );
-// returns ~5.25
+// returns <Complex64>[ ~-6.0, ~5.25 ]
 
 z = cx.get( 1 );
-// returns <Complex64>
-
-re = realf( z );
-// returns ~3.75
-
-im = imagf( z );
-// returns ~5.0
+// returns <Complex64>[ ~3.75, ~5.0 ]
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/lapack/base/crot/README.md
+++ b/lib/node_modules/@stdlib/lapack/base/crot/README.md
@@ -99,10 +99,10 @@ var s = new Complex64( 0.0, 0.75 );
 crot( 2, cx1, -2, cy1, 1, 1.25, s );
 
 var z = cy0.get( 2 );
-// returns <Complex64>[ ~-6, ~5.25 ]
+// returns <Complex64>[ ~-6.0, ~5.25 ]
 
 z = cx0.get( 3 );
-// returns <Complex64>[ ~8.75, ~10 ]
+// returns <Complex64>[ ~8.75, ~10.0 ]
 ```
 
 #### crot.ndarray( N, cx, strideCX, offsetCX, cy, strideCY, offsetCY, c, s )

--- a/lib/node_modules/@stdlib/lapack/base/crot/README.md
+++ b/lib/node_modules/@stdlib/lapack/base/crot/README.md
@@ -37,8 +37,6 @@ Applies a plane rotation with real cosine and complex sine.
 ```javascript
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
-var realf = require( '@stdlib/complex/float32/real' );
-var imagf = require( '@stdlib/complex/float32/imag' );
 
 var cx = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 var cy = new Complex64Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
@@ -66,8 +64,6 @@ The `N` and stride parameters determine how values from `cx` and `cy` are access
 ```javascript
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
-var realf = require( '@stdlib/complex/float32/real' );
-var imagf = require( '@stdlib/complex/float32/imag' );
 
 var cx = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 var cy = new Complex64Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
@@ -89,8 +85,6 @@ Note that indexing is relative to the first index. To introduce an offset, use [
 ```javascript
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
-var realf = require( '@stdlib/complex/float32/real' );
-var imagf = require( '@stdlib/complex/float32/imag' );
 
 // Initial arrays...
 var cx0 = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
@@ -118,8 +112,6 @@ Applies a plane rotation with real cosine and complex sine using alternative ind
 ```javascript
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
-var realf = require( '@stdlib/complex/float32/real' );
-var imagf = require( '@stdlib/complex/float32/imag' );
 
 var cx = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
 var cy = new Complex64Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
@@ -144,8 +136,6 @@ While [`typed array`][mdn-typed-array] views mandate a view offset based on the 
 ```javascript
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
-var realf = require( '@stdlib/complex/float32/real' );
-var imagf = require( '@stdlib/complex/float32/imag' );
 
 var cx = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 var cy = new Complex64Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );

--- a/lib/node_modules/@stdlib/lapack/base/crot/docs/repl.txt
+++ b/lib/node_modules/@stdlib/lapack/base/crot/docs/repl.txt
@@ -68,7 +68,7 @@
     > var s = new {{alias:@stdlib/complex/float32/ctor}}( 0.3, 0.4 );
     > {{alias}}( 1, cx1, 1, cy1, 1, 0.8, s );
     > z = cy0.get( 2 )
-    <Complex64>[ ~-2.5, 0 ]
+    <Complex64>[ ~-2.5, 0.0 ]
     > z = cx0.get( 1 )
     <Complex64>[ ~2.4, ~3.2 ]
 
@@ -133,7 +133,7 @@
     > var s = new {{alias:@stdlib/complex/float32/ctor}}( 0.3, 0.4 );
     > {{alias}}.ndarray( 1, cx, 2, 1, cy, 2, 1, 0.8, s );
     > z = cy.get( 1 )
-    <Complex64>[ ~-2.5, 0 ]
+    <Complex64>[ ~-2.5, 0.0 ]
     > z = cx.get( 1 )
     <Complex64>[ ~2.4, ~3.2 ]
 

--- a/lib/node_modules/@stdlib/lapack/base/crot/docs/repl.txt
+++ b/lib/node_modules/@stdlib/lapack/base/crot/docs/repl.txt
@@ -45,32 +45,20 @@
     > var cy = new {{alias:@stdlib/array/complex64}}( [ 0.0, 0.0, 0.0, 0.0 ] );
     > var s = new {{alias:@stdlib/complex/float32/ctor}}( 0.3, 0.4 );
     > {{alias}}( cx.length, cx, 1, cy, 1, 0.8, s );
-    > var z = cy.get( 0 );
-    > var re = {{alias:@stdlib/complex/float32/real}}( z )
-    ~-1.1
-    > var im = {{alias:@stdlib/complex/float32/imag}}( z )
-    ~-0.2
-    > z = cx.get( 0 );
-    > re = {{alias:@stdlib/complex/float32/real}}( z )
-    ~0.8
-    > im = {{alias:@stdlib/complex/float32/imag}}( z )
-    ~1.6
+    > var z = cy.get( 0 )
+    <Complex64>[ ~-1.1, ~-0.2 ]
+    > z = cx.get( 0 )
+    <Complex64>[ ~0.8, ~1.6 ]
 
     // Advanced indexing:
     > cx = new {{alias:@stdlib/array/complex64}}( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
     > cy = new {{alias:@stdlib/array/complex64}}( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
     > var s = new {{alias:@stdlib/complex/float32/ctor}}( 0.3, 0.4 );
     > {{alias}}( 2, cx, -2, cy, 1, 0.8, s );
-    > z = cy.get( 0 );
-    > re = {{alias:@stdlib/complex/float32/real}}( z )
-    ~-3.9
-    > im = {{alias:@stdlib/complex/float32/imag}}( z )
-    ~0.2
-    > z = cx.get( 2 );
-    > re = {{alias:@stdlib/complex/float32/real}}( z )
-    ~4.0
-    > im = {{alias:@stdlib/complex/float32/imag}}( z )
-    ~4.8
+    > z = cy.get( 0 )
+    <Complex64>[ ~-3.9, ~0.2 ]
+    > z = cx.get( 2 )
+    <Complex64>[ ~4.0, ~4.8 ]
 
     // Using typed array views:
     > var cx0 = new {{alias:@stdlib/array/complex64}}( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
@@ -79,16 +67,10 @@
     > var cy1 = new {{alias:@stdlib/array/complex64}}( cy0.buffer, cy0.BYTES_PER_ELEMENT*2 );
     > var s = new {{alias:@stdlib/complex/float32/ctor}}( 0.3, 0.4 );
     > {{alias}}( 1, cx1, 1, cy1, 1, 0.8, s );
-    > z = cy0.get( 2 );
-    > re = {{alias:@stdlib/complex/float32/real}}( z )
-    ~-2.5
-    > im = {{alias:@stdlib/complex/float32/imag}}( z )
-    ~0.0
-    > z = cx0.get( 1 );
-    > re = {{alias:@stdlib/complex/float32/real}}( z )
-    ~2.4
-    > im = {{alias:@stdlib/complex/float32/imag}}( z )
-    ~3.2
+    > z = cy0.get( 2 )
+    <Complex64>[ ~-2.5, 0 ]
+    > z = cx0.get( 1 )
+    <Complex64>[ ~2.4, ~3.2 ]
 
 
 {{alias}}.ndarray( N, cx, strideCX, offsetCX, cy, strideCY, offsetCY, c, s )
@@ -140,32 +122,20 @@
     > var cy = new {{alias:@stdlib/array/complex64}}( [ 0.0, 0.0, 0.0, 0.0 ] );
     > var s = new {{alias:@stdlib/complex/float32/ctor}}( 0.3, 0.4 );
     > {{alias}}.ndarray( cx.length, cx, 1, 0, cy, 1, 0, 0.8, s );
-    > var z = cy.get( 0 );
-    > var re = {{alias:@stdlib/complex/float32/real}}( z )
-    ~-1.1
-    > var im = {{alias:@stdlib/complex/float32/imag}}( z )
-    ~-0.2
-    > z = cx.get( 0 );
-    > re = {{alias:@stdlib/complex/float32/real}}( z )
-    ~0.8
-    > im = {{alias:@stdlib/complex/float32/imag}}( z )
-    ~1.6
+    > var z = cy.get( 0 )
+    <Complex64>[ ~-1.1, ~-0.2 ]
+    > z = cx.get( 0 )
+    <Complex64>[ ~0.8, ~1.6 ]
 
     // Advanced indexing:
     > cx = new {{alias:@stdlib/array/complex64}}( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
     > cy = new {{alias:@stdlib/array/complex64}}( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
     > var s = new {{alias:@stdlib/complex/float32/ctor}}( 0.3, 0.4 );
     > {{alias}}.ndarray( 1, cx, 2, 1, cy, 2, 1, 0.8, s );
-    > z = cy.get( 1 );
-    > re = {{alias:@stdlib/complex/float32/real}}( z )
-    ~-2.5
-    > im = {{alias:@stdlib/complex/float32/imag}}( z )
-    ~0.0
-    > z = cx.get( 1 );
-    > re = {{alias:@stdlib/complex/float32/real}}( z )
-    ~2.4
-    > im = {{alias:@stdlib/complex/float32/imag}}( z )
-    ~3.2
+    > z = cy.get( 1 )
+    <Complex64>[ ~-2.5, 0 ]
+    > z = cx.get( 1 )
+    <Complex64>[ ~2.4, ~3.2 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/lapack/base/crot/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/lapack/base/crot/docs/types/index.d.ts
@@ -42,8 +42,6 @@ interface Routine {
 	* @example
 	* var Complex64Array = require( '@stdlib/array/complex64' );
 	* var Complex64 = require( '@stdlib/complex/float32/ctor' );
-	* var realf = require( '@stdlib/complex/float32/real' );
-	* var imagf = require( '@stdlib/complex/float32/imag' );
 	*
 	* var cx = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 	* var cy = new Complex64Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
@@ -76,8 +74,6 @@ interface Routine {
 	* @example
 	* var Complex64Array = require( '@stdlib/array/complex64' );
 	* var Complex64 = require( '@stdlib/complex/float32/ctor' );
-	* var realf = require( '@stdlib/complex/float32/real' );
-	* var imagf = require( '@stdlib/complex/float32/imag' );
 	*
 	* var cx = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 	* var cy = new Complex64Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
@@ -109,8 +105,6 @@ interface Routine {
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * var cx = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var cy = new Complex64Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );
@@ -127,8 +121,6 @@ interface Routine {
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * var cx = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var cy = new Complex64Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );

--- a/lib/node_modules/@stdlib/lapack/base/crot/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/lapack/base/crot/docs/types/index.d.ts
@@ -52,22 +52,10 @@ interface Routine {
 	* crot( cx.length, cx, 1, cy, 1, 0.8, s );
 	*
 	* var z = cy.get( 0 );
-	* // returns <Complex64>
-	*
-	* var re = realf( z );
-	* // returns ~-1.1
-	*
-	* var im = imagf( z );
-	* // returns ~-0.2
+	* // returns <Complex64>[ ~-1.1, ~-0.2 ]
 	*
 	* z = cx.get( 0 );
-	* // returns <Complex64>
-	*
-	* re = realf( z );
-	* // returns ~0.8
-	*
-	* im = imagf( z );
-	* // returns ~1.6
+	* // returns <Complex64>[ ~0.8, ~1.6 ]
 	*/
 	( N: number, cx: Complex64Array, strideCX: number, cy: Complex64Array, strideCY: number, c: number, s: Complex64 ): Complex64Array;
 
@@ -98,22 +86,10 @@ interface Routine {
 	* crot.ndarray( cx.length, cx, 1, 0, cy, 1, 0, 0.8, s );
 	*
 	* var z = cy.get( 0 );
-	* // returns <Complex64>
-	*
-	* var re = realf( z );
-	* // returns ~-1.1
-	*
-	* var im = imagf( z );
-	* // returns ~-0.2
+	* // returns <Complex64>[ ~-1.1, ~-0.2 ]
 	*
 	* z = cx.get( 0 );
-	* // returns <Complex64>
-	*
-	* re = realf( z );
-	* // returns ~0.8
-	*
-	* im = imagf( z );
-	* // returns ~1.6
+	* // returns <Complex64>[ ~0.8, ~1.6 ]
 	*/
 	ndarray( N: number, cx: Complex64Array, strideCX: number, offsetCX: number, cy: Complex64Array, strideCY: number, offsetCY: number, c: number, s: Complex64 ): Complex64Array;
 }
@@ -143,22 +119,10 @@ interface Routine {
 * crot( 2, cx, 2, cy, 1, 0.8, s );
 *
 * var z = cy.get( 0 );
-* // returns <Complex64>
-*
-* var re = realf( z );
-* // returns ~-1.1
-*
-* var im = imagf( z );
-* // returns ~-0.2
+* // returns <Complex64>[ ~-1.1, ~-0.2 ]
 *
 * z = cx.get( 0 );
-* // returns <Complex64>
-*
-* re = realf( z );
-* // returns ~0.8
-*
-* im = imagf( z );
-* // returns ~1.6
+* // returns <Complex64>[ ~0.8, ~1.6 ]
 *
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
@@ -173,22 +137,10 @@ interface Routine {
 * crot.ndarray( 2, cx, 2, 0, cy, 1, 0, 0.8, s );
 *
 * var z = cy.get( 0 );
-* // returns <Complex64>
-*
-* var re = realf( z );
-* // returns ~-1.1
-*
-* var im = imagf( z );
-* // returns ~-0.2
+* // returns <Complex64>[ ~-1.1, ~-0.2 ]
 *
 * z = cx.get( 0 );
-* // returns <Complex64>
-*
-* re = realf( z );
-* // returns ~0.8
-*
-* im = imagf( z );
-* // returns ~1.6
+* // returns <Complex64>[ ~0.8, ~1.6 ]
 */
 declare var crot: Routine;
 

--- a/lib/node_modules/@stdlib/lapack/base/crot/lib/crot.js
+++ b/lib/node_modules/@stdlib/lapack/base/crot/lib/crot.js
@@ -41,8 +41,6 @@ var ndarray = require( './ndarray.js' );
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * var cx = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var cy = new Complex64Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );

--- a/lib/node_modules/@stdlib/lapack/base/crot/lib/crot.js
+++ b/lib/node_modules/@stdlib/lapack/base/crot/lib/crot.js
@@ -51,22 +51,10 @@ var ndarray = require( './ndarray.js' );
 * crot( cx.length, cx, 1, cy, 1, 0.8, s );
 *
 * var z = cy.get( 0 );
-* // returns <Complex64>
-*
-* var re = realf( z );
-* // returns ~-1.1
-*
-* var im = imagf( z );
-* // returns ~-0.2
+* // returns <Complex64>[ ~-1.1, ~-0.2 ]
 *
 * z = cx.get( 0 );
-* // returns <Complex64>
-*
-* re = realf( z );
-* // returns ~0.8
-*
-* im = imagf( z );
-* // returns ~1.6
+* // returns <Complex64>[ ~0.8, ~1.6 ]
 */
 function crot( N, cx, strideCX, cy, strideCY, c, s ) {
 	var ix = stride2offset( N, strideCX );

--- a/lib/node_modules/@stdlib/lapack/base/crot/lib/index.js
+++ b/lib/node_modules/@stdlib/lapack/base/crot/lib/index.js
@@ -26,8 +26,6 @@
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 * var crot = require( '@stdlib/lapack/base/crot' );
 *
 * var cx = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
@@ -45,8 +43,6 @@
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 * var crot = require( '@stdlib/lapack/base/crot' );
 *
 * var cx = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );

--- a/lib/node_modules/@stdlib/lapack/base/crot/lib/index.js
+++ b/lib/node_modules/@stdlib/lapack/base/crot/lib/index.js
@@ -37,22 +37,10 @@
 * crot( cx.length, cx, 1, cy, 1, 0.8, s );
 *
 * var z = cy.get( 0 );
-* // returns <Complex64>
-*
-* var re = realf( z );
-* // returns ~-0.6
-*
-* var im = imagf( z );
-* // returns ~-1.2
+* // returns <Complex64>[ ~-0.6, ~-1.2]
 *
 * z = cx.get( 0 );
-* // returns <Complex64>
-*
-* re = realf( z );
-* // returns ~0.8
-*
-* im = imagf( z );
-* // returns ~1.6
+* // returns <Complex64>[ ~0.8, ~1.6 ]
 *
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
@@ -68,22 +56,10 @@
 * crot.ndarray( cx.length, cx, 1, 0, cy, 1, 0, 0.8, s );
 *
 * var z = cy.get( 0 );
-* // returns <Complex64>
-*
-* var re = realf( z );
-* // returns ~-0.6
-*
-* var im = imagf( z );
-* // returns ~-1.2
+* // returns <Complex64>[ ~-0.6, ~-1.2 ]
 *
 * z = cx.get( 0 );
-* // returns <Complex64>
-*
-* re = realf( z );
-* // returns ~0.8
-*
-* im = imagf( z );
-* // returns ~1.6
+* // returns <Complex64>[ ~0.8, ~1.6 ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/lapack/base/crot/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/lapack/base/crot/lib/ndarray.js
@@ -45,8 +45,6 @@ var imagf = require( '@stdlib/complex/float32/imag' );
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * var cx = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ] );
 * var cy = new Complex64Array( [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ] );

--- a/lib/node_modules/@stdlib/lapack/base/crot/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/lapack/base/crot/lib/ndarray.js
@@ -55,22 +55,10 @@ var imagf = require( '@stdlib/complex/float32/imag' );
 * crot( cx.length, cx, 1, 0, cy, 1, 0, 0.8, s );
 *
 * var z = cy.get( 0 );
-* // returns <Complex64>
-*
-* var re = realf( z );
-* // returns ~-1.1
-*
-* var im = imagf( z );
-* // returns ~-0.2
+* // returns <Complex64>[ ~-1.1, ~-0.2 ]
 *
 * z = cx.get( 0 );
-* // returns <Complex64>
-*
-* re = realf( z );
-* // returns ~0.8
-*
-* im = imagf( z );
-* // returns ~1.6
+* // returns <Complex64>[ ~0.8, ~1.6 ]
 */
 function crot( N, cx, strideCX, offsetCX, cy, strideCY, offsetCY, c, s ) {
 	var viewX;


### PR DESCRIPTION
Resolves a part of  #8641.

## Description

> What is the purpose of this pull request?

This pull request:

- Updates REPL and documentation examples in the `lapack/base/crot` package to use the compact complex instance doctest notation.
- Replaces example decomposition using realf/imagf with concise doctest annotations.


## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8641

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
