### PR TITLE
docs: improve doctests for complex number instances in math/base/special/cflipsignf

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cflipsignf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/cflipsignf/README.md
@@ -46,17 +46,9 @@ Returns a single-precision complex floating-point number with the same magnitude
 
 ```javascript
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
-var real = require( '@stdlib/complex/float32/real' );
-var imag = require( '@stdlib/complex/float32/imag' );
 
 var v = cflipsignf( new Complex64( -4.0, 5.0 ), -1.0 );
-// returns <Complex64>
-
-var re = real( v );
-// returns 4.0
-
-var im = imag( v );
-// returns -5.0
+// returns <Complex64>[ 4.0, -5.0 ]
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/cflipsignf/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/cflipsignf/docs/repl.txt
@@ -19,11 +19,7 @@
     Examples
     --------
     > var v = {{alias}}( new {{alias:@stdlib/complex/float32/ctor}}( -4.0, 5.0 ), -9.0 )
-    <Complex64>
-    > var re = {{alias:@stdlib/complex/float32/real}}( v )
-    4.0
-    > var im = {{alias:@stdlib/complex/float32/imag}}( v )
-    -5.0
+    <Complex64>[ 4.0, -5.0 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/math/base/special/cflipsignf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/cflipsignf/docs/types/index.d.ts
@@ -31,17 +31,9 @@ import { Complex64 } from '@stdlib/types/complex';
 *
 * @example
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var real = require( '@stdlib/complex/float32/real' );
-* var imag = require( '@stdlib/complex/float32/imag' );
 *
 * var v = cflipsignf( new Complex64( -4.0, 5.0 ), -55.0 );
-* // returns <Complex64>
-*
-* var re = real( v );
-* // returns 4.0
-*
-* var im = imag( v );
-* // returns -5.0
+* // returns <Complex64>[ 4.0, -5.0 ]
 */
 declare function cflipsignf( z: Complex64, y: number ): Complex64;
 

--- a/lib/node_modules/@stdlib/math/base/special/cflipsignf/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/cflipsignf/lib/index.js
@@ -25,18 +25,10 @@
 *
 * @example
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var real = require( '@stdlib/complex/float32/real' );
-* var imag = require( '@stdlib/complex/float32/imag' );
 * var cflipsignf = require( '@stdlib/math/base/special/cflipsignf' );
 *
 * var v = cflipsignf( new Complex64( -4.0, 5.0 ), -55.0 );
-* // returns <Complex64>
-*
-* var re = real( v );
-* // returns 4.0
-*
-* var im = imag( v );
-* // returns -5.0
+* // returns <Complex64>[ 4.0, -5.0 ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/math/base/special/cflipsignf/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/cflipsignf/lib/main.js
@@ -37,17 +37,9 @@ var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * @example
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * var v = cflipsignf( new Complex64( -4.0, 5.0 ), -55.0 );
-* // returns <Complex64>
-*
-* var re = realf( v );
-* // returns 4.0
-*
-* var im = imagf( v );
-* // returns -5.0
+* // returns <Complex64>[ 4.0, -5.0 ]
 */
 function cflipsignf( z, y ) {
 	var re = realf( z );

--- a/lib/node_modules/@stdlib/math/base/special/cflipsignf/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cflipsignf/lib/native.js
@@ -36,17 +36,9 @@ var addon = require( './../src/addon.node' );
 *
 * @example
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var real = require( '@stdlib/complex/float32/real' );
-* var imag = require( '@stdlib/complex/float32/imag' );
 *
 * var v = cflipsignf( new Complex64( -4.0, 5.5 ), -55.0 );
-* // returns <Complex64>
-*
-* var re = real( v );
-* // returns 4.0
-*
-* var im = imag( v );
-* // returns -5.5
+* // returns <Complex64>[ 4.0, -5.5 ]
 */
 function cflipsignf( z, y ) {
 	var v = addon( z, y );


### PR DESCRIPTION
Resolves part of #8641

## Description

This pull request updates documentation examples for `math/base/special/croundn` to use complex number instance notation (e.g., `<Complex64>[ 4.0, -5.0 ]`) instead of decomposing values using `realf` and `imagf`, in accordance with the RFC guidance.

No functional code changes were made. Only documentation examples were updated.

## Related Issues

- #8641   

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] No
-   [ ] Yes

#### Disclosure

N/A

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
