### PR TITLE
feat: add `symbol/split`

### DIFF
--- a/lib/node_modules/@stdlib/symbol/lib/index.js
+++ b/lib/node_modules/@stdlib/symbol/lib/index.js
@@ -91,6 +91,15 @@ setReadOnly( ns, 'IteratorSymbol', require( '@stdlib/symbol/iterator' ) );
 setReadOnly( ns, 'ReplaceSymbol', require( '@stdlib/symbol/replace' ) );
 
 /**
+* @name SplitSymbol
+* @memberof ns
+* @readonly
+* @type {(symbol|null)}
+* @see {@link module:@stdlib/symbol/split}
+*/
+setReadOnly( ns, 'SplitSymbol', require( '@stdlib/symbol/split' ) );
+
+/**
 * @name ToPrimitiveSymbol
 * @memberof ns
 * @readonly

--- a/lib/node_modules/@stdlib/symbol/split/README.md
+++ b/lib/node_modules/@stdlib/symbol/split/README.md
@@ -1,0 +1,130 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2025 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# SplitSymbol
+
+> [Symbol][mdn-symbol] which specifies a method that splits a string at the indices that match a regular expression.
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- Package usage documentation. -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var SplitSymbol = require( '@stdlib/symbol/split' );
+```
+
+#### SplitSymbol
+
+[`symbol`][mdn-symbol] which specifies a method that splits a string at the indices that match a regular expression.
+
+```javascript
+var s = typeof SplitSymbol;
+// e.g., returns 'symbol'
+```
+
+</section>
+
+<!-- /.usage -->
+
+<!-- Package usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+## Notes
+
+-   The [symbol][mdn-symbol] is only supported in environments which support [symbols][mdn-symbol]. In non-supporting environments, the value is `null`.
+-   When calling `String.prototype.split` and the `separator` argument is an object with a `[SplitSymbol]()` method, this method is called with the target string and limit as arguments.
+
+</section>
+
+<!-- /.notes -->
+
+<!-- Package usage examples. -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var defineProperty = require( '@stdlib/utils/define-property' );
+var SplitSymbol = require( '@stdlib/symbol/split' );
+
+function splitter( str ) {
+    return str.split( '-' );
+}
+
+var obj = {};
+
+defineProperty( obj, SplitSymbol, {
+    'configurable': true,
+    'value': null
+});
+
+var str = 'a-b-c-d-e';
+console.log( str.split( obj ) );
+
+defineProperty( obj, SplitSymbol, {
+    'configurable': true,
+    'value': splitter
+});
+console.log( str.split( obj ) );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section to include cited references. If references are included, add a horizontal rule *before* the section. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="references">
+
+</section>
+
+<!-- /.references -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[mdn-symbol]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/symbol/split/docs/repl.txt
+++ b/lib/node_modules/@stdlib/symbol/split/docs/repl.txt
@@ -1,0 +1,18 @@
+
+{{alias}}
+    Split symbol.
+
+    This symbol specifies a method that splits a string at the indices that
+    match a regular expression.
+
+    The symbol is only supported in ES6/ES2015+ environments. For non-supporting
+    environments, the value is `null`.
+
+    Examples
+    --------
+    > var s = {{alias}}
+    e.g., <symbol>
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/symbol/split/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/symbol/split/docs/types/index.d.ts
@@ -1,0 +1,31 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+// EXPORTS //
+
+/**
+* Split symbol.
+*
+* ## Notes
+*
+* -   This symbol specifies a method that splits a string at the indices that match a regular expression.
+* -   The symbol is only supported in ES6/ES2015+ environments. For non-supporting environments, the value is `null`.
+*/
+export = Symbol.split;

--- a/lib/node_modules/@stdlib/symbol/split/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/symbol/split/docs/types/test.ts
@@ -1,0 +1,29 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
+import Split = require( './index' );
+
+
+// TESTS //
+
+// The exported value is the `split` symbol...
+{
+	Split;
+}

--- a/lib/node_modules/@stdlib/symbol/split/examples/index.js
+++ b/lib/node_modules/@stdlib/symbol/split/examples/index.js
@@ -1,0 +1,42 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var defineProperty = require( '@stdlib/utils/define-property' );
+var SplitSymbol = require( './../lib' );
+
+function splitter( str ) {
+	return str.split( '-' );
+}
+
+var obj = {};
+
+defineProperty( obj, SplitSymbol, {
+	'configurable': true,
+	'value': null
+});
+
+var str = 'a-b-c-d-e';
+console.log( str.split( obj ) );
+
+defineProperty( obj, SplitSymbol, {
+	'configurable': true,
+	'value': splitter
+});
+console.log( str.split( obj ) );

--- a/lib/node_modules/@stdlib/symbol/split/lib/index.js
+++ b/lib/node_modules/@stdlib/symbol/split/lib/index.js
@@ -1,0 +1,44 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Symbol which specifies a method that splits a string at the indices that match a regular expression.
+*
+* @module @stdlib/symbol/split
+*
+* @example
+* var SplitSymbol = require( '@stdlib/symbol/split' );
+*
+* function splitter( str, limit ) {
+*     return str.split( '-', limit );
+* }
+*
+* var obj = {};
+* obj[ SplitSymbol ] = splitter;
+*/
+
+// MAIN //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/symbol/split/lib/main.js
+++ b/lib/node_modules/@stdlib/symbol/split/lib/main.js
@@ -1,0 +1,48 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var hasSplitSymbolSupport = require( '@stdlib/assert/has-split-symbol-support' );
+
+
+// MAIN //
+
+/**
+* Split symbol.
+*
+* @name SplitSymbol
+* @constant
+* @type {(symbol|null)}
+*
+* @example
+* function splitter( str, limit ) {
+*     return str.split( '-', limit );
+* }
+*
+* var obj = {};
+* obj[ SplitSymbol ] = splitter;
+*/
+var SplitSymbol = ( hasSplitSymbolSupport() ) ? Symbol.split : null;
+
+
+// EXPORTS //
+
+module.exports = SplitSymbol;

--- a/lib/node_modules/@stdlib/symbol/split/package.json
+++ b/lib/node_modules/@stdlib/symbol/split/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@stdlib/symbol/split",
+  "version": "0.0.0",
+  "description": "Split symbol.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "symbol",
+    "sym",
+    "split",
+    "splitter",
+    "string",
+    "regex",
+    "regexp"
+  ]
+}

--- a/lib/node_modules/@stdlib/symbol/split/test/test.js
+++ b/lib/node_modules/@stdlib/symbol/split/test/test.js
@@ -1,0 +1,52 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var hasSplitSymbolSupport = require( '@stdlib/assert/has-split-symbol-support' );
+var isSymbol = require( '@stdlib/assert/is-symbol' );
+var Sym = require( './../lib' );
+
+
+// VARIABLES //
+
+var opts = {
+	'skip': !hasSplitSymbolSupport()
+};
+
+
+// TESTS //
+
+tape( 'main export is a symbol in supporting environments (ES6/2015+) or otherwise null', function test( t ) {
+	t.ok( true, __filename );
+	if ( opts.skip ) {
+		t.strictEqual( Sym, null, 'main export is null' );
+	} else {
+		t.strictEqual( typeof Sym, 'symbol', 'main export is a symbol' );
+		t.strictEqual( isSymbol( Sym ), true, 'main export is a symbol' );
+	}
+	t.end();
+});
+
+tape( 'the main export is an alias for `Symbol.split`', opts, function test( t ) {
+	t.strictEqual( Sym, Symbol.split, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
Resolves #8488.

## Description

This pull request adds the `@stdlib/symbol/split` package, which provides access to
the well-known `Symbol.split` symbol in environments that support it and `null`
otherwise.

The package follows established stdlib conventions and includes documentation,
examples, tests, REPL help text, TypeScript definitions, and namespace integration.

## Related Issues

- #8488

## Questions

No.

## Other

### Implementation Notes

The package structure follows existing conventions established by similar stdlib
packages, including:

- `@stdlib/symbol/replace`
- `@stdlib/symbol/has-instance`
- `@stdlib/symbol/is-concat-spreadable`

### Files Added

| File | Description |
|------|-------------|
| `lib/node_modules/@stdlib/symbol/split/lib/main.js` | Main implementation exporting `Symbol.split` or `null` |
| `lib/node_modules/@stdlib/symbol/split/lib/index.js` | Module entry point |
| `lib/node_modules/@stdlib/symbol/split/test/test.js` | Unit tests |
| `lib/node_modules/@stdlib/symbol/split/examples/index.js` | Usage examples |
| `lib/node_modules/@stdlib/symbol/split/README.md` | Package documentation |
| `lib/node_modules/@stdlib/symbol/split/package.json` | Package metadata |
| `lib/node_modules/@stdlib/symbol/split/docs/repl.txt` | REPL help text |
| `lib/node_modules/@stdlib/symbol/split/docs/types/index.d.ts` | TypeScript definitions |
| `lib/node_modules/@stdlib/symbol/split/docs/types/test.ts` | TypeScript tests |

### Files Modified

| File | Description |
|------|-------------|
| `lib/node_modules/@stdlib/symbol/lib/index.js` | Added `SplitSymbol` to the symbol namespace |

### Test Results

All tests pass.

## Checklist

- [x] Read, understood, and followed the [contributing guidelines][contributing].

## AI Assistance

- [x] Yes
- [ ] No

**Disclosure:**  
AI assistance was used to generate the initial implementation, tests, and
documentation based on existing stdlib symbol packages. I reviewed the generated
code, verified its behavior locally, ensured it follows project conventions, and
take responsibility for this contribution.


@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
