### PR TITLE
docs: improve doctests for ndarray instances in `stats/maxsorted`

### DIFF
--- a/lib/node_modules/@stdlib/stats/maxsorted/README.md
+++ b/lib/node_modules/@stdlib/stats/maxsorted/README.md
@@ -40,10 +40,7 @@ var array = require( '@stdlib/ndarray/array' );
 var x = array( [ 1.0, 2.0, 3.0 ] );
 
 var y = maxsorted( x );
-// returns <ndarray>
-
-var v = y.get();
-// returns 3.0
+// returns <ndarray>[ 3.0 ]
 ```
 
 The function has the following parameters:
@@ -60,81 +57,58 @@ The function accepts the following options:
 By default, the function performs a reduction over all elements in a provided input [ndarray][@stdlib/ndarray/ctor]. To perform a reduction over specific dimensions, provide a `dims` option.
 
 ```javascript
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var array = require( '@stdlib/ndarray/array' );
 
 var x = array( [ 1.0, 2.0, 3.0, 4.0 ], {
     'shape': [ 2, 2 ],
     'order': 'row-major'
 });
-var v = ndarray2array( x );
-// returns [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ]
+// returns <ndarray>
 
 var y = maxsorted( x, {
     'dims': [ 0 ]
 });
-// returns <ndarray>
-
-v = ndarray2array( y );
-// returns [ 3.0, 4.0 ]
+// returns <ndarray>[ 3.0, 4.0 ]
 
 y = maxsorted( x, {
     'dims': [ 1 ]
 });
-// returns <ndarray>
-
-v = ndarray2array( y );
-// returns [ 2.0, 4.0 ]
+// returns <ndarray>[ 2.0, 4.0 ]
 
 y = maxsorted( x, {
     'dims': [ 0, 1 ]
 });
-// returns <ndarray>
-
-v = y.get();
-// returns 4.0
+// returns <ndarray>[ 4.0 ]
 ```
 
 By default, the function excludes reduced dimensions from the output [ndarray][@stdlib/ndarray/ctor]. To include the reduced dimensions as singleton dimensions, set the `keepdims` option to `true`.
 
 ```javascript
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var array = require( '@stdlib/ndarray/array' );
 
 var x = array( [ 1.0, 2.0, 3.0, 4.0 ], {
     'shape': [ 2, 2 ],
     'order': 'row-major'
 });
-
-var v = ndarray2array( x );
-// returns [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ]
+// returns <ndarray>
 
 var y = maxsorted( x, {
     'dims': [ 0 ],
     'keepdims': true
 });
-// returns <ndarray>
-
-v = ndarray2array( y );
-// returns [ [ 3.0, 4.0 ] ]
+// returns <ndarray>[ [ 3.0, 4.0 ] ]
 
 y = maxsorted( x, {
     'dims': [ 1 ],
     'keepdims': true
 });
-// returns <ndarray>
-
-v = ndarray2array( y );
-// returns [ [ 2.0 ], [ 4.0 ] ]
+// returns <ndarray>[ [ 2.0 ], [ 4.0 ] ]
 
 y = maxsorted( x, {
     'dims': [ 0, 1 ],
     'keepdims': true
 });
-// returns <ndarray>
-
-v = ndarray2array( y );
-// returns [ [ 4.0 ] ]
+// returns <ndarray>[ [ 4.0 ] ]
 ```
 
 By default, the function returns an [ndarray][@stdlib/ndarray/ctor] having a [data type][@stdlib/ndarray/dtypes] determined by the function's output data type [policy][@stdlib/ndarray/output-dtype-policies]. To override the default behavior, set the `dtype` option.
@@ -168,10 +142,7 @@ var x = array( [ 1.0, 2.0, 3.0 ] );
 var y = zeros( [] );
 
 var out = maxsorted.assign( x, y );
-// returns <ndarray>
-
-var v = out.get();
-// returns 3.0
+// returns <ndarray>[ 3.0 ]
 
 var bool = ( out === y );
 // returns true

--- a/lib/node_modules/@stdlib/stats/maxsorted/README.md
+++ b/lib/node_modules/@stdlib/stats/maxsorted/README.md
@@ -63,7 +63,7 @@ var x = array( [ 1.0, 2.0, 3.0, 4.0 ], {
     'shape': [ 2, 2 ],
     'order': 'row-major'
 });
-// returns <ndarray>
+// returns <ndarray>[ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ]
 
 var y = maxsorted( x, {
     'dims': [ 0 ]
@@ -90,7 +90,7 @@ var x = array( [ 1.0, 2.0, 3.0, 4.0 ], {
     'shape': [ 2, 2 ],
     'order': 'row-major'
 });
-// returns <ndarray>
+// returns <ndarray>[ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ]
 
 var y = maxsorted( x, {
     'dims': [ 0 ],

--- a/lib/node_modules/@stdlib/stats/maxsorted/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/maxsorted/docs/repl.txt
@@ -31,9 +31,8 @@
     Examples
     --------
     > var x = {{alias:@stdlib/ndarray/array}}( [ 1.0, 2.0, 3.0, 4.0 ] );
-    > var y = {{alias}}( x );
-    > var v = y.get()
-    4.0
+    > var y = {{alias}}( x )
+    <ndarray>[ 4.0 ]
 
 
 {{alias}}.assign( x, out[, options] )
@@ -66,11 +65,9 @@
     > var x = {{alias:@stdlib/ndarray/array}}( [ 1.0, 2.0, 3.0, 4.0 ] );
     > var out = {{alias:@stdlib/ndarray/zeros}}( [] );
     > var y = {{alias}}.assign( x, out )
-    <ndarray>
+    <ndarray>[ 4.0 ]
     > var bool = ( out === y )
     true
-    > var v = out.get()
-    4.0
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/stats/maxsorted/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/maxsorted/docs/types/index.d.ts
@@ -75,10 +75,7 @@ interface Unary {
 	* var x = array( [ 1.0, 2.0, 3.0 ] );
 	*
 	* var y = maxsorted( x );
-	* // returns <ndarray>
-	*
-	* var v = y.get();
-	* // returns 3.0
+	* // returns <ndarray>[ 3.0 ]
 	*/
 	<T = unknown, U = unknown>( x: InputArray<T>, options?: Options ): OutputArray<U>; // NOTE: we lose type specificity here, but retaining specificity would likely be difficult and/or tedious to completely enumerate, as the output ndarray data type is dependent on how `x` interacts with output data type policy and whether that policy has been overridden by `options.dtype`.
 
@@ -98,10 +95,7 @@ interface Unary {
 	* var y = zeros( [] );
 	*
 	* var out = maxsorted.assign( x, y );
-	* // returns <ndarray>
-	*
-	* var v = out.get();
-	* // returns 3.0
+	* // returns <ndarray>[ 3.0 ]
 	*
 	* var bool = ( out === y );
 	* // returns true
@@ -122,10 +116,7 @@ interface Unary {
 * var x = array( [ 1.0, 2.0, 3.0 ] );
 *
 * var y = maxsorted( x );
-* // returns <ndarray>
-*
-* var v = y.get();
-* // returns 3.0
+* // returns <ndarray>[ 3.0 ]
 *
 * @example
 * var array = require( '@stdlib/ndarray/array' );
@@ -135,10 +126,7 @@ interface Unary {
 * var y = zeros( [] );
 *
 * var out = maxsorted.assign( x, y );
-* // returns <ndarray>
-*
-* var v = out.get();
-* // returns 3.0
+* // returns <ndarray>[ 3.0 ]
 *
 * var bool = ( out === y );
 * // returns true

--- a/lib/node_modules/@stdlib/stats/maxsorted/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/maxsorted/lib/index.js
@@ -45,10 +45,7 @@
 *
 * // Perform reduction:
 * var out = maxsorted( x );
-* // returns <ndarray>
-*
-* var v = out.get();
-* // returns 11.0
+* // returns <ndarray>[ 11.0 ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/stats/maxsorted/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/maxsorted/lib/main.js
@@ -88,10 +88,7 @@ var table = {
 *
 * // Perform reduction:
 * var out = maxsorted( x );
-* // returns <ndarray>
-*
-* var v = out.get();
-* // returns 11.0
+* // returns <ndarray>[ 11.0 ]
 */
 var maxsorted = factory( table, [ idtypes ], odtypes, policies );
 


### PR DESCRIPTION
Resolves a part of #9329 .

## Description
-   Improves doctest annotations in the `stats/maxsorted` package by replacing verbose decomposition logic (using `.get()` method and `ndarray2array()` function) with the new concise ndarray instance notation `<ndarray>[ ... ]`
-   Updates all documentation examples in README.md, docs/types/index.d.ts, docs/repl.txt, and JSDoc examples in lib/*.js files
-   Removes unused `ndarray2array` imports from documentation examples
-   Follows the pattern established in reference commit 46d9a44

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
