### PR TITLE
chore: fix JavaScript lint error (issue #9067)

### DIFF
--- a/lib/node_modules/@stdlib/array/base/assert/is-signed-integer-data-type/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/array/base/assert/is-signed-integer-data-type/docs/types/index.d.ts
@@ -58,7 +58,7 @@
 * bool = isSignedIntegerDataType( 'foo' );
 * // returns false
 */
-declare function isSignedIntegerDataType( v: any ): boolean;
+declare function isSignedIntegerDataType( v: unknown ): boolean;
 
 
 // EXPORTS //


### PR DESCRIPTION
Resolves #9067.

## Description

This pull request fixes a JavaScript/TypeScript linting error caused by the use of an explicit `any` type in a TypeScript declaration file.

Specifically, this change replaces `any` with `unknown` in the type definition for `isSignedIntegerDataType`, bringing the file into compliance with stdlib linting rules and TypeScript best practices.

## Related Issues

This pull request has the following related issues:

- #9067

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the contributing guidelines.

### AI Assistance

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

I consulted ChatGPT to understand the linting error and confirm the appropriate TypeScript type replacement. The code change itself was authored manually.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md).
