### PR TITLE
docs: improve doctests for complex number instances in `math/base/special/cinv`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cinv/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/cinv/README.md
@@ -53,17 +53,9 @@ Computes the inverse of a double-precision complex floating-point number.
 
 ```javascript
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
-var real = require( '@stdlib/complex/float64/real' );
-var imag = require( '@stdlib/complex/float64/imag' );
 
 var v = cinv( new Complex128( 2.0, 4.0 ) );
-// returns <Complex128>
-
-var re = real( v );
-// returns 0.1
-
-var im = imag( v );
-// returns -0.2
+// returns <Complex128>[ 0.1, -0.2 ]
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/cinv/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/cinv/docs/repl.txt
@@ -15,11 +15,7 @@
     Examples
     --------
     > var v = {{alias}}( new {{alias:@stdlib/complex/float64/ctor}}( 2.0, 4.0 ) )
-    <Complex128>
-    > var re = {{alias:@stdlib/complex/float64/real}}( v )
-    0.1
-    > var im = {{alias:@stdlib/complex/float64/imag}}( v )
-    -0.2
+    <Complex128>[ 0.1, -0.2 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/math/base/special/cinv/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/cinv/docs/types/index.d.ts
@@ -30,17 +30,9 @@ import { Complex128 } from '@stdlib/types/complex';
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var v = cinv( new Complex128( 2.0, 4.0 ) );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns 0.1
-*
-* var im = imag( v );
-* // returns -0.2
+* // returns <Complex128>[ ~0.1, ~-0.2 ]
 */
 declare function cinv( z: Complex128 ): Complex128;
 

--- a/lib/node_modules/@stdlib/math/base/special/cinv/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/cinv/lib/index.js
@@ -25,18 +25,10 @@
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 * var cinv = require( '@stdlib/math/base/special/cinv' );
 *
 * var v = cinv( new Complex128( 2.0, 4.0 ) );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns 0.1
-*
-* var im = imag( v );
-* // returns -0.2
+* // returns <Complex128>[ 0.1, -0.2 ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/math/base/special/cinv/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/cinv/lib/main.js
@@ -51,17 +51,9 @@ var RECIP_EPS_SQR = 2.0 / ( EPS * EPS );
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var v = cinv( new Complex128( 2.0, 4.0 ) );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns 0.1
-*
-* var im = imag( v );
-* // returns -0.2
+* // returns <Complex128>[ 0.1, -0.2 ]
 */
 function cinv( z ) {
 	var ab;

--- a/lib/node_modules/@stdlib/math/base/special/cinv/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cinv/lib/native.js
@@ -35,17 +35,9 @@ var addon = require( './../src/addon.node' );
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var v = cinv( new Complex128( 2.0, 4.0 ) );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns 0.1
-*
-* var im = imag( v );
-* // returns -0.2
+* // returns <Complex128>[ 0.1, -0.2 ]
 */
 function cinv( z ) {
 	var v = addon( z );


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: passed
  - task: lint_package_json status: na
  - task: lint_repl_help status: passed
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: passed
  - task: lint_license_headers status: passed ---

Resolves part of #8641  

## Description

This pull request updates documentation examples for `math/base/special/cinv` to use complex number instance notation (e.g., ` returns <Complex128>[ 0.1, -0.2 ]`) instead of decomposing values using `real` and `imag`, in accordance with the RFC guidance.

No functional code changes were made. Only documentation examples were updated.

## Related Issues

- #8641    

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] No
-   [ ] Yes

#### Disclosure

N/A

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md