### PR TITLE
feat: add ESLint rule disallowing string concatenation in benchmark descriptions

### DIFF
--- a/etc/eslint/.eslintrc.benchmarks.js
+++ b/etc/eslint/.eslintrc.benchmarks.js
@@ -126,6 +126,13 @@ eslint.rules[ 'stdlib/jsdoc-doctest' ] = 'off';
 */
 eslint.rules[ 'stdlib/no-unnecessary-nested-functions' ] = 'off';
 
+/**
+* Warn when using string concatenation in benchmark descriptions.
+*
+* @private
+*/
+eslint.rules[ 'stdlib/no-bench-string-concat' ] = 'warn';
+
 
 // EXPORTS //
 

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/lib/index.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/lib/index.js
@@ -838,6 +838,15 @@ setReadOnly( rules, 'new-cap-error', require( '@stdlib/_tools/eslint/rules/new-c
 setReadOnly( rules, 'new-cap-regexp', require( '@stdlib/_tools/eslint/rules/new-cap-regexp' ) );
 
 /**
+* @name no-bench-string-concat
+* @memberof rules
+* @readonly
+* @type {Function}
+* @see {@link module:@stdlib/_tools/eslint/rules/no-bench-string-concat}
+*/
+setReadOnly( rules, 'no-bench-string-concat', require( '@stdlib/_tools/eslint/rules/no-bench-string-concat' ) );
+
+/**
 * @name no-builtin-big-int
 * @memberof rules
 * @readonly

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-bench-string-concat/README.md
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-bench-string-concat/README.md
@@ -81,14 +81,10 @@ var Linter = require( 'eslint' ).Linter;
 var rule = require( '@stdlib/_tools/eslint/rules/no-bench-string-concat' );
 
 var linter = new Linter();
-var result;
-var code;
-
-code = 'bench( pkg+\':len=\'+len, f );';
-
 linter.defineRule( 'no-bench-string-concat', rule );
 
-result = linter.verify( code, {
+var code = 'bench( pkg+\':len=\'+len, f );';
+var result = linter.verify( code, {
     'rules': {
         'no-bench-string-concat': 'error'
     }

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-bench-string-concat/README.md
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-bench-string-concat/README.md
@@ -1,0 +1,128 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2025 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# no-bench-string-concat
+
+> [ESLint rule][eslint-rules] enforcing that `@stdlib/string/format` is used instead of string concatenation in benchmark descriptions.
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var rule = require( '@stdlib/_tools/eslint/rules/no-bench-string-concat' );
+```
+
+#### rule
+
+[ESLint rule][eslint-rules] enforcing that `@stdlib/string/format` is used instead of string concatenation in benchmark descriptions.
+
+**Bad**:
+
+<!-- eslint-disable stdlib/no-bench-string-concat, no-restricted-syntax -->
+
+```javascript
+bench( pkg+':len='+len, function benchmark( b ) {
+    // ...
+});
+```
+
+**Good**:
+
+<!-- eslint-disable no-restricted-syntax -->
+
+```javascript
+var format = require( '@stdlib/string/format' );
+
+bench( format( '%s:len=%d', pkg, len ), function benchmark( b ) {
+    // ...
+});
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var Linter = require( 'eslint' ).Linter;
+var rule = require( '@stdlib/_tools/eslint/rules/no-bench-string-concat' );
+
+var linter = new Linter();
+var result;
+var code;
+
+code = 'bench( pkg+\':len=\'+len, f );';
+
+linter.defineRule( 'no-bench-string-concat', rule );
+
+result = linter.verify( code, {
+    'rules': {
+        'no-bench-string-concat': 'error'
+    }
+});
+/* returns
+    [
+        {
+            'ruleId': 'no-bench-string-concat',
+            'severity': 2,
+            'message': 'Use `@stdlib/string/format` instead of string concatenation for benchmark descriptions.',
+            'line': 1,
+            'column': 8,
+            'nodeType': 'BinaryExpression',
+            'endLine': 1,
+            'endColumn': 23
+        }
+    ]
+*/
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[eslint-rules]: https://eslint.org/docs/developer-guide/working-with-rules
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-bench-string-concat/README.md
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-bench-string-concat/README.md
@@ -42,6 +42,8 @@ var rule = require( '@stdlib/_tools/eslint/rules/no-bench-string-concat' );
 
 **Bad**:
 
+<!-- run-disable -->
+
 <!-- eslint-disable stdlib/no-bench-string-concat, no-restricted-syntax -->
 
 ```javascript
@@ -51,6 +53,8 @@ bench( pkg+':len='+len, function benchmark( b ) {
 ```
 
 **Good**:
+
+<!-- run-disable -->
 
 <!-- eslint-disable no-restricted-syntax -->
 

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-bench-string-concat/examples/index.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-bench-string-concat/examples/index.js
@@ -22,14 +22,10 @@ var Linter = require( 'eslint' ).Linter;
 var rule = require( './../lib' );
 
 var linter = new Linter();
-var result;
-var code;
-
-code = 'bench( pkg+\':len=\'+len, f );';
-
 linter.defineRule( 'no-bench-string-concat', rule );
 
-result = linter.verify( code, {
+var code = 'bench( pkg+\':len=\'+len, f );';
+var result = linter.verify( code, {
 	'rules': {
 		'no-bench-string-concat': 'error'
 	}

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-bench-string-concat/examples/index.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-bench-string-concat/examples/index.js
@@ -1,0 +1,51 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var Linter = require( 'eslint' ).Linter;
+var rule = require( './../lib' );
+
+var linter = new Linter();
+var result;
+var code;
+
+code = 'bench( pkg+\':len=\'+len, f );';
+
+linter.defineRule( 'no-bench-string-concat', rule );
+
+result = linter.verify( code, {
+	'rules': {
+		'no-bench-string-concat': 'error'
+	}
+});
+console.log( result );
+/* =>
+	[
+		{
+			'ruleId': 'no-bench-string-concat',
+			'severity': 2,
+			'message': 'Use `@stdlib/string/format` instead of string concatenation for benchmark descriptions.',
+			'line': 1,
+			'column': 8,
+			'nodeType': 'BinaryExpression',
+			'endLine': 1,
+			'endColumn': 23
+		}
+	]
+*/

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-bench-string-concat/lib/index.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-bench-string-concat/lib/index.js
@@ -1,0 +1,39 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* ESLint rule enforcing that string concatenation is not used in benchmark descriptions.
+*
+* @module @stdlib/_tools/eslint/rules/no-bench-string-concat
+*
+* @example
+* var rule = require( '@stdlib/_tools/eslint/rules/no-bench-string-concat' );
+*
+* console.log( rule );
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-bench-string-concat/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-bench-string-concat/lib/main.js
@@ -1,0 +1,116 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// VARIABLES //
+
+var rule;
+
+
+// FUNCTIONS //
+
+/**
+* Checks whether a node is a BinaryExpression with a '+' operator.
+*
+* @private
+* @param {ASTNode} node - AST node
+* @returns {boolean} boolean indicating whether the node is a string concatenation
+*/
+function isStringConcatenation( node ) {
+	if ( node.type !== 'BinaryExpression' ) {
+		return false;
+	}
+	if ( node.operator !== '+' ) {
+		return false;
+	}
+	return true;
+}
+
+/**
+* Rule for validating that `@stdlib/string/format` is used instead of string concatenation in benchmark descriptions.
+*
+* @param {Object} context - ESLint context
+* @returns {Object} validators
+*/
+function main( context ) {
+	/**
+	* Reports the error message.
+	*
+	* @private
+	* @param {ASTNode} node - node to report
+	*/
+	function report( node ) {
+		context.report({
+			'node': node,
+			'message': 'Use `@stdlib/string/format` instead of string concatenation for benchmark descriptions.'
+		});
+	}
+
+	/**
+	* Checks whether a `bench()` call uses string concatenation in its first argument.
+	*
+	* @private
+	* @param {ASTNode} node - CallExpression node to examine
+	*/
+	function validate( node ) {
+		var firstArg;
+		var callee;
+
+		callee = node.callee;
+
+		// Check if this is a call to `bench`:
+		if ( callee.type !== 'Identifier' || callee.name !== 'bench' ) {
+			return;
+		}
+
+		// Check if there is at least one argument:
+		if ( node.arguments.length === 0 ) {
+			return;
+		}
+
+		firstArg = node.arguments[ 0 ];
+
+		// Check if the first argument is string concatenation:
+		if ( isStringConcatenation( firstArg ) ) {
+			report( firstArg );
+		}
+	}
+
+	return {
+		'CallExpression': validate
+	};
+}
+
+
+// MAIN //
+
+rule = {
+	'meta': {
+		'docs': {
+			'description': 'enforce that `@stdlib/string/format` is used instead of string concatenation in benchmark descriptions'
+		},
+		'schema': []
+	},
+	'create': main
+};
+
+
+// EXPORTS //
+
+module.exports = rule;

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-bench-string-concat/package.json
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-bench-string-concat/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@stdlib/_tools/eslint/rules/no-bench-string-concat",
+  "version": "0.0.0",
+  "description": "ESLint rule enforcing that `@stdlib/string/format` is used instead of string concatenation in benchmark descriptions.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "bin": {},
+  "main": "./lib",
+  "directories": {
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "tools",
+    "tool",
+    "eslint",
+    "lint",
+    "custom",
+    "rules",
+    "rule",
+    "plugin",
+    "benchmark",
+    "bench",
+    "string",
+    "concatenation",
+    "format"
+  ]
+}

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-bench-string-concat/test/fixtures/invalid.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-bench-string-concat/test/fixtures/invalid.js
@@ -1,0 +1,74 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var invalid = [];
+
+// Simple string concatenation:
+var test = {
+	'code': 'bench( pkg+\':len=\'+len, f );',
+	'errors': [
+		{
+			'message': 'Use `@stdlib/string/format` instead of string concatenation for benchmark descriptions.',
+			'type': 'BinaryExpression'
+		}
+	]
+};
+invalid.push( test );
+
+// String concatenation with dtype:
+test = {
+	'code': 'bench( pkg+\':dtype=\'+options.dtype+\',len=\'+len, f );',
+	'errors': [
+		{
+			'message': 'Use `@stdlib/string/format` instead of string concatenation for benchmark descriptions.',
+			'type': 'BinaryExpression'
+		}
+	]
+};
+invalid.push( test );
+
+// String concatenation with spaces:
+test = {
+	'code': 'bench( pkg + \':len=\' + len, f );',
+	'errors': [
+		{
+			'message': 'Use `@stdlib/string/format` instead of string concatenation for benchmark descriptions.',
+			'type': 'BinaryExpression'
+		}
+	]
+};
+invalid.push( test );
+
+// String concatenation with inline suffix:
+test = {
+	'code': 'bench( pkg+\'::inline\', f );',
+	'errors': [
+		{
+			'message': 'Use `@stdlib/string/format` instead of string concatenation for benchmark descriptions.',
+			'type': 'BinaryExpression'
+		}
+	]
+};
+invalid.push( test );
+
+
+// EXPORTS //
+
+module.exports = invalid;

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-bench-string-concat/test/fixtures/valid.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-bench-string-concat/test/fixtures/valid.js
@@ -1,0 +1,56 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var valid = [];
+
+// Using format function:
+var test = {
+	'code': 'bench( format( \'%s:len=%d\', pkg, len ), f );'
+};
+valid.push( test );
+
+// Using just pkg variable:
+test = {
+	'code': 'bench( pkg, f );'
+};
+valid.push( test );
+
+// Using a string literal:
+test = {
+	'code': 'bench( \'my-benchmark\', f );'
+};
+valid.push( test );
+
+// String concatenation in other function calls (not bench):
+test = {
+	'code': 'console.log( pkg + \':len=\' + len );'
+};
+valid.push( test );
+
+// Format with multiple parameters:
+test = {
+	'code': 'bench( format( \'%s:dtype=%s,len=%d\', pkg, dtype, len ), f );'
+};
+valid.push( test );
+
+
+// EXPORTS //
+
+module.exports = valid;

--- a/lib/node_modules/@stdlib/_tools/eslint/rules/no-bench-string-concat/test/test.js
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/no-bench-string-concat/test/test.js
@@ -1,0 +1,70 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var RuleTester = require( 'eslint' ).RuleTester;
+var rule = require( './../lib' );
+
+
+// FIXTURES //
+
+var valid = require( './fixtures/valid.js' );
+var invalid = require( './fixtures/invalid.js' );
+
+
+// TESTS //
+
+tape( 'main export is an object', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof rule, 'object', 'main export is an object' );
+	t.end();
+});
+
+tape( 'the rule positively validates code using `format` instead of string concatenation in benchmark descriptions', function test( t ) {
+	var tester = new RuleTester();
+
+	try {
+		tester.run( 'no-bench-string-concat', rule, {
+			'valid': valid,
+			'invalid': []
+		});
+		t.pass( 'passed without errors' );
+	} catch ( err ) {
+		t.fail( 'encountered an error: ' + err.message );
+	}
+	t.end();
+});
+
+tape( 'the rule negatively validates code using string concatenation instead of `format` in benchmark descriptions', function test( t ) {
+	var tester = new RuleTester();
+
+	try {
+		tester.run( 'no-bench-string-concat', rule, {
+			'valid': [],
+			'invalid': invalid
+		});
+		t.pass( 'passed without errors' );
+	} catch ( err ) {
+		t.fail( 'encountered an error: ' + err.message );
+	}
+	t.end();
+});


### PR DESCRIPTION
Resolves https://github.com/stdlib-js/metr-issue-tracker/issues/129.

## Description

> What is the purpose of this pull request?

This pull request:

-   add ESLint rule disallowing string concatenation in benchmark descriptions

## Related Issues

> Does this pull request have any related issues?

None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [x] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Implementation was written by Claude Code according to my specifications.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
