### PR TITLE
bench: refactor to use dynamic memory allocation in `number/uint8/base/mul`

### DIFF
--- a/lib/node_modules/@stdlib/number/uint8/base/mul/benchmark/c/benchmark.c
+++ b/lib/node_modules/@stdlib/number/uint8/base/mul/benchmark/c/benchmark.c
@@ -99,12 +99,13 @@ static uint8_t mul( const uint8_t x, const uint8_t y ) {
 * @return elapsed time in seconds
 */
 static double benchmark( void ) {
-	uint8_t x[ 100 ];
+	uint8_t *x;
 	double elapsed;
 	uint8_t y;
 	double t;
 	int i;
 
+	x = (uint8_t *) malloc( 100 * sizeof( uint8_t ) );
 	for ( i = 0; i < 100; i++ ) {
 		x[ i ] = (uint8_t)( 2.0*rand_double() ) + 10;
 	}
@@ -121,6 +122,7 @@ static double benchmark( void ) {
 	if ( y > 100 ) {
 		printf( "unexpected result\n" );
 	}
+	free( x );
 	return elapsed;
 }
 

--- a/lib/node_modules/@stdlib/number/uint8/base/mul/benchmark/c/native/benchmark.c
+++ b/lib/node_modules/@stdlib/number/uint8/base/mul/benchmark/c/native/benchmark.c
@@ -91,12 +91,13 @@ static double rand_double( void ) {
 * @return elapsed time in seconds
 */
 static double benchmark( void ) {
-	uint8_t x[ 100 ];
+	uint8_t *x;
 	double elapsed;
 	uint8_t y;
 	double t;
 	int i;
 
+	x = (uint8_t *) malloc( 100 * sizeof( uint8_t ) );
 	for ( i = 0; i < 100; i++ ) {
 		x[ i ] = (uint8_t)( 2.0*rand_double() ) + 10;
 	}
@@ -113,6 +114,7 @@ static double benchmark( void ) {
 	if ( y > 100 ) {
 		printf( "unexpected value\n" );
 	}
+	free( x );
 	return elapsed;
 }
 


### PR DESCRIPTION
Resolves a part of  #8643.

## Description

> What is the purpose of this pull request?

This pull request:

-   replace static memory allocation of large arrays in C benchmark at `number/uint8/base/mul` with dynamic memory allocation (tracking issue) 

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8643

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
