### PR TITLE
bench: refactor to use string interpolation in `array/base/take-indexed2`

### DIFF
--- a/lib/node_modules/@stdlib/array/base/take-indexed2/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/array/base/take-indexed2/benchmark/benchmark.js
@@ -23,13 +23,14 @@
 var bench = require( '@stdlib/bench' );
 var isArrayArray = require( '@stdlib/assert/is-array-array' );
 var zeroTo = require( '@stdlib/array/base/zero-to' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var take2 = require( './../lib' );
 
 
 // MAIN //
 
-bench( pkg+'::copy:len=100', function benchmark( b ) {
+bench( format( '%s::copy:len=%d', pkg, 100 ), function benchmark( b ) {
 	var x;
 	var i;
 	var v;

--- a/lib/node_modules/@stdlib/array/base/take-indexed2/benchmark/benchmark.length.js
+++ b/lib/node_modules/@stdlib/array/base/take-indexed2/benchmark/benchmark.length.js
@@ -25,6 +25,7 @@ var pow = require( '@stdlib/math/base/special/pow' );
 var filledBy = require( '@stdlib/array/base/filled-by' );
 var discreteUniform = require( '@stdlib/random/base/discrete-uniform' ).factory;
 var isArrayArray = require( '@stdlib/assert/is-array-array' );
+var format = require( '@stdlib/string/format' );
 var pkg = require( './../package.json' ).name;
 var take2 = require( './../lib' );
 
@@ -92,7 +93,7 @@ function main() {
 	for ( i = min; i <= max; i++ ) {
 		len = pow( 10, i );
 		f = createBenchmark( len );
-		bench( pkg+':len='+len, f );
+		bench( format( '%s:len=%d', pkg, len ), f );
 	}
 }
 


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: passed
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Ref: #8647

## Description

> What is the purpose of this pull request?

This pull request:

- Refactors JavaScript benchmarks in `@stdlib/array/base/take-indexed2` to use `@stdlib/string/format` for string interpolation instead of string concatenation when specifying benchmark names.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-  [RFC]: use string interpolation in JavaScript benchmarks for the benchmark name (tracking issue) #8647

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
