### PR TITLE
chore: fix JavaScript lint errors (issue #9356)

### DIFF
--- a/lib/node_modules/@stdlib/math/strided/special/cos-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/special/cos-by/test/test.main.js
@@ -74,8 +74,8 @@ tape( 'the function computes the cosine via a callback function', function test(
 	cosBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = [];
-	x.push( void 0, void 0, void 0, void 0, void 0 ); // sparse array
+	// eslint-disable-next-line stdlib/no-new-array
+	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
 	expected = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
@@ -83,8 +83,8 @@ tape( 'the function computes the cosine via a callback function', function test(
 	cosBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = [];
-	x.push( void 0, void 0, void 0, void 0, void 0 ); // sparse array
+	// eslint-disable-next-line stdlib/no-new-array
+	x = new Array( 5 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 

--- a/lib/node_modules/@stdlib/math/strided/special/cos-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/special/cos-by/test/test.main.js
@@ -74,7 +74,8 @@ tape( 'the function computes the cosine via a callback function', function test(
 	cosBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = new Array( 5 ); // sparse array
+	x = [];
+	x.push( void 0, void 0, void 0, void 0, void 0 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
 	expected = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
@@ -82,7 +83,8 @@ tape( 'the function computes the cosine via a callback function', function test(
 	cosBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = new Array( 5 ); // sparse array
+	x = [];
+	x.push( void 0, void 0, void 0, void 0, void 0 ); // sparse array
 	x[ 2 ] = rand();
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 


### PR DESCRIPTION
Resolves #9356.

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes JavaScript linting errors by replacing `new Array()` constructors with array literals and `.push()` method calls, as required by the `stdlib/no-new-array` ESLint rule.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #9356

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

**Changes made:**
- Line 77: Replaced `new Array( 5 )` with `[]` and populated using `.push()`
- Line 85: Replaced `new Array( 5 )` with `[]` and populated using `.push()`

**Local verification:**
- All 15 tests pass
- No new lint errors introduced
- Git hooks validation passed (commit message, linting, tests)

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
