### PR TITLE
docs: fix broken Markdown link (issue #9113)

### DIFF
--- a/etc/pydocstyle/README.md
+++ b/etc/pydocstyle/README.md
@@ -1,3 +1,23 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2017 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
 # pydocstyle
 
 > [pydocstyle][pydocstyle] configuration.
@@ -24,7 +44,7 @@ This directory contains [pydocstyle][pydocstyle] configuration files.
 
 <section class="links">
 
-[pydocstyle]: http://pydocstyle.com/
+[pydocstyle]: https://github.com/PyCQA/pydocstyle
 
 </section>
 


### PR DESCRIPTION
Resolves #9113

## Description

> What is the purpose of this pull request?
The purpose is to fix the broken markdown link of http://pydocstyle.com/ in etc/pydocstyle/README.md

This pull request:

-  This PR fixes the broken link `http://pydocstyle.com/` in `/etc/pydocstyle/README.md` by replacing it with the official GitHub repository URL `https://github.com/PyCQA/pydocstyle`.

The `pydocstyle.com` domain is no longer active. The GitHub repository is the official and authoritative source for the pydocstyle project. This change maintains consistency with how pydocstyle is already referenced throughout the codebase in:

- `tools/scripts/check_pydocstyle`
- `tools/make/lib/lint/python/pydocstyle.mk`
- `docs/contributing/development.md`
- `docs/links/database.json`

## Related Issues

> #9112

This pull request has the following related issues:

-   #9113

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
