### PR TITLE
docs: improve doctests for complex number instances in `math/base/special/cround`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cround/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/cround/README.md
@@ -36,44 +36,18 @@ Rounds each component of a double-precision complex floating-point number to the
 
 ```javascript
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
-var real = require( '@stdlib/complex/float64/real' );
-var imag = require( '@stdlib/complex/float64/imag' );
 
 var v = cround( new Complex128( -4.2, 5.5 ) );
-// returns <Complex128>
-
-var re = real( v );
-// returns -4.0
-
-var im = imag( v );
-// returns 6.0
+// returns <Complex128>[ -4.0, 6.0 ]
 
 v = cround( new Complex128( 9.99999, 0.1 ) );
-// returns <Complex128>
-
-re = real( v );
-// returns 10.0
-
-im = imag( v );
-// returns 0.0
+// returns <Complex128>[ 10.0, 0.0 ]
 
 v = cround( new Complex128( 0.0, 0.0 ) );
-// returns <Complex128>
-
-re = real( v );
-// returns 0.0
-
-im = imag( v );
-// returns 0.0
+// returns <Complex128>[ 0.0, 0.0 ]
 
 v = cround( new Complex128( NaN, NaN ) );
-// returns <Complex128>
-
-re = real( v );
-// returns NaN
-
-im = imag( v );
-// returns NaN
+// returns <Complex128>[ NaN, NaN ]
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/cround/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/cround/docs/repl.txt
@@ -16,11 +16,7 @@
     Examples
     --------
     > var v = {{alias}}( new {{alias:@stdlib/complex/float64/ctor}}( 5.5, 3.3 ) )
-    <Complex128>
-    > var re = {{alias:@stdlib/complex/float64/real}}( v )
-    6.0
-    > var im = {{alias:@stdlib/complex/float64/imag}}( v )
-    3.0
+    <Complex128>[ 6.0, 3.0 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/math/base/special/cround/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/cround/docs/types/index.d.ts
@@ -34,13 +34,7 @@ import { Complex128 } from '@stdlib/types/complex';
 * var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var v = cround( new Complex128( -4.2, 5.5 ) );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns -4.0
-*
-* var im = imag( v );
-* // returns 6.0
+* // returns <Complex128>[ -4.0, 6.0 ]
 */
 declare function cround( z: Complex128 ): Complex128;
 

--- a/lib/node_modules/@stdlib/math/base/special/cround/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/cround/lib/index.js
@@ -25,45 +25,19 @@
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 * var cround = require( '@stdlib/math/base/special/cround' );
 *
 * var v = cround( new Complex128( -4.2, 5.5 ) );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns -4.0
-*
-* var im = imag( v );
-* // returns 6.0
+* // returns <Complex128>[ -4.0, 6.0 ]
 *
 * v = cround( new Complex128( 9.99999, 0.1 ) );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns 10.0
-*
-* im = imag( v );
-* // returns 0.0
+* // returns <Complex128>[ 10.0, 0.0 ]
 *
 * v = cround( new Complex128( 0.0, 0.0 ) );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns 0.0
-*
-* im = imag( v );
-* // returns 0.0
+* // returns <Complex128>[ 0.0, 0.0 ]
 *
 * v = cround( new Complex128( NaN, NaN ) );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns NaN
-*
-* im = imag( v );
-* // returns NaN
+* // returns <Complex128>[ NaN, NaN ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/math/base/special/cround/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/cround/lib/main.js
@@ -36,44 +36,18 @@ var imag = require( '@stdlib/complex/float64/imag' );
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var v = cround( new Complex128( -4.2, 5.5 ) );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns -4.0
-*
-* var im = imag( v );
-* // returns 6.0
+* // returns <Complex128>[ -4.0, 6.0 ]
 *
 * v = cround( new Complex128( 9.99999, 0.1 ) );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns 10.0
-*
-* im = imag( v );
-* // returns 0.0
+* // returns <Complex128>[ 10.0, 0.0 ]
 *
 * v = cround( new Complex128( 0.0, 0.0 ) );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns 0.0
-*
-* im = imag( v );
-* // returns 0.0
+* // returns <Complex128>[ 0.0, 0.0 ]
 *
 * v = cround( new Complex128( NaN, NaN ) );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns NaN
-*
-* im = imag( v );
-* // returns NaN
+* // returns <Complex128>[ NaN, NaN ]
 */
 function cround( z ) {
 	return new Complex128( round( real( z ) ), round( imag( z ) ) );

--- a/lib/node_modules/@stdlib/math/base/special/cround/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cround/lib/native.js
@@ -39,13 +39,7 @@ var addon = require( './../src/addon.node' );
 * var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var v = cround( new Complex128( -4.2, 5.5 ) );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns -4
-*
-* var im = imag( v );
-* // returns 6.0
+* // returns <Complex128>[ -4, 6.0 ]
 */
 function cround( z ) {
 	var v = addon( z );

--- a/lib/node_modules/@stdlib/math/base/special/cround/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cround/lib/native.js
@@ -39,7 +39,7 @@ var addon = require( './../src/addon.node' );
 * var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var v = cround( new Complex128( -4.2, 5.5 ) );
-* // returns <Complex128>[ -4, 6.0 ]
+* // returns <Complex128>[ -4.0, 6.0 ]
 */
 function cround( z ) {
 	var v = addon( z );

--- a/lib/node_modules/@stdlib/math/base/special/cround/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/cround/src/main.c
@@ -35,12 +35,7 @@
 * stdlib_complex128_t z = stdlib_complex128( -4.2, 5.5 );
 *
 * stdlib_complex128_t out = stdlib_base_cround( z );
-*
-* double re = stdlib_complex128_real( out );
-* // returns -5.0
-*
-* double im = stdlib_complex128_imag( out );
-* // returns 6.0
+* // returns <Complex128>[ -5.0, 6.0 ]
 */
 stdlib_complex128_t stdlib_base_cround( const stdlib_complex128_t z ) {
 	double re;


### PR DESCRIPTION
Resolves part of #8641.

## Description

This pull request:

-   Updates REPL and documentation examples in the `math/base/special/cround` package to use the compact complex instance doctest notation.
- Replaces example decomposition using realf/imagf with concise doctest annotations.


## Related Issues


This pull request has the following related issues:

-   #8641

## Questions


No.

## Other


No.

## Checklist


-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

N.A.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
