### PR TITLE
docs: improve doctests for complex number instances in `math/base/special/cfloorn`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/cfloorn/README.md
+++ b/lib/node_modules/@stdlib/math/base/special/cfloorn/README.md
@@ -36,47 +36,21 @@ Rounds each component of a double-precision complex floating-point number to the
 
 ```javascript
 var Complex128 = require( '@stdlib/complex/float64/ctor' );
-var real = require( '@stdlib/complex/float64/real' );
-var imag = require( '@stdlib/complex/float64/imag' );
 
 // Round components to 2 decimal places:
 var v = cfloorn( new Complex128( -3.141592653589793, 3.141592653589793 ), -2 );
-// returns <Complex128>
-
-var re = real( v );
-// returns -3.15
-
-var im = imag( v );
-// returns 3.14
+// returns <Complex128>[ -3.15, 3.14 ]
 
 // If n = 0, `cfloorn` behaves like `cfloor`:
 v = cfloorn( new Complex128( -3.141592653589793, 3.141592653589793 ), 0 );
-// returns <Complex128>
-
-re = real( v );
-// returns -4.0
-
-im = imag( v );
-// returns 3.0
+// returns <Complex128>[ -4.0, 3.0 ]
 
 // Round components to the nearest thousand:
 v = cfloorn( new Complex128( -12368.0, 12368.0 ), 3 );
-// returns <Complex128>
-
-re = real( v );
-// returns -13000.0
-
-im = imag( v );
-// returns 12000.0
+// returns <Complex128>[ -13000.0, 12000.0 ]
 
 v = cfloorn( new Complex128( NaN, NaN ), 0 );
-// returns <Complex128>
-
-re = real( v );
-// returns NaN
-
-im = imag( v );
-// returns NaN
+// returns <Complex128>[ NaN, NaN ]
 ```
 
 </section>
@@ -91,21 +65,13 @@ im = imag( v );
 
     ```javascript
     var Complex128 = require( '@stdlib/complex/float64/ctor' );
-    var real = require( '@stdlib/complex/float64/real' );
-    var imag = require( '@stdlib/complex/float64/imag' );
 
     var x = -0.2 - 0.1;
     // returns -0.30000000000000004
 
     // Should round components to 0.3:
     var v = cfloorn( new Complex128( x, x ), -16 );
-    // returns <Complex128>
-
-    var re = real( v );
-    // returns -0.3000000000000001
-
-    var im = imag( v );
-    // returns -0.3000000000000001
+    // returns <Complex128>[ -0.3000000000000001, -0.3000000000000001 ]
     ```
 
 </section>

--- a/lib/node_modules/@stdlib/math/base/special/cfloorn/docs/repl.txt
+++ b/lib/node_modules/@stdlib/math/base/special/cfloorn/docs/repl.txt
@@ -19,11 +19,7 @@
     Examples
     --------
     > var v = {{alias}}( new {{alias:@stdlib/complex/float64/ctor}}( 5.555, -3.333 ), -2 )
-    <Complex128>
-    > var re = {{alias:@stdlib/complex/float64/real}}( v )
-    5.55
-    > var im = {{alias:@stdlib/complex/float64/imag}}( v )
-    -3.34
+    <Complex128>[ 5.55, -3.34 ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/math/base/special/cfloorn/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/math/base/special/cfloorn/docs/types/index.d.ts
@@ -31,17 +31,9 @@ import { Complex128 } from '@stdlib/types/complex';
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * var v = cfloorn( new Complex128( 5.555, -3.333 ), -2 );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns 5.55
-*
-* var im = imag( v );
-* // returns -3.34
+* // returns <Complex128>[ 5.55, -3.34 ]
 */
 declare function cfloorn( z: Complex128, n: number ): Complex128;
 

--- a/lib/node_modules/@stdlib/math/base/special/cfloorn/lib/index.js
+++ b/lib/node_modules/@stdlib/math/base/special/cfloorn/lib/index.js
@@ -25,48 +25,22 @@
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 * var cfloorn = require( '@stdlib/math/base/special/cfloorn' );
 *
 * // Round components to 2 decimal places:
 * var v = cfloorn( new Complex128( -3.141592653589793, 3.141592653589793 ), -2 );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns -3.15
-*
-* var im = imag( v );
-* // returns 3.14
+* // returns <Complex128>[ -3.15, 3.14 ]
 *
 * // If n = 0, `cfloorn` behaves like `cfloor`:
 * v = cfloorn( new Complex128( 9.99999, 0.1 ), 0 );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns 9.0
-*
-* im = imag( v );
-* // returns 0.0
+* // returns <Complex128>[ 9.0, 0.0 ]
 *
 * // Round components to the nearest thousand:
 * v = cfloorn( new Complex128( 12368.0, -12368.0 ), 2 );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns 12300.0
-*
-* im = imag( v );
-* // returns -12400.0
+* // returns <Complex128>[ 12300.0, -12400.0 ]
 *
 * v = cfloorn( new Complex128( NaN, NaN ), 2 );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns NaN
-*
-* im = imag( v );
-* // returns NaN
+* // returns <Complex128>[ NaN, NaN ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/math/base/special/cfloorn/lib/main.js
+++ b/lib/node_modules/@stdlib/math/base/special/cfloorn/lib/main.js
@@ -37,47 +37,21 @@ var imag = require( '@stdlib/complex/float64/imag' );
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * // Round components to 2 decimal places:
 * var v = cfloorn( new Complex128( -3.141592653589793, 3.141592653589793 ), -2 );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns -3.15
-*
-* var im = imag( v );
-* // returns 3.14
+* // returns <Complex128>[ -3.15, 3.14 ]
 *
 * // If n = 0, `cfloorn` behaves like `cfloor`:
 * v = cfloorn( new Complex128( 9.99999, 0.1 ), 0 );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns 9.0
-*
-* im = imag( v );
-* // returns 0.0
+* // returns <Complex128>[ 9.0, 0.0 ]
 *
 * // Round components to the nearest thousand:
 * v = cfloorn( new Complex128( 12368.0, -12368.0 ), 2 );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns 12300
-*
-* im = imag( v );
-* // returns -12400
+* // returns <Complex128>[ 12300.0, -12400.0 ]
 *
 * v = cfloorn( new Complex128( NaN, NaN ), 2 );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns NaN
-*
-* im = imag( v );
-* // returns NaN
+* // returns <Complex128>[ NaN, NaN ]
 */
 function cfloorn( z, n ) {
 	return new Complex128( floorn( real( z ), n ), floorn( imag( z ), n ) );

--- a/lib/node_modules/@stdlib/math/base/special/cfloorn/lib/native.js
+++ b/lib/node_modules/@stdlib/math/base/special/cfloorn/lib/native.js
@@ -36,47 +36,21 @@ var addon = require( './../src/addon.node' );
 *
 * @example
 * var Complex128 = require( '@stdlib/complex/float64/ctor' );
-* var real = require( '@stdlib/complex/float64/real' );
-* var imag = require( '@stdlib/complex/float64/imag' );
 *
 * // Round components to 2 decimal places:
 * var v = cfloorn( new Complex128( -3.141592653589793, 3.141592653589793 ), -2 );
-* // returns <Complex128>
-*
-* var re = real( v );
-* // returns -3.15
-*
-* var im = imag( v );
-* // returns 3.14
+* // returns <Complex128>[ -3.15, 3.14 ]
 *
 * // If n = 0, `cfloorn` behaves like `cfloor`:
 * v = cfloorn( new Complex128( 9.99999, 0.1 ), 0 );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns 9.0
-*
-* im = imag( v );
-* // returns 0.0
+* // returns <Complex128>[ 9.0, 0.0 ]
 *
 * // Round components to the nearest thousand:
 * v = cfloorn( new Complex128( 12368.0, -12368.0 ), 2 );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns 12300
-*
-* im = imag( v );
-* // returns -12400
+* // returns <Complex128>[ 12300.0, -12400.0 ]
 *
 * v = cfloorn( new Complex128( NaN, NaN ), 2 );
-* // returns <Complex128>
-*
-* re = real( v );
-* // returns NaN
-*
-* im = imag( v );
-* // returns NaN
+* // returns <Complex128>[ NaN, NaN ]
 */
 function cfloorn( z, n ) {
 	var v = addon( z, n );


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: passed
  - task: lint_package_json status: na
  - task: lint_repl_help status: passed
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: passed
  - task: lint_license_headers status: passed ---

Resolves part of #8641 

## Description

This pull request updates documentation examples for `math/base/special/cfloorn` to use complex number instance notation (e.g., ` returns <Complex128>[ -3.15, 3.14 ]`) instead of decomposing values using `realf` and `imagf`, in accordance with the RFC guidance.

No functional code changes were made. Only documentation examples were updated.

## Related Issues

- #8641    

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] No
-   [ ] Yes

#### Disclosure

N/A

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md