### PR TITLE
Fix no new arr unzip

### DIFF
--- a/lib/node_modules/@stdlib/utils/unzip/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/unzip/examples/index.js
@@ -23,15 +23,15 @@ var randu = require( '@stdlib/random/base/randu' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var unzip = require( './../lib' );
 
-var arr = new Array( 100 );
+var arr = [];
 var len = 5;
 
 var i;
 var j;
 for ( i = 0; i < arr.length; i++ ) {
-	arr[ i ] = new Array( len );
+	arr.push([]);
 	for ( j = 0; j < len; j++ ) {
-		arr[ i ][ j ] = round( randu() * pow(10, j) );
+		arr[ i ].push(round( randu() * pow(10, j) ) );
 	}
 }
 var out = unzip( arr );

--- a/lib/node_modules/@stdlib/utils/unzip/examples/index.js
+++ b/lib/node_modules/@stdlib/utils/unzip/examples/index.js
@@ -28,8 +28,8 @@ var len = 5;
 
 var i;
 var j;
-for ( i = 0; i < arr.length; i++ ) {
-	arr.push([]);
+for ( i = 0; i < 100; i++ ) {
+	arr.push( [] );
 	for ( j = 0; j < len; j++ ) {
 		arr[ i ].push(round( randu() * pow(10, j) ) );
 	}


### PR DESCRIPTION
## Description

This pull request removes usage of the `new Array()` constructor from the unzip example in order to comply with the `stdlib/no-new-array` ESLint rule. The example has been refactored to use array literals and `.push()` while preserving the original behavior.

## Related Issues

None.

## Questions

No.

## Other

No.

## Checklist

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
