### PR TITLE
docs: improve doctests for complex number instances in `math/base/special/csignumf`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/csignumf/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/README.md
@@ -46,35 +46,14 @@ Evaluates the [signum][signum] function of a single-precision complex floating-p
 
 ```javascript
 var Complex64 = require( '@stdlib/complex/float32/ctor' );
-var real = require( '@stdlib/complex/float32/real' );
-var imag = require( '@stdlib/complex/float32/imag' );
-
 var v = csignumf( new Complex64( -4.2, 5.5 ) );
-// returns <Complex64>
-
-var re = real( v );
-// returns ~-0.607
-
-var im = imag( v );
-// returns ~0.795
+// returns <Complex64>[ ~-0.607, ~0.795 ]
 
 v = csignumf( new Complex64( 0.0, 0.0 ) );
-// returns <Complex64>
-
-re = real( v );
-// returns 0.0
-
-im = imag( v );
-// returns 0.0
+// returns <Complex64>[ 0.0, 0.0 ]
 
 v = csignumf( new Complex64( NaN, NaN ) );
-// returns <Complex64>
-
-re = real( v );
-// returns NaN
-
-im = imag( v );
-// returns NaN
+// returns <Complex64>[ NaN, NaN ]
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/docs/repl.txt
@@ -16,11 +16,7 @@
     Examples
     --------
     > var v = {{alias}}( new {{alias:@stdlib/complex/float32/ctor}}( -4.2, 5.5 ) )
-    <Complex64>
-    > var re = {{alias:@stdlib/complex/float32/real}}( v )
-    ~-0.607
-    > var im = {{alias:@stdlib/complex/float32/imag}}( v )
-    ~0.795
+    <Complex64>[ ~-0.607, ~0.795 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/docs/types/index.d.ts
@@ -30,17 +30,9 @@ import { Complex64 } from '@stdlib/types/complex';
 *
 * @example
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var real = require( '@stdlib/complex/float32/real' );
-* var imag = require( '@stdlib/complex/float32/imag' );
 *
 * var v = csignumf( new Complex64( -4.2, 5.5 ) );
-* // returns <Complex64>
-*
-* var re = real( v );
-* // returns ~-0.607
-*
-* var im = imag( v );
-* // returns ~0.795
+* // returns <Complex64>[ ~-0.607, ~0.795 ]
 */
 declare function csignumf( z: Complex64 ): Complex64;
 

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/lib/index.js
@@ -25,36 +25,16 @@
 *
 * @example
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var real = require( '@stdlib/complex/float32/real' );
-* var imag = require( '@stdlib/complex/float32/imag' );
 * var csignumf = require( '@stdlib/math/base/special/csignumf' );
 *
 * var v = csignumf( new Complex64( -4.2, 5.5 ) );
-* // returns <Complex64>
-*
-* var re = real( v );
-* // returns ~-0.607
-*
-* var im = imag( v );
-* // returns ~0.795
+* // returns <Complex64>[ ~-0.607, ~0.795 ]
 *
 * v = csignumf( new Complex64( 0.0, 0.0 ) );
-* // returns <Complex64>
-*
-* re = real( v );
-* // returns 0.0
-*
-* im = imag( v );
-* // returns 0.0
+* // returns <Complex64>[ 0.0, 0.0 ]
 *
 * v = csignumf( new Complex64( NaN, NaN ) );
-* // returns <Complex64>
-*
-* re = real( v );
-* // returns NaN
-*
-* im = imag( v );
-* // returns NaN
+* // returns <Complex64>[ NaN, NaN ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/lib/main.js
@@ -37,35 +37,15 @@ var cabsf = require( '@stdlib/math/base/special/cabsf' );
 *
 * @example
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var real = require( '@stdlib/complex/float32/real' );
-* var imag = require( '@stdlib/complex/float32/imag' );
 *
 * var v = csignumf( new Complex64( -4.2, 5.5 ) );
-* // returns <Complex64>
-*
-* var re = real( v );
-* // returns ~-0.607
-*
-* var im = imag( v );
-* // returns ~0.795
+* // returns <Complex64>[ ~-0.607, ~0.795 ]
 *
 * v = csignumf( new Complex64( 0.0, 0.0 ) );
-* // returns <Complex64>
-*
-* re = real( v );
-* // returns 0.0
-*
-* im = imag( v );
-* // returns 0.0
+* // returns <Complex64>[ 0.0, 0.0 ]
 *
 * v = csignumf( new Complex64( NaN, NaN ) );
-* // returns <Complex64>
-*
-* re = real( v );
-* // returns NaN
-*
-* im = imag( v );
-* // returns NaN
+* // returns <Complex64>[ NaN, NaN ]
 */
 function csignumf( z ) {
 	var re;

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/lib/native.js
@@ -35,35 +35,15 @@ var addon = require( './../src/addon.node' );
 *
 * @example
 * var Complex64 = require( '@stdlib/complex/float32/ctor' );
-* var real = require( '@stdlib/complex/float32/real' );
-* var imag = require( '@stdlib/complex/float32/imag' );
 *
 * var v = csignumf( new Complex64( -4.2, 5.5 ) );
-* // returns <Complex64>
-*
-* var re = real( v );
-* // returns ~-0.607
-*
-* var im = imag( v );
-* // returns ~0.795
+* // returns <Complex64>[ ~-0.607, ~0.795 ]
 *
 * v = csignumf( new Complex64( 0.0, 0.0 ) );
-* // returns <Complex64>
-*
-* re = real( v );
-* // returns 0.0
-*
-* im = imag( v );
-* // returns 0.0
+* // returns <Complex64>[ 0.0, 0.0 ]
 *
 * v = csignumf( new Complex64( NaN, NaN ) );
-* // returns <Complex64>
-*
-* re = real( v );
-* // returns NaN
-*
-* im = imag( v );
-* // returns NaN
+* // returns <Complex64>[ NaN, NaN ]
 */
 function csignumf( z ) {
 	var v = addon( z );

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/src/main.c
@@ -35,7 +35,12 @@
 * stdlib_complex64_t z = stdlib_complex64( -4.2f, 5.5f );
 *
 * stdlib_complex64_t out = stdlib_base_csignumf( z );
-* // returns <Complex64>[ ~-0.607f, ~0.795f ]
+*
+* float re = stdlib_complex64_real( out );
+* // returns ~-0.607f
+*
+* float im = stdlib_complex64_imag( out );
+* // returns ~0.795f
 */
 stdlib_complex64_t stdlib_base_csignumf( const stdlib_complex64_t z ) {
 	float re;

--- a/lib/node_modules/@stdlib/math/base/special/csignumf/src/main.c
+++ b/lib/node_modules/@stdlib/math/base/special/csignumf/src/main.c
@@ -35,12 +35,7 @@
 * stdlib_complex64_t z = stdlib_complex64( -4.2f, 5.5f );
 *
 * stdlib_complex64_t out = stdlib_base_csignumf( z );
-*
-* float re = stdlib_complex64_real( out );
-* // returns ~-0.607f
-*
-* float im = stdlib_complex64_imag( out );
-* // returns ~0.795f
+* // returns <Complex64>[ ~-0.607f, ~0.795f ]
 */
 stdlib_complex64_t stdlib_base_csignumf( const stdlib_complex64_t z ) {
 	float re;


### PR DESCRIPTION
Resolves a part of #8641.

## Description

This pull request:

-   Updates REPL and documentation examples in the `maths/base/special/csignumf` package to use the compact complex instance doctest notation.
- Replaces example decomposition using realf/imagf with concise doctest annotations.


## Related Issues


This pull request has the following related issues:

-   #8641

## Questions


No.

## Other


No.

## Checklist


-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance


-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

N.A.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
