### PR TITLE
docs: improve doctests for complex number instances in `strided/base/cmap`

### DIFF
--- a/lib/node_modules/@stdlib/strided/base/cmap/README.md
+++ b/lib/node_modules/@stdlib/strided/base/cmap/README.md
@@ -42,8 +42,6 @@ Applies a unary function to a single-precision complex floating-point strided in
 
 ```javascript
 var Complex64Array = require( '@stdlib/array/complex64' );
-var real = require( '@stdlib/complex/float64/real' );
-var imag = require( '@stdlib/complex/float64/imag' );
 var cceilf = require( '@stdlib/math/base/special/cceilf' );
 
 var x = new Complex64Array( [ -2.3, 1.5, 3.1, -5.2, 4.8, 0.0, -1.6, 3.4 ] );
@@ -52,13 +50,7 @@ var y = new Complex64Array( x.length );
 cmap( x.length, x, 1, y, 1, cceilf );
 
 var v = y.get( 0 );
-// returns <Complex64>
-
-var re = real( v );
-// returns -2.0
-
-var im = imag( v );
-// returns 2.0
+// returns <Complex64>[ -2.0, 2.0 ]
 ```
 
 The function accepts the following arguments:
@@ -74,8 +66,6 @@ The `N` and stride parameters determine which elements in the strided arrays are
 
 ```javascript
 var Complex64Array = require( '@stdlib/array/complex64' );
-var real = require( '@stdlib/complex/float64/real' );
-var imag = require( '@stdlib/complex/float64/imag' );
 var cceilf = require( '@stdlib/math/base/special/cceilf' );
 
 var x = new Complex64Array( [ -2.3, 1.5, 3.1, -5.2, 4.8, 0.0, -1.6, 3.4 ] );
@@ -84,21 +74,13 @@ var y = new Complex64Array( x.length );
 cmap( 2, x, 2, y, -1, cceilf );
 
 var v = y.get( 0 );
-// returns <Complex64>
-
-var re = real( v );
-// returns 5.0
-
-var im = imag( v );
-// returns 0.0
+// returns <Complex64>[ 5.0, 0.0 ]
 ```
 
 Note that indexing is relative to the first index. To introduce an offset, use [`typed array`][@stdlib/array/complex64] views.
 
 ```javascript
 var Complex64Array = require( '@stdlib/array/complex64' );
-var real = require( '@stdlib/complex/float64/real' );
-var imag = require( '@stdlib/complex/float64/imag' );
 var cceilf = require( '@stdlib/math/base/special/cceilf' );
 
 // Initial arrays...
@@ -112,13 +94,7 @@ var y1 = new Complex64Array( y0.buffer, y0.BYTES_PER_ELEMENT*2 ); // start at 3r
 cmap( 2, x1, -2, y1, 1, cceilf );
 
 var v = y0.get( 2 );
-// returns <Complex64>
-
-var re = real( v );
-// returns -1.0
-
-var im = imag( v );
-// returns 4.0
+// returns <Complex64>[ -1.0, 4.0 ]
 ```
 
 #### cmap.ndarray( N, x, strideX, offsetX, y, strideY, offsetY, fcn )
@@ -127,8 +103,6 @@ Applies a unary function to a single-precision complex floating-point strided in
 
 ```javascript
 var Complex64Array = require( '@stdlib/array/complex64' );
-var real = require( '@stdlib/complex/float64/real' );
-var imag = require( '@stdlib/complex/float64/imag' );
 var cceilf = require( '@stdlib/math/base/special/cceilf' );
 
 var x = new Complex64Array( [ -2.3, 1.5, 3.1, -5.2, 4.8, 0.0, -1.6, 3.4 ] );
@@ -137,13 +111,7 @@ var y = new Complex64Array( x.length );
 cmap.ndarray( x.length, x, 1, 0, y, 1, 0, cceilf );
 
 var v = y.get( 0 );
-// returns <Complex64>
-
-var re = real( v );
-// returns -2.0
-
-var im = imag( v );
-// returns 2.0
+// returns <Complex64>[ -2.0, 2.0 ]
 ```
 
 The function accepts the following additional arguments:
@@ -155,8 +123,6 @@ While [`typed array`][@stdlib/array/complex64] views mandate a view offset based
 
 ```javascript
 var Complex64Array = require( '@stdlib/array/complex64' );
-var real = require( '@stdlib/complex/float64/real' );
-var imag = require( '@stdlib/complex/float64/imag' );
 var cceilf = require( '@stdlib/math/base/special/cceilf' );
 
 var x = new Complex64Array( [ -2.3, 1.5, 3.1, -5.2, 4.8, 0.0, -1.6, 3.4 ] );
@@ -165,13 +131,7 @@ var y = new Complex64Array( x.length );
 cmap.ndarray( 2, x, 2, 1, y, -1, y.length-1, cceilf );
 
 var v = y.get( y.length-1 );
-// returns <Complex64>
-
-var re = real( v );
-// returns 4.0
-
-var im = imag( v );
-// returns -5.0
+// returns <Complex64>[ 4.0, -5.0 ]
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/strided/base/cmap/docs/repl.txt
+++ b/lib/node_modules/@stdlib/strided/base/cmap/docs/repl.txt
@@ -43,21 +43,13 @@
     > var y = new {{alias:@stdlib/array/complex64}}( x.length );
     > {{alias}}( x.length, x, 1, y, 1, {{alias:@stdlib/complex/float32/base/identity}} );
     > var v = y.get( 0 )
-    <Complex64>
-    > var re = {{alias:@stdlib/complex/float64/real}}( v )
-    1.0
-    > var im = {{alias:@stdlib/complex/float64/imag}}( v )
-    2.0
+    <Complex64>[ 1.0, 2.0 ]
 
     // Using `N` and stride parameters:
     > y = new {{alias:@stdlib/array/complex64}}( x.length );
     > {{alias}}( 2, x, 2, y, -1, {{alias:@stdlib/complex/float32/base/identity}} );
     > v = y.get( 0 )
-    <Complex64>
-    > re = {{alias:@stdlib/complex/float64/real}}( v )
-    5.0
-    > im = {{alias:@stdlib/complex/float64/imag}}( v )
-    6.0
+    <Complex64>[ 5.0, 6.0 ]
 
     // Using view offsets:
     > var x0 = new {{alias:@stdlib/array/complex64}}( xbuf );
@@ -66,11 +58,7 @@
     > var y1 = new {{alias:@stdlib/array/complex64}}( y0.buffer, y0.BYTES_PER_ELEMENT*2 );
     > {{alias}}( 2, x1, -2, y1, 1, {{alias:@stdlib/complex/float32/base/identity}} );
     > v = y1.get( 0 )
-    <Complex64>
-    > re = {{alias:@stdlib/complex/float64/real}}( v )
-    7.0
-    > im = {{alias:@stdlib/complex/float64/imag}}( v )
-    8.0
+    <Complex64>[ 7.0, 8.0 ]
 
 
 {{alias}}.ndarray( N, x, strideX, offsetX, y, strideY, offsetY, fcn )
@@ -121,22 +109,14 @@
     > var y = new {{alias:@stdlib/array/complex64}}( x.length );
     > {{alias}}.ndarray( x.length, x, 1, 0, y, 1, 0, {{alias:@stdlib/complex/float32/base/identity}} );
     > var v = y.get( 0 )
-    <Complex64>
-    > var re = {{alias:@stdlib/complex/float64/real}}( v )
-    1.0
-    > var im = {{alias:@stdlib/complex/float64/imag}}( v )
-    2.0
+    <Complex64>[ 1.0, 2.0 ]
 
     // Advanced indexing:
     > x = new {{alias:@stdlib/array/complex64}}( xbuf );
     > y = new {{alias:@stdlib/array/complex64}}( x.length );
     > {{alias}}.ndarray( 2, x, 2, 1, y, -1, y.length-1, {{alias:@stdlib/complex/float32/base/identity}} );
     > v = y.get( y.length-1 )
-    <Complex64>
-    > re = {{alias:@stdlib/complex/float64/real}}( v )
-    3.0
-    > im = {{alias:@stdlib/complex/float64/imag}}( v )
-    4.0
+    <Complex64>[ 3.0, 4.0 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/strided/base/cmap/lib/index.js
+++ b/lib/node_modules/@stdlib/strided/base/cmap/lib/index.js
@@ -42,13 +42,7 @@
 * cmap( x.length, x, 1, y, 1, scale );
 *
 * var v = y.get( 0 );
-* // returns <Complex64>
-*
-* var re = real( v );
-* // returns 10.0
-*
-* var im = imag( v );
-* // returns 10.0
+* // returns <Complex64>[ 10.0, 10.0 ]
 *
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
@@ -69,13 +63,7 @@
 * cmap.ndarray( x.length, x, 1, 0, y, 1, 0, scale );
 *
 * var v = y.get( 0 );
-* // returns <Complex64>
-*
-* var re = real( v );
-* // returns 10.0
-*
-* var im = imag( v );
-* // returns 10.0
+* // returns <Complex64>[ 10.0, 10.0 ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/strided/base/cmap/lib/main.js
+++ b/lib/node_modules/@stdlib/strided/base/cmap/lib/main.js
@@ -55,13 +55,7 @@ var ndarray = require( './ndarray.js' );
 * cmap( x.length, x, 1, y, 1, scale );
 *
 * var v = y.get( 0 );
-* // returns <Complex64>
-*
-* var re = real( v );
-* // returns 10.0
-*
-* var im = imag( v );
-* // returns 10.0
+* // returns <Complex64>[ 10.0, 10.0 ]
 */
 function cmap( N, x, strideX, y, strideY, fcn ) {
 	return ndarray( N, x, strideX, stride2offset( N, strideX ), y, strideY, stride2offset( N, strideY ), fcn ); // eslint-disable-line max-len

--- a/lib/node_modules/@stdlib/strided/base/cmap/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/strided/base/cmap/lib/ndarray.js
@@ -51,13 +51,7 @@
 * cmap( x.length, x, 1, 0, y, 1, 0, scale );
 *
 * var v = y.get( 0 );
-* // returns <Complex64>
-*
-* var re = real( v );
-* // returns 10.0
-*
-* var im = imag( v );
-* // returns 10.0
+* // returns <Complex64>[ 10.0, 10.0 ]
 */
 function cmap( N, x, strideX, offsetX, y, strideY, offsetY, fcn ) {
 	var ix;


### PR DESCRIPTION
Resolves a part of #8641.

## Description


This pull request:

-  Updates REPL and documentation examples in the `strided/base/cmap` package to use the compact complex instance doctest notation.
- Replaces example decomposition using realf/imagf with concise doctest annotations.


## Related Issues


This pull request has the following related issues:

-   #8641

## Questions


No.

## Other


No.

## Checklist


-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance


-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure
NA

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
