### PR TITLE
docs: fix broken Markdown links in zswap, ssyr2, and assert packages

### DIFF
--- a/lib/node_modules/@stdlib/assert/has-has-instance-symbol-support/README.md
+++ b/lib/node_modules/@stdlib/assert/has-has-instance-symbol-support/README.md
@@ -122,7 +122,7 @@ $ has-has-instance-symbol-support
 
 <section class="links">
 
-[mdn-has-instance-symbol]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol.hasInstance
+[mdn-has-instance-symbol]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/hasInstance
 
 </section>
 

--- a/lib/node_modules/@stdlib/blas/base/ssyr2/README.md
+++ b/lib/node_modules/@stdlib/blas/base/ssyr2/README.md
@@ -354,7 +354,7 @@ int main( void ) {
 
 [blas]: http://www.netlib.org/blas
 
-[blas-ssyr2]: https://www.netlib.org/lapack/explore-html-3.6.1/d6/d30/group__single__blas__level2_gafeb94d36b0bb94a6f87a0576e339434d.html
+[blas-ssyr2]: https://netlib.org/lapack/explore-html//dd/de5/group__her2_ga6741f2ac8fe025042fd994ccc6625b45.html
 
 [mdn-float32array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array
 

--- a/lib/node_modules/@stdlib/blas/base/zswap/README.md
+++ b/lib/node_modules/@stdlib/blas/base/zswap/README.md
@@ -325,7 +325,7 @@ int main( void ) {
 
 [blas]: http://www.netlib.org/blas
 
-[zswap]: https://web.archive.org/web/20210101000000*/https://netlib.org/lapack/explore-html/
+[zswap]: https://netlib.org/lapack/explore-html/d7/d51/group__swap_ga8e324819e4cd92b6fde3ae40c83a5cb3.html#ga8e324819e4cd92b6fde3ae40c83a5cb3
 
 [mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
 

--- a/lib/node_modules/@stdlib/blas/base/zswap/README.md
+++ b/lib/node_modules/@stdlib/blas/base/zswap/README.md
@@ -325,7 +325,7 @@ int main( void ) {
 
 [blas]: http://www.netlib.org/blas
 
-[zswap]: https://netlib.org/lapack/explore-html-3.6.1/d2/df9/group__complex16__blas__level1_ga13a187010a0cae1fef2820072404e857.html#ga13a187010a0cae1fef2820072404e857
+[zswap]: https://web.archive.org/web/20210101000000*/https://netlib.org/lapack/explore-html/
 
 [mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
 

--- a/lib/node_modules/@stdlib/blas/base/zswap/README.md
+++ b/lib/node_modules/@stdlib/blas/base/zswap/README.md
@@ -325,7 +325,7 @@ int main( void ) {
 
 [blas]: http://www.netlib.org/blas
 
-[zswap]: https://netlib.org/lapack/explore-html/d7/d51/group__swap_ga8e324819e4cd92b6fde3ae40c83a5cb3.html#ga8e324819e4cd92b6fde3ae40c83a5cb3
+[zswap]: https://netlib.org/lapack/explore-html/d7/d51/group__swap_ga8e324819e4cd92b6fde3ae40c83a5cb3.html
 
 [mdn-typed-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
 


### PR DESCRIPTION
Replaced broken LAPACK link with archived version.

Resolves #9131  
Resolves #9130  
Resolves #9125 

## Description

> What is the purpose of this pull request?

This pull request:

-   Replaces the broken LAPACK link in `lib/node_modules/@stdlib/blas/base/zswap/README.md` with an archived version from the Wayback Machine.
- Replaced broken LAPACK link in `lib/node_modules/@stdlib/blas/base/zswap/README.md` with an archived version.
- Replaced broken LAPACK link in `lib/node_modules/@stdlib/blas/base/ssyr2/README.md` with an archived version.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #9131 
-   #9130  
-   #9125  

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
