### PR TITLE
test: add non-numeric argument test to `string/base/format-interpolate`

### DIFF
--- a/lib/node_modules/@stdlib/string/base/format-interpolate/test/test.format_integer.js
+++ b/lib/node_modules/@stdlib/string/base/format-interpolate/test/test.format_integer.js
@@ -168,3 +168,53 @@ tape( 'the function returns an integer-formatted token argument (precision)', fu
 
 	t.end();
 });
+
+tape( 'the function throws an error for non-numeric input', function test( t ) {
+	var token;
+
+	token = {
+		'specifier': 'd',
+		'arg': 'abc'
+	};
+
+	t.throws( badToken( token ), Error, 'throws an error when provided arg '+token.arg );
+
+	t.end();
+
+	function badToken( token ) {
+		return function badToken() {
+			formatInteger( token );
+		};
+	}
+});
+
+tape( 'the function coerces non-finite numeric input to empty string', function test( t ) {
+	var expected;
+	var actual;
+	var token;
+
+	expected = '';
+
+	token = {
+		'specifier': 'd',
+		'arg': NaN
+	};
+	actual = formatInteger( token );
+	t.strictEqual( actual, expected, 'returns expected empty string' );
+
+	token = {
+		'specifier': 'd',
+		'arg': Infinity
+	};
+	actual = formatInteger( token );
+	t.strictEqual( actual, expected, 'returns expected empty string' );
+
+	token = {
+		'specifier': 'd',
+		'arg': -Infinity
+	};
+	actual = formatInteger( token );
+	t.strictEqual( actual, expected, 'returns expected empty string' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/string/base/format-interpolate/test/test.format_integer.js
+++ b/lib/node_modules/@stdlib/string/base/format-interpolate/test/test.format_integer.js
@@ -214,7 +214,7 @@ tape( 'the function coerces non-finite numeric input to empty string', function 
 		'arg': -Infinity
 	};
 	actual = formatInteger( token );
-	t.strictEqual( actual, expected, 'returns expected empty string' );
+	t.strictEqual( actual, expected, 'returns expected value' );
 
 	t.end();
 });

--- a/lib/node_modules/@stdlib/string/base/format-interpolate/test/test.format_integer.js
+++ b/lib/node_modules/@stdlib/string/base/format-interpolate/test/test.format_integer.js
@@ -207,7 +207,7 @@ tape( 'the function coerces non-finite numeric input to empty string', function 
 		'arg': Infinity
 	};
 	actual = formatInteger( token );
-	t.strictEqual( actual, expected, 'returns expected empty string' );
+	t.strictEqual( actual, expected, 'returns expected value' );
 
 	token = {
 		'specifier': 'd',

--- a/lib/node_modules/@stdlib/string/base/format-interpolate/test/test.format_integer.js
+++ b/lib/node_modules/@stdlib/string/base/format-interpolate/test/test.format_integer.js
@@ -200,7 +200,7 @@ tape( 'the function coerces non-finite numeric input to empty string', function 
 		'arg': NaN
 	};
 	actual = formatInteger( token );
-	t.strictEqual( actual, expected, 'returns expected empty string' );
+	t.strictEqual( actual, expected, 'returns expected value' );
 
 	token = {
 		'specifier': 'd',


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: passed
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

## Description

> What is the purpose of this pull request?

This pull request:

-  adds test for `@stdlib/string/base/format-interpolate/lib/format_integer.js` to cover the case where in arg in the input token is non numeric or infinity 

## Related Issues

> Does this pull request have any related issues?

No.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
