### PR TITLE
docs: improve doctests for complex number instances in math/base/special/csignum

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/csignum/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/csignum/README.md
@@ -46,35 +46,15 @@ Evaluates the [signum][signum] function of a double-precision complex floating-p
 
 ```javascript
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
-var real = require( '@stdlib/complex/float64/real' );
-var imag = require( '@stdlib/complex/float64/imag' );
 
 var v = csignum( new Complex128( -4.2, 5.5 ) );
-// returns <Complex128>
-
-var re = real( v );
-// returns -0.6069136033622302
-
-var im = imag( v );
-// returns 0.79476781392673
+// returns <Complex128>[ -0.6069136033622302, 0.79476781392673 ]
 
 v = csignum( new Complex128( 0.0, 0.0 ) );
-// returns <Complex128>
-
-re = real( v );
-// returns 0.0
-
-im = imag( v );
-// returns 0.0
+// returns <Complex128>[ 0.0, 0.0 ]
 
 v = csignum( new Complex128( NaN, NaN ) );
-// returns <Complex128>
-
-re = real( v );
-// returns NaN
-
-im = imag( v );
-// returns NaN
+// returns <Complex128>[ NaN, NaN ]
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/csignum/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/csignum/docs/repl.txt
@@ -16,11 +16,7 @@
     Examples
     --------
     > var v = {{alias}}( new {{alias:@stdlib/complex/float64/ctor}}( -4.2, 5.5 ) )
-    <Complex128>
-    > var re = {{alias:@stdlib/complex/float64/real}}( v )
-    -0.6069136033622302
-    > var im = {{alias:@stdlib/complex/float64/imag}}( v )
-    0.79476781392673
+    <Complex128>[ -0.6069136033622302, 0.79476781392673 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/math/base/special/csignum/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/csignum/docs/types/index.d.ts
@@ -30,17 +30,9 @@ import { Complex128 } from '@stdlib/types/complex';
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var v = csignum( new Complex128( -4.2, 5.5 ) );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns -0.6069136033622302
-*
-* var im = imag( v );
-* // returns 0.79476781392673
+* // returns <Complex128>[ -0.6069136033622302, 0.79476781392673 ]
 */
 declare function csignum( z: Complex128 ): Complex128;
 

--- a/lib/node_modules/@stdlib/math/base/special/csignum/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/csignum/lib/index.js
@@ -25,36 +25,16 @@
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 * var csignum = require( '@stdlib/math/base/special/csignum' );
 *
 * var v = csignum( new Complex128( -4.2, 5.5 ) );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns -0.6069136033622302
-*
-* var im = imag( v );
-* // returns 0.79476781392673
+* // returns <Complex128>[ -0.6069136033622302, 0.79476781392673 ]
 *
 * v = csignum( new Complex128( 0.0, 0.0 ) );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns 0.0
-*
-* im = imag( v );
-* // returns 0.0
+* // returns <Complex128>[ 0.0, 0.0 ]
 *
 * v = csignum( new Complex128( NaN, NaN ) );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns NaN
-*
-* im = imag( v );
-* // returns NaN
+* // returns <Complex128>[ NaN, NaN ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/math/base/special/csignum/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/csignum/lib/main.js
@@ -36,35 +36,15 @@ var cabs = require( '@stdlib/math/base/special/cabs' );
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var v = csignum( new Complex128( -4.2, 5.5 ) );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns -0.6069136033622302
-*
-* var im = imag( v );
-* // returns 0.79476781392673
+* // returns <Complex128>[ -0.6069136033622302, 0.79476781392673 ]
 *
 * v = csignum( new Complex128( 0.0, 0.0 ) );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns 0.0
-*
-* im = imag( v );
-* // returns 0.0
+* // returns <Complex128>[ 0.0, 0.0 ]
 *
 * v = csignum( new Complex128( NaN, NaN ) );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns NaN
-*
-* im = imag( v );
-* // returns NaN
+* // returns <Complex128>[ NaN, NaN ]
 */
 function csignum( z ) {
 	var re;

--- a/lib/node_modules/@stdlib/math/base/special/csignum/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/csignum/lib/native.js
@@ -35,35 +35,15 @@ var addon = require( './../src/addon.node' );
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var v = csignum( new Complex128( -4.2, 5.5 ) );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns -0.6069136033622302
-*
-* var im = imag( v );
-* // returns 0.79476781392673
+* // returns <Complex128>[ -0.6069136033622302, 0.79476781392673 ]
 *
 * v = csignum( new Complex128( 0.0, 0.0 ) );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns 0.0
-*
-* im = imag( v );
-* // returns 0.0
+* // returns <Complex128>[ 0.0, 0.0 ]
 *
 * v = csignum( new Complex128( NaN, NaN ) );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns NaN
-*
-* im = imag( v );
-* // returns NaN
+* // returns <Complex128>[ NaN, NaN ]
 */
 function csignum( z ) {
 	var v = addon( z );


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: passed
  - task: lint_package_json status: na
  - task: lint_repl_help status: passed
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: passed
  - task: lint_license_headers status: passed ---

Resolves part of #8641 

## Description

This pull request updates documentation examples for `math/base/special/csignum` to use complex number instance notation (e.g., `<Complex128>[ -0.6069136033622302, 0.79476781392673 ]`) instead of decomposing values using `real` and `imag`, in accordance with the RFC guidance.

No functional code changes were made. Only documentation examples were updated.

## Related Issues

- #8641   

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] No
-   [ ] Yes

#### Disclosure

N/A

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
