### PR TITLE
docs: improve doctests for complex number instances in `ndarray/base/unary`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/0d_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/0d_accessors.js
@@ -46,11 +46,9 @@
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
+*     return new Complex64( z.re*10.0, z.im*10.0 );
 * }
 *
 * // Create data buffers:
@@ -101,12 +99,7 @@
 * unary0d( x, y, scale );
 *
 * var v = y.data.get( 0 );
-*
-* var re = realf( v );
-* // returns 30.0
-*
-* var im = imagf( v );
-* // returns 40.0
+* // returns <Complex64>[ 30.0, 40.0 ]
 */
 function unary0d( x, y, fcn ) {
 	y.accessors[ 1 ]( y.data, y.offset, fcn( x.accessors[ 0 ]( x.data, x.offset ) ) ); // eslint-disable-line max-len

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/0d_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/0d_accessors.js
@@ -46,9 +46,11 @@
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var realf = require( '@stdlib/complex/float32/real' );
+* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( z.re*10.0, z.im*10.0 );
+*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
 * }
 *
 * // Create data buffers:

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/10d_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/10d_accessors.js
@@ -49,11 +49,9 @@
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
+*     return new Complex64( z.re*10.0, z.im*10.0 );
 * }
 *
 * // Create data buffers:
@@ -104,12 +102,7 @@
 * unary10d( x, y, true, scale );
 *
 * var v = y.data.get( 0 );
-*
-* var re = realf( v );
-* // returns 10.0
-*
-* var im = imagf( v );
-* // returns 20.0
+* // returns <Complex64>[ 10.0, 20.0 ]
 */
 function unary10d( x, y, isRowMajor, fcn ) { // eslint-disable-line max-statements
 	var xbuf;

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/10d_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/10d_accessors.js
@@ -49,9 +49,11 @@
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var realf = require( '@stdlib/complex/float32/real' );
+* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( z.re*10.0, z.im*10.0 );
+*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
 * }
 *
 * // Create data buffers:

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/10d_blocked_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/10d_blocked_accessors.js
@@ -53,11 +53,9 @@ var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
+*     return new Complex64( z.re*10.0, z.im*10.0 );
 * }
 *
 * // Create data buffers:
@@ -108,12 +106,7 @@ var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 * blockedunary10d( x, y, scale );
 *
 * var v = y.data.get( 0 );
-*
-* var re = realf( v );
-* // returns 10.0
-*
-* var im = imagf( v );
-* // returns 20.0
+* // returns <Complex64>[ 10.0, 20.0 ]
 */
 function blockedunary10d( x, y, fcn ) { // eslint-disable-line max-statements, max-lines-per-function
 	var bsize;

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/10d_blocked_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/10d_blocked_accessors.js
@@ -53,9 +53,11 @@ var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var realf = require( '@stdlib/complex/float32/real' );
+* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( z.re*10.0, z.im*10.0 );
+*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
 * }
 *
 * // Create data buffers:

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/1d_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/1d_accessors.js
@@ -50,7 +50,7 @@
 * var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
+*     return new Complex64( z.re*10.0, z.im*10.0 );
 * }
 *
 * // Create data buffers:
@@ -101,12 +101,7 @@
 * unary1d( x, y, scale );
 *
 * var v = y.data.get( 0 );
-*
-* var re = realf( v );
-* // returns 10.0
-*
-* var im = imagf( v );
-* // returns 20.0
+* // returns <Complex64>[ 10.0, 20.0 ]
 */
 function unary1d( x, y, fcn ) {
 	var xbuf;

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/1d_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/1d_accessors.js
@@ -50,7 +50,7 @@
 * var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( z.re*10.0, z.im*10.0 );
+*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
 * }
 *
 * // Create data buffers:

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/2d_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/2d_accessors.js
@@ -47,11 +47,9 @@
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
+*     return new Complex64( z.re*10.0, z.im*10.0 );
 * }
 *
 * // Create data buffers:
@@ -102,12 +100,7 @@
 * unary2d( x, y, true, scale );
 *
 * var v = y.data.get( 0 );
-*
-* var re = realf( v );
-* // returns 10.0
-*
-* var im = imagf( v );
-* // returns 20.0
+* // returns <Complex64>[ 10.0, 20.0 ]
 */
 function unary2d( x, y, isRowMajor, fcn ) {
 	var xbuf;

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/2d_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/2d_accessors.js
@@ -47,9 +47,11 @@
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var realf = require( '@stdlib/complex/float32/real' );
+* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( z.re*10.0, z.im*10.0 );
+*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
 * }
 *
 * // Create data buffers:

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/2d_blocked_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/2d_blocked_accessors.js
@@ -51,11 +51,9 @@ var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
+*     return new Complex64( z.re*10.0, z.im*10.0 );
 * }
 *
 * // Create data buffers:
@@ -106,12 +104,7 @@ var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 * blockedunary2d( x, y, scale );
 *
 * var v = y.data.get( 0 );
-*
-* var re = realf( v );
-* // returns 10.0
-*
-* var im = imagf( v );
-* // returns 20.0
+* // returns <Complex64>[ 10.0, 20.0 ]
 */
 function blockedunary2d( x, y, fcn ) {
 	var bsize;

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/2d_blocked_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/2d_blocked_accessors.js
@@ -51,9 +51,11 @@ var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var realf = require( '@stdlib/complex/float32/real' );
+* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( z.re*10.0, z.im*10.0 );
+*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
 * }
 *
 * // Create data buffers:

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/3d_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/3d_accessors.js
@@ -47,11 +47,9 @@
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
+*     return new Complex64( z.re*10.0, z.im*10.0 );
 * }
 *
 * // Create data buffers:
@@ -102,12 +100,7 @@
 * unary3d( x, y, true, scale );
 *
 * var v = y.data.get( 0 );
-*
-* var re = realf( v );
-* // returns 10.0
-*
-* var im = imagf( v );
-* // returns 20.0
+* // returns <Complex64>[ 10.0, 20.0 ]
 */
 function unary3d( x, y, isRowMajor, fcn ) {
 	var xbuf;

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/3d_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/3d_accessors.js
@@ -47,9 +47,11 @@
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var realf = require( '@stdlib/complex/float32/real' );
+* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( z.re*10.0, z.im*10.0 );
+*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
 * }
 *
 * // Create data buffers:

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/3d_blocked_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/3d_blocked_accessors.js
@@ -53,11 +53,9 @@ var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
+*     return new Complex64( z.re*10.0, z.im*10.0 );
 * }
 *
 * // Create data buffers:
@@ -108,12 +106,7 @@ var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 * blockedunary3d( x, y, scale );
 *
 * var v = y.data.get( 0 );
-*
-* var re = realf( v );
-* // returns 10.0
-*
-* var im = imagf( v );
-* // returns 20.0
+* // returns <Complex64>[ 10.0, 20.0 ]
 */
 function blockedunary3d( x, y, fcn ) {
 	var bsize;

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/3d_blocked_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/3d_blocked_accessors.js
@@ -53,9 +53,11 @@ var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var realf = require( '@stdlib/complex/float32/real' );
+* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( z.re*10.0, z.im*10.0 );
+*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
 * }
 *
 * // Create data buffers:

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/4d_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/4d_accessors.js
@@ -47,11 +47,9 @@
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
+*     return new Complex64( z.re*10.0, z.im*10.0 );
 * }
 *
 * // Create data buffers:
@@ -102,12 +100,7 @@
 * unary4d( x, y, true, scale );
 *
 * var v = y.data.get( 0 );
-*
-* var re = realf( v );
-* // returns 10.0
-*
-* var im = imagf( v );
-* // returns 20.0
+* // returns <Complex64>[ 10.0, 20.0 ]
 */
 function unary4d( x, y, isRowMajor, fcn ) {
 	var xbuf;

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/4d_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/4d_accessors.js
@@ -47,9 +47,11 @@
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var realf = require( '@stdlib/complex/float32/real' );
+* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( z.re*10.0, z.im*10.0 );
+*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
 * }
 *
 * // Create data buffers:

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/4d_blocked_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/4d_blocked_accessors.js
@@ -53,11 +53,9 @@ var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
+*     return new Complex64( z.re*10.0, z.im*10.0 );
 * }
 *
 * // Create data buffers:
@@ -108,12 +106,7 @@ var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 * blockedunary4d( x, y, scale );
 *
 * var v = y.data.get( 0 );
-*
-* var re = realf( v );
-* // returns 10.0
-*
-* var im = imagf( v );
-* // returns 20.0
+* // returns <Complex64>[ 10.0, 20.0 ]
 */
 function blockedunary4d( x, y, fcn ) { // eslint-disable-line max-statements
 	var bsize;

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/4d_blocked_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/4d_blocked_accessors.js
@@ -53,9 +53,11 @@ var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var realf = require( '@stdlib/complex/float32/real' );
+* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( z.re*10.0, z.im*10.0 );
+*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
 * }
 *
 * // Create data buffers:

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/5d_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/5d_accessors.js
@@ -47,11 +47,9 @@
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
+*     return new Complex64( z.re*10.0, z.im*10.0 );
 * }
 *
 * // Create data buffers:
@@ -102,12 +100,7 @@
 * unary5d( x, y, true, scale );
 *
 * var v = y.data.get( 0 );
-*
-* var re = realf( v );
-* // returns 10.0
-*
-* var im = imagf( v );
-* // returns 20.0
+* // returns <Complex64>[ 10.0, 20.0 ]
 */
 function unary5d( x, y, isRowMajor, fcn ) {
 	var xbuf;

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/5d_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/5d_accessors.js
@@ -47,9 +47,11 @@
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var realf = require( '@stdlib/complex/float32/real' );
+* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( z.re*10.0, z.im*10.0 );
+*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
 * }
 *
 * // Create data buffers:

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/5d_blocked_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/5d_blocked_accessors.js
@@ -53,11 +53,9 @@ var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
+*     return new Complex64( z.re*10.0, z.im*10.0 );
 * }
 *
 * // Create data buffers:
@@ -108,12 +106,7 @@ var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 * blockedunary5d( x, y, scale );
 *
 * var v = y.data.get( 0 );
-*
-* var re = realf( v );
-* // returns 10.0
-*
-* var im = imagf( v );
-* // returns 20.0
+* // returns <Complex64>[ 10.0, 20.0 ]
 */
 function blockedunary5d( x, y, fcn ) { // eslint-disable-line max-statements
 	var bsize;

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/5d_blocked_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/5d_blocked_accessors.js
@@ -53,9 +53,11 @@ var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var realf = require( '@stdlib/complex/float32/real' );
+* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( z.re*10.0, z.im*10.0 );
+*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
 * }
 *
 * // Create data buffers:

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/6d_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/6d_accessors.js
@@ -49,11 +49,9 @@
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
+*     return new Complex64( z.re*10.0, z.im*10.0 );
 * }
 *
 * // Create data buffers:
@@ -104,12 +102,7 @@
 * unary6d( x, y, true, scale );
 *
 * var v = y.data.get( 0 );
-*
-* var re = realf( v );
-* // returns 10.0
-*
-* var im = imagf( v );
-* // returns 20.0
+* // returns <Complex64>[ 10.0, 20.0 ]
 */
 function unary6d( x, y, isRowMajor, fcn ) {
 	var xbuf;

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/6d_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/6d_accessors.js
@@ -49,9 +49,11 @@
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var realf = require( '@stdlib/complex/float32/real' );
+* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( z.re*10.0, z.im*10.0 );
+*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
 * }
 *
 * // Create data buffers:

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/6d_blocked_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/6d_blocked_accessors.js
@@ -53,11 +53,9 @@ var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
+*     return new Complex64( z.re*10.0, z.im*10.0 );
 * }
 *
 * // Create data buffers:
@@ -108,12 +106,7 @@ var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 * blockedunary6d( x, y, scale );
 *
 * var v = y.data.get( 0 );
-*
-* var re = realf( v );
-* // returns 10.0
-*
-* var im = imagf( v );
-* // returns 20.0
+* // returns <Complex64>[ 10.0, 20.0 ]
 */
 function blockedunary6d( x, y, fcn ) { // eslint-disable-line max-statements
 	var bsize;

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/6d_blocked_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/6d_blocked_accessors.js
@@ -53,9 +53,11 @@ var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var realf = require( '@stdlib/complex/float32/real' );
+* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( z.re*10.0, z.im*10.0 );
+*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
 * }
 *
 * // Create data buffers:

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/7d_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/7d_accessors.js
@@ -49,11 +49,9 @@
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
+*     return new Complex64( z.re*10.0, z.im*10.0 );
 * }
 *
 * // Create data buffers:
@@ -104,12 +102,7 @@
 * unary7d( x, y, true, scale );
 *
 * var v = y.data.get( 0 );
-*
-* var re = realf( v );
-* // returns 10.0
-*
-* var im = imagf( v );
-* // returns 20.0
+* // returns <Complex64>[ 10.0, 20.0 ]
 */
 function unary7d( x, y, isRowMajor, fcn ) { // eslint-disable-line max-statements
 	var xbuf;

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/7d_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/7d_accessors.js
@@ -49,9 +49,11 @@
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var realf = require( '@stdlib/complex/float32/real' );
+* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( z.re*10.0, z.im*10.0 );
+*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
 * }
 *
 * // Create data buffers:

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/7d_blocked_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/7d_blocked_accessors.js
@@ -53,11 +53,9 @@ var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
+*     return new Complex64( z.re*10.0, z.im*10.0 );
 * }
 *
 * // Create data buffers:
@@ -108,12 +106,7 @@ var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 * blockedunary7d( x, y, scale );
 *
 * var v = y.data.get( 0 );
-*
-* var re = realf( v );
-* // returns 10.0
-*
-* var im = imagf( v );
-* // returns 20.0
+* // returns <Complex64>[ 10.0, 20.0 ]
 */
 function blockedunary7d( x, y, fcn ) { // eslint-disable-line max-statements
 	var bsize;

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/7d_blocked_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/7d_blocked_accessors.js
@@ -53,9 +53,11 @@ var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var realf = require( '@stdlib/complex/float32/real' );
+* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( z.re*10.0, z.im*10.0 );
+*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
 * }
 *
 * // Create data buffers:

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/8d_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/8d_accessors.js
@@ -49,11 +49,9 @@
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
+*     return new Complex64( z.re*10.0, z.im*10.0 );
 * }
 *
 * // Create data buffers:
@@ -104,12 +102,7 @@
 * unary8d( x, y, true, scale );
 *
 * var v = y.data.get( 0 );
-*
-* var re = realf( v );
-* // returns 10.0
-*
-* var im = imagf( v );
-* // returns 20.0
+* // returns <Complex64>[ 10.0, 20.0 ]
 */
 function unary8d( x, y, isRowMajor, fcn ) { // eslint-disable-line max-statements
 	var xbuf;

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/8d_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/8d_accessors.js
@@ -49,9 +49,11 @@
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var realf = require( '@stdlib/complex/float32/real' );
+* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( z.re*10.0, z.im*10.0 );
+*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
 * }
 *
 * // Create data buffers:

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/8d_blocked_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/8d_blocked_accessors.js
@@ -53,11 +53,9 @@ var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
+*     return new Complex64( z.re*10.0, z.im*10.0 );
 * }
 *
 * // Create data buffers:
@@ -108,12 +106,7 @@ var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 * blockedunary8d( x, y, scale );
 *
 * var v = y.data.get( 0 );
-*
-* var re = realf( v );
-* // returns 10.0
-*
-* var im = imagf( v );
-* // returns 20.0
+* // returns <Complex64>[ 10.0, 20.0 ]
 */
 function blockedunary8d( x, y, fcn ) { // eslint-disable-line max-statements, max-lines-per-function
 	var bsize;

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/8d_blocked_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/8d_blocked_accessors.js
@@ -53,9 +53,11 @@ var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var realf = require( '@stdlib/complex/float32/real' );
+* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( z.re*10.0, z.im*10.0 );
+*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
 * }
 *
 * // Create data buffers:

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/9d_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/9d_accessors.js
@@ -49,11 +49,9 @@
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
+*     return new Complex64( z.re*10.0, z.im*10.0 );
 * }
 *
 * // Create data buffers:
@@ -104,12 +102,7 @@
 * unary9d( x, y, true, scale );
 *
 * var v = y.data.get( 0 );
-*
-* var re = realf( v );
-* // returns 10.0
-*
-* var im = imagf( v );
-* // returns 20.0
+* // returns <Complex64>[ 10.0, 20.0 ]
 */
 function unary9d( x, y, isRowMajor, fcn ) { // eslint-disable-line max-statements
 	var xbuf;

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/9d_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/9d_accessors.js
@@ -49,9 +49,11 @@
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var realf = require( '@stdlib/complex/float32/real' );
+* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( z.re*10.0, z.im*10.0 );
+*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
 * }
 *
 * // Create data buffers:

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/9d_blocked_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/9d_blocked_accessors.js
@@ -53,11 +53,9 @@ var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
+*     return new Complex64( z.re*10.0, z.im*10.0 );
 * }
 *
 * // Create data buffers:
@@ -108,12 +106,7 @@ var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 * blockedunary9d( x, y, scale );
 *
 * var v = y.data.get( 0 );
-*
-* var re = realf( v );
-* // returns 10.0
-*
-* var im = imagf( v );
-* // returns 20.0
+* // returns <Complex64>[ 10.0, 20.0 ]
 */
 function blockedunary9d( x, y, fcn ) { // eslint-disable-line max-statements, max-lines-per-function
 	var bsize;

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/9d_blocked_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/9d_blocked_accessors.js
@@ -53,9 +53,11 @@ var blockSize = require( '@stdlib/ndarray/base/unary-tiling-block-size' );
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var realf = require( '@stdlib/complex/float32/real' );
+* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( z.re*10.0, z.im*10.0 );
+*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
 * }
 *
 * // Create data buffers:

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/nd_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/nd_accessors.js
@@ -57,11 +57,9 @@ var MODE = 'throw';
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
+*     return new Complex64( z.re*10.0, z.im*10.0 );
 * }
 *
 * // Create data buffers:
@@ -112,12 +110,7 @@ var MODE = 'throw';
 * unarynd( x, y, scale );
 *
 * var v = y.data.get( 0 );
-*
-* var re = realf( v );
-* // returns 10.0
-*
-* var im = imagf( v );
-* // returns 20.0
+* // returns <Complex64>[ 10.0, 20.0 ]
 */
 function unarynd( x, y, fcn ) {
 	var xbuf;

--- a/lib/node_modules/@stdlib/ndarray/base/unary/lib/nd_accessors.js
+++ b/lib/node_modules/@stdlib/ndarray/base/unary/lib/nd_accessors.js
@@ -57,9 +57,11 @@ var MODE = 'throw';
 * @example
 * var Complex64Array = require( '@stdlib/array/complex64' );
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var realf = require( '@stdlib/complex/float32/real' );
+* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * function scale( z ) {
-*     return new Complex64( z.re*10.0, z.im*10.0 );
+*     return new Complex64( realf(z)*10.0, imagf(z)*10.0 );
 * }
 *
 * // Create data buffers:


### PR DESCRIPTION

---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Resolves part of #8641

## Description

This pull request updates documentation examples for `ndarray/base/unary/lib` to use complex number instance notation (e.g., `<Complex64>[ 10.0, 20.0 ]`) instead of decomposing values using `realf` and `imagf`, in accordance with the RFC guidance.

No functional code changes were made. Only documentation examples were updated.

## Related Issues

- #8641 

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] No
-   [ ] Yes

#### Disclosure

N/A

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md