### PR TITLE
chore: address commit comments for commit 9799f77 (issue #9288)

### DIFF
--- a/lib/node_modules/@stdlib/number/float16/ctor/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/number/float16/ctor/benchmark/benchmark.js
@@ -71,7 +71,7 @@ bench( format( '%s::get:value', pkg ), function benchmark( b ) {
 	b.end();
 });
 
-bench( format( '%s::toString', pkg ), function benchmark( b ) {
+bench( format( '%s:toString', pkg ), function benchmark( b ) {
 	var o;
 	var z;
 	var i;
@@ -93,7 +93,7 @@ bench( format( '%s::toString', pkg ), function benchmark( b ) {
 	b.end();
 });
 
-bench( format( '%s::toJSON', pkg ), function benchmark( b ) {
+bench( format( '%s:toJSON', pkg ), function benchmark( b ) {
 	var o;
 	var z;
 	var i;


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: na
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: passed
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Resolves #9288.

## Description

> What is the purpose of this pull request?

This pull request:

- This PR addresses reviewer comments left on commit 9799f77 regarding unintended formatting changes in benchmark.js.

Specifically, two benchmark labels were mistakenly modified from `:` to `::`. This PR reverts those changes to restore the original and intended output format.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #9288
Commit: 9799f77
Reviewer comments requesting revert:
- R74 — `%s:toString`
- R96 — `%s:toJSON`

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
