### PR TITLE
chore: fix JavaScript lint errors (issue #9356)

### DIFF
--- a/lib/node_modules/@stdlib/math/strided/special/cos-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/special/cos-by/test/test.main.js
@@ -74,7 +74,8 @@ tape( 'the function computes the cosine via a callback function', function test(
 	cosBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = new Array( 5 ); // sparse array
+	x = [];
+	x.length = 5; // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
 	expected = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
@@ -82,7 +83,8 @@ tape( 'the function computes the cosine via a callback function', function test(
 	cosBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = new Array( 5 ); // sparse array
+	x = [];
+	x.length = 5; // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 

--- a/lib/node_modules/@stdlib/math/strided/special/cos-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/special/cos-by/test/test.main.js
@@ -84,7 +84,7 @@ tape( 'the function computes the cosine via a callback function', function test(
 	t.deepEqual( y, expected, 'deep equal' );
 
 	x = [];
-	x.length = 5; // sparse array
+	x.length = 5;// sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 


### PR DESCRIPTION
Resolves #9356.

## Description

This pull request fixes JavaScript lint errors caused by usage of the
`new Array()` constructor in test files, in order to satisfy the
`stdlib/no-new-array` ESLint rule.

## Related Issues

- #9356

## Questions

No.

## Other

No.

## Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md)

### AI Assistance

- [x] Yes
- [ ] No

If you answered "yes" above, how did you use AI assistance?

- [ ] Code generation
- [ ] Test/benchmark generation
- [ ] Documentation
- [x] Research and understanding

#### Disclosure

I only consulted ChatGPT to help understand the linting error and stdlib contribution
process. All code changes were authored manually.