### PR TITLE
feat: add `constants/float16/sqrt-pi`

### DIFF
--- a/lib/node_modules/@stdlib/constants/float16/sqrt-pi/README.md
+++ b/lib/node_modules/@stdlib/constants/float16/sqrt-pi/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 # FLOAT16_SQRT_PI
 
-> Square root of the mathematical constant [π][@stdlib/constants/float16/pi].
+> Square root of the mathematical constant [π][pi].
 
 <section class="intro">
 
@@ -38,7 +38,7 @@ var FLOAT16_SQRT_PI = require( '@stdlib/constants/float16/sqrt-pi' );
 
 #### FLOAT16_SQRT_PI
 
-Square root of the mathematical constant [π][@stdlib/constants/float16/pi].
+Square root of the mathematical constant [π][pi].
 
 ```javascript
 var bool = ( FLOAT16_SQRT_PI === 1.7724609375 );
@@ -88,7 +88,7 @@ console.log( FLOAT16_SQRT_PI );
 
 <section class="links">
 
-[@stdlib/constants/float16/pi]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/constants/float16/pi
+[pi]: https://en.wikipedia.org/wiki/Pi
 
 </section>
 

--- a/lib/node_modules/@stdlib/constants/float16/sqrt-pi/README.md
+++ b/lib/node_modules/@stdlib/constants/float16/sqrt-pi/README.md
@@ -1,0 +1,95 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2025 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# FLOAT16_SQRT_PI
+
+> Square root of the mathematical constant [π][@stdlib/constants/float16/pi].
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var FLOAT16_SQRT_PI = require( '@stdlib/constants/float16/sqrt-pi' );
+```
+
+#### FLOAT16_SQRT_PI
+
+Square root of the mathematical constant [π][@stdlib/constants/float16/pi].
+
+```javascript
+var bool = ( FLOAT16_SQRT_PI === 1.7724609375 );
+// returns true
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+The value is approximately `1.7724538509055159...` in double precision. Due to the limited precision of half-precision floating-point format (float16), the constant is rounded to `1.7724609375`.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var FLOAT16_SQRT_PI = require( '@stdlib/constants/float16/sqrt-pi' );
+
+console.log( FLOAT16_SQRT_PI );
+// => 1.7724609375
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[@stdlib/constants/float16/pi]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/constants/float16/pi
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/constants/float16/sqrt-pi/docs/repl.txt
+++ b/lib/node_modules/@stdlib/constants/float16/sqrt-pi/docs/repl.txt
@@ -1,0 +1,12 @@
+
+{{alias}}
+    Square root of the mathematical constant `π`.
+
+    Examples
+    --------
+    > {{alias}}
+    1.7724609375
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/constants/float16/sqrt-pi/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/constants/float16/sqrt-pi/docs/types/index.d.ts
@@ -1,0 +1,33 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Square root of the mathematical constant `π`.
+*
+* @example
+* var val = FLOAT16_SQRT_PI;
+* // returns 1.7724609375
+*/
+declare const FLOAT16_SQRT_PI: number;
+
+
+// EXPORTS //
+
+export = FLOAT16_SQRT_PI;

--- a/lib/node_modules/@stdlib/constants/float16/sqrt-pi/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/constants/float16/sqrt-pi/docs/types/test.ts
@@ -1,0 +1,28 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import FLOAT16_SQRT_PI = require( './index' );
+
+
+// TESTS //
+
+// The export is a number...
+{
+	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+	FLOAT16_SQRT_PI; // $ExpectType number
+}

--- a/lib/node_modules/@stdlib/constants/float16/sqrt-pi/examples/index.js
+++ b/lib/node_modules/@stdlib/constants/float16/sqrt-pi/examples/index.js
@@ -18,7 +18,7 @@
 
 'use strict';
 
-var FLOAT16_SQRT_PI = require('./../lib');
+var FLOAT16_SQRT_PI = require( './../lib' );
 
-console.log(FLOAT16_SQRT_PI);
+console.log( FLOAT16_SQRT_PI );
 // => 1.7724609375

--- a/lib/node_modules/@stdlib/constants/float16/sqrt-pi/examples/index.js
+++ b/lib/node_modules/@stdlib/constants/float16/sqrt-pi/examples/index.js
@@ -1,0 +1,24 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var FLOAT16_SQRT_PI = require('./../lib');
+
+console.log(FLOAT16_SQRT_PI);
+// => 1.7724609375

--- a/lib/node_modules/@stdlib/constants/float16/sqrt-pi/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float16/sqrt-pi/lib/index.js
@@ -1,0 +1,49 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Square root of the mathematical constant `π`.
+*
+* @module @stdlib/constants/float16/sqrt-pi
+* @type {number}
+*
+* @example
+* var FLOAT16_SQRT_PI = require( '@stdlib/constants/float16/sqrt-pi' );
+* // returns 1.7724609375
+*/
+
+
+// MAIN //
+
+/**
+* Square root of the mathematical constant `π`.
+*
+* @constant
+* @type {number}
+* @default 1.7724609375
+* @see [OEIS]{@link https://oeis.org/A002161}
+* @see [Wikipedia]{@link https://en.wikipedia.org/wiki/Pi}
+*/
+var FLOAT16_SQRT_PI = 1.7724609375;
+
+
+// EXPORTS //
+
+module.exports = FLOAT16_SQRT_PI;

--- a/lib/node_modules/@stdlib/constants/float16/sqrt-pi/package.json
+++ b/lib/node_modules/@stdlib/constants/float16/sqrt-pi/package.json
@@ -1,0 +1,67 @@
+{
+    "name": "@stdlib/constants/float16/sqrt-pi",
+    "version": "0.0.0",
+    "description": "Square root of the mathematical constant π as a half-precision floating-point number.",
+    "license": "Apache-2.0",
+    "author": {
+        "name": "The Stdlib Authors",
+        "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    },
+    "contributors": [
+        {
+            "name": "The Stdlib Authors",
+            "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+        }
+    ],
+    "main": "./lib",
+    "directories": {
+        "doc": "./docs",
+        "example": "./examples",
+        "lib": "./lib",
+        "test": "./test"
+    },
+    "types": "./docs/types",
+    "scripts": {},
+    "homepage": "https://github.com/stdlib-js/stdlib",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/stdlib-js/stdlib.git"
+    },
+    "bugs": {
+        "url": "https://github.com/stdlib-js/stdlib/issues"
+    },
+    "dependencies": {},
+    "devDependencies": {},
+    "engines": {
+        "node": ">=0.10.0",
+        "npm": ">2.7.0"
+    },
+    "os": [
+        "aix",
+        "darwin",
+        "freebsd",
+        "linux",
+        "macos",
+        "openbsd",
+        "sunos",
+        "win32",
+        "windows"
+    ],
+    "keywords": [
+        "stdlib",
+        "stdmath",
+        "constant",
+        "const",
+        "mathematics",
+        "math",
+        "pi",
+        "sqrt",
+        "square",
+        "root",
+        "ieee754",
+        "half",
+        "precision",
+        "floating-point",
+        "float16"
+    ]
+}

--- a/lib/node_modules/@stdlib/constants/float16/sqrt-pi/package.json
+++ b/lib/node_modules/@stdlib/constants/float16/sqrt-pi/package.json
@@ -1,67 +1,64 @@
 {
-    "name": "@stdlib/constants/float16/sqrt-pi",
-    "version": "0.0.0",
-    "description": "Square root of the mathematical constant π as a half-precision floating-point number.",
-    "license": "Apache-2.0",
-    "author": {
-        "name": "The Stdlib Authors",
-        "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
-    },
-    "contributors": [
-        {
-            "name": "The Stdlib Authors",
-            "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
-        }
-    ],
-    "main": "./lib",
-    "directories": {
-        "doc": "./docs",
-        "example": "./examples",
-        "lib": "./lib",
-        "test": "./test"
-    },
-    "types": "./docs/types",
-    "scripts": {},
-    "homepage": "https://github.com/stdlib-js/stdlib",
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/stdlib-js/stdlib.git"
-    },
-    "bugs": {
-        "url": "https://github.com/stdlib-js/stdlib/issues"
-    },
-    "dependencies": {},
-    "devDependencies": {},
-    "engines": {
-        "node": ">=0.10.0",
-        "npm": ">2.7.0"
-    },
-    "os": [
-        "aix",
-        "darwin",
-        "freebsd",
-        "linux",
-        "macos",
-        "openbsd",
-        "sunos",
-        "win32",
-        "windows"
-    ],
-    "keywords": [
-        "stdlib",
-        "stdmath",
-        "constant",
-        "const",
-        "mathematics",
-        "math",
-        "pi",
-        "sqrt",
-        "square",
-        "root",
-        "ieee754",
-        "half",
-        "precision",
-        "floating-point",
-        "float16"
-    ]
+  "name": "@stdlib/constants/float16/sqrt-pi",
+  "version": "0.0.0",
+  "description": "Half-precision (float16) approximation of the square root of π.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "constant",
+    "const",
+    "mathematics",
+    "math",
+    "pi",
+    "sqrt",
+    "ieee754",
+    "float",
+    "floating-point",
+    "float16"
+  ]
 }

--- a/lib/node_modules/@stdlib/constants/float16/sqrt-pi/test/test.js
+++ b/lib/node_modules/@stdlib/constants/float16/sqrt-pi/test/test.js
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var FLOAT16_SQRT_PI = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a number', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof FLOAT16_SQRT_PI, 'number', 'main export is a number' );
+	t.end();
+});
+
+tape( 'export is a half-precision floating-point number equal to 1.7724609375', function test( t ) {
+	t.strictEqual( FLOAT16_SQRT_PI, 1.7724609375, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
## Description

> What is the purpose of this pull request?

This pull request:

-   adds `@stdlib/constants/float16/sqrt-pi`, which provides the square root of the mathematical constant π as a half-precision floating-point number

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

- **Float64 value**: `1.7724538509055159...`
- **Float16 value**: `1.7724609375`

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md