### PR TITLE
docs: update return annotations to use ndarray instance notation for `stats/nanmax`

### DIFF
--- a/lib/node_modules/@stdlib/stats/nanmax/README.md
+++ b/lib/node_modules/@stdlib/stats/nanmax/README.md
@@ -40,10 +40,7 @@ var array = require( '@stdlib/ndarray/array' );
 var x = array( [ -1.0, 2.0, NaN ] );
 
 var y = nanmax( x );
-// returns <ndarray>
-
-var v = y.get();
-// returns 2.0
+// returns <ndarray>[ 2.0 ]
 ```
 
 The function has the following parameters:
@@ -60,81 +57,58 @@ The function accepts the following options:
 By default, the function performs a reduction over all elements in a provided input [ndarray][@stdlib/ndarray/ctor]. To perform a reduction over specific dimensions, provide a `dims` option.
 
 ```javascript
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var array = require( '@stdlib/ndarray/array' );
 
 var x = array( [ -1.0, 2.0, NaN, 4.0 ], {
     'shape': [ 2, 2 ],
     'order': 'row-major'
 });
-var v = ndarray2array( x );
-// returns [ [ -1.0, 2.0 ], [ NaN, 4.0 ] ]
+// returns <ndarray>[ [ -1.0, 2.0 ], [ NaN, 4.0 ] ]
 
 var y = nanmax( x, {
     'dims': [ 0 ]
 });
-// returns <ndarray>
-
-v = ndarray2array( y );
-// returns [ -1.0, 4.0 ]
+// returns <ndarray>[ -1.0, 4.0 ]
 
 y = nanmax( x, {
     'dims': [ 1 ]
 });
-// returns <ndarray>
-
-v = ndarray2array( y );
-// returns [ 2.0, 4.0 ]
+// returns <ndarray>[ 2.0, 4.0 ]
 
 y = nanmax( x, {
     'dims': [ 0, 1 ]
 });
-// returns <ndarray>
-
-v = y.get();
-// returns 4.0
+// returns <ndarray>[ 4.0 ]
 ```
 
 By default, the function excludes reduced dimensions from the output [ndarray][@stdlib/ndarray/ctor]. To include the reduced dimensions as singleton dimensions, set the `keepdims` option to `true`.
 
 ```javascript
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var array = require( '@stdlib/ndarray/array' );
 
 var x = array( [ -1.0, 2.0, NaN, 4.0 ], {
     'shape': [ 2, 2 ],
     'order': 'row-major'
 });
-
-var v = ndarray2array( x );
-// returns [ [ -1.0, 2.0 ], [ NaN, 4.0 ] ]
+// returns <ndarray>[ [ -1.0, 2.0 ], [ NaN, 4.0 ] ]
 
 var y = nanmax( x, {
     'dims': [ 0 ],
     'keepdims': true
 });
-// returns <ndarray>
-
-v = ndarray2array( y );
-// returns [ [ -1.0, 4.0 ] ]
+// returns <ndarray>[ [ -1.0, 4.0 ] ]
 
 y = nanmax( x, {
     'dims': [ 1 ],
     'keepdims': true
 });
-// returns <ndarray>
-
-v = ndarray2array( y );
-// returns [ [ 2.0 ], [ 4.0 ] ]
+// returns <ndarray>[ [ 2.0 ], [ 4.0 ] ]
 
 y = nanmax( x, {
     'dims': [ 0, 1 ],
     'keepdims': true
 });
-// returns <ndarray>
-
-v = ndarray2array( y );
-// returns [ [ 4.0 ] ]
+// returns <ndarray>[ [ 4.0 ] ]
 ```
 
 By default, the function returns an [ndarray][@stdlib/ndarray/ctor] having a [data type][@stdlib/ndarray/dtypes] determined by the function's output data type [policy][@stdlib/ndarray/output-dtype-policies]. To override the default behavior, set the `dtype` option.
@@ -150,7 +124,7 @@ var x = array( [ -1.0, 2.0, NaN ], {
 var y = nanmax( x, {
     'dtype': 'float64'
 });
-// returns <ndarray>
+// returns <ndarray>[ 2.0 ]
 
 var dt = String( getDType( y ) );
 // returns 'float64'
@@ -168,10 +142,7 @@ var x = array( [ -1.0, 2.0, NaN ] );
 var y = zeros( [] );
 
 var out = nanmax.assign( x, y );
-// returns <ndarray>
-
-var v = out.get();
-// returns 2.0
+// returns <ndarray>[ 2.0 ]
 
 var bool = ( out === y );
 // returns true

--- a/lib/node_modules/@stdlib/stats/nanmax/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/nanmax/docs/repl.txt
@@ -31,9 +31,8 @@
     Examples
     --------
     > var x = {{alias:@stdlib/ndarray/array}}( [ -1.0, 2.0, NaN, -4.0 ] );
-    > var y = {{alias}}( x );
-    > var v = y.get()
-    2.0
+    > var y = {{alias}}( x )
+    <ndarray>[ 2.0 ]
 
 
 {{alias}}.assign( x, out[, options] )
@@ -66,11 +65,9 @@
     > var x = {{alias:@stdlib/ndarray/array}}( [ -1.0, 2.0, NaN, -4.0 ] );
     > var out = {{alias:@stdlib/ndarray/zeros}}( [] );
     > var y = {{alias}}.assign( x, out )
-    <ndarray>
+    <ndarray>[ 2.0 ]
     > var bool = ( out === y )
     true
-    > var v = out.get()
-    2.0
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/stats/nanmax/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/nanmax/docs/types/index.d.ts
@@ -75,10 +75,7 @@ interface Unary {
 	* var x = array( [ -1.0, 2.0, NaN ] );
 	*
 	* var y = nanmax( x );
-	* // returns <ndarray>
-	*
-	* var v = y.get();
-	* // returns 2.0
+	* // returns <ndarray>[ 2.0 ]
 	*/
 	<T = unknown, U = unknown>( x: InputArray<T>, options?: Options ): OutputArray<U>; // NOTE: we lose type specificity here, but retaining specificity would likely be difficult and/or tedious to completely enumerate, as the output ndarray data type is dependent on how `x` interacts with output data type policy and whether that policy has been overridden by `options.dtype`.
 
@@ -98,10 +95,7 @@ interface Unary {
 	* var y = zeros( [] );
 	*
 	* var out = nanmax.assign( x, y );
-	* // returns <ndarray>
-	*
-	* var v = out.get();
-	* // returns 2.0
+	* // returns <ndarray>[ 2.0 ]
 	*
 	* var bool = ( out === y );
 	* // returns true
@@ -122,10 +116,7 @@ interface Unary {
 * var x = array( [ -1.0, 2.0, NaN ] );
 *
 * var y = nanmax( x );
-* // returns <ndarray>
-*
-* var v = y.get();
-* // returns 2.0
+* // returns <ndarray>[ 2.0 ]
 *
 * @example
 * var array = require( '@stdlib/ndarray/array' );
@@ -135,10 +126,7 @@ interface Unary {
 * var y = zeros( [] );
 *
 * var out = nanmax.assign( x, y );
-* // returns <ndarray>
-*
-* var v = out.get();
-* // returns 2.0
+* // returns <ndarray>[ 2.0 ]
 *
 * var bool = ( out === y );
 * // returns true

--- a/lib/node_modules/@stdlib/stats/nanmax/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/nanmax/lib/index.js
@@ -45,10 +45,7 @@
 *
 * // Perform reduction:
 * var out = nanmax( x );
-* // returns <ndarray>
-*
-* var v = out.get();
-* // returns 11.0
+* // returns <ndarray>[ 11.0 ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/stats/nanmax/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/nanmax/lib/main.js
@@ -88,10 +88,7 @@ var table = {
 *
 * // Perform reduction:
 * var out = nanmax( x );
-* // returns <ndarray>
-*
-* var v = out.get();
-* // returns 11.0
+* // returns <ndarray>[ 11.0 ]
 */
 var nanmax = factory( table, [ idtypes ], odtypes, policies );
 


### PR DESCRIPTION
Resolves None.

## Description

> What is the purpose of this pull request?

This pull request:

-  docs: update return annotations to use ndarray instance notation for `stats/nanmax`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-  None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [X] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [X] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
