### PR TITLE
feat: add stats/incr/nanmidrange

### DIFF
--- a/lib/node_modules/@stdlib/stats/incr/nanmidrange/README.md
+++ b/lib/node_modules/@stdlib/stats/incr/nanmidrange/README.md
@@ -1,0 +1,164 @@
+<!--
+
+@license Apache-2.0
+
+Copyright (c) 2025 The Stdlib Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+
+# incrnanmidrange
+
+> Compute a [mid-range][mid-range] incrementally, ignoring `NaN` values.
+
+<section class="intro">
+
+The [**mid-range**][mid-range], or **mid-extreme**, is the arithmetic mean of maximum and minimum values. Accordingly, the [mid-range][mid-range] is the midpoint of the [range][range] and a measure of central tendency.
+
+</section>
+
+<!-- /.intro -->
+
+<section class="usage">
+
+## Usage
+
+```javascript
+var incrnanmidrange = require( '@stdlib/stats/incr/nanmidrange' );
+```
+
+#### incrnanmidrange()
+
+Returns an accumulator `function` which incrementally computes a [mid-range][mid-range], ignoring `NaN` values.
+
+```javascript
+var accumulator = incrnanmidrange();
+```
+
+#### accumulator( \[x] )
+
+If provided an input value `x`, the accumulator function returns an updated [mid-range][mid-range]. If not provided an input value `x`, the accumulator function returns the current [mid-range][mid-range].
+
+```javascript
+var accumulator = incrnanmidrange();
+
+var midrange = accumulator();
+// returns null
+
+midrange = accumulator( -2.0 );
+// returns -2.0
+
+midrange = accumulator( 1.0 );
+// returns -0.5
+
+midrange = accumulator( NaN );
+// returns -0.5
+
+midrange = accumulator( 3.0 );
+// returns 0.5
+
+midrange = accumulator();
+// returns 0.5
+```
+
+</section>
+
+<!-- /.usage -->
+
+<section class="notes">
+
+## Notes
+
+-   Input values are **not** type checked. If non-numeric inputs are possible, you are advised to type check and handle accordingly **before** passing the value to the accumulator function.
+
+</section>
+
+<!-- /.notes -->
+
+<section class="examples">
+
+## Examples
+
+<!-- eslint no-undef: "error" -->
+
+```javascript
+var randu = require( '@stdlib/random/base/randu' );
+var incrnanmidrange = require( '@stdlib/stats/incr/nanmidrange' );
+
+var accumulator;
+var v;
+var i;
+
+// Initialize an accumulator:
+accumulator = incrnanmidrange();
+
+// For each simulated datum, update the mid-range...
+for ( i = 0; i < 100; i++ ) {
+    if ( randu() < 0.2 ) {
+        v = NaN;
+    } else {
+        v = randu() * 100.0;
+    }
+    accumulator( v );
+}
+console.log( accumulator() );
+```
+
+</section>
+
+<!-- /.examples -->
+
+<!-- Section for related `stdlib` packages. Do not manually edit this section, as it is automatically populated. -->
+
+<section class="related">
+
+* * *
+
+## See Also
+
+-   <span class="package-name">[`@stdlib/stats/incr/midrange`][@stdlib/stats/incr/midrange]</span><span class="delimiter">: </span><span class="description">compute a mid-range incrementally.</span>
+-   <span class="package-name">[`@stdlib/stats/incr/nanmean`][@stdlib/stats/incr/nanmean]</span><span class="delimiter">: </span><span class="description">compute an arithmetic mean incrementally, ignoring NaN values.</span>
+-   <span class="package-name">[`@stdlib/stats/incr/nanmax`][@stdlib/stats/incr/nanmax]</span><span class="delimiter">: </span><span class="description">compute a maximum value incrementally, ignoring NaN values.</span>
+-   <span class="package-name">[`@stdlib/stats/incr/nanmin`][@stdlib/stats/incr/nanmin]</span><span class="delimiter">: </span><span class="description">compute a minimum value incrementally, ignoring NaN values.</span>
+-   <span class="package-name">[`@stdlib/stats/incr/nanrange`][@stdlib/stats/incr/nanrange]</span><span class="delimiter">: </span><span class="description">compute a range incrementally, ignoring NaN values.</span>
+
+</section>
+
+<!-- /.related -->
+
+<!-- Section for all links. Make sure to keep an empty line after the `section` element and another before the `/section` close. -->
+
+<section class="links">
+
+[range]: https://en.wikipedia.org/wiki/Range_%28statistics%29
+
+[mid-range]: https://en.wikipedia.org/wiki/Mid-range
+
+<!-- <related-links> -->
+
+[@stdlib/stats/incr/midrange]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/midrange
+
+[@stdlib/stats/incr/nanmean]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/nanmean
+
+[@stdlib/stats/incr/nanmax]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/nanmax
+
+[@stdlib/stats/incr/nanmin]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/nanmin
+
+[@stdlib/stats/incr/nanrange]: https://github.com/stdlib-js/stdlib/tree/develop/lib/node_modules/%40stdlib/stats/incr/nanrange
+
+<!-- </related-links> -->
+
+</section>
+
+<!-- /.links -->

--- a/lib/node_modules/@stdlib/stats/incr/nanmidrange/benchmark/benchmark.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmidrange/benchmark/benchmark.js
@@ -1,0 +1,69 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var bench = require( '@stdlib/bench' );
+var randu = require( '@stdlib/random/base/randu' );
+var pkg = require( './../package.json' ).name;
+var incrnanmidrange = require( './../lib' );
+
+
+// MAIN //
+
+bench( pkg, function benchmark( b ) {
+	var f;
+	var i;
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		f = incrnanmidrange();
+		if ( typeof f !== 'function' ) {
+			b.fail( 'should return a function' );
+		}
+	}
+	b.toc();
+	if ( typeof f !== 'function' ) {
+		b.fail( 'should return a function' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});
+
+bench( pkg+'::accumulator', function benchmark( b ) {
+	var acc;
+	var v;
+	var i;
+
+	acc = incrnanmidrange();
+
+	b.tic();
+	for ( i = 0; i < b.iterations; i++ ) {
+		v = acc( randu() );
+		if ( v !== v ) {
+			b.fail( 'should not return NaN' );
+		}
+	}
+	b.toc();
+	if ( v !== v ) {
+		b.fail( 'should not return NaN' );
+	}
+	b.pass( 'benchmark finished' );
+	b.end();
+});

--- a/lib/node_modules/@stdlib/stats/incr/nanmidrange/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/incr/nanmidrange/docs/repl.txt
@@ -1,0 +1,39 @@
+
+{{alias}}()
+    Returns an accumulator function which incrementally computes a mid-range,
+    ignoring NaN values.
+
+    The mid-range is the arithmetic mean of maximum and minimum values.
+    Accordingly, the mid-range is the midpoint of the range and a measure of
+    central tendency.
+
+    If provided a value, the accumulator function returns an updated mid-range.
+    If not provided a value, the accumulator function returns the current mid-
+    range.
+
+    NaN values are ignored.
+
+    Returns
+    -------
+    acc: Function
+        Accumulator function.
+
+    Examples
+    --------
+    > var accumulator = {{alias}}();
+    > var v = accumulator()
+    null
+    > v = accumulator( 3.14 )
+    3.14
+    > v = accumulator( -5.0 )
+    ~-0.93
+    > v = accumulator( NaN )
+    ~-0.93
+    > v = accumulator( 10.1 )
+    2.55
+    > v = accumulator()
+    2.55
+
+    See Also
+    --------
+

--- a/lib/node_modules/@stdlib/stats/incr/nanmidrange/docs/types/index.d.ts
+++ b/lib/node_modules/@stdlib/stats/incr/nanmidrange/docs/types/index.d.ts
@@ -1,0 +1,67 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// TypeScript Version: 4.1
+
+/// <reference types="@stdlib/types"/>
+
+/**
+* If provided a value, returns an updated mid-range; otherwise, returns the current mid-range.
+*
+* ## Notes
+*
+* -   The mid-range is the arithmetic mean of maximum and minimum values. Accordingly, the mid-range is the midpoint of the range and a measure of central tendency.
+* -   NaN values are ignored.
+*
+* @param x - value
+* @returns mid-range
+*/
+type accumulator = ( x?: number ) => number | null;
+
+/**
+* Returns an accumulator function which incrementally computes a mid-range, ignoring NaN values.
+*
+* @returns accumulator function
+*
+* @example
+* var accumulator = incrnanmidrange();
+*
+* var midrange = accumulator();
+* // returns null
+*
+* midrange = accumulator( 3.14 );
+* // returns 3.14
+*
+* midrange = accumulator( -5.0 );
+* // returns ~-0.93
+*
+* midrange = accumulator( NaN );
+* // returns ~-0.93
+*
+* midrange = accumulator( 10.1 );
+* // returns 2.55
+*
+* midrange = accumulator();
+* // returns 2.55
+*/
+declare function incrnanmidrange(): accumulator;
+
+
+// EXPORTS //
+
+export = incrnanmidrange;

--- a/lib/node_modules/@stdlib/stats/incr/nanmidrange/docs/types/test.ts
+++ b/lib/node_modules/@stdlib/stats/incr/nanmidrange/docs/types/test.ts
@@ -1,0 +1,63 @@
+/*
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import incrnanmidrange = require( './index' );
+
+
+// TESTS //
+
+// The function returns an accumulator function...
+{
+	incrnanmidrange(); // $ExpectType accumulator
+}
+
+// The compiler throws an error if the function is provided arguments...
+{
+	incrnanmidrange( '5' ); // $ExpectError
+	incrnanmidrange( 5 ); // $ExpectError
+	incrnanmidrange( true ); // $ExpectError
+	incrnanmidrange( false ); // $ExpectError
+	incrnanmidrange( null ); // $ExpectError
+	incrnanmidrange( undefined ); // $ExpectError
+	incrnanmidrange( [] ); // $ExpectError
+	incrnanmidrange( {} ); // $ExpectError
+	incrnanmidrange( ( x: number ): number => x ); // $ExpectError
+}
+
+// The function returns an accumulator function which returns an accumulated result...
+{
+	const acc = incrmidrange();
+
+	acc(); // $ExpectType number | null
+	acc( 3.14 ); // $ExpectType number | null
+	acc( 5 ); // $ExpectType number | null
+	acc( -2 ); // $ExpectType number | null
+}
+
+// The compiler throws an error if the returned accumulator function is provided invalid arguments...
+{
+	const acc = incrmidrange();
+
+	acc( '5' ); // $ExpectError
+	acc( true ); // $ExpectError
+	acc( false ); // $ExpectError
+	acc( null ); // $ExpectError
+	acc( [] ); // $ExpectError
+	acc( {} ); // $ExpectError
+	acc( ( x: number ): number => x ); // $ExpectError
+}

--- a/lib/node_modules/@stdlib/stats/incr/nanmidrange/examples/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmidrange/examples/index.js
@@ -1,0 +1,43 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+var randu = require( '@stdlib/random/base/randu' );
+var incrnanmidrange = require( './../lib' );
+
+var accumulator;
+var midrange;
+var v;
+var i;
+
+// Initialize an accumulator:
+accumulator = incrnanmidrange();
+
+// For each simulated datum, update the mid-range...
+console.log( '\nValue\tMid-range\n' );
+for ( i = 0; i < 100; i++ ) {
+	if ( randu() < 0.2 ) {
+		v = NaN;
+	} else {
+		v = randu() * 100.0;
+	}
+	midrange = accumulator( v );
+	console.log( '%d\t%d', v.toFixed( 4 ), midrange ? midrange.toFixed( 4 ) : 'null' );
+}
+console.log( '\nFinal mid-range: %d\n', accumulator() );

--- a/lib/node_modules/@stdlib/stats/incr/nanmidrange/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmidrange/lib/index.js
@@ -1,0 +1,57 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+/**
+* Compute a mid-range incrementally, ignoring NaN values.
+*
+* @module @stdlib/stats/incr/nanmidrange
+*
+* @example
+* var incrnanmidrange = require( '@stdlib/stats/incr/nanmidrange' );
+*
+* var accumulator = incrnanmidrange();
+*
+* var midrange = accumulator();
+* // returns null
+*
+* midrange = accumulator( 3.14 );
+* // returns 3.14
+*
+* midrange = accumulator( -5.0 );
+* // returns ~-0.93
+*
+* midrange = accumulator( NaN );
+* // returns ~-0.93
+*
+* midrange = accumulator( 10.1 );
+* // returns 2.55
+*
+* midrange = accumulator();
+* // returns 2.55
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/incr/nanmidrange/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmidrange/lib/main.js
@@ -1,0 +1,77 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var incrmidrange = require( '@stdlib/stats/incr/midrange' );
+
+
+// MAIN //
+
+/**
+* Returns an accumulator function which incrementally computes a mid-range, ignoring `NaN` values.
+*
+* @returns {Function} accumulator function
+*
+* @example
+* var accumulator = incrnanmidrange();
+*
+* var midrange = accumulator();
+* // returns null
+*
+* midrange = accumulator( 3.14 );
+* // returns 3.14
+*
+* midrange = accumulator( -5.0 );
+* // returns ~-0.93
+*
+* midrange = accumulator( NaN );
+* // returns ~-0.93
+*
+* midrange = accumulator( 10.1 );
+* // returns 2.55
+*
+* midrange = accumulator();
+* // returns 2.55
+*/
+function incrnanmidrange() {
+	var midrange = incrmidrange();
+	return accumulator;
+
+	/**
+	* If provided a value, the accumulator function returns an updated mid-range. If not provided a value, the accumulator function returns the current mid-range.
+	*
+	* @private
+	* @param {number} [x] - new value
+	* @returns {(number|null)} mid-range or null
+	*/
+	function accumulator( x ) {
+		if ( arguments.length === 0 || isnan( x ) ) {
+			return midrange();
+		}
+		return midrange( x );
+	}
+}
+
+
+// EXPORTS //
+
+module.exports = incrnanmidrange;

--- a/lib/node_modules/@stdlib/stats/incr/nanmidrange/package.json
+++ b/lib/node_modules/@stdlib/stats/incr/nanmidrange/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@stdlib/stats/incr/nanmidrange",
+  "version": "0.0.0",
+  "description": "Compute a mid-range incrementally, ignoring NaN values.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "benchmark": "./benchmark",
+    "doc": "./docs",
+    "example": "./examples",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {},
+  "homepage": "https://github.com/stdlib-js/stdlib",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "statistics",
+    "stats",
+    "mathematics",
+    "math",
+    "maximum",
+    "max",
+    "minimum",
+    "min",
+    "mid",
+    "range",
+    "mid-range",
+    "mid-extreme",
+    "mean",
+    "central tendency",
+    "incremental",
+    "accumulator",
+    "nan",
+    "ignore"
+  ]
+}

--- a/lib/node_modules/@stdlib/stats/incr/nanmidrange/test/test.js
+++ b/lib/node_modules/@stdlib/stats/incr/nanmidrange/test/test.js
@@ -1,0 +1,138 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+var zeros = require( '@stdlib/array/base/zeros' );
+var incrnanmidrange = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, __filename );
+	t.strictEqual( typeof incrnanmidrange, 'function', 'main export is a function' );
+	t.end();
+});
+
+tape( 'the function returns an accumulator function', function test( t ) {
+	t.strictEqual( typeof incrnanmidrange(), 'function', 'returns expected value' );
+	t.end();
+});
+
+tape( 'if not provided any values, the initial returned mid-range is `null`', function test( t ) {
+	var acc = incrnanmidrange();
+	t.strictEqual( acc(), null, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the accumulator function incrementally computes a mid-range, ignoring NaN values', function test( t ) {
+	var expected;
+	var actual;
+	var data;
+	var acc;
+	var max;
+	var min;
+	var N;
+	var d;
+	var i;
+
+	data = [ 2.0, 3.0, NaN, -2.0, 4.0, NaN, -3.0, 4.0 ];
+	N = data.length;
+
+	expected = zeros( N );
+	actual = zeros( N );
+
+	acc = incrnanmidrange();
+
+	max = NINF;
+	min = PINF;
+	for ( i = 0; i < N; i++ ) {
+		d = data[ i ];
+		if ( isnan( d ) === false ) {
+			if ( d > max ) {
+				max = d;
+			}
+			if ( d < min ) {
+				min = d;
+			}
+		}
+		expected[ i ] = (max + min) / 2.0;
+		actual[ i ] = acc( d );
+	}
+	t.deepEqual( actual, expected, 'returns expected incremental results' );
+	t.end();
+});
+
+tape( 'if not provided an input value, the accumulator function returns the current mid-range', function test( t ) {
+	var data;
+	var acc;
+	var i;
+
+	data = [ -2.0, NaN, 3.0, NaN, 1.0 ];
+	acc = incrnanmidrange();
+	for ( i = 0; i < data.length; i++ ) {
+		acc( data[ i ] );
+	}
+	t.strictEqual( acc(), 0.5, 'returns the current accumulated mid-range' );
+	t.end();
+});
+
+tape( 'if provided only `NaN` values, the accumulator function returns `null`', function test( t ) {
+	var data;
+	var acc;
+	var i;
+
+	data = [ NaN, NaN, NaN ];
+	acc = incrnanmidrange();
+	for ( i = 0; i < data.length; i++ ) {
+		acc( data[ i ] );
+	}
+	t.strictEqual( acc(), null, 'returns expected value' );
+	t.end();
+});
+
+tape( 'the accumulator function correctly handles NaN values', function test( t ) {
+	var acc;
+	var v;
+
+	acc = incrnanmidrange();
+
+	v = acc( 2.0 );
+	t.strictEqual( v, 2.0, 'returns expected value' );
+
+	v = acc( NaN );
+	t.strictEqual( v, 2.0, 'returns expected value' );
+
+	v = acc( 3.0 );
+	t.strictEqual( v, 2.5, 'returns expected value' );
+
+	v = acc( NaN );
+	t.strictEqual( v, 2.5, 'returns expected value' );
+
+	v = acc( -5.0 );
+	t.strictEqual( v, -1.0, 'returns expected value' );
+
+	t.end();
+});


### PR DESCRIPTION
# Add `stats/incr/nanmidrange`

Resolves #5578.

## Description

> What is the purpose of this pull request?

This pull request:

-   Adds `@stdlib/stats/incr/nanmidrange` package for incrementally computing mid-range while ignoring `NaN` values
-   Implements the accumulator following the same pattern as other `nan*` packages in the `stats/incr` namespace
-   Uses a thin wrapper around `@stdlib/stats/incr/midrange` that skips `NaN` inputs

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #5578 (parent tracking issue: #5966)

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

The implementation follows the established pattern from `@stdlib/stats/incr/nanmin` and `@stdlib/stats/incr/nansum`. The package wraps the existing `incrmidrange` accumulator and filters out `NaN` values before passing them through.

All standard package files are included:
- Main implementation (`lib/`)
- Comprehensive tests with NaN handling scenarios
- Example demonstrating usage with NaN values
- Benchmark suite
- TypeScript definitions
- REPL documentation

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [x] Yes
-   [ ] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [x] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

Used AI to understand the codebase structure and identify the appropriate pattern to follow from existing `nan*` packages. The implementation was manually written by adapting the `midrange` package with the NaN-handling wrapper pattern observed in `nanmin` and `nansum`.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
