### PR TITLE
chore: fix JavaScript lint errors (issue #9301)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/bundle/pkg-list/examples/multiple-bundles-single-scope/index.js
+++ b/lib/node_modules/@stdlib/_tools/bundle/pkg-list/examples/multiple-bundles-single-scope/index.js
@@ -20,10 +20,10 @@
 
 var join = require( 'path' ).join;
 var mkdirp = require( 'mkdirp' ).sync;
-var collapse = require( 'bundle-collapser/plugin' );
+var collapse = require( 'bundle-collapser/plugin.js' );
 var uglifyify = require( 'uglifyify' );
 var uglify = require( 'uglify-js' );
-var packFlat = require( 'browser-pack-flat/plugin' );
+var packFlat = require( 'browser-pack-flat/plugin.js' );
 var pkgNames = require( '@stdlib/_tools/pkgs/names' ).sync;
 var instanceOf = require( '@stdlib/assert/instance-of' );
 var writeFile = require( '@stdlib/fs/write-file' ).sync;


### PR DESCRIPTION
Resolves #9301.

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixed linting errors by adding explicit .js file extensions to require statements in lib/node_modules/@stdlib/_tools/bundle/pkg-list/examples/multiple-bundles-single-scope/index.js

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #9301

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

I used Gemini to help understand the linting error logs
* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
