### PR TITLE
docs: improve doctests for ndarray instances in `ndarray/count-falsy`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/count-falsy/docs/repl.txt
+++ b/lib/node_modules/@stdlib/ndarray/count-falsy/docs/repl.txt
@@ -29,9 +29,7 @@
     --------
     > var x = {{alias:@stdlib/ndarray/array}}( [ [ 1.0, 1.0 ], [ 0.0, 1.0 ] ] );
     > var y = {{alias}}( x )
-    <ndarray>
-    > y.get()
-    1
+    <ndarray>[ 1 ]
     > y = {{alias}}( x, { 'keepdims': true } )
     <ndarray>[ [ 1 ] ]
 


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: na
  - task: lint_package_json status: na
  - task: lint_repl_help status: passed
  - task: lint_javascript_src status: na
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---


Progresses #9329.

## Description

This pull request improves doctests for ndarray instances in the `ndarray/count-falsy` package.  
Specifically, it replaces explicit element access using `get()` in REPL documentation with the new compact ndarray instance notation (e.g., `<ndarray>[ 1 ]`). This aligns the package documentation with the behavior demonstrated in commit `46d9a44` and the corresponding RFC.

No other example logic or behavior was modified.

## Related Issues

None.

## Questions

No.

## Other

No additional notes.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

-   [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
