### PR TITLE
docs: fix broken Markdown link (issue #9149)

### DIFF
--- a/lib/node_modules/@stdlib/lapack/base/dlaset/README.md
+++ b/lib/node_modules/@stdlib/lapack/base/dlaset/README.md
@@ -237,7 +237,7 @@ TODO
 
 [lapack]: https://www.netlib.org/lapack/explore-html/
 
-[lapack-dlaset]: https://www.netlib.org/lapack/explore-html-3.6.1/d7/d43/group__aux_o_t_h_e_rauxiliary_ga89e332374c7cd87e5db54bfe21550bc3.html
+[lapack-dlaset]: https://web.archive.org/web/20240806172401/https://netlib.org/lapack/explore-html-3.6.1/d7/d43/group__aux_o_t_h_e_rauxiliary_ga89e332374c7cd87e5db54bfe21550bc3.html#ga89e332374c7cd87e5db54bfe21550bc3
 
 [mdn-float64array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float64Array
 


### PR DESCRIPTION
Resolves #9149

## Description

> What is the purpose of this pull request?

This pull request:

- This resolved the broken link issue (error 404) by replacing it with the correct link
- gets the user to their concerned path not on a false/damaged link

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-  Resolves #9149

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

Found the working link for dlaset from LAPACK using Wayback Machine.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [ * ] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [ * ] No

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
