### PR TITLE
docs: fix broken Markdown link (issue #9464)

### DIFF
--- a/lib/node_modules/@stdlib/datasets/nightingales-rose/README.md
+++ b/lib/node_modules/@stdlib/datasets/nightingales-rose/README.md
@@ -191,7 +191,7 @@ The data files (databases) are licensed under an [Open Data Commons Public Domai
 
 [polar-area-diagram]: https://en.wikipedia.org/wiki/Polar_area_diagram
 
-[@nightingale:1859a]: https://web.archive.org/web/20190312000000/https://curiosity.lib.harvard.edu/contagion/catalog/36-990101646750203941
+[@nightingale:1859a]: https://id.lib.harvard.edu/curiosity/contagion/36-990101646750203941
 
 [csv]: https://tools.ietf.org/html/rfc4180
 

--- a/lib/node_modules/@stdlib/datasets/nightingales-rose/README.md
+++ b/lib/node_modules/@stdlib/datasets/nightingales-rose/README.md
@@ -191,7 +191,7 @@ The data files (databases) are licensed under an [Open Data Commons Public Domai
 
 [polar-area-diagram]: https://en.wikipedia.org/wiki/Polar_area_diagram
 
-[@nightingale:1859a]: https://curiosity.lib.harvard.edu/contagion/catalog/36-990101646750203941
+[@nightingale:1859a]: https://web.archive.org/web/20190312000000/https://curiosity.lib.harvard.edu/contagion/catalog/36-990101646750203941
 
 [csv]: https://tools.ietf.org/html/rfc4180
 


### PR DESCRIPTION
Resolves #9464 

## Description

> What is the purpose of this pull request?

This pull request:

- Replaced a broken external link in the Nightingale's Rose dataset README with an archived Wayback Machine version.

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   #9464 

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

{{TODO: add disclosure if applicable}}

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
