### PR TITLE
fix: return `NaN` when the number of indexed elements is zero in `stats/strided/distances/dcosine-similarity`

### DIFF
--- a/lib/node_modules/@stdlib/stats/strided/distances/dcosine-similarity/README.md
+++ b/lib/node_modules/@stdlib/stats/strided/distances/dcosine-similarity/README.md
@@ -140,7 +140,7 @@ var z = dcosineSimilarity.ndarray( 3, x, 2, 1, y, -1, y.length-1 );
 
 ## Notes
 
--   If `N <= 0`, both functions return `0.0`.
+-   If `N <= 0`, both functions return `NaN`.
 
 </section>
 

--- a/lib/node_modules/@stdlib/stats/strided/distances/dcosine-similarity/docs/repl.txt
+++ b/lib/node_modules/@stdlib/stats/strided/distances/dcosine-similarity/docs/repl.txt
@@ -9,7 +9,7 @@
     Indexing is relative to the first index. To introduce an offset, use a typed
     array view.
 
-    If `N <= 0`, the function returns `0`.
+    If `N <= 0`, the function returns `NaN`.
 
     Parameters
     ----------

--- a/lib/node_modules/@stdlib/stats/strided/distances/dcosine-similarity/lib/ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/distances/dcosine-similarity/lib/ndarray.js
@@ -53,7 +53,7 @@ function dcosineSimilarity( N, x, strideX, offsetX, y, strideY, offsetY ) {
 	var dot;
 
 	if ( N <= 0 ) {
-		return 0.0;
+		return NaN;
 	}
 	dot = ddot( N, x, strideX, offsetX, y, strideY, offsetY );
 	xnrm = dnrm2( N, x, strideX, offsetX );

--- a/lib/node_modules/@stdlib/stats/strided/distances/dcosine-similarity/src/main.c
+++ b/lib/node_modules/@stdlib/stats/strided/distances/dcosine-similarity/src/main.c
@@ -56,7 +56,7 @@ double API_SUFFIX( stdlib_strided_dcosine_similarity_ndarray )( const CBLAS_INT 
 	double dot;
 
 	if ( N <= 0 ) {
-		return 0.0;
+		return 0.0 / 0.0;
 	}
 	dot = c_ddot_ndarray( N, X, strideX, offsetX, Y, strideY, offsetY );
 	xnrm = c_dnrm2_ndarray( N, X, strideX, offsetX );

--- a/lib/node_modules/@stdlib/stats/strided/distances/dcosine-similarity/test/test.dcosine_similarity.js
+++ b/lib/node_modules/@stdlib/stats/strided/distances/dcosine-similarity/test/test.dcosine_similarity.js
@@ -61,7 +61,7 @@ tape( 'the function calculates the cosine similarity of two strided arrays', fun
 	t.end();
 });
 
-tape( 'if provided an `N` parameter less than or equal to `0`, the function returns `0`', function test( t ) {
+tape( 'if provided an `N` parameter less than or equal to `0`, the function returns `NaN`', function test( t ) {
 	var sim;
 	var x;
 	var y;
@@ -70,10 +70,10 @@ tape( 'if provided an `N` parameter less than or equal to `0`, the function retu
 	y = new Float64Array( [ 1.0, -2.0, 3.0 ] );
 
 	sim = dcosineSimilarity( 0, x, 1, y, 1 );
-	t.strictEqual( isAlmostSameValue( sim, 0.0, 1 ), true, 'returns expected value' );
+	t.strictEqual( isAlmostSameValue( sim, NaN, 1 ), true, 'returns expected value' );
 
 	sim = dcosineSimilarity( -4, x, 1, y, 1 );
-	t.strictEqual( isAlmostSameValue( sim, 0.0, 1 ), true, 'returns expected value' );
+	t.strictEqual( isAlmostSameValue( sim, NaN, 1 ), true, 'returns expected value' );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/stats/strided/distances/dcosine-similarity/test/test.dcosine_similarity.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/distances/dcosine-similarity/test/test.dcosine_similarity.native.js
@@ -70,7 +70,7 @@ tape( 'the function calculates the cosine similarity of two strided arrays', opt
 	t.end();
 });
 
-tape( 'if provided an `N` parameter less than or equal to `0`, the function returns `0`', opts, function test( t ) {
+tape( 'if provided an `N` parameter less than or equal to `0`, the function returns `NaN`', opts, function test( t ) {
 	var sim;
 	var x;
 	var y;
@@ -80,11 +80,11 @@ tape( 'if provided an `N` parameter less than or equal to `0`, the function retu
 
 	// Test against textbook algorithm for computing cosine similarity:
 	sim = dcosineSimilarity( 0, x, 1, y, 1 );
-	t.strictEqual( isAlmostSameValue( sim, 0.0, 1 ), true, 'returns expected value' );
+	t.strictEqual( isAlmostSameValue( sim, NaN, 1 ), true, 'returns expected value' );
 
 	// Test against textbook algorithm for computing cosine similarity:
 	sim = dcosineSimilarity( -4, x, 1, y, 1 );
-	t.strictEqual( isAlmostSameValue( sim, 0.0, 1 ), true, 'returns expected value' );
+	t.strictEqual( isAlmostSameValue( sim, NaN, 1 ), true, 'returns expected value' );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/stats/strided/distances/dcosine-similarity/test/test.ndarray.js
+++ b/lib/node_modules/@stdlib/stats/strided/distances/dcosine-similarity/test/test.ndarray.js
@@ -61,7 +61,7 @@ tape( 'the function calculates the cosine similarity of two strided arrays', fun
 	t.end();
 });
 
-tape( 'if provided an `N` parameter less than or equal to `0`, the function returns `0`', function test( t ) {
+tape( 'if provided an `N` parameter less than or equal to `0`, the function returns `NaN`', function test( t ) {
 	var sim;
 	var x;
 	var y;
@@ -71,11 +71,11 @@ tape( 'if provided an `N` parameter less than or equal to `0`, the function retu
 
 	// Test against textbook algorithm for computing cosine similarity:
 	sim = dcosineSimilarity( 0, x, 1, 0, y, 1, 0 );
-	t.strictEqual( isAlmostSameValue( sim, 0.0, 1 ), true, 'returns expected value' );
+	t.strictEqual( isAlmostSameValue( sim, NaN, 1 ), true, 'returns expected value' );
 
 	// Test against textbook algorithm for computing cosine similarity:
 	sim = dcosineSimilarity( -4, x, 1, 0, y, 1, 0 );
-	t.strictEqual( isAlmostSameValue( sim, 0.0, 1 ), true, 'returns expected value' );
+	t.strictEqual( isAlmostSameValue( sim, NaN, 1 ), true, 'returns expected value' );
 	t.end();
 });
 

--- a/lib/node_modules/@stdlib/stats/strided/distances/dcosine-similarity/test/test.ndarray.native.js
+++ b/lib/node_modules/@stdlib/stats/strided/distances/dcosine-similarity/test/test.ndarray.native.js
@@ -70,7 +70,7 @@ tape( 'the function calculates the cosine similarity of two strided arrays', opt
 	t.end();
 });
 
-tape( 'if provided an `N` parameter less than or equal to `0`, the function returns `0`', opts, function test( t ) {
+tape( 'if provided an `N` parameter less than or equal to `0`, the function returns `NaN`', opts, function test( t ) {
 	var sim;
 	var x;
 	var y;
@@ -80,11 +80,11 @@ tape( 'if provided an `N` parameter less than or equal to `0`, the function retu
 
 	// Test against textbook algorithm for computing cosine similarity:
 	sim = dcosineSimilarity( 0, x, 1, 0, y, 1, 0 );
-	t.strictEqual( isAlmostSameValue( sim, 0.0, 1 ), true, 'returns expected value' );
+	t.strictEqual( isAlmostSameValue( sim, NaN, 1 ), true, 'returns expected value' );
 
 	// Test against textbook algorithm for computing cosine similarity:
 	sim = dcosineSimilarity( -4, x, 1, 0, y, 1, 0 );
-	t.strictEqual( isAlmostSameValue( sim, 0.0, 1 ), true, 'returns expected value' );
+	t.strictEqual( isAlmostSameValue( sim, NaN, 1 ), true, 'returns expected value' );
 	t.end();
 });
 


### PR DESCRIPTION
---
type: pre_commit_static_analysis_report
description: Results of running static analysis checks when committing changes. report:
  - task: lint_filenames status: passed
  - task: lint_editorconfig status: passed
  - task: lint_markdown status: passed
  - task: lint_package_json status: na
  - task: lint_repl_help status: passed
  - task: lint_javascript_src status: passed
  - task: lint_javascript_cli status: na
  - task: lint_javascript_examples status: na
  - task: lint_javascript_tests status: passed
  - task: lint_javascript_benchmarks status: na
  - task: lint_python status: na
  - task: lint_r status: na
  - task: lint_c_src status: passed
  - task: lint_c_examples status: na
  - task: lint_c_benchmarks status: na
  - task: lint_c_tests_fixtures status: na
  - task: lint_shell status: na
  - task: lint_typescript_declarations status: passed
  - task: lint_typescript_tests status: na
  - task: lint_license_headers status: passed ---

Resolves None.

## Description

> What is the purpose of this pull request?

This pull request:

-   Updates the current implementation to return NaN when `N <= 0` for `stats/strided/distances/dcosine-similarity`

## Related Issues

> Does this pull request have any related issues?

This pull request has the following related issues:

-   None.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

> When authoring the changes proposed in this PR, did you use any kind of AI assistance?

-   [ ] Yes
-   [x] No

If you answered "yes" above, how did you use AI assistance?

-   [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-   [ ] Test/benchmark generation
-   [ ] Documentation (including examples)
-   [ ] Research and understanding

#### Disclosure

> If you answered "yes" to using AI assistance, please provide a short disclosure indicating how you used AI assistance. This helps reviewers determine how much scrutiny to apply when reviewing your contribution. Example disclosures: "This PR was written primarily by Claude Code." or "I consulted ChatGPT to understand the codebase, but the proposed changes were fully authored manually by myself.".

None.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
