### PR TITLE
chore: fix JavaScript lint errors (issue #9419)

### DIFF
--- a/lib/node_modules/@stdlib/math/strided/special/abs-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/special/abs-by/test/test.main.js
@@ -62,7 +62,8 @@ tape( 'the function computes the absolute value of each indexed strided array el
 	absBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = [ , , , , , ]; // sparse array of size 5
+	// eslint-disable-next-line stdlib/no-new-array
+	x = new Array( 5 ); // sparse array
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
 	expected = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
@@ -70,7 +71,8 @@ tape( 'the function computes the absolute value of each indexed strided array el
 	absBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = [ , , , , , ]; // sparse array of size 5
+	// eslint-disable-next-line stdlib/no-new-array
+	x = new Array( 5 ); // sparse array
 	x[ 2 ] = -3.0;
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 

--- a/lib/node_modules/@stdlib/math/strided/special/abs-by/test/test.main.js
+++ b/lib/node_modules/@stdlib/math/strided/special/abs-by/test/test.main.js
@@ -62,7 +62,7 @@ tape( 'the function computes the absolute value of each indexed strided array el
 	absBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = new Array( 5 ); // sparse array
+	x = [ , , , , , ]; // sparse array of size 5
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 
 	expected = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
@@ -70,7 +70,7 @@ tape( 'the function computes the absolute value of each indexed strided array el
 	absBy( x.length, x, 1, y, 1, accessor );
 	t.deepEqual( y, expected, 'deep equal' );
 
-	x = new Array( 5 ); // sparse array
+	x = [ , , , , , ]; // sparse array of size 5
 	x[ 2 ] = -3.0;
 	y = [ 0.0, 0.0, 0.0, 0.0, 0.0 ];
 


### PR DESCRIPTION
Resolves #9419.

## Description

> What is the purpose of this pull request?

This pull request:

-   Fixes javascript lint error.

Cause and Solution of the issue:
-   Cause :  `new Array()` declaration for creating 'sparse array' 
-   Solution : used array literal instead of array constructor.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues: 

-   #9419.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
