### PR TITLE
docs: improve doctests for complex number instances in `math/base/special/cinvf`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cinvf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/cinvf/README.md
@@ -52,17 +52,9 @@ Computes the inverse of a single-precision complex floating-point number.
 
 ```javascript
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
-var realf = require( '@stdlib/complex/float32/real' );
-var imagf = require( '@stdlib/complex/float32/imag' );
 
 var v = cinvf( new Complex64( 2.0, 4.0 ) );
-// returns <Complex64>
-
-var re = realf( v );
-// returns ~0.1
-
-var im = imagf( v );
-// returns ~-0.2
+// returns <Complex64>[ ~0.1, ~-0.2 ]
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/cinvf/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/cinvf/docs/repl.txt
@@ -15,11 +15,7 @@
     Examples
     --------
     > var v = {{alias}}( new {{alias:@stdlib/complex/float32/ctor}}( 2.0, 4.0 ) )
-    <Complex64>
-    > var re = {{alias:@stdlib/complex/float32/real}}( v )
-    ~0.1
-    > var im = {{alias:@stdlib/complex/float32/imag}}( v )
-    ~-0.2
+    <Complex64>[ ~0.1, ~-0.2 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/math/base/special/cinvf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/cinvf/docs/types/index.d.ts
@@ -30,17 +30,9 @@ import { Complex64 } from '@stdlib/types/complex';
 *
 * @example
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * var v = cinvf( new Complex64( 2.0, 4.0 ) );
-* // returns <Complex64>
-*
-* var re = realf( v );
-* // returns ~0.1
-*
-* var im = imagf( v );
-* // returns ~-0.2
+* // returns <Complex64>[ ~0.1, ~-0.2 ]
 */
 declare function cinvf( z: Complex64 ): Complex64;
 

--- a/lib/node_modules/@stdlib/math/base/special/cinvf/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/cinvf/lib/index.js
@@ -25,18 +25,10 @@
 *
 * @example
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 * var cinvf = require( '@stdlib/math/base/special/cinvf' );
 *
 * var v = cinvf( new Complex64( 2.0, 4.0 ) );
-* // returns <Complex64>
-*
-* var re = realf( v );
-* // returns ~0.1
-*
-* var im = imagf( v );
-* // returns ~-0.2
+* // returns <Complex64>[ ~0.1, ~-0.2 ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/math/base/special/cinvf/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/cinvf/lib/main.js
@@ -55,17 +55,9 @@ var RECIP_EPS_SQR = f32( TWO / f32(EPS*EPS) );
 *
 * @example
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * var v = cinvf( new Complex64( 2.0, 4.0 ) );
-* // returns <Complex64>
-*
-* var re = realf( v );
-* // returns ~0.1
-*
-* var im = imagf( v );
-* // returns ~-0.2
+* // returns <Complex64>[ ~0.1, ~-0.2 ]
 */
 function cinvf( z ) {
 	var ab;

--- a/lib/node_modules/@stdlib/math/base/special/cinvf/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cinvf/lib/native.js
@@ -35,17 +35,9 @@ var addon = require( './../src/addon.node' );
 *
 * @example
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var realf = require( '@stdlib/complex/float32/real' );
-* var imagf = require( '@stdlib/complex/float32/imag' );
 *
 * var v = cinvf( new Complex64( 2.0, 4.0 ) );
-* // returns <Complex64>
-*
-* var re = realf( v );
-* // returns ~0.1
-*
-* var im = imagf( v );
-* // returns ~-0.2
+* // returns <Complex64>[ ~0.1, ~-0.2 ]
 */
 function cinvf( z ) {
 	var v = addon( z );


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: passed
  - task: lint_package_json status: na
  - task: lint_repl_help status: passed
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: passed
  - task: lint_license_headers status: passed ---

Ref: #8641  

## Description

This pull request updates documentation examples for `math/base/special/cinvf` to use complex number instance notation (e.g., `returns <Complex64>[ ~0.1, ~0.2 ]`) instead of decomposing values using `realf` and `imagf`, in accordance with the RFC guidance.

No functional code changes were made. Only documentation examples were updated.

## Related Issues

- #8641    

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] No
-   [ ] Yes

#### Disclosure

N/A

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md