### PR TITLE
feat: add `constants/float16/ln-two`

### DIFF
--- a/lib/node_modules/@stdlib/constants/float16/ln-two/README.md
+++ b/lib/node_modules/@stdlib/constants/float16/ln-two/README.md
@@ -1,0 +1,79 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2025 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# FLOAT16_LN2
+
+> Natural logarithm of `2`.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var FLOAT16_LN2 = require( '@stdlib/constants/float16/ln-two' );
+```
+
+#### FLOAT16_LN2
+
+Natural logarithm of `2`.
+
+```javascript
+var bool = ( FLOAT16_LN2 === 0.69336 );
+// returns true
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- TODO: better example -->
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var FLOAT16_LN2 = require( '@stdlib/constants/float16/ln-two' );
+
+console.log( FLOAT16_LN2 );
+// => 0.69336
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/constants/float16/ln-two/docs/repl.txt
+++ b/lib/node_modules/@stdlib/constants/float16/ln-two/docs/repl.txt
@@ -1,0 +1,12 @@
+
+{{alias}}
+    Natural logarithm of 2.
+
+    Examples
+    --------
+    > {{alias}}
+    0.69336
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/constants/float16/ln-two/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/constants/float16/ln-two/docs/types/index.d.ts
@@ -1,0 +1,33 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Natural logarithm of `2`.
+*
+* @example
+* var val = FLOAT16_LN2;
+* // returns 0.69336
+*/
+declare const FLOAT16_LN2: number;
+
+
+// EXPORTS //
+
+export = FLOAT16_LN2;

--- a/lib/node_modules/@stdlib/constants/float16/ln-two/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/constants/float16/ln-two/docs/types/test.ts
@@ -1,0 +1,28 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import FLOAT16_LN2 = require( './index' );
+
+
+// TESTS //
+
+// The export is a number...
+{
+	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+	FLOAT16_LN2; // $ExpectType number
+}

--- a/lib/node_modules/@stdlib/constants/float16/ln-two/examples/index.js
+++ b/lib/node_modules/@stdlib/constants/float16/ln-two/examples/index.js
@@ -1,0 +1,24 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var FLOAT16_LN2 = require( './../lib' );
+
+console.log( FLOAT16_LN2 );
+// => 0.69336

--- a/lib/node_modules/@stdlib/constants/float16/ln-two/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float16/ln-two/lib/index.js
@@ -1,0 +1,51 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Natural logarithm of `2`.
+*
+* @module @stdlib/constants/float16/ln-two
+* @type {number}
+*
+* @example
+* var FLOAT16_LN2 = require( '@stdlib/constants/float16/ln-two' );
+* // returns 0.69336
+*/
+
+
+// MAIN //
+
+/**
+* Natural logarithm of `2`.
+*
+* ```tex
+* \ln 2
+* ```
+*
+* @constant
+* @type {number}
+* @default 0.69336
+*/
+var FLOAT16_LN2 = 0.69336;
+
+
+// EXPORTS //
+
+module.exports = FLOAT16_LN2;

--- a/lib/node_modules/@stdlib/constants/float16/ln-two/package.json
+++ b/lib/node_modules/@stdlib/constants/float16/ln-two/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@stdlib/constants/float16/ln-two",
+  "version": "0.0.0",
+  "description": "Half-precision (float16) approximation of the natural logarithm of 2.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "constant",
+    "const",
+    "mathematics",
+    "math",
+    "ln",
+    "log",
+    "logarithm",
+    "natural",
+    "two",
+    "ln2",
+    "math.ln2",
+    "ieee754",
+    "float",
+    "floating-point",
+    "float16"
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float16/ln-two/test/test.js
+++ b/lib/node_modules/@stdlib/constants/float16/ln-two/test/test.js
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var FLOAT16_LN2 = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a number', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof FLOAT16_LN2, 'number', 'main export is a number' );
+	t.end();
+});
+
+tape( 'export is a half-precision floating-point number equal to 0.69336', function test( t ) {
+	t.strictEqual( FLOAT16_LN2, 0.69336, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes.
report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: passed
  - task: lint_package_json status: passed
  - task: lint_repl_help status: passed
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: passed
  - task: lint_javascript_tests status: passed
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: passed
  - task: lint_license_headers status: passed
---

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds the `@stdlib/constants/float16/ln-two` package, which provides the half-precision (float16) approximation of the natural logarithm of 2 (`ln(2) ≈ 0.69336`).
-   Includes complete implementation with documentation, unit tests, examples, TypeScript declarations, and REPL help text.
-   Follows all stdlib package conventions and style guidelines.

## Related Issues

> Does this pull request have any related issues?

This pull request addresses the need for additional float16 mathematical constants in stdlib, complementing the existing float64 `ln-two` constant.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Implementation Notes:**
- The float16 value `0.69336` was calculated as the half-precision representation of `ln(2) ≈ 0.6931471805599453`
- All tests pass with 100% coverage
- Package structure mirrors existing float16 constants (e.g., `@stdlib/constants/float16/e`)

**Test Results:**
<img width="1149" height="216" alt="image" src="https://github.com/user-attachments/assets/035ba326-a9d5-4dc8-a0a5-4a4457d794f2" />



## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md