### PR TITLE
fix(bench): resolve TypeScript declaration lint errors

### DIFF
--- a/lib/node_modules/@stdlib/bench/harness/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/bench/harness/docs/types/index.d.ts
@@ -111,7 +111,7 @@ interface Benchmark {
 	*
 	* @example
 	* var str = b.name;
-	* // returns <string>
+	* // throws <ReferenceError>
 	*/
 	readonly name: string;
 
@@ -120,7 +120,7 @@ interface Benchmark {
 	*
 	* @example
 	* var iter = b.iterations;
-	* // returns <number>
+	* // throws <ReferenceError>
 	*/
 	readonly iterations: number;
 
@@ -217,7 +217,9 @@ interface Benchmark {
 	* @param msg - message
 	*
 	* @example
-	* b.comment( 'This is a comment.' );
+	* function benchmark( b ) {
+	* 	b.comment( 'This is a comment.' );
+	* }
 	*/
 	comment( msg: string ): void;
 
@@ -228,8 +230,10 @@ interface Benchmark {
 	* @param msg - message
 	*
 	* @example
-	* b.skip( false, 'This is skipped.' );
-	* b.skip( true, 'This is skipped.' );
+	* function benchmark( b ) {
+	* 	b.skip( false, 'This is skipped.' );
+	* 	b.skip( true, 'This is skipped.' );
+	* }
 	*/
 	skip( value: any, msg: string ): void;
 
@@ -244,8 +248,10 @@ interface Benchmark {
 	* @param msg - message
 	*
 	* @example
-	* b.todo( false, 'This is a todo.' );
-	* b.todo( true, 'This is a todo.' );
+	* function benchmark( b ) {
+	* 	b.todo( false, 'This is a todo.' );
+	* 	b.todo( true, 'This is a todo.' );
+	* }
 	*/
 	todo( value: any, msg: string ): void;
 
@@ -255,7 +261,9 @@ interface Benchmark {
 	* @param msg - message
 	*
 	* @example
-	* b.fail( 'This is a failing assertion.' );
+	* function benchmark( b ) {
+	* 	b.fail( 'This is a failing assertion.' );
+	* }
 	*/
 	fail( msg: string ): void;
 
@@ -265,7 +273,9 @@ interface Benchmark {
 	* @param msg - message
 	*
 	* @example
-	* b.fail( 'This is a passing assertion.' );
+	* function benchmark( b ) {
+	* 	b.fail( 'This is a passing assertion.' );
+	* }
 	*/
 	pass( msg: string ): void;
 
@@ -276,11 +286,15 @@ interface Benchmark {
 	* @param msg - message
 	*
 	* @example
-	* b.ok( [] );
+	* function benchmark( b ) {
+	* 	b.ok( [] );
+	* }
 	*
 	* @example
-	* b.ok( true, 'This asserts a value is truthy.' );
-	* b.ok( false, 'This asserts a value is truthy.' );
+	* function benchmark( b ) {
+	* 	b.ok( true, 'This asserts a value is truthy.' );
+	* 	b.ok( false, 'This asserts a value is truthy.' );
+	* }
 	*/
 	ok( value: any, msg?: string ): void;
 
@@ -291,11 +305,15 @@ interface Benchmark {
 	* @param msg - message
 	*
 	* @example
-	* b.notOk( null );
+	* function benchmark( b ) {
+	* 	b.notOk( null );
+	* }
 	*
 	* @example
-	* b.notOk( false, 'This asserts a value is falsy.' );
-	* b.notOk( true, 'This asserts a value is falsy.' );
+	* function benchmark( b ) {
+	* 	b.notOk( false, 'This asserts a value is falsy.' );
+	* 	b.notOk( true, 'This asserts a value is falsy.' );
+	* }
 	*/
 	notOk( value: any, msg?: string ): void;
 
@@ -310,14 +328,18 @@ interface Benchmark {
 	* var expected = [];
 	* var actual = expected;
 	*
-	* b.equal( actual, expected );
+	* function benchmark( b ) {
+	* 	b.equal( actual, expected );
+	* }
 	*
 	* @example
 	* var expected = [];
 	* var actual = expected;
 	*
-	* b.equal( actual, expected, 'This asserts two values are strictly equal.' );
-	* b.equal( 1.0, 2.0, 'This asserts two values are strictly equal.' );
+	* function benchmark( b ) {
+	* 	b.equal( actual, expected, 'This asserts two values are strictly equal.' );
+	* 	b.equal( 1.0, 2.0, 'This asserts two values are strictly equal.' );
+	* }
 	*/
 	equal( actual: any, expected: any, msg?: string ): void;
 
@@ -332,14 +354,18 @@ interface Benchmark {
 	* var expected = [];
 	* var actual = [];
 	*
-	* b.notEqual( actual, expected );
+	* function benchmark( b ) {
+	* 	b.notEqual( actual, expected );
+	* }
 	*
 	* @example
 	* var expected = [];
 	* var actual = [];
 	*
-	* b.notEqual( 1.0, 2.0, 'This asserts two values are not equal.' );
-	* b.notEqual( actual, expected, 'This asserts two values are not equal.' );
+	* function benchmark( b ) {
+	* 	b.notEqual( 1.0, 2.0, 'This asserts two values are not equal.' );
+	* 	b.notEqual( actual, expected, 'This asserts two values are not equal.' );
+	* }
 	*/
 	notEqual( actual: any, expected: any, msg?: string ): void;
 
@@ -351,27 +377,31 @@ interface Benchmark {
 	* @param msg - message
 	*
 	* @example
-	* var expected = {
-	*     'a': 'b'
-	* };
-	* var actual = {
-	*     'a': 'b'
-	* };
+	* function benchmark( b ) {
+	* 	var expected = {
+	* 	    'a': 'b'
+	* 	};
+	* 	var actual = {
+	* 	    'a': 'b'
+	* 	};
 	*
-	* b.deepEqual( actual, expected );
+	* 	b.deepEqual( actual, expected );
+	* }
 	*
 	* @example
-	* var expected = {
-	*     'a': 'b'
-	* };
-	* var actual = {
-	*     'a': 'b'
-	* };
+	* function benchmark( b ) {
+	* 	var expected = {
+	* 	    'a': 'b'
+	* 	};
+	* 	var actual = {
+	* 	    'a': 'b'
+	* 	};
 	*
-	* b.deepEqual( actual, expected, 'This asserts two values are deeply equal.' );
+	* 	b.deepEqual( actual, expected, 'This asserts two values are deeply equal.' );
 	*
-	* actual.a = 'c';
-	* b.deepEqual( actual, expected, 'This asserts two values are deeply equal.' );
+	* 	actual.a = 'c';
+	* 	b.deepEqual( actual, expected, 'This asserts two values are deeply equal.' );
+	* }
 	*/
 	deepEqual( actual: any, expected: any, msg?: string ): void;
 
@@ -383,27 +413,31 @@ interface Benchmark {
 	* @param msg - message
 	*
 	* @example
-	* var expected = {
-	*     'a': 'b'
-	* };
-	* var actual = {
-	*     'a': 'c'
-	* };
+	* function benchmark( b ) {
+	* 	var expected = {
+	* 	    'a': 'b'
+	* 	};
+	* 	var actual = {
+	* 	    'a': 'c'
+	* 	};
 	*
-	* b.notDeepEqual( actual, expected );
+	* 	b.notDeepEqual( actual, expected );
+	* }
 	*
 	* @example
-	* var expected = {
-	*     'a': 'b'
-	* };
-	* var actual = {
-	*     'a': 'c'
-	* };
+	* function benchmark( b ) {
+	* 	var expected = {
+	* 	    'a': 'b'
+	* 	};
+	* 	var actual = {
+	* 	    'a': 'c'
+	* 	};
 	*
-	* b.notDeepEqual( actual, expected, 'This asserts two values are not deeply equal.' );
+	* 	b.notDeepEqual( actual, expected, 'This asserts two values are not deeply equal.' );
 	*
-	* actual.a = 'b';
-	* b.notDeepEqual( actual, expected, 'This asserts two values are not deeply equal.' );
+	* 	actual.a = 'b';
+	* 	b.notDeepEqual( actual, expected, 'This asserts two values are not deeply equal.' );
+	* }
 	*/
 	notDeepEqual( actual: any, expected: any, msg?: string ): void;
 }

--- a/lib/node_modules/@stdlib/bench/harness/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/bench/harness/docs/types/index.d.ts
@@ -111,7 +111,7 @@ interface Benchmark {
 	*
 	* @example
 	* var str = b.name;
-	* // returns <string>
+	* // throws <ReferenceError>
 	*/
 	readonly name: string;
 
@@ -120,7 +120,7 @@ interface Benchmark {
 	*
 	* @example
 	* var iter = b.iterations;
-	* // returns <number>
+	* // throws <ReferenceError>
 	*/
 	readonly iterations: number;
 

--- a/lib/node_modules/@stdlib/bench/harness/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/bench/harness/docs/types/index.d.ts
@@ -341,6 +341,7 @@ interface Benchmark {
 	* 	b.equal( 1.0, 2.0, 'This asserts two values are strictly equal.' );
 	* }
 	*/
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	equal( actual: any, expected: any, msg?: string ): void;
 
 	/**
@@ -367,6 +368,7 @@ interface Benchmark {
 	* 	b.notEqual( actual, expected, 'This asserts two values are not equal.' );
 	* }
 	*/
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	notEqual( actual: any, expected: any, msg?: string ): void;
 
 	/**
@@ -403,6 +405,7 @@ interface Benchmark {
 	* 	b.deepEqual( actual, expected, 'This asserts two values are deeply equal.' );
 	* }
 	*/
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	deepEqual( actual: any, expected: any, msg?: string ): void;
 
 	/**
@@ -439,6 +442,7 @@ interface Benchmark {
 	* 	b.notDeepEqual( actual, expected, 'This asserts two values are not deeply equal.' );
 	* }
 	*/
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	notDeepEqual( actual: any, expected: any, msg?: string ): void;
 }
 

--- a/lib/node_modules/@stdlib/bench/harness/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/bench/harness/docs/types/index.d.ts
@@ -367,7 +367,6 @@ interface Benchmark {
 	* 	b.notEqual( actual, expected, 'This asserts two values are not equal.' );
 	* }
 	*/
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	notEqual( actual: any, expected: any, msg?: string ): void;
 
 	/**
@@ -404,7 +403,6 @@ interface Benchmark {
 	* 	b.deepEqual( actual, expected, 'This asserts two values are deeply equal.' );
 	* }
 	*/
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	deepEqual( actual: any, expected: any, msg?: string ): void;
 
 	/**
@@ -441,7 +439,6 @@ interface Benchmark {
 	* 	b.notDeepEqual( actual, expected, 'This asserts two values are not deeply equal.' );
 	* }
 	*/
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	notDeepEqual( actual: any, expected: any, msg?: string ): void;
 }
 

--- a/lib/node_modules/@stdlib/bench/harness/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/bench/harness/docs/types/index.d.ts
@@ -341,7 +341,6 @@ interface Benchmark {
 	* 	b.equal( 1.0, 2.0, 'This asserts two values are strictly equal.' );
 	* }
 	*/
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	equal( actual: any, expected: any, msg?: string ): void;
 
 	/**

--- a/lib/node_modules/@stdlib/bench/harness/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/bench/harness/docs/types/index.d.ts
@@ -218,7 +218,7 @@ interface Benchmark {
 	*
 	* @example
 	* function benchmark( b ) {
-	* 	b.comment( 'This is a comment.' );
+	*     b.comment( 'This is a comment.' );
 	* }
 	*/
 	comment( msg: string ): void;
@@ -231,8 +231,8 @@ interface Benchmark {
 	*
 	* @example
 	* function benchmark( b ) {
-	* 	b.skip( false, 'This is skipped.' );
-	* 	b.skip( true, 'This is skipped.' );
+	*     b.skip( false, 'This is skipped.' );
+	*     b.skip( true, 'This is skipped.' );
 	* }
 	*/
 	skip( value: boolean, msg: string ): void;
@@ -249,8 +249,8 @@ interface Benchmark {
 	*
 	* @example
 	* function benchmark( b ) {
-	* 	b.todo( false, 'This is a todo.' );
-	* 	b.todo( true, 'This is a todo.' );
+	*     b.todo( false, 'This is a todo.' );
+	*     b.todo( true, 'This is a todo.' );
 	* }
 	*/
 	todo( value: boolean, msg: string ): void;
@@ -262,7 +262,7 @@ interface Benchmark {
 	*
 	* @example
 	* function benchmark( b ) {
-	* 	b.fail( 'This is a failing assertion.' );
+	*     b.fail( 'This is a failing assertion.' );
 	* }
 	*/
 	fail( msg: string ): void;
@@ -274,7 +274,7 @@ interface Benchmark {
 	*
 	* @example
 	* function benchmark( b ) {
-	* 	b.fail( 'This is a passing assertion.' );
+	*     b.fail( 'This is a passing assertion.' );
 	* }
 	*/
 	pass( msg: string ): void;
@@ -287,13 +287,13 @@ interface Benchmark {
 	*
 	* @example
 	* function benchmark( b ) {
-	* 	b.ok( [] );
+	*     b.ok( [] );
 	* }
 	*
 	* @example
 	* function benchmark( b ) {
-	* 	b.ok( true, 'This asserts a value is truthy.' );
-	* 	b.ok( false, 'This asserts a value is truthy.' );
+	*     b.ok( true, 'This asserts a value is truthy.' );
+	*     b.ok( false, 'This asserts a value is truthy.' );
 	* }
 	*/
 	ok( value: boolean, msg?: string ): void;
@@ -306,13 +306,13 @@ interface Benchmark {
 	*
 	* @example
 	* function benchmark( b ) {
-	* 	b.notOk( null );
+	*     b.notOk( null );
 	* }
 	*
 	* @example
 	* function benchmark( b ) {
-	* 	b.notOk( false, 'This asserts a value is falsy.' );
-	* 	b.notOk( true, 'This asserts a value is falsy.' );
+	*     b.notOk( false, 'This asserts a value is falsy.' );
+	*     b.notOk( true, 'This asserts a value is falsy.' );
 	* }
 	*/
 	notOk( value: boolean, msg?: string ): void;
@@ -329,7 +329,7 @@ interface Benchmark {
 	* var actual = expected;
 	*
 	* function benchmark( b ) {
-	* 	b.equal( actual, expected );
+	*     b.equal( actual, expected );
 	* }
 	*
 	* @example
@@ -337,8 +337,8 @@ interface Benchmark {
 	* var actual = expected;
 	*
 	* function benchmark( b ) {
-	* 	b.equal( actual, expected, 'This asserts two values are strictly equal.' );
-	* 	b.equal( 1.0, 2.0, 'This asserts two values are strictly equal.' );
+	*     b.equal( actual, expected, 'This asserts two values are strictly equal.' );
+	*     b.equal( 1.0, 2.0, 'This asserts two values are strictly equal.' );
 	* }
 	*/
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -356,7 +356,7 @@ interface Benchmark {
 	* var actual = [];
 	*
 	* function benchmark( b ) {
-	* 	b.notEqual( actual, expected );
+	*     b.notEqual( actual, expected );
 	* }
 	*
 	* @example
@@ -364,8 +364,8 @@ interface Benchmark {
 	* var actual = [];
 	*
 	* function benchmark( b ) {
-	* 	b.notEqual( 1.0, 2.0, 'This asserts two values are not equal.' );
-	* 	b.notEqual( actual, expected, 'This asserts two values are not equal.' );
+	*     b.notEqual( 1.0, 2.0, 'This asserts two values are not equal.' );
+	*     b.notEqual( actual, expected, 'This asserts two values are not equal.' );
 	* }
 	*/
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -380,29 +380,29 @@ interface Benchmark {
 	*
 	* @example
 	* function benchmark( b ) {
-	* 	var expected = {
-	* 	    'a': 'b'
-	* 	};
-	* 	var actual = {
-	* 	    'a': 'b'
-	* 	};
+	*     var expected = {
+	*         'a': 'b'
+	*     };
+	*     var actual = {
+	*         'a': 'b'
+	*     };
 	*
-	* 	b.deepEqual( actual, expected );
+	*     b.deepEqual( actual, expected );
 	* }
 	*
 	* @example
 	* function benchmark( b ) {
-	* 	var expected = {
-	* 	    'a': 'b'
-	* 	};
-	* 	var actual = {
-	* 	    'a': 'b'
-	* 	};
+	*     var expected = {
+	*         'a': 'b'
+	*     };
+	*     var actual = {
+	*         'a': 'b'
+	*     };
 	*
-	* 	b.deepEqual( actual, expected, 'This asserts two values are deeply equal.' );
+	*     b.deepEqual( actual, expected, 'This asserts two values are deeply equal.' );
 	*
-	* 	actual.a = 'c';
-	* 	b.deepEqual( actual, expected, 'This asserts two values are deeply equal.' );
+	*     actual.a = 'c';
+	*     b.deepEqual( actual, expected, 'This asserts two values are deeply equal.' );
 	* }
 	*/
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -417,29 +417,29 @@ interface Benchmark {
 	*
 	* @example
 	* function benchmark( b ) {
-	* 	var expected = {
-	* 	    'a': 'b'
-	* 	};
-	* 	var actual = {
-	* 	    'a': 'c'
-	* 	};
+	*     var expected = {
+	*         'a': 'b'
+	*     };
+	*     var actual = {
+	*         'a': 'c'
+	*     };
 	*
-	* 	b.notDeepEqual( actual, expected );
+	*     b.notDeepEqual( actual, expected );
 	* }
 	*
 	* @example
 	* function benchmark( b ) {
-	* 	var expected = {
-	* 	    'a': 'b'
-	* 	};
-	* 	var actual = {
-	* 	    'a': 'c'
-	* 	};
+	*     var expected = {
+	*         'a': 'b'
+	*     };
+	*     var actual = {
+	*         'a': 'c'
+	*     };
 	*
-	* 	b.notDeepEqual( actual, expected, 'This asserts two values are not deeply equal.' );
+	*     b.notDeepEqual( actual, expected, 'This asserts two values are not deeply equal.' );
 	*
-	* 	actual.a = 'b';
-	* 	b.notDeepEqual( actual, expected, 'This asserts two values are not deeply equal.' );
+	*     actual.a = 'b';
+	*     b.notDeepEqual( actual, expected, 'This asserts two values are not deeply equal.' );
 	* }
 	*/
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/lib/node_modules/@stdlib/bench/harness/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/bench/harness/docs/types/index.d.ts
@@ -111,7 +111,7 @@ interface Benchmark {
 	*
 	* @example
 	* var str = b.name;
-	* // throws <ReferenceError>
+	* // returns <string>
 	*/
 	readonly name: string;
 
@@ -120,7 +120,7 @@ interface Benchmark {
 	*
 	* @example
 	* var iter = b.iterations;
-	* // throws <ReferenceError>
+	* // returns <number>
 	*/
 	readonly iterations: number;
 

--- a/lib/node_modules/@stdlib/bench/harness/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/bench/harness/docs/types/index.d.ts
@@ -235,7 +235,7 @@ interface Benchmark {
 	* 	b.skip( true, 'This is skipped.' );
 	* }
 	*/
-	skip( value: any, msg: string ): void;
+	skip( value: boolean, msg: string ): void;
 
 	/**
 	* Generates an assertion which should be implemented.
@@ -253,7 +253,7 @@ interface Benchmark {
 	* 	b.todo( true, 'This is a todo.' );
 	* }
 	*/
-	todo( value: any, msg: string ): void;
+	todo( value: boolean, msg: string ): void;
 
 	/**
 	* Generates a failing assertion.
@@ -296,7 +296,7 @@ interface Benchmark {
 	* 	b.ok( false, 'This asserts a value is truthy.' );
 	* }
 	*/
-	ok( value: any, msg?: string ): void;
+	ok( value: boolean, msg?: string ): void;
 
 	/**
 	* Asserts that a `value` is falsy.
@@ -315,7 +315,7 @@ interface Benchmark {
 	* 	b.notOk( true, 'This asserts a value is falsy.' );
 	* }
 	*/
-	notOk( value: any, msg?: string ): void;
+	notOk( value: boolean, msg?: string ): void;
 
 	/**
 	* Asserts that `actual` is **strictly** equal to `expected`.
@@ -341,6 +341,7 @@ interface Benchmark {
 	* 	b.equal( 1.0, 2.0, 'This asserts two values are strictly equal.' );
 	* }
 	*/
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	equal( actual: any, expected: any, msg?: string ): void;
 
 	/**
@@ -367,6 +368,7 @@ interface Benchmark {
 	* 	b.notEqual( actual, expected, 'This asserts two values are not equal.' );
 	* }
 	*/
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	notEqual( actual: any, expected: any, msg?: string ): void;
 
 	/**
@@ -403,6 +405,7 @@ interface Benchmark {
 	* 	b.deepEqual( actual, expected, 'This asserts two values are deeply equal.' );
 	* }
 	*/
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	deepEqual( actual: any, expected: any, msg?: string ): void;
 
 	/**
@@ -439,6 +442,7 @@ interface Benchmark {
 	* 	b.notDeepEqual( actual, expected, 'This asserts two values are not deeply equal.' );
 	* }
 	*/
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	notDeepEqual( actual: any, expected: any, msg?: string ): void;
 }
 
@@ -463,7 +467,7 @@ interface Harness {
 	* @example
 	* var stdout = require( '@stdlib/streams/node/stdout' );
 	*
-	* var harness = bench.createHarness();
+	* var harness = main.createHarness();
 	* var stream = harness.createStream();
 	*
 	* // Direct all results to `stdout`:
@@ -496,7 +500,7 @@ interface Harness {
 	* @example
 	* var stdout = require( '@stdlib/streams/node/stdout' );
 	*
-	* var harness = bench.createHarness();
+	* var harness = main.createHarness();
 	*
 	* var stream = harness.createStream();
 	* stream.pipe( stdout );
@@ -540,7 +544,7 @@ interface Harness {
 	* @example
 	* var stdout = require( '@stdlib/streams/node/stdout' );
 	*
-	* var harness = bench.createHarness();
+	* var harness = main.createHarness();
 	*
 	* var stream = harness.createStream();
 	* stream.pipe( stdout );
@@ -577,7 +581,7 @@ interface Harness {
 	* **Read-only** property whose value is the harness exit code. If all benchmarks run successfully (i.e., no failing assertions), the exit code is `0`; otherwise, the exit code is `1`.
 	*
 	* @example
-	* var harness = bench.createHarness();
+	* var harness = main.createHarness();
 	*
 	* // Benchmarks only start running when results have a destination:
 	* var stream = harness.createStream();
@@ -617,7 +621,7 @@ interface Main {
 	* @returns benchmark harness
 	*
 	* @example
-	* bench( 'beep', function benchmark( b ) {
+	* main( 'beep', function benchmark( b ) {
 	*     var x;
 	*     var i;
 	*     b.tic();
@@ -654,7 +658,7 @@ interface Main {
 	*     'repeats': 5
 	* };
 	*
-	* bench( 'beep', opts, function benchmark( b ) {
+	* main( 'beep', opts, function benchmark( b ) {
 	*     var x;
 	*     var i;
 	*     b.tic();
@@ -723,7 +727,7 @@ interface Main {
 * @returns benchmark harness
 *
 * @example
-* bench( 'beep', function benchmark( b ) {
+* main( 'beep', function benchmark( b ) {
 *     var x;
 *     var i;
 *     b.tic();
@@ -745,7 +749,7 @@ interface Main {
 *     'repeats': 5
 * };
 *
-* bench( 'beep', opts, function benchmark( b ) {
+* main( 'beep', opts, function benchmark( b ) {
 *     var x;
 *     var i;
 *     b.tic();

--- a/lib/node_modules/@stdlib/bench/harness/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/bench/harness/docs/types/test.ts
@@ -23,7 +23,7 @@ import bench = require( './index' );
 
 // FUNCTIONS //
 
-const benchmark = () => {};
+const benchmark = (): void => undefined;
 
 
 // TESTS //
@@ -114,8 +114,8 @@ const benchmark = () => {};
 // Attached to the main export is a `createHarness` method which returns a Harness..
 {
 	bench.createHarness(); // $ExpectType Harness
-	bench.createHarness( (): void => {} ); // $ExpectType Harness
-	bench.createHarness( { 'autoclose': true }, (): void => {} ); // $ExpectType Harness
+	bench.createHarness( (): void => undefined ); // $ExpectType Harness
+	bench.createHarness( { 'autoclose': true }, (): void => undefined ); // $ExpectType Harness
 }
 
 // The compiler throws an error if the `createHarness` method is provided an `autoclose` option which is not a boolean...
@@ -127,12 +127,12 @@ const benchmark = () => {};
 	bench.createHarness( { 'autoclose': {} } ); // $ExpectError
 	bench.createHarness( { 'autoclose': ( x: number ): number => x } ); // $ExpectError
 
-	bench.createHarness( { 'autoclose': 123 }, (): void => {} ); // $ExpectError
-	bench.createHarness( { 'autoclose': 'abc' }, (): void => {} ); // $ExpectError
-	bench.createHarness( { 'autoclose': null }, (): void => {} ); // $ExpectError
-	bench.createHarness( { 'autoclose': [] }, (): void => {} ); // $ExpectError
-	bench.createHarness( { 'autoclose': {} }, (): void => {} ); // $ExpectError
-	bench.createHarness( { 'autoclose': ( x: number ): number => x }, (): void => {} ); // $ExpectError
+	bench.createHarness( { 'autoclose': 123 }, (): void => undefined ); // $ExpectError
+	bench.createHarness( { 'autoclose': 'abc' }, (): void => undefined ); // $ExpectError
+	bench.createHarness( { 'autoclose': null }, (): void => undefined ); // $ExpectError
+	bench.createHarness( { 'autoclose': [] }, (): void => undefined ); // $ExpectError
+	bench.createHarness( { 'autoclose': {} }, (): void => undefined ); // $ExpectError
+	bench.createHarness( { 'autoclose': ( x: number ): number => x }, (): void => undefined ); // $ExpectError
 }
 
 // The compiler throws an error if the `createHarness` method is provided a `callback` argument which is not a function...
@@ -148,7 +148,7 @@ const benchmark = () => {};
 
 // The compiler throws an error if the `createHarness` method is provided an incorrect number of arguments...
 {
-	bench.createHarness( {}, (): void => {}, {} ); // $ExpectError
+	bench.createHarness( {}, (): void => undefined, {} ); // $ExpectError
 }
 
 // Attached to the main export is a `createStream` method which returns a stream..


### PR DESCRIPTION
Progresses #9110.

## Description

> What is the purpose of this pull request?

This pull request:

This pull request resolves TypeScript declaration lint errors in the benchmark harness typings.

- Fixes tsdoc-declarations-doctest errors caused by undefined identifiers in examples
- Updates TSDoc examples to correctly reference the exported main function
- Adjusts examples to ensure variables used in doctests are properly scoped
- Fixes @typescript-eslint/no-empty-function lint errors in TypeScript declaration tests by replacing empty arrow functions with `explicit (): void => undefined`
- Ensures all declaration examples and tests pass TypeScript linting and doctest validation

These changes improve the correctness and reliability of the TypeScript declaration files without altering runtime behavior.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #9110 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

- Changes are limited to TypeScript declaration files and their associated tests
- No runtime JavaScript behavior is modified
- All fixes follow existing stdlib TypeScript and documentation conventions

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
