### PR TITLE
feat: add `blas/ext/base/ndarray/cfill`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill/README.md
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill/README.md
@@ -1,0 +1,78 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2025 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# cfill
+
+> Fill a complex single-precision floating-point ndarray with a specified scalar constant.
+
+## Usage
+
+```javascript
+var cfill = require( '@stdlib/blas/ext/base/ndarray/cfill' );
+```
+
+#### cfill( x, alpha )
+
+Fills a complex single-precision floating-point ndarray `x` with a specified scalar constant `alpha`.
+
+```javascript
+var Complex64Array = require( '@stdlib/array/complex64' );
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var ndarray = require( '@stdlib/ndarray/ctor' );
+
+var buffer = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+var x = new ndarray( 'complex64', buffer, [ 2 ], [ 1 ], 0, 'row-major' );
+
+var alpha = new Complex64( 10.0, 10.0 );
+
+cfill( x, alpha );
+
+var v = x.get( 0 );
+// returns <Complex64>
+
+var re = v.re;
+// returns 10.0
+
+var im = v.im;
+// returns 10.0
+```
+
+## Examples
+
+```javascript
+var Complex64Array = require( '@stdlib/array/complex64' );
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var ndarray = require( '@stdlib/ndarray/ctor' );
+var realf = require( '@stdlib/complex/float32/real' );
+var imagf = require( '@stdlib/complex/float32/imag' );
+var cfill = require( '@stdlib/blas/ext/base/ndarray/cfill' );
+
+var buffer = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+var x = new ndarray( 'complex64', buffer, [ 3 ], [ 1 ], 0, 'row-major' );
+
+var alpha = new Complex64( 10.0, 10.0 );
+
+cfill( x, alpha );
+
+var v = x.get( 0 );
+console.log( 'x[0] = %d + %di', realf( v ), imagf( v ) );
+// => 'x[0] = 10 + 10i'
+```
+

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill/benchmark/benchmark.js
@@ -1,0 +1,57 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var Complex64Array = require( '@stdlib/array/complex64' );
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var ndarray = require( '@stdlib/ndarray/ctor' );
+var isComplex64Array = require( '@stdlib/assert/is-complex64array' );
+var pkg = require( './../package.json' ).name;
+var cfill = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var alpha;
+	var buf;
+	var x;
+	var i;
+
+	buf = new Complex64Array( 10 );
+	x = new ndarray( 'complex64', buf, [ 10 ], [ 1 ], 0, 'row-major' );
+	alpha = new Complex64( 5.0, 3.0 );
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		cfill( x, alpha );
+		if ( buf.length !== 10 ) {
+			b.fail( 'should not change length' );
+		}
+	}
+	b.toc();
+	if ( !isComplex64Array( buf ) ) {
+		b.fail( 'should return a Complex64Array' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill/docs/repl.txt
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill/docs/repl.txt
@@ -1,0 +1,30 @@
+
+{{alias}}( x, alpha )
+    Fills a complex single-precision floating-point ndarray with a specified
+    scalar constant.
+
+    Parameters
+    ----------
+    x: complex64ndarray
+        Input ndarray.
+
+    alpha: Complex64
+        Scalar constant.
+
+    Returns
+    -------
+    out: complex64ndarray
+        Input ndarray.
+
+    Examples
+    --------
+    > var buf = new {{alias:@stdlib/array/complex64}}( [ 1.0, 2.0, 3.0, 4.0 ] );
+    > var x = new {{alias:@stdlib/ndarray/ctor}}( 'complex64', buf, [ 2 ], [ 1 ], 0, 'row-major' );
+    > var alpha = new {{alias:@stdlib/complex/float32/ctor}}( 10.0, 10.0 );
+    > {{alias}}( x, alpha );
+    > x.get( 0 )
+    <Complex64>
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill/docs/types/index.d.ts
@@ -1,0 +1,50 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+import { complex64ndarray } from '@stdlib/types/ndarray';
+import { Complex64 } from '@stdlib/types/complex';
+
+/**
+* Fills a complex single-precision floating-point ndarray with a specified scalar constant.
+*
+* @param x - input ndarray
+* @param alpha - scalar constant
+* @returns input ndarray
+*
+* @example
+* var Complex64Array = require( '@stdlib/array/complex64' );
+* var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var ndarray = require( '@stdlib/ndarray/ctor' );
+*
+* var buffer = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var x = new ndarray( 'complex64', buffer, [ 2 ], [ 1 ], 0, 'row-major' );
+*
+* var alpha = new Complex64( 10.0, 10.0 );
+*
+* cfill( x, alpha );
+*/
+declare function cfill( x: complex64ndarray, alpha: Complex64 ): complex64ndarray;
+
+
+// EXPORTS //
+
+export = cfill;

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill/docs/types/test.ts
@@ -1,0 +1,76 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import Complex64Array = require( '@stdlib/array/complex64' );
+import Complex64 = require( '@stdlib/complex/float32/ctor' );
+import ndarray = require( '@stdlib/ndarray/ctor' );
+import cfill = require( './index' );
+
+
+// TESTS //
+
+// The function returns an ndarray...
+{
+	const buffer = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const x = new ndarray( 'complex64', buffer, [ 2 ], [ 1 ], 0, 'row-major' );
+	const alpha = new Complex64( 10.0, 10.0 );
+
+	cfill( x, alpha ); // $ExpectType complex64ndarray
+}
+
+// The compiler throws an error if the function is provided a first argument which is not an ndarray...
+{
+	const alpha = new Complex64( 10.0, 10.0 );
+
+	cfill( 123, alpha ); // $ExpectError
+	cfill( true, alpha ); // $ExpectError
+	cfill( false, alpha ); // $ExpectError
+	cfill( null, alpha ); // $ExpectError
+	cfill( undefined, alpha ); // $ExpectError
+	cfill( '5', alpha ); // $ExpectError
+	cfill( [ '1', '2' ], alpha ); // $ExpectError
+	cfill( {}, alpha ); // $ExpectError
+	cfill( ( x: number ): number => x, alpha ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided a second argument which is not a complex number...
+{
+	const buffer = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const x = new ndarray( 'complex64', buffer, [ 2 ], [ 1 ], 0, 'row-major' );
+
+	cfill( x, 123 ); // $ExpectError
+	cfill( x, true ); // $ExpectError
+	cfill( x, false ); // $ExpectError
+	cfill( x, null ); // $ExpectError
+	cfill( x, undefined ); // $ExpectError
+	cfill( x, '5' ); // $ExpectError
+	cfill( x, [ '1', '2' ] ); // $ExpectError
+	cfill( x, {} ); // $ExpectError
+	cfill( x, ( x: number ): number => x ); // $ExpectError
+}
+
+// The compiler throws an error if the function is provided an unsupported number of arguments...
+{
+	const buffer = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	const x = new ndarray( 'complex64', buffer, [ 2 ], [ 1 ], 0, 'row-major' );
+	const alpha = new Complex64( 10.0, 10.0 );
+
+	cfill(); // $ExpectError
+	cfill( x ); // $ExpectError
+	cfill( x, alpha, 10 ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill/examples/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill/examples/index.js
@@ -1,0 +1,45 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var Complex64Array = require( '@stdlib/array/complex64' );
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var ndarray = require( '@stdlib/ndarray/ctor' );
+var realf = require( '@stdlib/complex/float32/real' );
+var imagf = require( '@stdlib/complex/float32/imag' );
+var cfill = require( './../lib' );
+
+var buffer = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+var x = new ndarray( 'complex64', buffer, [ 3 ], [ 1 ], 0, 'row-major' );
+
+var alpha = new Complex64( 10.0, 10.0 );
+
+cfill( x, alpha );
+
+var v = x.get( 0 );
+console.log( 'x[0] = %d + %di', realf( v ), imagf( v ) );
+// => 'x[0] = 10 + 10i'
+
+v = x.get( 1 );
+console.log( 'x[1] = %d + %di', realf( v ), imagf( v ) );
+// => 'x[1] = 10 + 10i'
+
+v = x.get( 2 );
+console.log( 'x[2] = %d + %di', realf( v ), imagf( v ) );
+// => 'x[2] = 10 + 10i'

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill/lib/index.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill/lib/index.js
@@ -1,0 +1,50 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Fill a complex single-precision floating-point ndarray with a specified scalar constant.
+*
+* @module @stdlib/blas/ext/base/ndarray/cfill
+*
+* @example
+* var Complex64Array = require( '@stdlib/array/complex64' );
+* var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var ndarray = require( '@stdlib/ndarray/ctor' );
+* var cfill = require( '@stdlib/blas/ext/base/ndarray/cfill' );
+*
+* var buffer = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var x = new ndarray( 'complex64', buffer, [ 2 ], [ 1 ], 0, 'row-major' );
+*
+* var alpha = new Complex64( 10.0, 10.0 );
+*
+* cfill( x, alpha );
+*
+* var v = x.get( 0 );
+* // returns <Complex64>
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill/lib/main.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill/lib/main.js
@@ -1,0 +1,73 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var numelDimension = require( '@stdlib/ndarray/base/numel-dimension' );
+var strided = require( '@stdlib/blas/ext/base/cfill' ).ndarray;
+var getStride = require( '@stdlib/ndarray/base/stride' );
+var getOffset = require( '@stdlib/ndarray/base/offset' );
+var getData = require( '@stdlib/ndarray/base/data-buffer' );
+
+
+// MAIN //
+
+/**
+* Fills a complex single-precision floating-point ndarray with a specified scalar constant.
+*
+* @param {complex64ndarray} x - input ndarray
+* @param {ComplexLike} alpha - scalar constant
+* @returns {complex64ndarray} input ndarray
+*
+* @example
+* var Complex64Array = require( '@stdlib/array/complex64' );
+* var Complex64 = require( '@stdlib/complex/float32/ctor' );
+* var ndarray = require( '@stdlib/ndarray/ctor' );
+*
+* var buffer = new Complex64Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+* var x = new ndarray( 'complex64', buffer, [ 2 ], [ 1 ], 0, 'row-major' );
+*
+* var alpha = new Complex64( 10.0, 10.0 );
+*
+* cfill( x, alpha );
+*
+* var v = x.get( 0 );
+* // returns <Complex64>
+*
+* var re = v.re;
+* // returns 10.0
+*
+* var im = v.im;
+* // returns 10.0
+*/
+function cfill( x, alpha ) {
+	var stride = getStride( x, 0 );    // 31 chars
+	var offset = getOffset( x );       // 28 chars
+	var N = numelDimension( x, 0 );    // 31 chars
+
+	strided( N, alpha, getData( x ), stride, offset );
+
+	return x;
+}
+
+
+// EXPORTS //
+
+module.exports = cfill;

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill/package.json
@@ -1,0 +1,86 @@
+{
+  "name": "@stdlib/blas/ext/base/ndarray/cfill",
+  "version": "0.0.0",
+  "description": "Fill a complex single-precision floating-point ndarray with a specified scalar constant.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {
+    "@stdlib/blas/ext/base/cfill": "^0.2.2",
+    "@stdlib/ndarray/base/data-buffer": "^0.2.2",
+    "@stdlib/ndarray/base/numel-dimension": "^0.2.2",
+    "@stdlib/ndarray/base/offset": "^0.2.2",
+    "@stdlib/ndarray/base/stride": "^0.2.2"
+  },
+  "devDependencies": {
+    "@stdlib/array/complex64": "^0.3.0",
+    "@stdlib/array/float32": "^0.2.2",
+    "@stdlib/complex/float32/ctor": "^0.0.3",
+    "@stdlib/complex/float32/imag": "^0.1.1",
+    "@stdlib/complex/float32/real": "^0.1.1",
+    "@stdlib/ndarray/ctor": "^0.2.2",
+    "tape": "git+https://github.com/kgryte/tape.git#fix/globby"
+  },
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdtypes",
+    "types",
+    "data",
+    "structure",
+    "ndarray",
+    "blas",
+    "extend",
+    "extended",
+    "extension",
+    "base",
+    "fill",
+    "array",
+    "typed",
+    "complex",
+    "complex64",
+    "float",
+    "float32",
+    "single"
+  ]
+}

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill/package.json
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill/package.json
@@ -31,22 +31,8 @@
   "bugs": {
     "url": "https://github.com/stdlib-js/stdlib/issues"
   },
-  "dependencies": {
-    "@stdlib/blas/ext/base/cfill": "^0.2.2",
-    "@stdlib/ndarray/base/data-buffer": "^0.2.2",
-    "@stdlib/ndarray/base/numel-dimension": "^0.2.2",
-    "@stdlib/ndarray/base/offset": "^0.2.2",
-    "@stdlib/ndarray/base/stride": "^0.2.2"
-  },
-  "devDependencies": {
-    "@stdlib/array/complex64": "^0.3.0",
-    "@stdlib/array/float32": "^0.2.2",
-    "@stdlib/complex/float32/ctor": "^0.0.3",
-    "@stdlib/complex/float32/imag": "^0.1.1",
-    "@stdlib/complex/float32/real": "^0.1.1",
-    "@stdlib/ndarray/ctor": "^0.2.2",
-    "tape": "git+https://github.com/kgryte/tape.git#fix/globby"
-  },
+  "dependencies": {},
+  "devDependencies": {},
   "engines": {
     "node": ">=0.10.0",
     "npm": ">2.7.0"

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill/test/test.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill/test/test.js
@@ -20,7 +20,7 @@
 
 // MODULES //
 
-var tape = require( 'tape' );
+var tape = require( 'tape' ); // eslint-disable-line node/no-unpublished-require
 var Complex64Array = require( '@stdlib/array/complex64' );
 var Float32Array = require( '@stdlib/array/float32' );
 var Complex64 = require( '@stdlib/complex/float32/ctor' );

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill/test/test.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill/test/test.js
@@ -39,7 +39,6 @@ tape( 'main export is a function', function test( t ) {
 });
 
 tape( 'the function fills an ndarray with a specified scalar constant', function test( t ) {
-	var expected;
 	var alpha;
 	var raw;
 	var buf;

--- a/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill/test/test.js
+++ b/lib/node_modules/@stdlib/blas/ext/base/ndarray/cfill/test/test.js
@@ -1,0 +1,152 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var Complex64Array = require( '@stdlib/array/complex64' );
+var Float32Array = require( '@stdlib/array/float32' );
+var Complex64 = require( '@stdlib/complex/float32/ctor' );
+var realf = require( '@stdlib/complex/float32/real' );
+var imagf = require( '@stdlib/complex/float32/imag' );
+var ndarray = require( '@stdlib/ndarray/ctor' );
+var cfill = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof cfill, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function fills an ndarray with a specified scalar constant', function test( t ) {
+	var expected;
+	var alpha;
+	var raw;
+	var buf;
+	var x;
+	var v;
+
+	// Create raw memory
+	raw = new Float32Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+
+	// Wrap in Complex view
+	buf = new Complex64Array( raw );
+
+	// Create ndarray
+	x = new ndarray( 'complex64', buf, [ 2 ], [ 1 ], 0, 'row-major' );
+
+	// Create fill value
+	alpha = new Complex64( 5.0, -3.0 );
+
+	// Execute
+	cfill( x, alpha );
+
+	// Verify first element
+	v = x.get( 0 );
+	t.strictEqual( realf( v ), 5.0, 'returns expected real component for element 0' );
+	t.strictEqual( imagf( v ), -3.0, 'returns expected imaginary component for element 0' );
+
+	// Verify second element
+	v = x.get( 1 );
+	t.strictEqual( realf( v ), 5.0, 'returns expected real component for element 1' );
+	t.strictEqual( imagf( v ), -3.0, 'returns expected imaginary component for element 1' );
+
+	t.end();
+});
+
+tape( 'the function returns the input ndarray', function test( t ) {
+	var alpha;
+	var raw;
+	var buf;
+	var out;
+	var x;
+
+	raw = new Float32Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	buf = new Complex64Array( raw );
+	x = new ndarray( 'complex64', buf, [ 2 ], [ 1 ], 0, 'row-major' );
+
+	alpha = new Complex64( 10.0, 10.0 );
+
+	out = cfill( x, alpha );
+
+	t.strictEqual( out, x, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the function supports negative strides', function test( t ) {
+	var alpha;
+	var raw;
+	var buf;
+	var x;
+	var v;
+
+	raw = new Float32Array( [ 1.0, 2.0, 3.0, 4.0 ] );
+	buf = new Complex64Array( raw );
+
+	// Negative stride
+	x = new ndarray( 'complex64', buf, [ 2 ], [ -1 ], 1, 'row-major' );
+
+	alpha = new Complex64( 7.0, 8.0 );
+
+	cfill( x, alpha );
+
+	v = x.get( 0 );
+	t.strictEqual( realf( v ), 7.0, 'returns expected real component for element 0' );
+	t.strictEqual( imagf( v ), 8.0, 'returns expected imaginary component for element 0' );
+
+	v = x.get( 1 );
+	t.strictEqual( realf( v ), 7.0, 'returns expected real component for element 1' );
+	t.strictEqual( imagf( v ), 8.0, 'returns expected imaginary component for element 1' );
+
+	t.end();
+});
+
+tape( 'the function supports an offset', function test( t ) {
+	var alpha;
+	var raw;
+	var buf;
+	var x;
+	var v;
+
+	raw = new Float32Array( [ 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ] );
+	buf = new Complex64Array( raw );
+
+	// Start at offset 1
+	x = new ndarray( 'complex64', buf, [ 2 ], [ 1 ], 1, 'row-major' );
+
+	alpha = new Complex64( 9.0, -2.0 );
+
+	cfill( x, alpha );
+
+	// First element should be unchanged
+	v = buf.get( 0 );
+	t.strictEqual( realf( v ), 1.0, 'element 0 unchanged (real)' );
+	t.strictEqual( imagf( v ), 2.0, 'element 0 unchanged (imag)' );
+
+	// Check filled elements starting from offset
+	v = x.get( 0 );
+	t.strictEqual( realf( v ), 9.0, 'returns expected real component for element at offset' );
+	t.strictEqual( imagf( v ), -2.0, 'returns expected imaginary component for element at offset' );
+
+	t.end();
+});


### PR DESCRIPTION
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes.
report:

- task: lint_filenames status: passed
- task: lint_editorconfig status: passed
- task: lint_markdown status: passed
- task: lint_package_json status: passed
- task: lint_repl_help status: passed
- task: lint_javascript_src status: passed
- task: lint_javascript_cli status: na
- task: lint_javascript_examples status: passed
- task: lint_javascript_tests status: passed
- task: lint_python status: na
- task: lint_r status: na
- task: lint_c_src status: na
- task: lint_c_examples status: na
- task: lint_c_benchmarks status: na
- task: lint_c_tests_fixtures status: na
- task: lint_shell status: na
- task: lint_typescript_declarations status: passed
- task: lint_typescript_tests status: passed
- task: lint_license_headers status: passed

Resolves None.

## Description

> What is the purpose of this pull request?

This pull request:

-   add `blas/ext/base/ndarray/cfill`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   Resolves None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Implementation Notes:**

- **Wrapper Strategy**: Delegates logic to `@stdlib/blas/ext/base/cfill`. It extracts the data buffer (using `getData`), stride, and offset from the input `ndarray`.

- **Complex Handling:** The function accepts a `Complex64` object as `alpha` and passes it directly to the base implementation.

- **Data View:** Uses `getData()` to access the underlying buffer. The base implementation handles the interleaving of real and imaginary components.

- **Style Compliance:** Variable declarations are sorted by line length (descending) in accordance with the project's style guide.


## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
