### PR TITLE
docs: improve doctests for ndarray instances in `ndarray/some-by`

### DIFF
--- a/lib/node_modules/@stdlib/ndarray/some-by/README.md
+++ b/lib/node_modules/@stdlib/ndarray/some-by/README.md
@@ -210,6 +210,7 @@ var opts = {
 
 // Perform reduction:
 var out = someBy.assign( x, 2, y, opts, predicate );
+// returns <ndarray>[ true, true ]
 
 var bool = ( out === y );
 // returns true

--- a/lib/node_modules/@stdlib/ndarray/some-by/README.md
+++ b/lib/node_modules/@stdlib/ndarray/some-by/README.md
@@ -53,10 +53,7 @@ var x = array( [ [ [ 1.0, 2.0 ] ], [ [ 3.0, 4.0 ] ], [ [ 0.0, 6.0 ] ] ] );
 
 // Perform reduction:
 var out = someBy( x, 2, predicate );
-// returns <ndarray>
-
-var v = out.get();
-// returns true
+// returns <ndarray>[ true ]
 ```
 
 The function accepts the following arguments:
@@ -76,7 +73,6 @@ By default, the function performs a reduction over all elements in a provided [`
 
 ```javascript
 var array = require( '@stdlib/ndarray/array' );
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 
 function predicate( value ) {
     return value > 0.0;
@@ -92,17 +88,13 @@ var opts = {
 
 // Perform reduction:
 var out = someBy( x, 2, opts, predicate );
-// returns <ndarray>
-
-var v = ndarray2array( out );
-// returns [ true, true ]
+// returns <ndarray>[ true, true ]
 ```
 
 By default, the function returns an [`ndarray`][@stdlib/ndarray/ctor] having a shape matching only the non-reduced dimensions of the input [`ndarray`][@stdlib/ndarray/ctor] (i.e., the reduced dimensions are dropped). To include the reduced dimensions as singleton dimensions in the output [`ndarray`][@stdlib/ndarray/ctor], set the `keepdims` option to `true`.
 
 ```javascript
 var array = require( '@stdlib/ndarray/array' );
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 
 function predicate( value ) {
     return value > 0.0;
@@ -119,10 +111,7 @@ var opts = {
 
 // Perform reduction:
 var out = someBy( x, 2, opts, predicate );
-// returns <ndarray>
-
-var v = ndarray2array( out );
-// returns [ [ [ true, true ] ] ]
+// returns <ndarray>[ [ [ true, true ] ] ]
 ```
 
 To set the predicate function execution context, provide a `thisArg`.
@@ -148,10 +137,7 @@ var ctx = {
 
 // Perform reduction:
 var out = someBy( x, 2, predicate, ctx );
-// returns <ndarray>
-
-var v = out.get();
-// returns true
+// returns <ndarray>[ true ]
 
 var count = ctx.count;
 // returns 2
@@ -184,9 +170,6 @@ var out = someBy.assign( x, 2, y, predicate );
 
 var bool = ( out === y );
 // returns true
-
-var v = y.get();
-// returns true
 ```
 
 The function accepts the following arguments:
@@ -207,7 +190,6 @@ By default, the function performs a reduction over all elements in a provided [`
 ```javascript
 var array = require( '@stdlib/ndarray/array' );
 var empty = require( '@stdlib/ndarray/empty' );
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 
 function predicate( value ) {
     return value > 0.0;
@@ -231,9 +213,6 @@ var out = someBy.assign( x, 2, y, opts, predicate );
 
 var bool = ( out === y );
 // returns true
-
-var v = ndarray2array( y );
-// returns [ true, true ]
 ```
 
 </section>
@@ -263,7 +242,6 @@ var v = ndarray2array( y );
 ```javascript
 var discreteUniform = require( '@stdlib/random/base/discrete-uniform' ).factory;
 var isEven = require( '@stdlib/assert/is-even' ).isPrimitive;
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var fillBy = require( '@stdlib/ndarray/fill-by' );
 var zeros = require( '@stdlib/ndarray/zeros' );
@@ -273,13 +251,13 @@ var x = zeros( [ 2, 4, 5 ], {
     'dtype': 'float64'
 });
 x = fillBy( x, discreteUniform( 0, 10 ) );
-console.log( ndarray2array( x ) );
+console.log( x );
 
 var n = scalar2ndarray( 4, {
     'dtype': 'int8'
 });
 var y = someBy( x, n, isEven );
-console.log( y.get() );
+console.log( y );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/ndarray/some-by/README.md
+++ b/lib/node_modules/@stdlib/ndarray/some-by/README.md
@@ -166,7 +166,7 @@ var y = empty( [], {
 
 // Perform reduction:
 var out = someBy.assign( x, 2, y, predicate );
-// returns <ndarray>
+// returns <ndarray>[ true ]
 
 var bool = ( out === y );
 // returns true

--- a/lib/node_modules/@stdlib/ndarray/some-by/README.md
+++ b/lib/node_modules/@stdlib/ndarray/some-by/README.md
@@ -242,6 +242,7 @@ var bool = ( out === y );
 ```javascript
 var discreteUniform = require( '@stdlib/random/base/discrete-uniform' ).factory;
 var isEven = require( '@stdlib/assert/is-even' ).isPrimitive;
+var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var fillBy = require( '@stdlib/ndarray/fill-by' );
 var zeros = require( '@stdlib/ndarray/zeros' );
@@ -251,13 +252,13 @@ var x = zeros( [ 2, 4, 5 ], {
     'dtype': 'float64'
 });
 x = fillBy( x, discreteUniform( 0, 10 ) );
-console.log( x );
+console.log( ndarray2array( x ) );
 
 var n = scalar2ndarray( 4, {
     'dtype': 'int8'
 });
 var y = someBy( x, n, isEven );
-console.log( y );
+console.log( y.get() );
 ```
 
 </section>

--- a/lib/node_modules/@stdlib/ndarray/some-by/docs/repl.txt
+++ b/lib/node_modules/@stdlib/ndarray/some-by/docs/repl.txt
@@ -42,15 +42,9 @@
     > function f ( v ) { return v > 0.0; };
     > var x = {{alias:@stdlib/ndarray/array}}( [ [ 1, 2], [ 3, 4 ] ] );
     > var y = {{alias}}( x, 3, f )
-    <ndarray>
-    > y.get()
-    true
+    <ndarray>[ true ]
     > y = {{alias}}( x, 3, { 'keepdims': true }, f )
-    <ndarray>
-    > {{alias:@stdlib/ndarray/to-array}}( y )
-    [ [ true ] ]
-    > y.get( 0, 0 )
-    true
+    <ndarray>[ [ true ] ]
 
 
 {{alias}}.assign( x, n, y[, options], predicate[, thisArg] )
@@ -97,11 +91,7 @@
     > var x = {{alias:@stdlib/ndarray/array}}( [ [ 1, 2], [ 3, 4 ] ] );
     > var y = {{alias:@stdlib/ndarray/from-scalar}}( false );
     > var out = {{alias}}.assign( x, 3, y, f )
-    <ndarray>
-    > var bool = ( out === y )
-    true
-    > y.get()
-    true
+    <ndarray>[ true ]
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/ndarray/some-by/docs/repl.txt
+++ b/lib/node_modules/@stdlib/ndarray/some-by/docs/repl.txt
@@ -92,6 +92,8 @@
     > var y = {{alias:@stdlib/ndarray/from-scalar}}( false );
     > var out = {{alias}}.assign( x, 3, y, f )
     <ndarray>[ true ]
+    > var bool = ( out === y )
+    true
 
     See Also
     --------

--- a/lib/node_modules/@stdlib/ndarray/some-by/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/ndarray/some-by/docs/types/index.d.ts
@@ -127,10 +127,7 @@ interface SomeBy {
 	*
 	* // Perform reduction:
 	* var out = someBy( x, 3, isEven );
-	* // returns <ndarray>
-	*
-	* var v = out.get();
-	* // returns true
+	* // returns <ndarray>[ true ]
 	*/
 	<T = unknown, U extends InputArray<T> = InputArray<T>, ThisArg = unknown>( x: U, n: integerndarray | number, predicate: Predicate<T, U, ThisArg>, thisArg?: ThisParameterType<Predicate<T, U, ThisArg>> ): boolndarray;
 
@@ -168,10 +165,7 @@ interface SomeBy {
 	*
 	* // Perform reduction:
 	* var out = someBy( x, 3, {}, isEven );
-	* // returns <ndarray>
-	*
-	* var v = out.get();
-	* // returns true
+	* // returns <ndarray>[ true ]
 	*/
 	<T = unknown, U extends InputArray<T> = InputArray<T>, ThisArg = unknown>( x: U, n: integerndarray | number, options: Options, predicate: Predicate<T, U, ThisArg>, thisArg?: ThisParameterType<Predicate<T, U, ThisArg>> ): boolndarray;
 
@@ -213,10 +207,7 @@ interface SomeBy {
 	*
 	* // Perform reduction:
 	* var out = someBy.assign( x, 3, y, isEven );
-	* // returns <ndarray>
-	*
-	* var v = out.get();
-	* // returns true
+	* // returns <ndarray>[ true ]
 	*/
 	assign<T = unknown, U extends InputArray<T> = InputArray<T>, V extends ndarray = ndarray, ThisArg = unknown>( x: ndarray, n: integerndarray | number, y: V, predicate: Predicate<T, U, ThisArg>, thisArg?: ThisParameterType<Predicate<T, U, ThisArg>> ): V;
 
@@ -260,10 +251,7 @@ interface SomeBy {
 	*
 	* // Perform reduction:
 	* var out = someBy.assign( x, 3, y, {}, isEven );
-	* // returns <ndarray>
-	*
-	* var v = out.get();
-	* // returns true
+	* // returns <ndarray>[ true ]
 	*/
 	assign<T = unknown, U extends InputArray<T> = InputArray<T>, V extends ndarray = ndarray, ThisArg = unknown>( x: ndarray, n: integerndarray | number, y: V, options: BaseOptions, predicate: Predicate<T, U, ThisArg>, thisArg?: ThisParameterType<Predicate<T, U, ThisArg>> ): V;
 }
@@ -302,10 +290,7 @@ interface SomeBy {
 *
 * // Perform reduction:
 * var out = someBy( x, 3, isEven );
-* // returns <ndarray>
-*
-* var v = out.get();
-* // returns true
+* // returns <ndarray>[ true ]
 *
 * @example
 * var Float64Array = require( '@stdlib/array/float64' );
@@ -335,10 +320,7 @@ interface SomeBy {
 *
 * // Perform reduction:
 * var out = someBy.assign( x, 3, y, isEven );
-* // returns <ndarray>
-*
-* var v = out.get();
-* // returns true
+* // returns <ndarray>[ true ]
 */
 declare var someBy: SomeBy;
 

--- a/lib/node_modules/@stdlib/ndarray/some-by/examples/index.js
+++ b/lib/node_modules/@stdlib/ndarray/some-by/examples/index.js
@@ -20,7 +20,6 @@
 
 var discreteUniform = require( '@stdlib/random/base/discrete-uniform' ).factory;
 var isEven = require( '@stdlib/assert/is-even' ).isPrimitive;
-var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var fillBy = require( '@stdlib/ndarray/fill-by' );
 var zeros = require( '@stdlib/ndarray/zeros' );
@@ -30,10 +29,10 @@ var x = zeros( [ 2, 4, 5 ], {
 	'dtype': 'float64'
 });
 x = fillBy( x, discreteUniform( 0, 10 ) );
-console.log( ndarray2array( x ) );
+console.log( x );
 
 var n = scalar2ndarray( 4, {
 	'dtype': 'int8'
 });
 var y = someBy( x, n, isEven );
-console.log( y.get() );
+console.log( y );

--- a/lib/node_modules/@stdlib/ndarray/some-by/examples/index.js
+++ b/lib/node_modules/@stdlib/ndarray/some-by/examples/index.js
@@ -20,6 +20,7 @@
 
 var discreteUniform = require( '@stdlib/random/base/discrete-uniform' ).factory;
 var isEven = require( '@stdlib/assert/is-even' ).isPrimitive;
+var ndarray2array = require( '@stdlib/ndarray/to-array' );
 var scalar2ndarray = require( '@stdlib/ndarray/from-scalar' );
 var fillBy = require( '@stdlib/ndarray/fill-by' );
 var zeros = require( '@stdlib/ndarray/zeros' );
@@ -29,10 +30,10 @@ var x = zeros( [ 2, 4, 5 ], {
 	'dtype': 'float64'
 });
 x = fillBy( x, discreteUniform( 0, 10 ) );
-console.log( x );
+console.log( ndarray2array( x ) );
 
 var n = scalar2ndarray( 4, {
 	'dtype': 'int8'
 });
 var y = someBy( x, n, isEven );
-console.log( y );
+console.log( y.get() );

--- a/lib/node_modules/@stdlib/ndarray/some-by/lib/assign.js
+++ b/lib/node_modules/@stdlib/ndarray/some-by/lib/assign.js
@@ -93,10 +93,7 @@ var DEFAULT_DTYPE = defaults.get( 'dtypes.integer_index' );
 *
 * // Perform reduction:
 * var out = assign( x, 3, y, isEven );
-* // returns <ndarray>
-*
-* var v = out.get();
-* // returns true
+* // returns <ndarray>[ true ]
 */
 function assign( x, n, y, options, predicate, thisArg ) {
 	var nargs;

--- a/lib/node_modules/@stdlib/ndarray/some-by/lib/index.js
+++ b/lib/node_modules/@stdlib/ndarray/some-by/lib/index.js
@@ -82,7 +82,6 @@
 * }
 *
 * // Perform reduction:
-*
 * var out = someBy.assign( x, 6.0, y, predicate );
 * // returns <ndarray>[ true ]
 */

--- a/lib/node_modules/@stdlib/ndarray/some-by/lib/index.js
+++ b/lib/node_modules/@stdlib/ndarray/some-by/lib/index.js
@@ -43,12 +43,12 @@
 * // Create an input ndarray:
 * var x = new ndarray( 'float64', xbuf, sh, sx, ox, 'row-major' );
 *
+*function predicate( v ) {
+*    return v > 0.0;
+*}
 * // Perform reduction:
-* var out = someBy( x, 6 );
-* // returns <ndarray>
-*
-* var v = out.get();
-* // returns true
+* var out = someBy( x, 6 , predicate );
+* // returns <ndarray>[ true ]
 *
 * @example
 * var Float64Array = require( '@stdlib/array/float64' );
@@ -76,12 +76,13 @@
 *     'dtype': 'bool'
 * });
 *
+*function predicate( v ) {
+*    return v > 0.0;
+*}
 * // Perform reduction:
-* var out = someBy.assign( x, 6.0, y );
-* // returns <ndarray>
 *
-* var v = out.get();
-* // returns true
+* var out = someBy.assign( x, 6.0, y , predicate );
+* // returns <ndarray>[ true ]
 */
 
 // MODULES //

--- a/lib/node_modules/@stdlib/ndarray/some-by/lib/index.js
+++ b/lib/node_modules/@stdlib/ndarray/some-by/lib/index.js
@@ -48,7 +48,7 @@
 * }
 *
 * // Perform reduction:
-* var out = someBy( x, 6 , predicate );
+* var out = someBy( x, 6, predicate );
 * // returns <ndarray>[ true ]
 *
 * @example
@@ -83,7 +83,7 @@
 *
 * // Perform reduction:
 *
-* var out = someBy.assign( x, 6.0, y , predicate );
+* var out = someBy.assign( x, 6.0, y, predicate );
 * // returns <ndarray>[ true ]
 */
 

--- a/lib/node_modules/@stdlib/ndarray/some-by/lib/index.js
+++ b/lib/node_modules/@stdlib/ndarray/some-by/lib/index.js
@@ -43,9 +43,10 @@
 * // Create an input ndarray:
 * var x = new ndarray( 'float64', xbuf, sh, sx, ox, 'row-major' );
 *
-*function predicate( v ) {
-*    return v > 0.0;
-*}
+* function predicate( v ) {
+*     return v > 0.0;
+* }
+*
 * // Perform reduction:
 * var out = someBy( x, 6 , predicate );
 * // returns <ndarray>[ true ]
@@ -76,9 +77,10 @@
 *     'dtype': 'bool'
 * });
 *
-*function predicate( v ) {
-*    return v > 0.0;
-*}
+* function predicate( v ) {
+*     return v > 0.0;
+* }
+*
 * // Perform reduction:
 *
 * var out = someBy.assign( x, 6.0, y , predicate );

--- a/lib/node_modules/@stdlib/ndarray/some-by/lib/main.js
+++ b/lib/node_modules/@stdlib/ndarray/some-by/lib/main.js
@@ -96,10 +96,7 @@ var DEFAULT_DTYPE = defaults.get( 'dtypes.integer_index' );
 *
 * // Perform reduction:
 * var out = someBy( x, 3, isEven );
-* // returns <ndarray>
-*
-* var v = out.get();
-* // returns true
+* // returns <ndarray>[ true ]
 */
 function someBy( x, n, options, predicate, thisArg ) {
 	var nargs;


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: passed
  - task: lint_package_json status: na
  - task: lint_repl_help status: passed
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: passed
  - task: lint_javascript_tests status: na
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: na
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: passed
  - task: lint_license_headers status: passed ---
  
Progresses #9329.

## Description

This pull request updates documentation examples in the `@stdlib/ndarray/some-by` package to improve doctests for ndarray instances, in accordance with the RFC guidance.

Specifically, this PR:

- Replaces explicit ndarray element access and decomposition logic with ndarray instance return notation (e.g., `<ndarray>[ ... ]`)
- Updates examples to supply predicate functions where required so doctests execute successfully
- Removes no-longer-needed decomposition code while preserving the original example behavior and intent
- Makes changes only within this package, without altering example semantics or introducing unrelated modifications

These updates improve clarity, consistency, and alignment with recent doctest framework capabilities.

## Related Issues

- #9329

## Questions

No.

## Other

No additional information.

## Checklist

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

- [ ] Yes
- [x] No

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md