### PR TITLE
docs: fix broken Markdown link (issue #9146)

### DIFF
--- a/docs/links/database.json
+++ b/docs/links/database.json
@@ -8319,8 +8319,8 @@
       "lint"
     ]
   },
-  "https://github.com/kangax/compat-table/issues/392": {
-    "id": "@bug:kangax:compat-table:392",
+  "https://github.com/compat-table/compat-table/issues/392": {
+    "id": "@bug:compat-table:compat-table:392",
     "description": "GitHub issue thread on the accuracy of Math.cbrt, Math.expm1, Math.log1p.",
     "short_url": "",
     "keywords": [

--- a/docs/misc/built_in_math_bugs.md
+++ b/docs/misc/built_in_math_bugs.md
@@ -28,7 +28,7 @@ limitations under the License.
 -   [V8 not IEEE 754-2008 compliant][@bug:v8:3089]
 -   [Mozilla discussion on sine and cosine in V8][@bug:mozilla:967709]
 -   [V8 replaced a lookup table by computing `Math.tan` as `Math.sin/Math.cos`][@bug:chromium:78263005]
--   [Browser math accuracy issues][@bug:kangax:compat-table:392]
+-   [Browser math accuracy issues][@bug:compat-table:compat-table:392]
 -   [Mozilla attempt to address precision in new Math functions][@bug:mozilla:933257]
 -   [Mozilla's previous lack of tolerance tests for Math functions][@bug:mozilla:892671]
 -   [Mozilla `Math.expm1` accuracy][@bug:mozilla:897634]
@@ -89,7 +89,7 @@ limitations under the License.
 
 [@bug:chromium:78263005]: https://github.com/v8/v8/commit/33b5db090258c2a2dc825659c3ad109bd02110c1
 
-[@bug:kangax:compat-table:392]: https://github.com/kangax/compat-table/issues/392
+[@bug:compat-table:compat-table:392]: https://github.com/compat-table/compat-table/issues/392
 
 [@bug:mozilla:933257]: https://bugzilla.mozilla.org/show_bug.cgi?id=933257
 

--- a/docs/references/bugs.bib
+++ b/docs/references/bugs.bib
@@ -38,11 +38,11 @@
 	year = {2013}
 }
 
-@misc{bug:kangax:compat-table:392,
+@misc{bug:compat-table:compat-table:392,
 	abstract = {Accuracy errors in the JavaScript standard Math library and associated shims.},
 	keywords = {javascript, bug, math, standard, shims},
 	title = {{Accuracy of Math.cbrt, Math.expm1, Math.log1p}},
-	url = {https://github.com/kangax/compat-table/issues/392},
+	url = {https://github.com/compat-table/compat-table/issues/392},
 	year = {2015}
 }
 
@@ -159,7 +159,7 @@
 }
 
 @misc{bug:paulmillr:es6-shim:334,
-	abstract = {var isAsinhOK = Math.asinh(0.0002) >= 0.0001999999986666666 &&  Math.asinh(0.0002) <= 0.0001999999986666668; var isAtanhOK = Math.atanh(0.0002) >= 0.0002000000026666667 && Math.atanh(0.0002) <= 0.0002000000026666668; Both of these are true in shimmed Firefox 37 and Safari 8, both false in Chrome 41 and Chrome Canary 44. From kangax/compat-table#392 (comment)},
+	abstract = {var isAsinhOK = Math.asinh(0.0002) >= 0.0001999999986666666 &&  Math.asinh(0.0002) <= 0.0001999999986666668; var isAtanhOK = Math.atanh(0.0002) >= 0.0002000000026666667 && Math.atanh(0.0002) <= 0.0002000000026666668; Both of these are true in shimmed Firefox 37 and Safari 8, both false in Chrome 41 and Chrome Canary 44. From compat-table/compat-table#392 (comment)},
 	keywords = {math, shim, javascript, precision, chrome, v8},
 	title = {{Chrome 41: `Math.asinh` and `Math.atanh` are imprecise}},
 	url = {https://github.com/paulmillr/es6-shim/issues/334},


### PR DESCRIPTION
Update repository owner from kangax to compat-table organization.

The repository moved from kangax/compat-table to compat-table/compat-table
due to ownership transfer. Updated all URL references and identifiers.

Updated files:
- docs/misc/built_in_math_bugs.md: URL and reference label
- docs/links/database.json: URL and reference label
- docs/references/bugs.bib: Updated URL and citation reference

Closes: #9146

Resolves #9146.

## Description

> What is the purpose of this pull request?

This pull request:

-   Updates compat-table repository references from `kangax/compat-table` to `compat-table/compat-table` to reflect repository ownership transfer

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #9146 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Old URL returns 404:
```bash
$ curl -I https://github.com/kangax/compat-table/issues/392
HTTP/1.1 404 Not Found
```

New URL returns 200:
```bash
$ curl -I https://github.com/compat-table/compat-table/issues/392
HTTP/1.1 200 OK
```

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
