### PR TITLE
docs: improve doctests for complex number instances in `math/base/special/ccis`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/ccis/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/ccis/README.md
@@ -57,30 +57,16 @@ Evaluates the [cis][cis] function for a double-precision complex floating-point 
 
 ```javascript
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
-var real = require( '@stdlib/complex/float64/real' );
-var imag = require( '@stdlib/complex/float64/imag' );
 
 var z = new Complex128( 0.0, 0.0 );
 
 var v = ccis( z );
-// returns <Complex128>
-
-var re = real( v );
-// returns 1.0
-
-var im = imag( v );
-// returns 0.0
+// returns <Complex128>[ 1.0, 0.0 ]
 
 z = new Complex128( 1.0, 0.0 );
 
 v = ccis( z );
-// returns <Complex128>
-
-re = real( v );
-// returns ~0.540
-
-im = imag( v );
-// returns ~0.841
+// returns <Complex128>[ ~0.540, ~0.841 ]
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/ccis/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/ccis/docs/repl.txt
@@ -16,17 +16,9 @@
     Examples
     --------
     > var y = {{alias}}( new {{alias:@stdlib/complex/float64/ctor}}( 0.0, 0.0 ) )
-    <Complex128>
-    > var re = {{alias:@stdlib/complex/float64/real}}( y )
-    1.0
-    > var im = {{alias:@stdlib/complex/float64/imag}}( y )
-    0.0
+    <Complex128>[ 1.0, 0.0 ]
     > y = {{alias}}( new {{alias:@stdlib/complex/float64/ctor}}( 1.0, 0.0 ) )
-    <Complex128>
-    > re = {{alias:@stdlib/complex/float64/real}}( y )
-    ~0.540
-    > im = {{alias:@stdlib/complex/float64/imag}}( y )
-    ~0.841
+    <Complex128>[ ~0.540, ~0.841 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/math/base/special/ccis/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/ccis/lib/index.js
@@ -25,39 +25,23 @@
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 * var ccis = require( '@stdlib/math/base/special/ccis' );
 *
 * var z = new Complex128( 0.0, 0.0 );
 * // returns <Complex128>
 *
 * var out = ccis( z );
-* // returns <Complex128>
-*
-* var re = real( out );
-* // returns 1.0
-*
-* var im = imag( out );
-* // returns 0.0
+* // returns <Complex128>[ 1.0, 0.0 ]
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 * var ccis = require( '@stdlib/math/base/special/ccis' );
 *
 * var z = new Complex128( 1.0, 0.0 );
 * // returns <Complex128>
 *
 * var out = ccis( z );
-* // returns <Complex128>
-*
-* var re = real( out );
-* // returns ~0.540
-*
-* var im = imag( out );
-* // returns ~0.841
+* // returns <Complex128>[ ~0.540, ~0.841 ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/math/base/special/ccis/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/ccis/lib/main.js
@@ -43,37 +43,21 @@ var WORKSPACE = [ 0.0, 0.0 ];
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var z = new Complex128( 0.0, 0.0 );
 * // returns <Complex128>
 *
 * var out = ccis( z );
-* // returns <Complex128>
-*
-* var re = real( out );
-* // returns 1.0
-*
-* var im = imag( out );
-* // returns 0.0
+* // returns <Complex128>[ 1.0, 0.0 ]
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var z = new Complex128( 1.0, 0.0 );
 * // returns <Complex128>
 *
 * var out = ccis( z );
-* // returns <Complex128>
-*
-* var re = real( out );
-* // returns ~0.54
-*
-* var im = imag( out );
-* // returns ~0.841
+* // returns <Complex128>[ ~0.540, ~0.841 ]
 */
 function ccis( z ) {
 	var re;

--- a/lib/node_modules/@stdlib/math/base/special/ccis/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/ccis/lib/native.js
@@ -35,37 +35,21 @@ var addon = require( './../src/addon.node' );
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var z = new Complex128( 0.0, 0.0 );
 * // returns <Complex128>
 *
 * var out = ccis( z );
-* // returns <Complex128>
-*
-* var re = real( out );
-* // returns 1.0
-*
-* var im = imag( out );
-* // returns 0.0
+* // returns <Complex128>[ 1.0, 0.0 ]
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var z = new Complex128( 1.0, 0.0 );
 * // returns <Complex128>
 *
 * var out = ccis( z );
-* // returns <Complex128>
-*
-* var re = real( out );
-* // returns ~0.540
-*
-* var im = imag( out );
-* // returns ~0.841
+* // returns <Complex128>[ ~0.540, ~0.841 ]
 */
 function ccis( z ) {
 	var v = addon( z );


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: passed
  - task: lint_package_json status: na
  - task: lint_repl_help status: passed
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Resolves part of #8641  

## Description

This pull request updates documentation examples for `math/base/special/ccis` to use complex number instance notation (e.g., `returns <Complex128>[ ~0.540, ~0.841 ]`) instead of decomposing values using `real` and `imag`, in accordance with the RFC guidance.

No functional code changes were made. Only documentation examples were updated.

## Related Issues

- #8641    

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] No
-   [ ] Yes

#### Disclosure

N/A

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
