### PR TITLE
fix: doctest linter

### DIFF
--- a/lib/node_modules/@stdlib/_tools/doctest/compare-values/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/doctest/compare-values/lib/main.js
@@ -435,6 +435,9 @@ function checkArray( actual, expected ) {
 					return false;
 				}
 			} else if ( isPrimitive( a ) ) {
+				if ( isArray( b ) ) {
+					return false;
+				}
 				b = String( b );
 				if ( !checkPrimitive( a, b ) ) {
 					return false;

--- a/lib/node_modules/@stdlib/_tools/doctest/compare-values/lib/main.js
+++ b/lib/node_modules/@stdlib/_tools/doctest/compare-values/lib/main.js
@@ -435,7 +435,7 @@ function checkArray( actual, expected ) {
 					return false;
 				}
 			} else if ( isPrimitive( a ) ) {
-				if ( isArray( b ) ) {
+				if ( !isPrimitive( b ) ) {
 					return false;
 				}
 				b = String( b );

--- a/lib/node_modules/@stdlib/_tools/doctest/compare-values/test/test.js
+++ b/lib/node_modules/@stdlib/_tools/doctest/compare-values/test/test.js
@@ -611,3 +611,55 @@ tape( 'the function compares a function and a corresponding return annotation', 
 		return x;
 	}
 });
+
+tape( 'the function detects a mismatch when an actual array element is a primitive and the expected array element is an array', function test( t ) {
+	var expected;
+	var actual;
+	var msg;
+
+	actual = [ 300, 700 ];
+	expected = '[[ 300, 700 ]]';
+	msg = 'Displayed return value is `[[ 300, 700 ]]`, but expected `[ 300, 700 ]` instead';
+	t.strictEqual( compareValues( actual, expected ), msg, 'returns expected message' );
+
+	t.end();
+});
+
+tape( 'the function detects a mismatch when an actual array element is a primitive and the expected array element is an object', function test( t ) {
+	var expected;
+	var actual;
+	var msg;
+
+	actual = [ 1 ];
+	expected = '[ {} ]';
+	msg = 'Displayed return value is `[ {} ]`, but expected `[ 1 ]` instead';
+	t.strictEqual( compareValues( actual, expected ), msg, 'returns expected message' );
+
+	t.end();
+});
+
+tape( 'the function detects a mismatch when an actual array element is a primitive and the expected array element is a RegExp', function test( t ) {
+	var expected;
+	var actual;
+	var msg;
+
+	actual = [ 1 ];
+	expected = '[ /abc/ ]';
+	msg = 'Displayed return value is `[ /abc/ ]`, but expected `[ 1 ]` instead';
+	t.strictEqual( compareValues( actual, expected ), msg, 'returns expected message' );
+
+	t.end();
+});
+
+tape( 'the function detects a mismatch in a mixed array where a primitive corresponds to an array', function test( t ) {
+	var expected;
+	var actual;
+	var msg;
+
+	actual = [ 1, 2 ];
+	expected = '[ 1, [ 2 ] ]';
+	msg = 'Displayed return value is `[ 1, [ 2 ] ]`, but expected `[ 1, 2 ]` instead';
+	t.strictEqual( compareValues( actual, expected ), msg, 'returns expected message' );
+
+	t.end();
+});


### PR DESCRIPTION
Resolves None.

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes a bug in the doctest linter where incorrect dimensionality in return value annotations was silently ignored.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   None

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [X] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [X] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
