### PR TITLE
bench: refactor to use dynamic memory allocation in `blas/ext/base/drrss`

### DIFF
--- a/lib/node_modules/@stdlib/blas/ext/base/drrss/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/blas/ext/base/drrss/benchmark/c/benchmark.length.c
@@ -96,12 +96,14 @@ static double rand_double( void ) {
 */
 static double benchmark1( int iterations, int len ) {
 	double elapsed;
-	double x[ len ];
-	double y[ len ];
+	double *x;
+	double *y;
 	double v;
 	double t;
 	int i;
 
+	x = (double *) malloc( len * sizeof( double ) );
+	y = (double *) malloc( len * sizeof( double ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = ( rand_double() * 20000.0 ) - 10000.0;
 		y[ i ] = ( rand_double() * 20000.0 ) - 10000.0;
@@ -120,6 +122,8 @@ static double benchmark1( int iterations, int len ) {
 	if ( v != v ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( y );
 	return elapsed;
 }
 
@@ -132,12 +136,14 @@ static double benchmark1( int iterations, int len ) {
 */
 static double benchmark2( int iterations, int len ) {
 	double elapsed;
-	double x[ len ];
-	double y[ len ];
+	double *x;
+	double *y;
 	double v;
 	double t;
 	int i;
 
+	x = (double *) malloc( len * sizeof( double ) );
+	y = (double *) malloc( len * sizeof( double ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = ( rand_double() * 20000.0 ) - 10000.0;
 		y[ i ] = ( rand_double() * 20000.0 ) - 10000.0;
@@ -156,6 +162,8 @@ static double benchmark2( int iterations, int len ) {
 	if ( v != v ) {
 		printf( "should not return NaN\n" );
 	}
+	free( x );
+	free( y );
 	return elapsed;
 }
 


### PR DESCRIPTION
Progresses #8643 .

## Description

> What is the purpose of this pull request?

This pull request:

- This PR refactors C benchmarks in `blas/ext/base/drrss` to use dynamic memory allocation instead of static allocation for large arrays, following the guidance in #8643.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8643 .

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

### Changes
- Replaced `double x[len]` with `double *x = malloc(len * sizeof(double))`
- Replaced `double y[len]` with `double *y = malloc(len * sizeof(double))`
- Added `free(x)` and `free(y)` calls after benchmark execution
- Applied changes to both `benchmark1` and `benchmark2` functions

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
