### PR TITLE
docs: improve doctests for complex number instances in `strided/base/zmap`

### DIFF
--- a/lib/node_modules/@stdlib/strided/base/zmap/README.md
+++ b/lib/node_modules/@stdlib/strided/base/zmap/README.md
@@ -52,13 +52,7 @@ var y = new Complex128Array( x.length );
 zmap( x.length, x, 1, y, 1, cceil );
 
 var v = y.get( 0 );
-// returns <Complex128>
-
-var re = real( v );
-// returns -2.0
-
-var im = imag( v );
-// returns 2.0
+// returns <Complex128>[ -2.0, 2.0 ]
 ```
 
 The function accepts the following arguments:
@@ -84,13 +78,7 @@ var y = new Complex128Array( x.length );
 zmap( 2, x, 2, y, -1, cceil );
 
 var v = y.get( 0 );
-// returns <Complex128>
-
-var re = real( v );
-// returns 5.0
-
-var im = imag( v );
-// returns 0.0
+// returns <Complex128>[ 5.0, 0.0 ]
 ```
 
 Note that indexing is relative to the first index. To introduce an offset, use [`typed array`][@stdlib/array/complex128] views.
@@ -112,13 +100,7 @@ var y1 = new Complex128Array( y0.buffer, y0.BYTES_PER_ELEMENT*2 ); // start at 3
 zmap( 2, x1, -2, y1, 1, cceil );
 
 var v = y0.get( 2 );
-// returns <Complex128>
-
-var re = real( v );
-// returns -1.0
-
-var im = imag( v );
-// returns 4.0
+// returns <Complex128>[ -1.0, 4.0 ]
 ```
 
 #### zmap.ndarray( N, x, strideX, offsetX, y, strideY, offsetY, fcn )
@@ -137,13 +119,7 @@ var y = new Complex128Array( x.length );
 zmap.ndarray( x.length, x, 1, 0, y, 1, 0, cceil );
 
 var v = y.get( 0 );
-// returns <Complex128>
-
-var re = real( v );
-// returns -2.0
-
-var im = imag( v );
-// returns 2.0
+// returns <Complex128>[ -2.0, 2.0 ]
 ```
 
 The function accepts the following additional arguments:
@@ -165,13 +141,7 @@ var y = new Complex128Array( x.length );
 zmap.ndarray( 2, x, 2, 1, y, -1, y.length-1, cceil );
 
 var v = y.get( y.length-1 );
-// returns <Complex128>
-
-var re = real( v );
-// returns 4.0
-
-var im = imag( v );
-// returns -5.0
+// returns <Complex128>[ 4.0, -5.0 ]
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/strided/base/zmap/README.md
+++ b/lib/node_modules/@stdlib/strided/base/zmap/README.md
@@ -42,8 +42,6 @@ Applies a unary function to a double-precision complex floating-point strided in
 
 ```javascript
 var Complex128Array = require( '@stdlib/array/complex128' );
-var real = require( '@stdlib/complex/float64/real' );
-var imag = require( '@stdlib/complex/float64/imag' );
 var cceil = require( '@stdlib/math/base/special/cceil' );
 
 var x = new Complex128Array( [ -2.3, 1.5, 3.1, -5.2, 4.8, 0.0, -1.6, 3.4 ] );
@@ -68,8 +66,6 @@ The `N` and stride parameters determine which elements in the strided arrays are
 
 ```javascript
 var Complex128Array = require( '@stdlib/array/complex128' );
-var real = require( '@stdlib/complex/float64/real' );
-var imag = require( '@stdlib/complex/float64/imag' );
 var cceil = require( '@stdlib/math/base/special/cceil' );
 
 var x = new Complex128Array( [ -2.3, 1.5, 3.1, -5.2, 4.8, 0.0, -1.6, 3.4 ] );
@@ -85,8 +81,6 @@ Note that indexing is relative to the first index. To introduce an offset, use [
 
 ```javascript
 var Complex128Array = require( '@stdlib/array/complex128' );
-var real = require( '@stdlib/complex/float64/real' );
-var imag = require( '@stdlib/complex/float64/imag' );
 var cceil = require( '@stdlib/math/base/special/cceil' );
 
 // Initial arrays...
@@ -109,8 +103,6 @@ Applies a unary function to a double-precision complex floating-point strided in
 
 ```javascript
 var Complex128Array = require( '@stdlib/array/complex128' );
-var real = require( '@stdlib/complex/float64/real' );
-var imag = require( '@stdlib/complex/float64/imag' );
 var cceil = require( '@stdlib/math/base/special/cceil' );
 
 var x = new Complex128Array( [ -2.3, 1.5, 3.1, -5.2, 4.8, 0.0, -1.6, 3.4 ] );
@@ -131,8 +123,6 @@ While [`typed array`][@stdlib/array/complex128] views mandate a view offset base
 
 ```javascript
 var Complex128Array = require( '@stdlib/array/complex128' );
-var real = require( '@stdlib/complex/float64/real' );
-var imag = require( '@stdlib/complex/float64/imag' );
 var cceil = require( '@stdlib/math/base/special/cceil' );
 
 var x = new Complex128Array( [ -2.3, 1.5, 3.1, -5.2, 4.8, 0.0, -1.6, 3.4 ] );

--- a/lib/node_modules/@stdlib/strided/base/zmap/docs/repl.txt
+++ b/lib/node_modules/@stdlib/strided/base/zmap/docs/repl.txt
@@ -43,21 +43,13 @@
     > var y = new {{alias:@stdlib/array/complex128}}( x.length );
     > {{alias}}( x.length, x, 1, y, 1, {{alias:@stdlib/complex/float64/base/identity}} );
     > var v = y.get( 0 )
-    <Complex128>
-    > var re = {{alias:@stdlib/complex/float64/real}}( v )
-    1.0
-    > var im = {{alias:@stdlib/complex/float64/imag}}( v )
-    2.0
+    <Complex128>[ 1.0, 2.0 ]
 
     // Using `N` and stride parameters:
     > y = new {{alias:@stdlib/array/complex128}}( x.length );
     > {{alias}}( 2, x, 2, y, -1, {{alias:@stdlib/complex/float64/base/identity}} );
     > v = y.get( 0 )
-    <Complex128>
-    > re = {{alias:@stdlib/complex/float64/real}}( v )
-    5.0
-    > im = {{alias:@stdlib/complex/float64/imag}}( v )
-    6.0
+    <Complex128>[ 5.0, 6.0 ]
 
     // Using view offsets:
     > var x0 = new {{alias:@stdlib/array/complex128}}( xbuf );
@@ -66,11 +58,7 @@
     > var y1 = new {{alias:@stdlib/array/complex128}}( y0.buffer, y0.BYTES_PER_ELEMENT*2 );
     > {{alias}}( 2, x1, -2, y1, 1, {{alias:@stdlib/complex/float64/base/identity}} );
     > v = y1.get( 0 )
-    <Complex128>
-    > re = {{alias:@stdlib/complex/float64/real}}( v )
-    7.0
-    > im = {{alias:@stdlib/complex/float64/imag}}( v )
-    8.0
+    <Complex128>[ 7.0, 8.0 ]
 
 
 {{alias}}.ndarray( N, x, strideX, offsetX, y, strideY, offsetY, fcn )
@@ -121,22 +109,14 @@
     > var y = new {{alias:@stdlib/array/complex128}}( x.length );
     > {{alias}}.ndarray( x.length, x, 1, 0, y, 1, 0, {{alias:@stdlib/complex/float64/base/identity}} );
     > var v = y.get( 0 )
-    <Complex128>
-    > var re = {{alias:@stdlib/complex/float64/real}}( v )
-    1.0
-    > var im = {{alias:@stdlib/complex/float64/imag}}( v )
-    2.0
+    <Complex128>[ 1.0, 2.0 ]
 
     // Advanced indexing:
     > x = new {{alias:@stdlib/array/complex128}}( xbuf );
     > y = new {{alias:@stdlib/array/complex128}}( x.length );
     > {{alias}}.ndarray( 2, x, 2, 1, y, -1, y.length-1, {{alias:@stdlib/complex/float64/base/identity}} );
     > v = y.get( y.length-1 )
-    <Complex128>
-    > re = {{alias:@stdlib/complex/float64/real}}( v )
-    3.0
-    > im = {{alias:@stdlib/complex/float64/imag}}( v )
-    4.0
+    <Complex128>[ 3.0, 4.0 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/strided/base/zmap/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/strided/base/zmap/docs/types/index.d.ts
@@ -64,13 +64,7 @@ interface Routine {
 	* zmap( x.length, x, 1, y, 1, scale );
 	*
 	* var v = y.get( 0 );
-	* // returns <Complex128>
-	*
-	* var re = real( v );
-	* // returns 10.0
-	*
-	* var im = imag( v );
-	* // returns 10.0
+	* // returns <Complex128>[ 10.0, 10.0 ]
 	*/
 	( N: number, x: Complex128Array, strideX: number, y: Complex128Array, strideY: number, fcn: Unary ): Complex128Array;
 
@@ -105,13 +99,7 @@ interface Routine {
 	* zmap.ndarray( x.length, x, 1, 0, y, 1, 0, scale );
 	*
 	* var v = y.get( 0 );
-	* // returns <Complex128>
-	*
-	* var re = real( v );
-	* // returns 10.0
-	*
-	* var im = imag( v );
-	* // returns 10.0
+	* // returns <Complex128>[ 10.0, 10.0 ]
 	*/
 	ndarray( N: number, x: Complex128Array, strideX: number, offsetX: number, y: Complex128Array, strideY: number, offsetY: number, fcn: Unary ): Complex128Array;
 }
@@ -145,13 +133,7 @@ interface Routine {
 * zmap( x.length, x, 1, y, 1, scale );
 *
 * var v = y.get( 0 );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns 10.0
-*
-* var im = imag( v );
-* // returns 10.0
+* // returns <Complex128>[ 10.0, 10.0 ]
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
@@ -171,13 +153,7 @@ interface Routine {
 * zmap.ndarray( x.length, x, 1, 0, y, 1, 0, scale );
 *
 * var v = y.get( 0 );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns 10.0
-*
-* var im = imag( v );
-* // returns 10.0
+* // returns <Complex128>[ 10.0, 10.0 ]
 */
 declare var zmap: Routine;
 

--- a/lib/node_modules/@stdlib/strided/base/zmap/lib/index.js
+++ b/lib/node_modules/@stdlib/strided/base/zmap/lib/index.js
@@ -42,13 +42,7 @@
 * zmap( x.length, x, 1, y, 1, scale );
 *
 * var v = y.get( 0 );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns 10.0
-*
-* var im = imag( v );
-* // returns 10.0
+* // returns <Complex128>[ 10.0, 10.0 ]
 *
 * @example
 * var Complex128Array = require( '@stdlib/array/complex128' );
@@ -69,13 +63,7 @@
 * zmap.ndarray( x.length, x, 1, 0, y, 1, 0, scale );
 *
 * var v = y.get( 0 );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns 10.0
-*
-* var im = imag( v );
-* // returns 10.0
+* // returns <Complex128>[ 10.0, 10.0 ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/strided/base/zmap/lib/main.js
+++ b/lib/node_modules/@stdlib/strided/base/zmap/lib/main.js
@@ -55,13 +55,7 @@ var ndarray = require( './ndarray.js' );
 * zmap( x.length, x, 1, y, 1, scale );
 *
 * var v = y.get( 0 );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns 10.0
-*
-* var im = imag( v );
-* // returns 10.0
+* // returns <Complex128>[ 10.0, 10.0 ]
 */
 function zmap( N, x, strideX, y, strideY, fcn ) {
 	return ndarray( N, x, strideX, stride2offset( N, strideX ), y, strideY, stride2offset( N, strideY ), fcn ); // eslint-disable-line max-len

--- a/lib/node_modules/@stdlib/strided/base/zmap/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/strided/base/zmap/lib/ndarray.js
@@ -51,13 +51,7 @@
 * zmap( x.length, x, 1, 0, y, 1, 0, scale );
 *
 * var v = y.get( 0 );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns 10.0
-*
-* var im = imag( v );
-* // returns 10.0
+* // returns <Complex128>[ 10.0, 10.0 ]
 */
 function zmap( N, x, strideX, offsetX, y, strideY, offsetY, fcn ) {
 	var ix;


### PR DESCRIPTION
Resolves a part of #8641.

## Description

This pull request:

-  Updates REPL and documentation examples in the `strided/base/zmap` to use the compact complex instance doctest notation.
-  Replaces example decomposition using realf/imagf with concise doctest annotations.


## Related Issues


This pull request has the following related issues:

-   #8641

## Questions


No.

## Other


No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

N.A.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
