### PR TITLE
feat: add float16 Glaisher-Kinkelin constant

### DIFF
--- a/lib/node_modules/@stdlib/constants/float16/glaisher-kinkelin/README.md
+++ b/lib/node_modules/@stdlib/constants/float16/glaisher-kinkelin/README.md
@@ -1,0 +1,81 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2025 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# FLOAT16_GLAISHER
+
+> [Glaisher-Kinkelin][glaisher-constant] constant as a half-precision floating-point number.
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var FLOAT16_GLAISHER = require( '@stdlib/constants/float16/glaisher-kinkelin' );
+```
+
+#### FLOAT16_GLAISHER
+
+[Glaisher-Kinkelin][glaisher-constant] constant as a half-precision floating-point number.
+
+```javascript
+var bool = ( FLOAT16_GLAISHER === 1.2822265625 );
+// returns true
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- TODO: better example -->
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var FLOAT16_GLAISHER = require( '@stdlib/constants/float16/glaisher-kinkelin' );
+
+console.log( FLOAT16_GLAISHER );
+// => 1.2822265625
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[glaisher-constant]: https://en.wikipedia.org/wiki/Glaisher%E2%80%93Kinkelin_constant
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/constants/float16/glaisher-kinkelin/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/constants/float16/glaisher-kinkelin/docs/types/index.d.ts
@@ -1,0 +1,33 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Glaisher-Kinkelin constant.
+*
+* @example
+* var val = FLOAT16_GLAISHER;
+* // returns 1.2822265625
+*/
+declare const FLOAT16_GLAISHER: number;
+
+
+// EXPORTS //
+
+export = FLOAT16_GLAISHER;

--- a/lib/node_modules/@stdlib/constants/float16/glaisher-kinkelin/examples/index.js
+++ b/lib/node_modules/@stdlib/constants/float16/glaisher-kinkelin/examples/index.js
@@ -1,0 +1,24 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var FLOAT16_GLAISHER = require( './../lib' );
+
+console.log(FLOAT16_GLAISHER);
+// => 1.2822265625

--- a/lib/node_modules/@stdlib/constants/float16/glaisher-kinkelin/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float16/glaisher-kinkelin/lib/index.js
@@ -1,0 +1,51 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Glaisher-Kinkelin constant.
+*
+* @module @stdlib/constants/float16/glaisher-kinkelin
+* @type {number}
+*
+* @example
+* var FLOAT16_GLAISHER = require( '@stdlib/constants/float16/glaisher-kinkelin' );
+* // returns 1.2822265625
+*/
+
+
+// MAIN //
+
+/**
+* Glaisher-Kinkelin constant.
+*
+* ```tex
+* A = \lim_{n\to\infty} \frac{K(n + 1)}{n^{n^2/2 + n/2 + 1/12}e^{-n^2/4}}
+* ```
+*
+* @constant
+* @type {number}
+* @default 1.2822265625
+*/
+var FLOAT16_GLAISHER = 1.2822265625;
+
+
+// EXPORTS //
+
+module.exports = FLOAT16_GLAISHER;

--- a/lib/node_modules/@stdlib/constants/float16/glaisher-kinkelin/package.json
+++ b/lib/node_modules/@stdlib/constants/float16/glaisher-kinkelin/package.json
@@ -1,0 +1,75 @@
+{
+  "name": "@stdlib/constants/float16/glaisher-kinkelin",
+  "version": "0.0.0",
+  "description": "Glaisher-Kinkelin constant as a half-precision floating-point number.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "tape": "git+https://github.com/stdlib-js/tape.git#main"
+  },
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "constant",
+    "const",
+    "mathematics",
+    "math",
+    "glaisher-kinkelin",
+    "glaisher",
+    "kinkelin",
+    "riemann",
+    "zeta",
+    "special functions",
+    "k function",
+    "barnes g function",
+    "gamma",
+    "ieee754",
+    "float",
+    "floating-point",
+    "float16",
+    "half-precision",
+    "half"
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float16/glaisher-kinkelin/test/test.js
+++ b/lib/node_modules/@stdlib/constants/float16/glaisher-kinkelin/test/test.js
@@ -1,0 +1,39 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+// eslint-disable-next-line node/no-unpublished-require
+var tape = require( 'tape' );
+var FLOAT16_GLAISHER = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a number', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof FLOAT16_GLAISHER, 'number', 'main export is a number' );
+	t.end();
+});
+
+tape( 'export is a half-precision floating-point number equal to 1.2822265625', function test( t ) {
+	t.strictEqual( FLOAT16_GLAISHER, 1.2822265625, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION

---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: passed
  - task: lint_package_json status: passed
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: passed
  - task: lint_javascript_tests status: passed
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---


## Description

> What is the purpose of this pull request?

This pull request:

-   Implements the [Glaisher-Kinkelin constant][glaisher-kinkelin] as a half-precision floating-point number.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #9061 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
[glaisher-kinkelin]: https://en.wikipedia.org/wiki/Glaisher%E2%80%93Kinkelin_constant