### PR TITLE
feat: implement mean and variance for half-normal distribution

### DIFF
--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/lib/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/lib/index.js
@@ -1,0 +1,25 @@
+'use strict';
+
+/**
+* Half-normal distribution expected value.
+*
+* @module @stdlib/stats/base/dists/halfnormal/mean
+*
+* @example
+* var mean = require( '@stdlib/stats/base/dists/halfnormal/mean' );
+*
+* var v = mean( 1.0 );
+* // returns ~0.798
+*
+* var v = mean( 2.0 );
+* // returns ~1.596
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/lib/index.js
@@ -1,4 +1,23 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 'use strict';
+
 /**
 * Half-normal distribution expected value.
 *
@@ -13,7 +32,12 @@
 * var v = mean( 2.0 );
 * // returns ~1.596
 */
+
 // MODULES //
+
 var main = require( './main.js' );
+
+
 // EXPORTS //
+
 module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/lib/index.js
@@ -1,21 +1,3 @@
-/**
-* @license Apache-2.0
-*
-* Copyright (c) 2026 The Stdlib Authors.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
-
 'use strict';
 
 /**

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/lib/index.js
@@ -1,5 +1,4 @@
 'use strict';
-
 /**
 * Half-normal distribution expected value.
 *
@@ -14,12 +13,7 @@
 * var v = mean( 2.0 );
 * // returns ~1.596
 */
-
 // MODULES //
-
 var main = require( './main.js' );
-
-
 // EXPORTS //
-
 module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/lib/main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/lib/main.js
@@ -1,11 +1,37 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 'use strict';
+
 // MODULES //
+
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
 var PI = require( '@stdlib/constants/float64/pi' );
+
+
 // CONSTANTS //
+
 var SQRT_TWO_OVER_PI = sqrt( 2.0 / PI );
+
+
 // MAIN //
+
 /**
 * Returns the expected value of a half-normal distribution.
 *
@@ -25,10 +51,13 @@ var SQRT_TWO_OVER_PI = sqrt( 2.0 / PI );
 * // returns NaN
 */
 function mean( sigma ) {
-    if ( isnan( sigma ) || sigma <= 0.0 ) {
-        return NaN;
-    }
-    return sigma * SQRT_TWO_OVER_PI;
+	if ( isnan( sigma ) || sigma <= 0.0 ) {
+		return NaN;
+	}
+	return sigma * SQRT_TWO_OVER_PI;
 }
+
+
 // EXPORTS //
+
 module.exports = mean;

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/lib/main.js
@@ -25,7 +25,7 @@ var sqrt = require( '@stdlib/math/base/special/sqrt' );
 var PI = require( '@stdlib/constants/float64/pi' );
 
 
-// CONSTANTS //
+// VARIABLES //
 
 var SQRT_TWO_OVER_PI = sqrt( 2.0 / PI );
 

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/lib/main.js
@@ -1,21 +1,3 @@
-/**
-* @license Apache-2.0
-*
-* Copyright (c) 2026 The Stdlib Authors.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
-
 'use strict';
 
 // MODULES //

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/lib/main.js
@@ -1,0 +1,45 @@
+'use strict';
+
+// MODULES //
+
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var sqrt = require( '@stdlib/math/base/special/sqrt' );
+var PI = require( '@stdlib/constants/float64/pi' );
+
+
+// CONSTANTS //
+
+var SQRT_TWO_OVER_PI = sqrt( 2.0 / PI );
+
+
+// MAIN //
+
+/**
+* Returns the expected value of a half-normal distribution.
+*
+* @param {number} sigma - scale parameter
+* @returns {number} expected value
+*
+* @example
+* var v = mean( 1.0 );
+* // returns ~0.798
+*
+* @example
+* var v = mean( 2.0 );
+* // returns ~1.596
+*
+* @example
+* var v = mean( -1.0 );
+* // returns NaN
+*/
+function mean( sigma ) {
+    if ( isnan( sigma ) || sigma <= 0.0 ) {
+        return NaN;
+    }
+    return sigma * SQRT_TWO_OVER_PI;
+}
+
+
+// EXPORTS //
+
+module.exports = mean;

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/lib/main.js
@@ -1,19 +1,11 @@
 'use strict';
-
 // MODULES //
-
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var sqrt = require( '@stdlib/math/base/special/sqrt' );
 var PI = require( '@stdlib/constants/float64/pi' );
-
-
 // CONSTANTS //
-
 var SQRT_TWO_OVER_PI = sqrt( 2.0 / PI );
-
-
 // MAIN //
-
 /**
 * Returns the expected value of a half-normal distribution.
 *
@@ -38,8 +30,5 @@ function mean( sigma ) {
     }
     return sigma * SQRT_TWO_OVER_PI;
 }
-
-
 // EXPORTS //
-
 module.exports = mean;

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@stdlib/stats/base/dists/halfnormal/mean",
+  "name": "@stdlib/stats-base-dists-halfnormal-mean",
   "version": "0.0.0",
   "description": "Half-normal distribution expected value.",
   "license": "Apache-2.0",
@@ -16,7 +16,9 @@
   "main": "./lib",
   "directories": {
     "lib": "./lib",
-    "test": "./test"
+    "doc": "./docs",
+    "test": "./test",
+    "benchmark": "./benchmark"
   },
   "types": "./docs/types",
   "scripts": {
@@ -41,7 +43,8 @@
     "@stdlib/math/base/special/abs": "^0.2.2",
     "tape": "git+https://github.com/kgryte/tape.git#fix/globby",
     "istanbul": "^0.4.1",
-    "tap-min": "git+https://github.com/Planeshifter/tap-min.git"
+    "tap-min": "git+https://github.com/Planeshifter/tap-min.git",
+    "@stdlib/bench/harness": "^0.2.2"
   },
   "engines": {
     "node": ">=0.10.0",

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@stdlib/stats/base/dists/halfnormal/mean",
+  "name": "@stdlib/stats-base-dists-halfnormal-mean",
   "version": "0.0.0",
   "description": "Half-normal distribution expected value.",
   "license": "Apache-2.0",

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/package.json
@@ -1,0 +1,76 @@
+{
+  "name": "@stdlib/stats/base/dists/halfnormal/mean",
+  "version": "0.0.0",
+  "description": "Half-normal distribution expected value.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "lib": "./lib",
+    "doc": "./docs",
+    "test": "./test",
+    "benchmark": "./benchmark"
+  },
+  "types": "./docs/types",
+  "scripts": {
+    "test": "make test",
+    "test-cov": "make test-cov",
+    "test-browsers": "make test-browsers"
+  },
+  "homepage": "https://stdlib.io",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {
+    "@stdlib/constants/float64/pi": "^0.2.2",
+    "@stdlib/math/base/assert/is-nan": "^0.2.2",
+    "@stdlib/math/base/special/sqrt": "^0.2.2"
+  },
+  "devDependencies": {
+    "@stdlib/math/base/special/abs": "^0.2.2",
+    "tape": "git+https://github.com/kgryte/tape.git#fix/globby",
+    "istanbul": "^0.4.1",
+    "tap-min": "git+https://github.com/Planeshifter/tap-min.git",
+    "@stdlib/bench/harness": "^0.2.2"
+  },
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "statistics",
+    "stats",
+    "distribution",
+    "half-normal",
+    "halfnormal",
+    "mean",
+    "expected value",
+    "expectation"
+  ]
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@stdlib/stats-base-dists-halfnormal-mean",
+  "name": "@stdlib/stats/base/dists/halfnormal/mean",
   "version": "0.0.0",
   "description": "Half-normal distribution expected value.",
   "license": "Apache-2.0",
@@ -16,9 +16,7 @@
   "main": "./lib",
   "directories": {
     "lib": "./lib",
-    "doc": "./docs",
-    "test": "./test",
-    "benchmark": "./benchmark"
+    "test": "./test"
   },
   "types": "./docs/types",
   "scripts": {
@@ -43,8 +41,7 @@
     "@stdlib/math/base/special/abs": "^0.2.2",
     "tape": "git+https://github.com/kgryte/tape.git#fix/globby",
     "istanbul": "^0.4.1",
-    "tap-min": "git+https://github.com/Planeshifter/tap-min.git",
-    "@stdlib/bench/harness": "^0.2.2"
+    "tap-min": "git+https://github.com/Planeshifter/tap-min.git"
   },
   "engines": {
     "node": ">=0.10.0",

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/test/test.js
@@ -1,5 +1,25 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 'use strict';
+
 // MODULES //
+
 var tape = require( 'tape' );
 var abs = require( '@stdlib/math/base/special/abs' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
@@ -8,57 +28,58 @@ var NINF = require( '@stdlib/constants/float64/ninf' );
 var mean = require( './../lib' );
 
 // TESTS //
+
 tape( 'main export is a function', function test( t ) {
-    t.ok( true, __filename );
-    t.equal( typeof mean, 'function', 'main export is a function' );
-    t.end();
+	t.ok( true, __filename );
+	t.equal( typeof mean, 'function', 'main export is a function' );
+	t.end();
 });
 
 tape( 'if provided `NaN` for `sigma`, the function returns `NaN`', function test( t ) {
-    var v = mean( NaN );
-    t.equal( isnan( v ), true, 'returns NaN' );
-    t.end();
+	var v = mean( NaN );
+	t.equal( isnan( v ), true, 'returns NaN' );
+	t.end();
 });
 
 tape( 'if provided a value less than or equal to 0 for `sigma`, the function returns `NaN`', function test( t ) {
-    var v;
+	var v;
 
-    v = mean( 0.0 );
-    t.equal( isnan( v ), true, 'returns NaN' );
+	v = mean( 0.0 );
+	t.equal( isnan( v ), true, 'returns NaN' );
 
-    v = mean( -1.0 );
-    t.equal( isnan( v ), true, 'returns NaN' );
+	v = mean( -1.0 );
+	t.equal( isnan( v ), true, 'returns NaN' );
 
-    v = mean( NINF );
-    t.equal( isnan( v ), true, 'returns NaN' );
+	v = mean( NINF );
+	t.equal( isnan( v ), true, 'returns NaN' );
 
-    t.end();
+	t.end();
 });
 
 tape( 'the function returns the expected value', function test( t ) {
-    var expected;
-    var sigma;
-    var v;
-    var i;
+	var expected;
+	var sigma;
+	var v;
+	var i;
 
-    // Test cases (sigma, expected)
-    // Mean = sigma * sqrt(2/pi) -> sigma * ~0.79788456
-    sigma = [ 1.0, 2.0, 5.0, 0.5 ];
-    expected = [
-        0.79788456,
-        1.59576912,
-        3.98942280,
-        0.39894228
-    ];
+	// Test cases (sigma, expected)
+	// Mean = sigma * sqrt(2/pi) -> sigma * ~0.79788456
+	sigma = [ 1.0, 2.0, 5.0, 0.5 ];
+	expected = [
+		0.79788456,
+		1.59576912,
+		3.98942280,
+		0.39894228
+	];
 
-    for ( i = 0; i < sigma.length; i++ ) {
-        v = mean( sigma[ i ] );
-        // We check if the difference is very small (epsilon)
-        if ( abs( v - expected[ i ] ) > 1e-7 ) {
-            t.fail( 'returns ' + v + ' when expected ' + expected[ i ] );
-        } else {
-            t.pass( 'returns ' + v + ' when expected ' + expected[ i ] );
-        }
-    }
-    t.end();
+	for ( i = 0; i < sigma.length; i++ ) {
+		v = mean( sigma[ i ] );
+		// We check if the difference is very small (epsilon)
+		if ( abs( v - expected[ i ] ) > 1e-7 ) {
+			t.fail( 'returns ' + v + ' when expected ' + expected[ i ] );
+		} else {
+			t.pass( 'returns ' + v + ' when expected ' + expected[ i ] );
+		}
+	}
+	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/test/test.js
@@ -1,0 +1,68 @@
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var abs = require( '@stdlib/math/base/special/abs' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+var mean = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+    t.ok( true, __filename );
+    t.equal( typeof mean, 'function', 'main export is a function' );
+    t.end();
+});
+
+tape( 'if provided `NaN` for `sigma`, the function returns `NaN`', function test( t ) {
+    var v = mean( NaN );
+    t.equal( isnan( v ), true, 'returns NaN' );
+    t.end();
+});
+
+tape( 'if provided a value less than or equal to 0 for `sigma`, the function returns `NaN`', function test( t ) {
+    var v;
+
+    v = mean( 0.0 );
+    t.equal( isnan( v ), true, 'returns NaN' );
+
+    v = mean( -1.0 );
+    t.equal( isnan( v ), true, 'returns NaN' );
+
+    v = mean( NINF );
+    t.equal( isnan( v ), true, 'returns NaN' );
+
+    t.end();
+});
+
+tape( 'the function returns the expected value', function test( t ) {
+    var expected;
+    var sigma;
+    var v;
+    var i;
+
+    // Test cases (sigma, expected)
+    // Mean = sigma * sqrt(2/pi) -> sigma * ~0.79788456
+    sigma = [ 1.0, 2.0, 5.0, 0.5 ];
+    expected = [
+        0.79788456,
+        1.59576912,
+        3.98942280,
+        0.39894228
+    ];
+
+    for ( i = 0; i < sigma.length; i++ ) {
+        v = mean( sigma[ i ] );
+        // We check if the difference is very small (epsilon)
+        if ( abs( v - expected[ i ] ) > 1e-7 ) {
+            t.fail( 'returns ' + v + ' when expected ' + expected[ i ] );
+        } else {
+            t.pass( 'returns ' + v + ' when expected ' + expected[ i ] );
+        }
+    }
+    t.end();
+});

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/test/test.js
@@ -1,21 +1,3 @@
-/**
-* @license Apache-2.0
-*
-* Copyright (c) 2026 The Stdlib Authors.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
-
 'use strict';
 
 // MODULES //

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/mean/test/test.js
@@ -1,7 +1,5 @@
 'use strict';
-
 // MODULES //
-
 var tape = require( 'tape' );
 var abs = require( '@stdlib/math/base/special/abs' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
@@ -9,9 +7,7 @@ var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var mean = require( './../lib' );
 
-
 // TESTS //
-
 tape( 'main export is a function', function test( t ) {
     t.ok( true, __filename );
     t.equal( typeof mean, 'function', 'main export is a function' );

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/lib/index.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/lib/index.js
@@ -1,5 +1,4 @@
 'use strict';
-
 /**
 * Half-normal distribution variance.
 *
@@ -14,12 +13,7 @@
 * var v = variance( 2.0 );
 * // returns ~1.454
 */
-
 // MODULES //
-
 var main = require( './main.js' );
-
-
 // EXPORTS //
-
 module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/lib/index.js
@@ -1,4 +1,23 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 'use strict';
+
 /**
 * Half-normal distribution variance.
 *
@@ -13,7 +32,12 @@
 * var v = variance( 2.0 );
 * // returns ~1.454
 */
+
 // MODULES //
+
 var main = require( './main.js' );
+
+
 // EXPORTS //
+
 module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/lib/index.js
@@ -1,0 +1,25 @@
+'use strict';
+
+/**
+* Half-normal distribution variance.
+*
+* @module @stdlib/stats/base/dists/halfnormal/variance
+*
+* @example
+* var variance = require( '@stdlib/stats/base/dists/halfnormal/variance' );
+*
+* var v = variance( 1.0 );
+* // returns ~0.363
+*
+* var v = variance( 2.0 );
+* // returns ~1.454
+*/
+
+// MODULES //
+
+var main = require( './main.js' );
+
+
+// EXPORTS //
+
+module.exports = main;

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/lib/index.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/lib/index.js
@@ -1,21 +1,3 @@
-/**
-* @license Apache-2.0
-*
-* Copyright (c) 2026 The Stdlib Authors.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
-
 'use strict';
 
 /**

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/lib/main.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/lib/main.js
@@ -1,17 +1,12 @@
 'use strict';
-
 // MODULES //
-
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var PI = require( '@stdlib/constants/float64/pi' );
-
-
 // CONSTANTS //
 
 // 1 - 2/pi
 var FACTOR = 1.0 - ( 2.0 / PI );
-
 
 // MAIN //
 
@@ -40,7 +35,5 @@ function variance( sigma ) {
     return pow( sigma, 2.0 ) * FACTOR;
 }
 
-
 // EXPORTS //
-
 module.exports = variance;

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/lib/main.js
@@ -1,21 +1,3 @@
-/**
-* @license Apache-2.0
-*
-* Copyright (c) 2026 The Stdlib Authors.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
-
 'use strict';
 
 // MODULES //

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/lib/main.js
@@ -1,12 +1,35 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 'use strict';
+
 // MODULES //
+
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var pow = require( '@stdlib/math/base/special/pow' );
 var PI = require( '@stdlib/constants/float64/pi' );
+
+
 // CONSTANTS //
 
 // 1 - 2/pi
 var FACTOR = 1.0 - ( 2.0 / PI );
+
 
 // MAIN //
 
@@ -29,11 +52,13 @@ var FACTOR = 1.0 - ( 2.0 / PI );
 * // returns NaN
 */
 function variance( sigma ) {
-    if ( isnan( sigma ) || sigma <= 0.0 ) {
-        return NaN;
-    }
-    return pow( sigma, 2.0 ) * FACTOR;
+	if ( isnan( sigma ) || sigma <= 0.0 ) {
+		return NaN;
+	}
+	return pow( sigma, 2.0 ) * FACTOR;
 }
 
+
 // EXPORTS //
+
 module.exports = variance;

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/lib/main.js
@@ -1,0 +1,46 @@
+'use strict';
+
+// MODULES //
+
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var pow = require( '@stdlib/math/base/special/pow' );
+var PI = require( '@stdlib/constants/float64/pi' );
+
+
+// CONSTANTS //
+
+// 1 - 2/pi
+var FACTOR = 1.0 - ( 2.0 / PI );
+
+
+// MAIN //
+
+/**
+* Returns the variance of a half-normal distribution.
+*
+* @param {number} sigma - scale parameter
+* @returns {number} variance
+*
+* @example
+* var v = variance( 1.0 );
+* // returns ~0.363
+*
+* @example
+* var v = variance( 2.0 );
+* // returns ~1.454
+*
+* @example
+* var v = variance( -1.0 );
+* // returns NaN
+*/
+function variance( sigma ) {
+    if ( isnan( sigma ) || sigma <= 0.0 ) {
+        return NaN;
+    }
+    return pow( sigma, 2.0 ) * FACTOR;
+}
+
+
+// EXPORTS //
+
+module.exports = variance;

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/lib/main.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/lib/main.js
@@ -25,7 +25,7 @@ var pow = require( '@stdlib/math/base/special/pow' );
 var PI = require( '@stdlib/constants/float64/pi' );
 
 
-// CONSTANTS //
+// VARIABLES //
 
 // 1 - 2/pi
 var FACTOR = 1.0 - ( 2.0 / PI );

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@stdlib/stats/base/dists/halfnormal/variance",
+  "name": "@stdlib/stats-base-dists-halfnormal-variance",
   "version": "0.0.0",
   "description": "Half-normal distribution variance.",
   "license": "Apache-2.0",
@@ -15,6 +15,7 @@
   ],
   "main": "./lib",
   "directories": {
+    "doc": "./docs",
     "lib": "./lib",
     "test": "./test"
   },

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@stdlib/stats-base-dists-halfnormal-variance",
+  "name": "@stdlib/stats/base/dists/halfnormal/variance",
   "version": "0.0.0",
   "description": "Half-normal distribution variance.",
   "license": "Apache-2.0",
@@ -15,7 +15,6 @@
   ],
   "main": "./lib",
   "directories": {
-    "doc": "./docs",
     "lib": "./lib",
     "test": "./test"
   },

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@stdlib/stats/base/dists/halfnormal/variance",
+  "version": "0.0.0",
+  "description": "Half-normal distribution variance.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "The Stdlib Authors",
+    "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+  },
+  "contributors": [
+    {
+      "name": "The Stdlib Authors",
+      "url": "https://github.com/stdlib-js/stdlib/graphs/contributors"
+    }
+  ],
+  "main": "./lib",
+  "directories": {
+    "doc": "./docs",
+    "lib": "./lib",
+    "test": "./test"
+  },
+  "types": "./docs/types",
+  "scripts": {
+    "test": "make test",
+    "test-cov": "make test-cov",
+    "test-browsers": "make test-browsers"
+  },
+  "homepage": "https://stdlib.io",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stdlib-js/stdlib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/stdlib-js/stdlib/issues"
+  },
+  "dependencies": {
+    "@stdlib/constants/float64/pi": "^0.2.2",
+    "@stdlib/math/base/assert/is-nan": "^0.2.2",
+    "@stdlib/math/base/special/pow": "^0.2.2"
+  },
+  "devDependencies": {
+    "@stdlib/math/base/special/abs": "^0.2.2",
+    "tape": "git+https://github.com/kgryte/tape.git#fix/globby",
+    "istanbul": "^0.4.1",
+    "tap-min": "git+https://github.com/Planeshifter/tap-min.git"
+  },
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">2.7.0"
+  },
+  "os": [
+    "aix",
+    "darwin",
+    "freebsd",
+    "linux",
+    "macos",
+    "openbsd",
+    "sunos",
+    "win32",
+    "windows"
+  ],
+  "keywords": [
+    "stdlib",
+    "stdmath",
+    "statistics",
+    "stats",
+    "distribution",
+    "half-normal",
+    "halfnormal",
+    "variance",
+    "var",
+    "dispersion"
+  ]
+}

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/package.json
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@stdlib/stats/base/dists/halfnormal/variance",
+  "name": "@stdlib/stats-base-dists-halfnormal-variance",
   "version": "0.0.0",
   "description": "Half-normal distribution variance.",
   "license": "Apache-2.0",

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/test/test.js
@@ -1,7 +1,7 @@
 /**
 * @license Apache-2.0
 *
-* Copyright (c) 2025 The Stdlib Authors.
+* Copyright (c) 2026 The Stdlib Authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/test/test.js
@@ -1,7 +1,5 @@
 'use strict';
-
 // MODULES //
-
 var tape = require( 'tape' );
 var abs = require( '@stdlib/math/base/special/abs' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
@@ -9,9 +7,7 @@ var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var variance = require( './../lib' );
 
-
 // TESTS //
-
 tape( 'main export is a function', function test( t ) {
     t.ok( true, __filename );
     t.equal( typeof variance, 'function', 'main export is a function' );

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/test/test.js
@@ -1,5 +1,25 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2025 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 'use strict';
+
 // MODULES //
+
 var tape = require( 'tape' );
 var abs = require( '@stdlib/math/base/special/abs' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
@@ -7,57 +27,59 @@ var PINF = require( '@stdlib/constants/float64/pinf' );
 var NINF = require( '@stdlib/constants/float64/ninf' );
 var variance = require( './../lib' );
 
+
 // TESTS //
+
 tape( 'main export is a function', function test( t ) {
-    t.ok( true, __filename );
-    t.equal( typeof variance, 'function', 'main export is a function' );
-    t.end();
+	t.ok( true, __filename );
+	t.equal( typeof variance, 'function', 'main export is a function' );
+	t.end();
 });
 
 tape( 'if provided `NaN` for `sigma`, the function returns `NaN`', function test( t ) {
-    var v = variance( NaN );
-    t.equal( isnan( v ), true, 'returns NaN' );
-    t.end();
+	var v = variance( NaN );
+	t.equal( isnan( v ), true, 'returns NaN' );
+	t.end();
 });
 
 tape( 'if provided a value less than or equal to 0 for `sigma`, the function returns `NaN`', function test( t ) {
-    var v;
+	var v;
 
-    v = variance( 0.0 );
-    t.equal( isnan( v ), true, 'returns NaN' );
+	v = variance( 0.0 );
+	t.equal( isnan( v ), true, 'returns NaN' );
 
-    v = variance( -1.0 );
-    t.equal( isnan( v ), true, 'returns NaN' );
+	v = variance( -1.0 );
+	t.equal( isnan( v ), true, 'returns NaN' );
 
-    v = variance( NINF );
-    t.equal( isnan( v ), true, 'returns NaN' );
+	v = variance( NINF );
+	t.equal( isnan( v ), true, 'returns NaN' );
 
-    t.end();
+	t.end();
 });
 
 tape( 'the function returns the variance', function test( t ) {
-    var expected;
-    var sigma;
-    var v;
-    var i;
+	var expected;
+	var sigma;
+	var v;
+	var i;
 
-    // Test cases (sigma, expected)
-    // Variance = sigma^2 * (1 - 2/pi)
-    // 1 - 2/pi ≈ 0.3633802276
-    sigma = [ 1.0, 2.0, 5.0 ];
-    expected = [
-        0.36338023,
-        1.45352091,
-        9.08450569
-    ];
+	// Test cases (sigma, expected)
+	// Variance = sigma^2 * (1 - 2/pi)
+	// 1 - 2/pi ≈ 0.3633802276
+	sigma = [ 1.0, 2.0, 5.0 ];
+	expected = [
+		0.36338023,
+		1.45352091,
+		9.08450569
+	];
 
-    for ( i = 0; i < sigma.length; i++ ) {
-        v = variance( sigma[ i ] );
-        if ( abs( v - expected[ i ] ) > 1e-7 ) {
-            t.fail( 'returns ' + v + ' when expected ' + expected[ i ] );
-        } else {
-            t.pass( 'returns ' + v + ' when expected ' + expected[ i ] );
-        }
-    }
-    t.end();
+	for ( i = 0; i < sigma.length; i++ ) {
+		v = variance( sigma[ i ] );
+		if ( abs( v - expected[ i ] ) > 1e-7 ) {
+			t.fail( 'returns ' + v + ' when expected ' + expected[ i ] );
+		} else {
+			t.pass( 'returns ' + v + ' when expected ' + expected[ i ] );
+		}
+	}
+	t.end();
 });

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/test/test.js
@@ -1,21 +1,3 @@
-/**
-* @license Apache-2.0
-*
-* Copyright (c) 2026 The Stdlib Authors.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
-
 'use strict';
 
 // MODULES //

--- a/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/test/test.js
+++ b/lib/node_modules/@stdlib/stats/base/dists/halfnormal/variance/test/test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var abs = require( '@stdlib/math/base/special/abs' );
+var isnan = require( '@stdlib/math/base/assert/is-nan' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
+var variance = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+    t.ok( true, __filename );
+    t.equal( typeof variance, 'function', 'main export is a function' );
+    t.end();
+});
+
+tape( 'if provided `NaN` for `sigma`, the function returns `NaN`', function test( t ) {
+    var v = variance( NaN );
+    t.equal( isnan( v ), true, 'returns NaN' );
+    t.end();
+});
+
+tape( 'if provided a value less than or equal to 0 for `sigma`, the function returns `NaN`', function test( t ) {
+    var v;
+
+    v = variance( 0.0 );
+    t.equal( isnan( v ), true, 'returns NaN' );
+
+    v = variance( -1.0 );
+    t.equal( isnan( v ), true, 'returns NaN' );
+
+    v = variance( NINF );
+    t.equal( isnan( v ), true, 'returns NaN' );
+
+    t.end();
+});
+
+tape( 'the function returns the variance', function test( t ) {
+    var expected;
+    var sigma;
+    var v;
+    var i;
+
+    // Test cases (sigma, expected)
+    // Variance = sigma^2 * (1 - 2/pi)
+    // 1 - 2/pi ≈ 0.3633802276
+    sigma = [ 1.0, 2.0, 5.0 ];
+    expected = [
+        0.36338023,
+        1.45352091,
+        9.08450569
+    ];
+
+    for ( i = 0; i < sigma.length; i++ ) {
+        v = variance( sigma[ i ] );
+        if ( abs( v - expected[ i ] ) > 1e-7 ) {
+            t.fail( 'returns ' + v + ' when expected ' + expected[ i ] );
+        } else {
+            t.pass( 'returns ' + v + ' when expected ' + expected[ i ] );
+        }
+    }
+    t.end();
+});


### PR DESCRIPTION
Addresses #9416

## Description

> What is the purpose of this pull request?

This pull request:

-   Implements the `mean` and `variance` sub-packages for the Half-Normal distribution.
-   Adds unit tests and documentation for both properties.
-   Establishes the initial directory structure for `@stdlib/stats/base/dists/halfnormal`.

This is the first step in addressing the tracking issue #9416. Future PRs will add the PDF, CDF, and other distribution properties.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #9416

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

***

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md