### PR TITLE
docs: improve doctests for complex number instances in `math/base/special/croundn`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/croundn/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/croundn/README.md
@@ -36,44 +36,18 @@ Rounds each component of a double-precision complex floating-point number to the
 
 ```javascript
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
-var real = require( '@stdlib/complex/float64/real' );
-var imag = require( '@stdlib/complex/float64/imag' );
 
 var v = croundn( new Complex128( -3.141592653589793, 3.141592653589793 ), -2 );
-// returns <Complex128>
-
-var re = real( v );
-// returns -3.14
-
-var im = imag( v );
-// returns 3.14
+// returns <Complex128>[ -3.14, 3.14 ]
 
 v = croundn( new Complex128( -3.141592653589793, 3.141592653589793 ), 0 );
-// returns <Complex128>
-
-re = real( v );
-// returns -3.0
-
-im = imag( v );
-// returns 3.0
+// returns <Complex128>[ -3.0, 3.0 ]
 
 v = croundn( new Complex128( -12368.0, 12368.0 ), 3 );
-// returns <Complex128>
-
-re = real( v );
-// returns -12000.0
-
-im = imag( v );
-// returns 12000.0
+// returns <Complex128>[ -12000.0, 12000.0 ]
 
 v = croundn( new Complex128( NaN, NaN ), 3 );
-// returns <Complex128>
-
-re = real( v );
-// returns NaN
-
-im = imag( v );
-// returns NaN
+// returns <Complex128>[ NaN, NaN ]
 ```
 
 </section>
@@ -88,21 +62,13 @@ im = imag( v );
 
     ```javascript
     var Complex128 = require( '@stdlib/complex/float64/ctor' );
-    var real = require( '@stdlib/complex/float64/real' );
-    var imag = require( '@stdlib/complex/float64/imag' );
 
     var x = 0.2 + 0.1;
     // returns 0.30000000000000004
 
     // Should round components to 0.3:
     var v = croundn( new Complex128( x, x ), -16 );
-    // returns <Complex128>
-
-    var re = real( v );
-    // returns 0.3000000000000001
-
-    var im = imag( v );
-    // returns 0.3000000000000001
+    // returns <Complex128>[ 0.3000000000000001, 0.3000000000000001 ]
     ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/croundn/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/croundn/docs/repl.txt
@@ -22,11 +22,7 @@
     Examples
     --------
     > var v = {{alias}}( new {{alias:@stdlib/complex/float64/ctor}}( 5.555, -3.336 ), -2 )
-    <Complex128>
-    > var re = {{alias:@stdlib/complex/float64/real}}( v )
-    5.56
-    > var im = {{alias:@stdlib/complex/float64/imag}}( v )
-    -3.34
+    <Complex128>[ 5.56, -3.34 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/math/base/special/croundn/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/croundn/docs/types/index.d.ts
@@ -35,17 +35,9 @@ import { Complex128 } from '@stdlib/types/complex';
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var v = croundn( new Complex128( 5.555, -3.333 ), -2 );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns 5.56
-*
-* var im = imag( v );
-* // returns -3.33
+* // returns <Complex128>[ 5.56, -3.33 ]
 */
 declare function croundn( z: Complex128, n: number ): Complex128;
 

--- a/lib/node_modules/@stdlib/math/base/special/croundn/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/croundn/lib/index.js
@@ -25,47 +25,21 @@
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 * var croundn = require( '@stdlib/math/base/special/croundn' );
 *
 * var v = croundn( new Complex128( -3.141592653589793, 3.141592653589793 ), -2 );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns -3.14
-*
-* var im = imag( v );
-* // returns 3.14
+* // returns <Complex128>[ -3.14, 3.14 ]
 *
 * // If n = 0, `croundn` behaves like `cround`:
 * v = croundn( new Complex128( 9.99999, 0.1 ), 0 );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns 10.0
-*
-* im = imag( v );
-* // returns 0.0
+* // returns <Complex128>[ 10.0, 0.0 ]
 *
 * // Round components to the nearest thousand:
 * v = croundn( new Complex128( 12368.0, -12368.0 ), 3 );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns 12000.0
-*
-* im = imag( v );
-* // returns -12000.0
+* // returns <Complex128>[ 12000.0, -12000.0 ]
 *
 * v = croundn( new Complex128( NaN, NaN ), 2 );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns NaN
-*
-* im = imag( v );
-* // returns NaN
+* // returns <Complex128>[ NaN, NaN ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/math/base/special/croundn/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/croundn/lib/main.js
@@ -37,46 +37,20 @@ var imag = require( '@stdlib/complex/float64/imag' );
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var v = croundn( new Complex128( -3.141592653589793, 3.141592653589793 ), -2 );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns -3.14
-*
-* var im = imag( v );
-* // returns 3.14
+* // returns <Complex128>[ -3.14, 3.14 ]
 *
 * // If n = 0, `croundn` behaves like `cround`:
 * v = croundn( new Complex128( 9.99999, 0.1 ), 0 );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns 10.0
-*
-* im = imag( v );
-* // returns 0.0
+* // returns <Complex128>[ 10.0, 0.0 ]
 *
 * // Round components to the nearest thousand:
 * v = croundn( new Complex128( 12368.0, -12368.0 ), 3 );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns 12000.0
-*
-* im = imag( v );
-* // returns -12000.0
+* // returns <Complex128>[ 12000.0, -12000.0 ]
 *
 * v = croundn( new Complex128( NaN, NaN ), 2 );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns NaN
-*
-* im = imag( v );
-* // returns NaN
+* // returns <Complex128>[ NaN, NaN ]
 */
 function croundn( z, n ) {
 	return new Complex128( roundn( real( z ), n ), roundn( imag( z ), n ) );

--- a/lib/node_modules/@stdlib/math/base/special/croundn/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/croundn/lib/native.js
@@ -36,46 +36,20 @@ var addon = require( './../src/addon.node' );
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var v = croundn( new Complex128( -3.141592653589793, 3.141592653589793 ), -2 );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns -3.14
-*
-* var im = imag( v );
-* // returns 3.14
+* // returns <Complex128>[ -3.14, 3.14 ]
 *
 * // If n = 0, `croundn` behaves like `cround`:
 * v = croundn( new Complex128( 9.99999, 0.1 ), 0 );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns 10.0
-*
-* im = imag( v );
-* // returns 0.0
+* // returns <Complex128>[ 10.0, 0.0 ]
 *
 * // Round components to the nearest thousand:
 * v = croundn( new Complex128( 12368.0, -12368.0 ), 3 );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns 12000.0
-*
-* im = imag( v );
-* // returns -12000.0
+* // returns <Complex128>[ 12000.0, -12000.0 ]
 *
 * v = croundn( new Complex128( NaN, NaN ), 2 );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns NaN
-*
-* im = imag( v );
-* // returns NaN
+* // returns <Complex128>[ NaN, NaN ]
 */
 function croundn( z, n ) {
 	var v = addon( z, n );


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: passed
  - task: lint_package_json status: na
  - task: lint_repl_help status: passed
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: passed
  - task: lint_license_headers status: passed ---

Resolves part of #8641

## Description

This pull request updates documentation examples for `math/base/special/croundn` to use complex number instance notation (e.g., `<Complex128>[ -3.14, 3.14 ]`) instead of decomposing values using `real` and `imag`, in accordance with the RFC guidance.

No functional code changes were made. Only documentation examples were updated.

## Related Issues

- #8641  

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] No
-   [ ] Yes

#### Disclosure

N/A

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
