### PR TITLE
test: add special cases tests in `math/base/special/xlog1py`

### DIFF
--- a/lib/node_modules/@stdlib/math/base/special/log1pmx/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/log1pmx/test/test.js
@@ -88,3 +88,20 @@ tape( 'the function returns a Taylor series expansion otherwise', function test(
 	}
 	t.end();
 });
+tape( 'the function handles special values', function test( t ) {
+	var v;
+
+	v = log1pmx( NaN );
+	t.strictEqual( isnan( v ), true, 'returns NaN for NaN' );
+
+	v = log1pmx( Infinity );
+	t.strictEqual( isnan( v ), true, 'returns NaN for +Infinity' );
+
+	v = log1pmx( -Infinity );
+	t.strictEqual( isnan( v ), true, 'returns NaN for -Infinity' );
+
+	v = log1pmx( -0.0 );
+	t.strictEqual( Object.is( v, -0.0 ), true, 'preserves negative zero' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/log1pmx/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/log1pmx/test/test.js
@@ -88,20 +88,3 @@ tape( 'the function returns a Taylor series expansion otherwise', function test(
 	}
 	t.end();
 });
-tape( 'the function handles special values', function test( t ) {
-	var v;
-
-	v = log1pmx( NaN );
-	t.strictEqual( isnan( v ), true, 'returns NaN for NaN' );
-
-	v = log1pmx( Infinity );
-	t.strictEqual( isnan( v ), true, 'returns NaN for +Infinity' );
-
-	v = log1pmx( -Infinity );
-	t.strictEqual( isnan( v ), true, 'returns NaN for -Infinity' );
-
-	v = log1pmx( -0.0 );
-	t.strictEqual( Object.is( v, -0.0 ), true, 'preserves negative zero' );
-
-	t.end();
-});

--- a/lib/node_modules/@stdlib/math/base/special/xlog1py/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/xlog1py/test/test.js
@@ -173,6 +173,7 @@ tape( 'the function evaluates `x * ln(y+1)` for large `x` and `y`', function tes
 	}
 	t.end();
 });
+
 tape( 'the function handles infinite values', function test( t ) {
 	var v;
 

--- a/lib/node_modules/@stdlib/math/base/special/xlog1py/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/xlog1py/test/test.js
@@ -173,3 +173,26 @@ tape( 'the function evaluates `x * ln(y+1)` for large `x` and `y`', function tes
 	}
 	t.end();
 });
+tape( 'the function handles infinite values', function test( t ) {
+	var v;
+
+	v = xlog1py( Infinity, 1.0 );
+	t.strictEqual( v, Infinity, 'Infinity * finite positive returns Infinity' );
+
+	v = xlog1py( Infinity, 0.0 );
+	t.strictEqual( isnan( v ), true, 'Infinity * 0 returns NaN' );
+
+	v = xlog1py( Infinity, -1.0 );
+	t.strictEqual( v, -Infinity, 'Infinity * negative returns -Infinity' );
+
+	v = xlog1py( 2.0, Infinity );
+	t.strictEqual( v, Infinity, 'finite positive * Infinity returns Infinity' );
+
+	v = xlog1py( -2.0, Infinity );
+	t.strictEqual( v, -Infinity, 'finite negative * Infinity returns -Infinity' );
+
+	v = xlog1py( 0.0, Infinity );
+	t.strictEqual( v, 0.0, '0 * Infinity returns 0' );
+
+	t.end();
+});

--- a/lib/node_modules/@stdlib/math/base/special/xlog1py/test/test.js
+++ b/lib/node_modules/@stdlib/math/base/special/xlog1py/test/test.js
@@ -24,6 +24,8 @@ var tape = require( 'tape' );
 var isnan = require( '@stdlib/math/base/assert/is-nan' );
 var EPS = require( '@stdlib/constants/float64/eps' );
 var abs = require( '@stdlib/math/base/special/abs' );
+var PINF = require( '@stdlib/constants/float64/pinf' );
+var NINF = require( '@stdlib/constants/float64/ninf' );
 var xlog1py = require( './../lib' );
 
 
@@ -175,25 +177,22 @@ tape( 'the function evaluates `x * ln(y+1)` for large `x` and `y`', function tes
 });
 
 tape( 'the function handles infinite values', function test( t ) {
-	var v;
+	var out;
 
-	v = xlog1py( Infinity, 1.0 );
-	t.strictEqual( v, Infinity, 'Infinity * finite positive returns Infinity' );
+	out = xlog1py( PINF, 1.0 );
+	t.strictEqual( out, PINF, 'returns expected value' );
 
-	v = xlog1py( Infinity, 0.0 );
-	t.strictEqual( isnan( v ), true, 'Infinity * 0 returns NaN' );
+	out = xlog1py( PINF, 0.0 );
+	t.strictEqual( isnan( out ), true, 'returns expected value' );
 
-	v = xlog1py( Infinity, -1.0 );
-	t.strictEqual( v, -Infinity, 'Infinity * negative returns -Infinity' );
+	out = xlog1py( NINF, 1.0 );
+	t.strictEqual( out, NINF, 'returns expected value' );
 
-	v = xlog1py( 2.0, Infinity );
-	t.strictEqual( v, Infinity, 'finite positive * Infinity returns Infinity' );
+	out = xlog1py( 2.0, PINF );
+	t.strictEqual( out, PINF, 'returns expected value' );
 
-	v = xlog1py( -2.0, Infinity );
-	t.strictEqual( v, -Infinity, 'finite negative * Infinity returns -Infinity' );
-
-	v = xlog1py( 0.0, Infinity );
-	t.strictEqual( v, 0.0, '0 * Infinity returns 0' );
+	out = xlog1py( -2.0, PINF );
+	t.strictEqual( out, NINF, 'returns expected value' );
 
 	t.end();
 });


### PR DESCRIPTION
Resolves N/A.

## Description

This pull request adds explicit unit tests covering infinite-value edge cases for `xlog1py`.

The current implementation already exhibits well-defined behavior for `±Infinity` inputs. These tests make that behavior explict

Specifically, this PR verifies:
- Behavior when `x` is `±Infinity`
- Behavior when `y` is `Infinity`
- Interactions between zero and infinite values

## Related Issues

This pull request has no related issues.

## Questions

No.

## Other

No.

## Checklist

- [x] Read, understood, and followed the [contributing guidelines][contributing].

### AI Assistance

- [x] Yes
- [ ] No

If you answered "yes" above, how did you use AI assistance?

- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding

#### Disclosure

I consulted AI only to understand the stdlib codebase, existing behavior, and testing conventions. All tests in this pull request were written, validated, and run manually.

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
