### PR TITLE
docs: improve doctests for ndarray instances in `ndarray/any`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/any/README.md
+++ b/lib/node_modules/@stdlib/ndarray/any/README.md
@@ -49,10 +49,7 @@ var x = array( [ [ [ -1.0, 0.0 ] ], [ [ -3.0, -4.0 ] ], [ [ 5.0, -6.0 ] ] ] );
 
 // Perform reduction:
 var out = any( x );
-// returns <ndarray>
-
-var v = out.get();
-// returns true
+// returns <ndarray>[ true ]
 ```
 
 The function accepts the following arguments:
@@ -69,7 +66,6 @@ By default, the function performs a reduction over all elements in a provided [`
 
 ```javascript
 var array = require( '@stdlib/ndarray/array' );
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 
 // Create an input ndarray:
 var x = array( [ [ [ -1.0, 0.0 ] ], [ [ -3.0, 0.0 ] ], [ [ 5.0, 0.0 ] ] ] );
@@ -79,17 +75,13 @@ var x = array( [ [ [ -1.0, 0.0 ] ], [ [ -3.0, 0.0 ] ], [ [ 5.0, 0.0 ] ] ] );
 var out = any( x, {
     'dims': [ 1, 2 ]
 });
-// returns <ndarray>
-
-var v = ndarray2array( out );
-// returns [ true, true, true ]
+// returns <ndarray>[ true, true, true ]
 ```
 
 By default, the function returns an [`ndarray`][@stdlib/ndarray/ctor] having a shape matching only the non-reduced dimensions of the input [`ndarray`][@stdlib/ndarray/ctor] (i.e., the reduced dimensions are dropped). To include the reduced dimensions as singleton dimensions in the output [`ndarray`][@stdlib/ndarray/ctor], set the `keepdims` option to `true`.
 
 ```javascript
 var array = require( '@stdlib/ndarray/array' );
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 
 // Create an input ndarray:
 var x = array( [ [ [ -1.0, 0.0 ] ], [ [ -3.0, 0.0 ] ], [ [ 5.0, 0.0 ] ] ] );
@@ -100,10 +92,7 @@ var out = any( x, {
     'dims': [ 1, 2 ],
     'keepdims': true
 });
-// returns <ndarray>
-
-var v = ndarray2array( out );
-// returns [ [ [ true ] ], [ [ true ] ], [ [ true ] ] ]
+// returns <ndarray>[ [ [ true ] ], [ [ true ] ], [ [ true ] ] ]
 ```
 
 #### any.assign( x, out\[, options] )
@@ -125,12 +114,9 @@ var y = empty( [], {
 
 // Perform reduction:
 var out = any.assign( x, y );
-// returns <ndarray>
+// returns <ndarray>[ true ]
 
 var bool = ( out === y );
-// returns true
-
-var v = y.get();
 // returns true
 ```
 
@@ -149,7 +135,6 @@ By default, the function performs a reduction over all elements in a provided [`
 ```javascript
 var array = require( '@stdlib/ndarray/array' );
 var empty = require( '@stdlib/ndarray/empty' );
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 
 // Create an input ndarray:
 var x = array( [ [ [ -1.0, 0.0 ] ], [ [ -3.0, 0.0 ] ], [ [ 5.0, 0.0 ] ] ] );
@@ -164,12 +149,10 @@ var y = empty( [ 3 ], {
 var out = any.assign( x, y, {
     'dims': [ 1, 2 ]
 });
+// returns <ndarray>[ true, true, true ]
 
 var bool = ( out === y );
 // returns true
-
-var v = ndarray2array( y );
-// returns [ true, true, true ]
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/ndarray/any/docs/repl.txt
+++ b/lib/node_modules/@stdlib/ndarray/any/docs/repl.txt
@@ -34,11 +34,7 @@
     > y.get()
     true
     > y = {{alias}}( x, { 'keepdims': true } )
-    <ndarray>
-    > {{alias:@stdlib/ndarray/to-array}}( y )
-    [ [ true ] ]
-    > y.get( 0, 0 )
-    true
+    <ndarray>[ [ true ] ]
 
 
 {{alias}}.assign( x, y[, options] )
@@ -72,10 +68,8 @@
     > var x = {{alias:@stdlib/ndarray/array}}( [ [ 1.0, 0.0 ], [ 0.0, 1.0 ] ] );
     > var y = {{alias:@stdlib/ndarray/from-scalar}}( false );
     > var out = {{alias}}.assign( x, y )
-    <ndarray>
+    <ndarray>[ true ]
     > var bool = ( out === y )
-    true
-    > y.get()
     true
 
     See Also

--- a/lib/node_modules/@stdlib/ndarray/any/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/any/docs/types/index.d.ts
@@ -77,10 +77,7 @@ interface Any {
 	*
 	* // Perform reduction:
 	* var out = any( x );
-	* // returns <ndarray>
-	*
-	* var v = out.get();
-	* // returns true
+	* // returns <ndarray>[ true ]
 	*/
 	( x: ndarray, options?: Options ): boolndarray;
 
@@ -120,10 +117,7 @@ interface Any {
 	*
 	* // Perform reduction:
 	* var out = any.assign( x, y );
-	* // returns <ndarray>
-	*
-	* var v = out.get();
-	* // returns true
+	* // returns <ndarray>[ true ]
 	*/
 	assign<T extends ndarray>( x: ndarray, y: T, options?: BaseOptions ): T;
 }
@@ -158,10 +152,7 @@ interface Any {
 *
 * // Perform reduction:
 * var out = any( x );
-* // returns <ndarray>
-*
-* var v = out.get();
-* // returns true
+* // returns <ndarray>[ true ]
 *
 * @example
 * var Float64Array = require( '@stdlib/array/float64' );
@@ -190,10 +181,7 @@ interface Any {
 *
 * // Perform reduction:
 * var out = any.assign( x, y );
-* // returns <ndarray>
-*
-* var v = out.get();
-* // returns true
+* // returns <ndarray>[ true ]
 */
 declare var any: Any;
 

--- a/lib/node_modules/@stdlib/ndarray/any/lib/assign.js
+++ b/lib/node_modules/@stdlib/ndarray/any/lib/assign.js
@@ -73,10 +73,7 @@ var validate = require( './validate.js' );
 *
 * // Perform reduction:
 * var out = assign( x, y );
-* // returns <ndarray>
-*
-* var v = out.get();
-* // returns true
+* // returns <ndarray>[ true ]
 */
 function assign( x, y, options ) {
 	var opts;

--- a/lib/node_modules/@stdlib/ndarray/any/lib/index.js
+++ b/lib/node_modules/@stdlib/ndarray/any/lib/index.js
@@ -45,10 +45,7 @@
 *
 * // Perform reduction:
 * var out = any( x );
-* // returns <ndarray>
-*
-* var v = out.get();
-* // returns true
+* // returns <ndarray>[ true ]
 *
 * @example
 * var Float64Array = require( '@stdlib/array/float64' );
@@ -78,10 +75,7 @@
 *
 * // Perform reduction:
 * var out = any.assign( x, y );
-* // returns <ndarray>
-*
-* var v = out.get();
-* // returns true
+* // returns <ndarray>[ true ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/ndarray/any/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/any/lib/main.js
@@ -78,10 +78,7 @@ var validate = require( './validate.js' );
 *
 * // Perform reduction:
 * var out = any( x );
-* // returns <ndarray>
-*
-* var v = out.get();
-* // returns true
+* // returns <ndarray>[ true ]
 */
 function any( x, options ) {
 	var opts;


### PR DESCRIPTION
Progresses #9329.

## Description

> What is the purpose of this pull request?

This pull request:

This PR updates documentation examples in `@stdlib/ndarray/any` to use ndarray instance notation (e.g., `<ndarray>[ ... ]`) instead of explicit element access or decomposition logic.


## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #9329

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
