### PR TITLE
bench: refactor to use dynamic memory allocation in `math/strided/special/smskdeg2rad`

### DIFF
--- a/lib/node_modules/@stdlib/math/strided/special/smskdeg2rad/benchmark/c/benchmark.length.c
+++ b/lib/node_modules/@stdlib/math/strided/special/smskdeg2rad/benchmark/c/benchmark.length.c
@@ -115,12 +115,15 @@ float rand_uniformf( float a, float b ) {
 */
 static double benchmark( int iterations, int len ) {
 	double elapsed;
-	uint8_t m[ len ];
-	float x[ len ];
-	float y[ len ];
+	uint8_t *m;
+	float *x;
+	float *y;
 	double t;
 	int i;
 
+	m = (uint8_t *) malloc( len * sizeof( uint8_t ) );
+	x = (float *) malloc( len * sizeof( float ) );
+	y = (float *) malloc( len * sizeof( float ) );
 	for ( i = 0; i < len; i++ ) {
 		x[ i ] = rand_uniformf( -180.0f, 180.0f );
 		y[ i ] = 0.0f;
@@ -138,6 +141,9 @@ static double benchmark( int iterations, int len ) {
 	if ( y[ 0 ] != y[ 0 ] ) {
 		printf( "should not return NaN\n" );
 	}
+	free( m );
+	free( x );
+	free( y );
 	return elapsed;
 }
 


### PR DESCRIPTION
Progresses #8643 .

## Description

> What is the purpose of this pull request?

This pull request:

-   This PR refactors C benchmarks in math/strided/special/smskdeg2rad to use dynamic memory allocation instead of static allocation for large arrays, following the guidance in #8643 .

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #8643 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".


* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
