### PR TITLE
feat: implemented max-nth-double-factorial missing constant

### DIFF
--- a/lib/node_modules/@stdlib/constants/float16/max-nth-double-factorial/README.md
+++ b/lib/node_modules/@stdlib/constants/float16/max-nth-double-factorial/README.md
@@ -1,0 +1,164 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2025 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# FLOAT16_MAX_NTH_DOUBLE_FACTORIAL
+
+> Maximum nth [double factorial][double-factorial] when stored in [half-precision floating-point][ieee754] format.
+
+<section class="usage">
+
+## Usage
+
+<!-- eslint-disable id-length -->
+
+```javascript
+var FLOAT16_MAX_NTH_DOUBLE_FACTORIAL = require( '@stdlib/constants/float16/max-nth-double-factorial' );
+```
+
+#### FLOAT16_MAX_NTH_DOUBLE_FACTORIAL
+
+The maximum nth [double factorial][double-factorial] when stored in [half-precision floating-point][ieee754] format.
+
+<!-- eslint-disable id-length -->
+
+```javascript
+var bool = ( FLOAT16_MAX_NTH_DOUBLE_FACTORIAL === 12 );
+// returns true
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint-disable id-length -->
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var FLOAT16_MAX_NTH_DOUBLE_FACTORIAL = require( '@stdlib/constants/float16/max-nth-double-factorial' );
+
+function factorial2( n ) {
+    var a;
+    var i;
+
+    a = 1;
+    for ( i = n; i >= 2; i -= 2 ) {
+        a *= i;
+    }
+    return a;
+}
+
+var v;
+var i;
+for ( i = 0; i < 100; i++ ) {
+    v = factorial2( i );
+    if ( i > FLOAT16_MAX_NTH_DOUBLE_FACTORIAL ) {
+        console.log( 'Overflow: %d', v );
+    } else {
+        console.log( 'Valid:    %d', v );
+    }
+}
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- C interface documentation. -->
+
+* * *
+
+<section class="c">
+
+## C APIs
+
+<!-- Section to include introductory text. Make sure to keep an empty line after the intro `section` element and another before the `/section` close. -->
+
+<section class="intro">
+
+</section>
+
+<!-- /.intro -->
+
+<!-- C usage documentation. -->
+
+<section class="usage">
+
+### Usage
+
+```c
+#include "stdlib/constants/float16/max_nth_double_factorial.h"
+```
+
+#### STDLIB_CONSTANT_FLOAT16_MAX_NTH_DOUBLE_FACTORIAL
+
+Macro for the maximum nth [double factorial][double-factorial] when stored in [half-precision floating-point][ieee754] format.
+
+</section>
+
+<!-- /.usage -->
+
+<!-- C API usage notes. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="notes">
+
+</section>
+
+<!-- /.notes -->
+
+<!-- C API usage examples. -->
+
+<section class="examples">
+
+</section>
+
+<!-- /.examples -->
+
+</section>
+
+<!-- /.c -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[double-factorial]: https://en.wikipedia.org/wiki/Double_factorial
+
+[ieee754]: https://en.wikipedia.org/wiki/IEEE_754-1985
+
+<!-- <related-links> -->
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/constants/float16/max-nth-double-factorial/docs/repl.txt
+++ b/lib/node_modules/@stdlib/constants/float16/max-nth-double-factorial/docs/repl.txt
@@ -1,0 +1,13 @@
+
+{{alias}}
+    Maximum nth double factorial when stored in half-precision floating-point
+    format.
+
+    Examples
+    --------
+    > {{alias}}
+    12
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/constants/float16/max-nth-double-factorial/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/constants/float16/max-nth-double-factorial/docs/types/index.d.ts
@@ -1,0 +1,33 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/**
+* Maximum nth double factorial when stored in half-precision floating-point format.
+*
+* @example
+* var max = FLOAT16_MAX_NTH_DOUBLE_FACTORIAL;
+* // returns 12
+*/
+declare const FLOAT16_MAX_NTH_DOUBLE_FACTORIAL: number;
+
+
+// EXPORTS //
+
+export = FLOAT16_MAX_NTH_DOUBLE_FACTORIAL;

--- a/lib/node_modules/@stdlib/constants/float16/max-nth-double-factorial/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/constants/float16/max-nth-double-factorial/docs/types/test.ts
@@ -1,0 +1,28 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import FLOAT16_MAX_NTH_DOUBLE_FACTORIAL = require( './index' );
+
+
+// TESTS //
+
+// The export is a number...
+{
+	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+	FLOAT16_MAX_NTH_DOUBLE_FACTORIAL; // $ExpectType number
+}

--- a/lib/node_modules/@stdlib/constants/float16/max-nth-double-factorial/examples/index.js
+++ b/lib/node_modules/@stdlib/constants/float16/max-nth-double-factorial/examples/index.js
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var FLOAT16_MAX_NTH_DOUBLE_FACTORIAL = require( './../lib' ); // eslint-disable-line id-length
+
+function factorial2( n ) {
+	var a;
+	var i;
+
+	a = 1;
+	for ( i = n; i >= 2; i -= 2 ) {
+		a *= i;
+	}
+	return a;
+}
+
+var v;
+var i;
+for ( i = 0; i < 100; i++ ) {
+	v = factorial2( i );
+	if ( i > FLOAT16_MAX_NTH_DOUBLE_FACTORIAL ) {
+		console.log( 'Overflow: %d', v );
+	} else {
+		console.log( 'Valid:    %d', v );
+	}
+}

--- a/lib/node_modules/@stdlib/constants/float16/max-nth-double-factorial/include/stdlib/constants/float16/max_nth_double_factorial.h
+++ b/lib/node_modules/@stdlib/constants/float16/max-nth-double-factorial/include/stdlib/constants/float16/max_nth_double_factorial.h
@@ -1,0 +1,27 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef STDLIB_CONSTANTS_FLOAT16_MAX_NTH_DOUBLE_FACTORIAL_H
+#define STDLIB_CONSTANTS_FLOAT16_MAX_NTH_DOUBLE_FACTORIAL_H
+
+/**
+* Macro for the maximum nth double factorial when stored in half-precision floating-point format.
+*/
+#define STDLIB_CONSTANT_FLOAT16_MAX_NTH_DOUBLE_FACTORIAL 12
+
+#endif // !STDLIB_CONSTANTS_FLOAT16_MAX_NTH_DOUBLE_FACTORIAL_H

--- a/lib/node_modules/@stdlib/constants/float16/max-nth-double-factorial/lib/index.js
+++ b/lib/node_modules/@stdlib/constants/float16/max-nth-double-factorial/lib/index.js
@@ -1,0 +1,51 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* eslint-disable id-length */
+
+'use strict';
+
+/**
+* Maximum nth double factorial when stored in half-precision floating-point format.
+*
+* @module @stdlib/constants/float16/max-nth-double-factorial
+* @type {integer32}
+*
+* @example
+* var FLOAT16_MAX_NTH_DOUBLE_FACTORIAL = require( '@stdlib/constants/float16/max-nth-double-factorial' );
+* // returns 12
+*/
+
+
+// MAIN //
+
+/**
+* The maximum nth double factorial when stored in half-precision floating-point format.
+*
+* @constant
+* @type {integer32}
+* @default 12
+* @see [double factorial]{@link https://en.wikipedia.org/wiki/Double_factorial}
+* @see [IEEE 754]{@link https://en.wikipedia.org/wiki/IEEE_754-1985}
+*/
+var FLOAT16_MAX_NTH_DOUBLE_FACTORIAL = 12|0; // asm type annotation
+
+
+// EXPORTS //
+
+module.exports = FLOAT16_MAX_NTH_DOUBLE_FACTORIAL;

--- a/lib/node_modules/@stdlib/constants/float16/max-nth-double-factorial/manifest.json
+++ b/lib/node_modules/@stdlib/constants/float16/max-nth-double-factorial/manifest.json
@@ -1,0 +1,36 @@
+{
+  "options": {},
+  "fields": [
+    {
+      "field": "src",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "include",
+      "resolve": true,
+      "relative": true
+    },
+    {
+      "field": "libraries",
+      "resolve": false,
+      "relative": false
+    },
+    {
+      "field": "libpath",
+      "resolve": true,
+      "relative": false
+    }
+  ],
+  "confs": [
+    {
+      "src": [],
+      "include": [
+        "./include"
+      ],
+      "libraries": [],
+      "libpath": [],
+      "dependencies": []
+    }
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float16/max-nth-double-factorial/package.json
+++ b/lib/node_modules/@stdlib/constants/float16/max-nth-double-factorial/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@stdlib/constants/float16/max-nth-double-factorial",
+  "version": "0.0.0",
+  "description": "Maximum nth double factorial when stored in half-precision floating-point format.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "doc": "./docs",
+    "example": "./examples",
+    "include": "./include",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "constant",
+    "const",
+    "max",
+    "maximum",
+    "factorial2",
+    "number",
+    "integer",
+    "float",
+    "floating",
+    "point",
+    "floating-point",
+    "float16",
+    "half",
+    "ieee754"
+  ]
+}

--- a/lib/node_modules/@stdlib/constants/float16/max-nth-double-factorial/test/test.js
+++ b/lib/node_modules/@stdlib/constants/float16/max-nth-double-factorial/test/test.js
@@ -1,0 +1,38 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var FLOAT16_MAX_NTH_DOUBLE_FACTORIAL = require( './../lib' ); // eslint-disable-line id-length
+
+
+// TESTS //
+
+tape( 'main export is a number', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof FLOAT16_MAX_NTH_DOUBLE_FACTORIAL, 'number', 'main export is a number' );
+	t.end();
+});
+
+tape( 'the exported value is 12', function test( t ) {
+	t.strictEqual( FLOAT16_MAX_NTH_DOUBLE_FACTORIAL, 12, 'returns expected value' );
+	t.end();
+});


### PR DESCRIPTION
  ---
  type: pre_commit_static_analysis_report
  description: Results of running static analysis checks when committing changes.
  report:
    - task: lint_filenames status: passed
    - task: lint_editorconfig status: passed
    - task: lint_markdown status: passed
    - task: lint_package_json status: passed
    - task: lint_repl_help status: passed
    - task: lint_javascript_src status: passed
    - task: lint_javascript_cli status: na
    - task: lint_javascript_examples status: passed
    - task: lint_javascript_tests status: passed
    - task: lint_javascript_benchmarks status: na
    - task: lint_python status: na
    - task: lint_r status: na
    - task: lint_c_src status: na
    - task: lint_c_examples status: na
    - task: lint_c_benchmarks status: na
    - task: lint_c_tests_fixtures status: na
    - task: lint_shell status: na
    - task: lint_typescript_declarations status: passed
    - task: lint_typescript_tests status: passed
    - task: lint_license_headers status: passed 

  Progresses #9061.

  ## Description

  > What is the purpose of this pull request?

  This pull request:

  -   Adds `@stdlib/constants/float16/max-nth-double-factorial` constant
  -   Implements the maximum nth value for which the double factorial can be stored in half-precision floating-point format without overflow
  -   The constant value is `12`, since `12!! = 46080` fits within float16 max (`65504`), while `13!! = 135135` overflows

  ## Related Issues

  > Does this pull request have any related issues?

  This pull request has the following related issues:

  -   #9061 (tracking issue for missing float16 constants)

  ## Questions

  > Any questions for reviewers of this pull request?

  No.

  ## Other

  > Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

  **Implementation Details:**
  - Constant value: `12`
  - Calculation: `12!! = 12 × 10 × 8 × 6 × 4 × 2 = 46,080` (within float16 range)
  - Overflow check: `13!! = 135,135` (exceeds float16 max of 65,504)
  - Follows the same structure as existing float32/float64 `max-nth-double-factorial` constants
  - Includes full test coverage, TypeScript declarations, C header, and documentation

  ## Checklist

  > Please ensure the following tasks are completed before submitting this pull request.

  -   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

  > When authoring the changes proposed in this PR, did you use any kind of AI assistance?

  -   [x] Yes
  -   [ ] No

  If you answered "yes" above, how did you use AI assistance?

  -   [x] Code generation (e.g., when writing an implementation or fixing a bug)
  -   [x] Test/benchmark generation
  -   [x] Documentation (including examples)
  -   [ ] Research and understanding

  #### Disclosure

  > If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself."

This PR was partially written with the help of Claude Code for initial implementation, following the existing patterns from float32/float64 max-nth-double-factorial constants and merged float16 PRs. The constant value was calculated programmatically, and the entire implementation was thoroughly reviewed and verified by me to ensure correctness and adherence to project standards.

  * * *

  @stdlib-js/reviewers

  [contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md