### PR TITLE
docs: update return annotations to use ndarray instance notation for `stats/nanmax-by`

### DIFF
--- a/lib/node_modules/@stdlib/stats/nanmax-by/README.md
+++ b/lib/node_modules/@stdlib/stats/nanmax-by/README.md
@@ -44,10 +44,7 @@ function clbk( v ) {
 }
 
 var y = nanmaxBy( x, clbk );
-// returns <ndarray>
-
-var v = y.get();
-// returns 4.0
+// returns <ndarray>[ 4.0 ]
 ```
 
 The function has the following parameters:
@@ -81,10 +78,7 @@ var ctx = {
     'count': 0
 };
 var y = nanmaxBy( x, clbk, ctx );
-// returns <ndarray>
-
-var v = y.get();
-// returns 4.0
+// returns <ndarray>[ 4.0 ]
 
 var count = ctx.count;
 // returns 3
@@ -99,7 +93,6 @@ The function accepts the following options:
 By default, the function performs a reduction over all elements in a provided input [ndarray][@stdlib/ndarray/ctor]. To perform a reduction over specific dimensions, provide a `dims` option.
 
 ```javascript
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var array = require( '@stdlib/ndarray/array' );
 
 function clbk( v ) {
@@ -110,41 +103,30 @@ var x = array( [ -1.0, 2.0, NaN, 4.0 ], {
     'shape': [ 2, 2 ],
     'order': 'row-major'
 });
-var v = ndarray2array( x );
-// returns [ [ -1.0, 2.0 ], [ NaN, 4.0 ] ]
+// returns <ndarray>[ [ -1.0, 2.0 ], [ NaN, 4.0 ] ]
 
 var opts = {
     'dims': [ 0 ]
 };
 var y = nanmaxBy( x, opts, clbk );
-// returns <ndarray>
-
-v = ndarray2array( y );
-// returns [ -100.0, 400.0 ]
+// returns <ndarray>[ -100.0, 400.0 ]
 
 opts = {
     'dims': [ 1 ]
 };
 y = nanmaxBy( x, opts, clbk );
-// returns <ndarray>
-
-v = ndarray2array( y );
-// returns [ 200.0, 400.0 ]
+// returns <ndarray>[ 200.0, 400.0 ]
 
 opts = {
     'dims': [ 0, 1 ]
 };
 y = nanmaxBy( x, opts, clbk );
-// returns <ndarray>
-
-v = y.get();
-// returns 400.0
+// returns <ndarray>[ 400.0 ]
 ```
 
 By default, the function excludes reduced dimensions from the output [ndarray][@stdlib/ndarray/ctor]. To include the reduced dimensions as singleton dimensions, set the `keepdims` option to `true`.
 
 ```javascript
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var array = require( '@stdlib/ndarray/array' );
 
 function clbk( v ) {
@@ -155,39 +137,28 @@ var x = array( [ -1.0, 2.0, NaN, 4.0 ], {
     'shape': [ 2, 2 ],
     'order': 'row-major'
 });
-
-var v = ndarray2array( x );
-// returns [ [ -1.0, 2.0 ], [ NaN, 4.0 ] ]
+// returns <ndarray>[ [ -1.0, 2.0 ], [ NaN, 4.0 ] ]
 
 var opts = {
     'dims': [ 0 ],
     'keepdims': true
 };
 var y = nanmaxBy( x, opts, clbk );
-// returns <ndarray>
-
-v = ndarray2array( y );
-// returns [ [ -100.0, 400.0 ] ]
+// returns <ndarray>[ [ -100.0, 400.0 ] ]
 
 opts = {
     'dims': [ 1 ],
     'keepdims': true
 };
 y = nanmaxBy( x, opts, clbk );
-// returns <ndarray>
-
-v = ndarray2array( y );
-// returns [ [ 200.0 ], [ 400.0 ] ]
+// returns <ndarray>[ [ 200.0 ], [ 400.0 ] ]
 
 opts = {
     'dims': [ 0, 1 ],
     'keepdims': true
 };
 y = nanmaxBy( x, opts, clbk );
-// returns <ndarray>
-
-v = ndarray2array( y );
-// returns [ [ 400.0 ] ]
+// returns <ndarray>[ [ 400.0 ] ]
 ```
 
 By default, the function returns an [ndarray][@stdlib/ndarray/ctor] having a [data type][@stdlib/ndarray/dtypes] determined by the function's output data type [policy][@stdlib/ndarray/output-dtype-policies]. To override the default behavior, set the `dtype` option.
@@ -208,7 +179,7 @@ var opts = {
     'dtype': 'float64'
 };
 var y = nanmaxBy( x, opts, clbk );
-// returns <ndarray>
+// returns <ndarray>[ 200.0 ]
 
 var dt = String( getDType( y ) );
 // returns 'float64'
@@ -230,10 +201,7 @@ var x = array( [ -1.0, 2.0, NaN ] );
 var y = zeros( [] );
 
 var out = nanmaxBy.assign( x, y, clbk );
-// returns <ndarray>
-
-var v = out.get();
-// returns 200.0
+// returns <ndarray>[ 200.0 ]
 
 var bool = ( out === y );
 // returns true

--- a/lib/node_modules/@stdlib/stats/nanmax-by/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/nanmax-by/docs/repl.txt
@@ -51,9 +51,8 @@
     --------
     > var x = {{alias:@stdlib/ndarray/array}}( [ -1.0, 2.0, NaN, -4.0 ] );
     > function clbk( v ) { return v * 2.0; };
-    > var y = {{alias}}( x, clbk );
-    > var v = y.get()
-    4.0
+    > var y = {{alias}}( x, clbk )
+    <ndarray>[ 4.0 ]
 
 
 {{alias}}.assign( x, out[, options], clbk[, thisArg] )
@@ -107,11 +106,9 @@
     > var out = {{alias:@stdlib/ndarray/zeros}}( [] );
     > function clbk( v ) { return v * 2.0; };
     > var y = {{alias}}.assign( x, out, clbk )
-    <ndarray>
+    <ndarray>[ 4.0 ]
     > var bool = ( out === y )
     true
-    > var v = out.get()
-    4.0
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/stats/nanmax-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/nanmax-by/docs/types/index.d.ts
@@ -124,10 +124,7 @@ interface Unary {
 	* var x = array( [ -1.0, 2.0, NaN ] );
 	*
 	* var y = nanmaxBy( x, clbk );
-	* // returns <ndarray>
-	*
-	* var v = y.get();
-	* // returns 4.0
+	* // returns <ndarray>[ 4.0 ]
 	*/
 	<T = unknown, U extends InputArray<T> = InputArray<T>, ThisArg = unknown>( x: U, clbk: Callback<T, U, ThisArg>, thisArg?: ThisParameterType<Callback<T, U, ThisArg>> ): OutputArray<number>; // NOTE: we lose type specificity here, but retaining specificity would likely be difficult and/or tedious to completely enumerate, as the output ndarray data type is dependent on how `x` interacts with output data type policy and whether that policy has been overridden by `options.dtype`.
 
@@ -150,10 +147,7 @@ interface Unary {
 	* var x = array( [ -1.0, 2.0, NaN ] );
 	*
 	* var y = nanmaxBy( x, {}, clbk );
-	* // returns <ndarray>
-	*
-	* var v = y.get();
-	* // returns 4.0
+	* // returns <ndarray>[ 4.0 ]
 	*/
 	<T = unknown, U extends InputArray<T> = InputArray<T>, ThisArg = unknown>( x: U, options: Options, clbk: Callback<T, U, ThisArg>, thisArg?: ThisParameterType<Callback<T, U, ThisArg>> ): OutputArray<number>; // NOTE: we lose type specificity here, but retaining specificity would likely be difficult and/or tedious to completely enumerate, as the output ndarray data type is dependent on how `x` interacts with output data type policy and whether that policy has been overridden by `options.dtype`.
 
@@ -178,10 +172,7 @@ interface Unary {
 	* }
 	*
 	* var out = nanmaxBy.assign( x, y, clbk );
-	* // returns <ndarray>
-	*
-	* var v = out.get();
-	* // returns 4.0
+	* // returns <ndarray>[ 4.0 ]
 	*
 	* var bool = ( out === y );
 	* // returns true
@@ -210,10 +201,7 @@ interface Unary {
 	* }
 	*
 	* var out = nanmaxBy.assign( x, y, {}, clbk );
-	* // returns <ndarray>
-	*
-	* var v = out.get();
-	* // returns 4.0
+	* // returns <ndarray>[ 4.0 ]
 	*
 	* var bool = ( out === y );
 	* // returns true
@@ -240,10 +228,7 @@ interface Unary {
 * }
 *
 * var y = nanmaxBy( x, clbk );
-* // returns <ndarray>
-*
-* var v = y.get();
-* // returns 4.0
+* // returns <ndarray>[ 4.0 ]
 *
 * @example
 * var array = require( '@stdlib/ndarray/array' );
@@ -257,10 +242,7 @@ interface Unary {
 * }
 *
 * var out = nanmaxBy.assign( x, y, clbk );
-* // returns <ndarray>
-*
-* var v = out.get();
-* // returns 4.0
+* // returns <ndarray>[ 4.0 ]
 *
 * var bool = ( out === y );
 * // returns true

--- a/lib/node_modules/@stdlib/stats/nanmax-by/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/nanmax-by/lib/index.js
@@ -50,10 +50,7 @@
 *
 * // Perform reduction:
 * var out = nanmaxBy( x, clbk );
-* // returns <ndarray>
-*
-* var v = out.get();
-* // returns 22.0
+* // returns <ndarray>[ 22.0 ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/stats/nanmax-by/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/nanmax-by/lib/main.js
@@ -86,10 +86,7 @@ var table = {
 *
 * // Perform reduction:
 * var out = nanmaxBy( x, clbk );
-* // returns <ndarray>
-*
-* var v = out.get();
-* // returns 22.0
+* // returns <ndarray>[ 22.0 ]
 */
 var nanmaxBy = factory( table, [ idtypes ], odtypes, policies );
 


### PR DESCRIPTION
Resolves None.

## Description

> What is the purpose of this pull request?

This pull request:

-   docs: update return annotations to use ndarray instance notation for `stats/nanmax-by`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-  None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [X] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [X] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
