### PR TITLE
docs: improve doctests for complex number instances in `math/base/special/cceil`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cceil/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/cceil/docs/repl.txt
@@ -16,11 +16,7 @@
     Examples
     --------
     > var v = {{alias}}( new {{alias:@stdlib/complex/float64/ctor}}( -1.5, 2.5 ) )
-    <Complex128>
-    > var re = {{alias:@stdlib/complex/float64/real}}( v )
-    -1.0
-    > var im = {{alias:@stdlib/complex/float64/imag}}( v )
-    3.0
+    <Complex128>[ -1.0, 3.0 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/math/base/special/cceil/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/cceil/docs/types/index.d.ts
@@ -30,17 +30,9 @@ import { Complex128 } from '@stdlib/types/complex';
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var v = cceil( new Complex128( -1.5, 2.5 ) );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns -1.0
-*
-* var im = imag( v );
-* // returns 3.0
+* // returns <Complex128>[ -1.0, 3.0 ]
 */
 declare function cceil( z: Complex128 ): Complex128;
 

--- a/lib/node_modules/@stdlib/math/base/special/cceil/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/cceil/lib/index.js
@@ -25,18 +25,10 @@
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 * var cceil = require( '@stdlib/math/base/special/cceil' );
 *
 * var v = cceil( new Complex128( -1.5, 2.5 ) );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns -1.0
-*
-* var im = imag( v );
-* // returns 3.0
+* // returns <Complex128>[ -1.0, 3.0 ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/math/base/special/cceil/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/cceil/lib/main.js
@@ -36,17 +36,9 @@ var imag = require( '@stdlib/complex/float64/imag' );
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var v = cceil( new Complex128( -1.5, 2.5 ) );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns -1.0
-*
-* var im = imag( v );
-* // returns 3.0
+* // returns <Complex128>[ -1.0, 3.0 ]
 */
 function cceil( z ) {
 	return new Complex128( ceil( real( z ) ), ceil( imag( z ) ) );

--- a/lib/node_modules/@stdlib/math/base/special/cceil/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cceil/lib/native.js
@@ -35,17 +35,9 @@ var addon = require( './../src/addon.node' );
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var v = cceil( new Complex128( -1.5, 2.5 ) );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns -1.0
-*
-* var im = imag( v );
-* // returns 3.0
+* // returns <Complex128>[ -1.0, 3.0 ]
 */
 function cceil( z ) {
 	var v = addon( z );


### PR DESCRIPTION

---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: passed
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: passed
  - task: lint_license_headers status: passed ---

Resolves part of #8641

## Description

This pull request updates documentation examples for `math/base/special/cceil` to use complex number instance notation (e.g., `<Complex128>[ -1.0, 3.0 ]`) instead of decomposing values using `real` and `imag`, in accordance with the RFC guidance.

No functional code changes were made. Only documentation examples were updated.

## Related Issues

- #8641 

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] No
-   [ ] Yes

#### Disclosure

N/A

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md